### PR TITLE
Edge vsphere

### DIFF
--- a/pkg/distro/distro_test_common/distro_test_common.go
+++ b/pkg/distro/distro_test_common/distro_test_common.go
@@ -76,6 +76,7 @@ func TestDistro_KernelOption(t *testing.T, d distro.Distro) {
 		"iot-raw-image":             true,
 		"edge-raw-image":            true,
 		"edge-ami":                  true,
+		"edge-vsphere":              true,
 
 		// the tar image type is a minimal image type which is not expected to
 		// be usable without a blueprint (see commit 83a63aaf172f556f6176e6099ffaa2b5357b58f5).
@@ -165,6 +166,7 @@ func TestDistro_OSTreeOptions(t *testing.T, d distro.Distro) {
 	}
 
 	typesWithPayload := map[string]bool{
+		"edge-vsphere":              true,
 		"edge-ami":                  true,
 		"edge-installer":            true,
 		"edge-raw-image":            true,

--- a/pkg/distro/rhel9/distro.go
+++ b/pkg/distro/rhel9/distro.go
@@ -324,6 +324,17 @@ func newDistro(name string, minor int) *distribution {
 	x86_64.addImageTypes(
 		&platform.X86{
 			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_VMDK,
+			},
+			BIOS:       true,
+			UEFIVendor: rd.vendor,
+		},
+		edgeVsphereImgType,
+	)
+
+	x86_64.addImageTypes(
+		&platform.X86{
+			BasePlatform: platform.BasePlatform{
 				ImageFormat: platform.FORMAT_RAW,
 			},
 			BIOS:       false,
@@ -367,6 +378,17 @@ func newDistro(name string, minor int) *distribution {
 		imageInstaller,
 		edgeAMIImgType,
 	)
+
+	aarch64.addImageTypes(
+		&platform.Aarch64{
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_VMDK,
+			},
+			UEFIVendor: rd.vendor,
+		},
+		edgeVsphereImgType,
+	)
+
 	aarch64.addImageTypes(
 		&platform.Aarch64{
 			BasePlatform: platform.BasePlatform{

--- a/pkg/distro/rhel9/distro_test.go
+++ b/pkg/distro/rhel9/distro_test.go
@@ -205,6 +205,14 @@ func TestFilenameFromType(t *testing.T) {
 			},
 		},
 		{
+			name: "edge-vsphere",
+			args: args{"edge-vsphere"},
+			want: wantResult{
+				filename: "image.vmdk",
+				mimeType: "application/x-vmdk",
+			},
+		},
+		{
 			name: "invalid-output-type",
 			args: args{"foobar"},
 			want: wantResult{wantErr: true},
@@ -479,7 +487,7 @@ func TestDistro_ManifestError(t *testing.T) {
 			_, _, err := imgType.Manifest(&bp, imgOpts, nil, 0)
 			if imgTypeName == "edge-commit" || imgTypeName == "edge-container" {
 				assert.EqualError(t, err, "kernel boot parameter customizations are not supported for ostree types")
-			} else if imgTypeName == "edge-raw-image" || imgTypeName == "edge-ami" {
+			} else if imgTypeName == "edge-raw-image" || imgTypeName == "edge-ami" || imgTypeName == "edge-vsphere" {
 				assert.EqualError(t, err, fmt.Sprintf("\"%s\" images require specifying a URL from which to retrieve the OSTree commit", imgTypeName))
 			} else if imgTypeName == "edge-installer" || imgTypeName == "edge-simplified-installer" {
 				assert.EqualError(t, err, fmt.Sprintf("boot ISO image type \"%s\" requires specifying a URL from which to retrieve the OSTree commit", imgTypeName))
@@ -515,6 +523,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"edge-raw-image",
 				"edge-simplified-installer",
 				"edge-ami",
+				"edge-vsphere",
 				"gce",
 				"gce-rhui",
 				"tar",
@@ -537,6 +546,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"edge-simplified-installer",
 				"edge-raw-image",
 				"edge-ami",
+				"edge-vsphere",
 				"tar",
 				"image-installer",
 				"vhd",
@@ -662,7 +672,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
 			if imgTypeName == "edge-commit" || imgTypeName == "edge-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
-			} else if imgTypeName == "edge-installer" || imgTypeName == "edge-simplified-installer" || imgTypeName == "edge-raw-image" || imgTypeName == "edge-ami" {
+			} else if imgTypeName == "edge-installer" || imgTypeName == "edge-simplified-installer" || imgTypeName == "edge-raw-image" || imgTypeName == "edge-ami" || imgTypeName == "edge-vsphere" {
 				continue
 			} else {
 				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/etc\"]")
@@ -690,7 +700,7 @@ func TestDistro_TestRootMountPoint(t *testing.T) {
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
 			if imgTypeName == "edge-commit" || imgTypeName == "edge-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
-			} else if imgTypeName == "edge-installer" || imgTypeName == "edge-simplified-installer" || imgTypeName == "edge-raw-image" || imgTypeName == "edge-ami" {
+			} else if imgTypeName == "edge-installer" || imgTypeName == "edge-simplified-installer" || imgTypeName == "edge-raw-image" || imgTypeName == "edge-ami" || imgTypeName == "edge-vsphere" {
 				continue
 			} else {
 				assert.NoError(t, err)
@@ -824,7 +834,7 @@ func TestDistro_CustomFileSystemPatternMatching(t *testing.T) {
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
 			if imgTypeName == "edge-commit" || imgTypeName == "edge-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
-			} else if imgTypeName == "edge-installer" || imgTypeName == "edge-simplified-installer" || imgTypeName == "edge-raw-image" || imgTypeName == "edge-ami" {
+			} else if imgTypeName == "edge-installer" || imgTypeName == "edge-simplified-installer" || imgTypeName == "edge-raw-image" || imgTypeName == "edge-ami" || imgTypeName == "edge-vsphere" {
 				continue
 			} else {
 				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/variable\" \"/variable/log/audit\"]")
@@ -852,7 +862,7 @@ func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
 			if imgTypeName == "edge-commit" || imgTypeName == "edge-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
-			} else if imgTypeName == "edge-installer" || imgTypeName == "edge-simplified-installer" || imgTypeName == "edge-raw-image" || imgTypeName == "edge-ami" {
+			} else if imgTypeName == "edge-installer" || imgTypeName == "edge-simplified-installer" || imgTypeName == "edge-raw-image" || imgTypeName == "edge-ami" || imgTypeName == "edge-vsphere" {
 				continue
 			} else {
 				assert.NoError(t, err)

--- a/pkg/distro/rhel9/edge.go
+++ b/pkg/distro/rhel9/edge.go
@@ -153,6 +153,25 @@ var (
 		environment:         &environment.EC2{},
 	}
 
+	edgeVsphereImgType = imageType{
+		name:        "edge-vsphere",
+		filename:    "image.vmdk",
+		mimeType:    "application/x-vmdk",
+		packageSets: nil,
+		defaultImageConfig: &distro.ImageConfig{
+			Locale: common.ToPtr("en_US.UTF-8"),
+		},
+		defaultSize:         10 * common.GibiByte,
+		rpmOstree:           true,
+		bootable:            true,
+		bootISO:             false,
+		image:               edgeRawImage,
+		buildPipelines:      []string{"build"},
+		payloadPipelines:    []string{"ostree-deployment", "image", "vmdk"},
+		exports:             []string{"vmdk"},
+		basePartitionTables: edgeBasePartitionTables,
+	}
+
 	minimalrawImgType = imageType{
 		name:        "minimal-raw",
 		filename:    "raw.img.xz",
@@ -171,6 +190,7 @@ var (
 		exports:             []string{"xz"},
 		basePartitionTables: defaultBasePartitionTables,
 	}
+
 	// Shared Services
 	edgeServices = []string{
 		// TODO(runcom): move fdo-client-linuxapp.service to presets?

--- a/pkg/distro/rhel9/imagetype.go
+++ b/pkg/distro/rhel9/imagetype.go
@@ -343,7 +343,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		}
 	}
 
-	if t.name == "edge-raw-image" || t.name == "edge-ami" {
+	if t.name == "edge-raw-image" || t.name == "edge-ami" || t.name == "edge-vsphere" {
 		// ostree-based bootable images require a URL from which to pull a payload commit
 		if ostreeURL == "" {
 			return warnings, fmt.Errorf("%q images require specifying a URL from which to retrieve the OSTree commit", t.name)

--- a/pkg/image/live.go
+++ b/pkg/image/live.go
@@ -87,14 +87,14 @@ func (img *LiveImage) InstantiateManifest(m *manifest.Manifest,
 		artifactPipeline = vpcPipeline
 		artifact = vpcPipeline.Export()
 	case platform.FORMAT_VMDK:
-		vmdkPipeline := manifest.NewVMDK(m, buildPipeline, imagePipeline)
+		vmdkPipeline := manifest.NewVMDK(m, buildPipeline, imagePipeline, nil)
 		if img.Compression == "" {
 			vmdkPipeline.Filename = img.Filename
 		}
 		artifactPipeline = vmdkPipeline
 		artifact = vmdkPipeline.Export()
 	case platform.FORMAT_OVA:
-		vmdkPipeline := manifest.NewVMDK(m, buildPipeline, imagePipeline)
+		vmdkPipeline := manifest.NewVMDK(m, buildPipeline, imagePipeline, nil)
 		ovfPipeline := manifest.NewOVF(m, buildPipeline, vmdkPipeline)
 		artifactPipeline := manifest.NewTar(m, buildPipeline, ovfPipeline, "archive")
 		artifactPipeline.Format = osbuild.TarArchiveFormatOldgnu

--- a/test/cases/generate-build-config
+++ b/test/cases/generate-build-config
@@ -22,7 +22,8 @@ ARCHITECTURES = ["x86_64", "aarch64"]
 
 # skip image types that we can't test right now
 SKIPS = [
-    "edge-ami"
+    "edge-ami",
+    "edge-vsphere",
     "edge-installer",
     "edge-raw-image",
     "edge-simplified-installer",

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -22,6 +22,9 @@
   "edge-simplified-installer": [
     "./test/configs/ostree-device.json"
   ],
+  "edge-vsphere": [
+    "./test/configs/ostree-deploy.json"
+  ],
   "iot-ami": [
     "./test/configs/ostree-deploy.json"
   ],


### PR DESCRIPTION
This adds the `edge-vsphere` image type for x86_64 and
aarch64. It is based on the `edge-raw-image` but produces
a .vmdk image in order to upload the artifact to vSphere.

This image has Ignition support.

This has been moved from [osbuild/osbuild-composer#3539](https://github.com/osbuild/osbuild-composer/pull/3539)

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue (I think so?)
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
