### PR TITLE
Imagetype: minimal-raw support for rhel8/9 with xz compression

### DIFF
--- a/image-types/README.md
+++ b/image-types/README.md
@@ -6,3 +6,23 @@ This directory contains high-level descriptions of all image types that
 Each of them contains a short description of the purpose and intended use case
 of the image type, and any peculiarities that make this image type differ from
 a standard installation.
+
+## minimal-raw Image type
+
+This image type is basically a pre-canned, bootable, minimal rpm image.
+From RHEL PoV this will enable us to support arm or similar devices as part
+of the SystemReadyIR/ES "Edge on Arm" initiative. In cases where the customer
+may not wish to run R4E or to use for development/testing/prototyping where a
+ostree image may not be the most straight forward way to do things, `minimal-raw`
+will be useful.
+
+
+The `minimal-raw` image generated using Image Builder will be compressed in
+`xz` format. User needs to uncompress it to be able to boot it. User can `dd`
+the uncompressed image to any bootable device such as an SD card.
+
+``` bash
+
+xz -d <uuid-minimal-raw.img.xz> -o <minimal-raw.img>
+
+```

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -330,9 +330,10 @@ var (
 	}
 
 	minimalrawImgType = imageType{
-		name:     "minimal-raw",
-		filename: "raw.img",
-		mimeType: "application/disk",
+		name:        "minimal-raw",
+		filename:    "raw.img.xz",
+		compression: "xz",
+		mimeType:    "application/xz",
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: minimalrpmPackageSet,
 		},
@@ -342,8 +343,8 @@ var (
 		defaultSize:         2 * common.GibiByte,
 		image:               liveImage,
 		buildPipelines:      []string{"build"},
-		payloadPipelines:    []string{"os", "image"},
-		exports:             []string{"image"},
+		payloadPipelines:    []string{"os", "image", "xz"},
+		exports:             []string{"xz"},
 		basePartitionTables: defaultBasePartitionTables,
 	}
 )

--- a/pkg/distro/fedora/distro_test.go
+++ b/pkg/distro/fedora/distro_test.go
@@ -193,8 +193,8 @@ func TestFilenameFromType(t *testing.T) {
 			name: "minimal-raw",
 			args: args{"minimal-raw"},
 			want: wantResult{
-				filename: "raw.img",
-				mimeType: "application/disk",
+				filename: "raw.img.xz",
+				mimeType: "application/xz",
 			},
 		},
 	}

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -213,6 +213,7 @@ func liveImage(workload workload.Workload,
 	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, customizations)
 	img.Environment = t.environment
 	img.Workload = workload
+	img.Compression = t.compression
 	// TODO: move generation into LiveImage
 	pt, err := t.getPartitionTable(customizations.GetFilesystems(), options, rng)
 	if err != nil {

--- a/pkg/distro/rhel8/distro.go
+++ b/pkg/distro/rhel8/distro.go
@@ -369,6 +369,7 @@ func newDistro(name string, minor int) *distribution {
 	aarch64.addImageTypes(
 		rawAarch64Platform,
 		amiImgTypeAarch64(rd),
+		minimalRawImgType(rd),
 	)
 
 	ppc64le.addImageTypes(
@@ -425,6 +426,11 @@ func newDistro(name string, minor int) *distribution {
 		BIOS:       false,
 		UEFIVendor: rd.vendor,
 	}
+
+	x86_64.addImageTypes(
+		rawUEFIx86Platform,
+		minimalRawImgType(rd),
+	)
 
 	if rd.isRHEL() {
 		if !common.VersionLessThan(rd.osVersion, "8.6") {

--- a/pkg/distro/rhel8/distro_test.go
+++ b/pkg/distro/rhel8/distro_test.go
@@ -216,6 +216,14 @@ func TestFilenameFromType(t *testing.T) {
 			args: args{"foobar"},
 			want: wantResult{wantErr: true},
 		},
+		{
+			name: "minimal-raw",
+			args: args{"minimal-raw"},
+			want: wantResult{
+				filename: "raw.img.xz",
+				mimeType: "application/xz",
+			},
+		},
 	}
 	for _, dist := range rhelFamilyDistros {
 		t.Run(dist.name, func(t *testing.T) {
@@ -324,6 +332,7 @@ func TestImageType_Name(t *testing.T) {
 				"edge-installer",
 				"tar",
 				"image-installer",
+				"minimal-raw",
 			},
 		},
 		{
@@ -338,6 +347,7 @@ func TestImageType_Name(t *testing.T) {
 				"edge-commit",
 				"edge-container",
 				"tar",
+				"minimal-raw",
 			},
 		},
 		{
@@ -523,6 +533,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"image-installer",
 				"oci",
 				"wsl",
+				"minimal-raw",
 			},
 		},
 		{
@@ -542,6 +553,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"tar",
 				"image-installer",
 				"wsl",
+				"minimal-raw",
 			},
 		},
 		{

--- a/pkg/distro/rhel8/edge.go
+++ b/pkg/distro/rhel8/edge.go
@@ -139,6 +139,28 @@ func edgeSimplifiedInstallerImgType(rd distribution) imageType {
 	return it
 }
 
+func minimalRawImgType(rd distribution) imageType {
+	it := imageType{
+		name:        "minimal-raw",
+		filename:    "raw.img.xz",
+		compression: "xz",
+		mimeType:    "application/xz",
+		packageSets: map[string]packageSetFunc{
+			osPkgsKey: minimalrpmPackageSet,
+		},
+		rpmOstree:           false,
+		kernelOptions:       "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
+		bootable:            true,
+		defaultSize:         2 * common.GibiByte,
+		image:               liveImage,
+		buildPipelines:      []string{"build"},
+		payloadPipelines:    []string{"os", "image", "xz"},
+		exports:             []string{"xz"},
+		basePartitionTables: defaultBasePartitionTables,
+	}
+	return it
+}
+
 // edge commit OS package set
 func edgeCommitPackageSet(t *imageType) rpmmd.PackageSet {
 	ps := rpmmd.PackageSet{

--- a/pkg/distro/rhel8/package_sets.go
+++ b/pkg/distro/rhel8/package_sets.go
@@ -73,3 +73,11 @@ func distroSpecificPackageSet(t *imageType) rpmmd.PackageSet {
 	}
 	return rpmmd.PackageSet{}
 }
+
+func minimalrpmPackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"@core",
+		},
+	}
+}

--- a/pkg/distro/rhel9/distro.go
+++ b/pkg/distro/rhel9/distro.go
@@ -330,6 +330,7 @@ func newDistro(name string, minor int) *distribution {
 			UEFIVendor: rd.vendor,
 		},
 		edgeSimplifiedInstallerImgType,
+		minimalrawImgType,
 	)
 
 	x86_64.addImageTypes(
@@ -374,6 +375,7 @@ func newDistro(name string, minor int) *distribution {
 			UEFIVendor: rd.vendor,
 		},
 		edgeRawImgType,
+		minimalrawImgType,
 	)
 
 	aarch64.addImageTypes(

--- a/pkg/distro/rhel9/distro_test.go
+++ b/pkg/distro/rhel9/distro_test.go
@@ -209,6 +209,14 @@ func TestFilenameFromType(t *testing.T) {
 			args: args{"foobar"},
 			want: wantResult{wantErr: true},
 		},
+		{
+			name: "minimal-raw",
+			args: args{"minimal-raw"},
+			want: wantResult{
+				filename: "raw.img.xz",
+				mimeType: "application/xz",
+			},
+		},
 	}
 	for _, dist := range rhelFamilyDistros {
 		t.Run(dist.name, func(t *testing.T) {
@@ -314,6 +322,7 @@ func TestImageType_Name(t *testing.T) {
 				"gce",
 				"tar",
 				"image-installer",
+				"minimal-raw",
 			},
 		},
 		{
@@ -329,6 +338,7 @@ func TestImageType_Name(t *testing.T) {
 				"image-installer",
 				"vhd",
 				"azure-rhui",
+				"minimal-raw",
 			},
 		},
 		{
@@ -511,6 +521,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"image-installer",
 				"oci",
 				"wsl",
+				"minimal-raw",
 			},
 		},
 		{
@@ -531,6 +542,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"vhd",
 				"azure-rhui",
 				"wsl",
+				"minimal-raw",
 			},
 		},
 		{

--- a/pkg/distro/rhel9/edge.go
+++ b/pkg/distro/rhel9/edge.go
@@ -153,6 +153,24 @@ var (
 		environment:         &environment.EC2{},
 	}
 
+	minimalrawImgType = imageType{
+		name:        "minimal-raw",
+		filename:    "raw.img.xz",
+		compression: "xz",
+		mimeType:    "application/xz",
+		packageSets: map[string]packageSetFunc{
+			osPkgsKey: minimalrpmPackageSet,
+		},
+		rpmOstree:           false,
+		kernelOptions:       "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
+		bootable:            true,
+		defaultSize:         2 * common.GibiByte,
+		image:               liveImage,
+		buildPipelines:      []string{"build"},
+		payloadPipelines:    []string{"os", "image", "xz"},
+		exports:             []string{"xz"},
+		basePartitionTables: defaultBasePartitionTables,
+	}
 	// Shared Services
 	edgeServices = []string{
 		// TODO(runcom): move fdo-client-linuxapp.service to presets?

--- a/pkg/distro/rhel9/package_sets.go
+++ b/pkg/distro/rhel9/package_sets.go
@@ -245,3 +245,11 @@ func distroSpecificPackageSet(t *imageType) rpmmd.PackageSet {
 	}
 	return rpmmd.PackageSet{}
 }
+
+func minimalrpmPackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"@core",
+		},
+	}
+}

--- a/test/cases/minimal-raw.sh
+++ b/test/cases/minimal-raw.sh
@@ -57,7 +57,8 @@ TEST_UUID=$(uuidgen)
 IMAGE_KEY="minimal-raw-${TEST_UUID}"
 UEFI_GUEST_ADDRESS=192.168.100.51
 MINIMAL_RAW_TYPE=minimal-raw
-MINIMAL_RAW_FILENAME=raw.img
+MINIMAL_RAW_DECOMPRESSED=raw.img
+MINIMAL_RAW_FILENAME=raw.img.xz
 BOOT_ARGS="uefi"
 
 # Set up temporary files.
@@ -239,13 +240,14 @@ build_image minimal-raw "${MINIMAL_RAW_TYPE}"
 # Download the image
 greenprint "📥 Downloading the minimal-raw image"
 sudo composer-cli compose image "${COMPOSE_ID}" > /dev/null
-MINIMAL_RAW_FILENAME="${COMPOSE_ID}-${MINIMAL_RAW_FILENAME}"
 
 greenprint "Extracting and converting the raw image to a qcow2 file"
+MINIMAL_RAW_FILENAME="${COMPOSE_ID}-${MINIMAL_RAW_FILENAME}"
+sudo xz -d "${MINIMAL_RAW_FILENAME}"
 LIBVIRT_IMAGE_PATH_UEFI=/var/lib/libvirt/images/"${IMAGE_KEY}-uefi.qcow2"
-sudo qemu-img convert -f raw "$MINIMAL_RAW_FILENAME" -O qcow2 "$LIBVIRT_IMAGE_PATH_UEFI"
+sudo qemu-img convert -f raw "${COMPOSE_ID}-${MINIMAL_RAW_DECOMPRESSED}" -O qcow2 "$LIBVIRT_IMAGE_PATH_UEFI"
 # Remove raw file
-sudo rm -f "$MINIMAL_RAW_FILENAME"
+sudo rm -f "${COMPOSE_ID}-${MINIMAL_RAW_DECOMPRESSED}"
 
 # Clean compose and blueprints.
 greenprint "🧹 Clean up minimal-raw blueprint and compose"

--- a/test/data/ansible/check-minimal.yaml
+++ b/test/data/ansible/check-minimal.yaml
@@ -4,6 +4,7 @@
   vars:
     total_counter: "0"
     failed_counter: "0"
+    download_node: ""
 
   tasks:
     # current target host's IP address
@@ -56,6 +57,46 @@
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
+
+    - name: add RHEL 9.3 BaseOS repository
+      yum_repository:
+        name: baseos
+        description: RHEL repository
+        baseurl: "http://{{ download_node }}/rhel-9/nightly/RHEL-9/latest-RHEL-9.3.0/compose/BaseOS/{{ ansible_facts['architecture'] }}/os/"
+        gpgcheck: no
+        file: rhel_repo
+      become: yes
+      when: ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('9.3', '==')
+
+    - name: add RHEL 9.3 AppStream repository
+      yum_repository:
+        name: appstream
+        description: RHEL repository
+        baseurl: "http://{{ download_node }}/rhel-9/nightly/RHEL-9/latest-RHEL-9.3.0/compose/AppStream/{{ ansible_facts['architecture'] }}/os/"
+        gpgcheck: no
+        file: rhel_repo
+      become: yes
+      when: ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('9.3', '==')
+
+    - name: add RHEL 8.9 BaseOS repository
+      yum_repository:
+        name: baseos
+        description: RHEL repository
+        baseurl: "http://{{ download_node }}/rhel-8/nightly/RHEL-8/latest-RHEL-8.9.0/compose/BaseOS/{{ ansible_facts['architecture'] }}/os/"
+        gpgcheck: no
+        file: rhel_repo
+      become: yes
+      when: ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('8.9', '==')
+
+    - name: add RHEL 8.9 AppStream repository
+      yum_repository:
+        name: appstream
+        description: RHEL repository
+        baseurl: "http://{{ download_node }}/rhel-8/nightly/RHEL-8/latest-RHEL-8.9.0/compose/AppStream/{{ ansible_facts['architecture'] }}/os/"
+        gpgcheck: no
+        file: rhel_repo
+      become: yes
+      when: ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('8.9', '==')
 
     - name: install podman
       dnf:


### PR DESCRIPTION
This pull request includes:

- minimal-raw image type support for rhel8/9 cs8/9
- fedora already had this image type , just added xz compression stage.
- xz compression brings down the image size from ~3.96GB to  ~700MB.
- updated README.md under image-types/ folder.
- osbuild-composer PR : https://github.com/osbuild/osbuild-composer/pull/3518

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
