### PR TITLE
blueprint: add `sysconfig` customization

### DIFF
--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -24,6 +24,7 @@ type Customizations struct {
 	Directories        []DirectoryCustomization  `json:"directories,omitempty" toml:"directories,omitempty"`
 	Files              []FileCustomization       `json:"files,omitempty" toml:"files,omitempty"`
 	Repositories       []RepositoryCustomization `json:"repositories,omitempty" toml:"repositories,omitempty"`
+	Sysconfig          *SysconfigCustomization   `json:"sysconfig,omitempty" toml:"sysconfig,omitempty"`
 }
 
 type IgnitionCustomization struct {
@@ -109,6 +110,20 @@ type ServicesCustomization struct {
 type OpenSCAPCustomization struct {
 	DataStream string `json:"datastream,omitempty" toml:"datastream,omitempty"`
 	ProfileID  string `json:"profile_id,omitempty" toml:"profile_id,omitempty"`
+}
+
+type SysconfigCustomization struct {
+	Desktop *SysconfigDesktopCustomization `json:"desktop,omitempty" toml:"desktop,omitempty"`
+	Livesys *SysconfigLivesysCustomization `json:"livesys,omitempty" toml:"livesys,omitempty"`
+}
+
+type SysconfigLivesysCustomization struct {
+	Session string `json:"session" toml:"session"`
+}
+
+type SysconfigDesktopCustomization struct {
+	Preferred      string `json:"preferred,omitempty" toml:"preferred,omitempty"`
+	DisplayManager string `json:"displaymanager,omitempty" toml:"displaymanager,omitempty"`
 }
 
 type CustomizationError struct {
@@ -348,4 +363,11 @@ func (c *Customizations) GetRepositories() ([]RepositoryCustomization, error) {
 	}
 
 	return c.Repositories, nil
+}
+
+func (c *Customizations) GetSysconfig() *SysconfigCustomization {
+	if c == nil {
+		return nil
+	}
+	return c.Sysconfig
 }

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -250,7 +250,7 @@ func TestError(t *testing.T) {
 
 }
 
-// This tests calling all the functions on a Blueprint with no Customizations
+//This tests calling all the functions on a Blueprint with no Customizations
 func TestNoCustomizationsInBlueprint(t *testing.T) {
 
 	TestBP := Blueprint{}
@@ -271,7 +271,7 @@ func TestNoCustomizationsInBlueprint(t *testing.T) {
 	assert.Nil(t, nilNTPServers)
 }
 
-// This tests additional scenarios where GetPrimaryLocale() returns nil values
+//This tests additional scenarios where GetPrimaryLocale() returns nil values
 func TestNilGetPrimaryLocale(t *testing.T) {
 
 	//Case empty Customization
@@ -299,7 +299,7 @@ func TestNilGetPrimaryLocale(t *testing.T) {
 
 }
 
-// This tests additional scenario where GetTimezoneSEtting() returns nil values
+//This tests additional scenario where GetTimezoneSEtting() returns nil values
 func TestNilGetTimezoneSettings(t *testing.T) {
 
 	TestCustomizationsEmpty := Customizations{}
@@ -386,4 +386,28 @@ func TestGetOpenSCAPConfig(t *testing.T) {
 	retOpenSCAPCustomiztions := TestCustomizations.GetOpenSCAP()
 
 	assert.EqualValues(t, expectedOscap, *retOpenSCAPCustomiztions)
+}
+
+func TestGetSysconfig(t *testing.T) {
+
+	expectedDesktop := SysconfigDesktopCustomization{
+		Preferred:      "/usr/bin/sway",
+		DisplayManager: "/bin/sddm",
+	}
+	expectedLivesys := SysconfigLivesysCustomization{
+		Session: "gnome",
+	}
+
+	expectedSysconfig := SysconfigCustomization{
+		Desktop: &expectedDesktop,
+		Livesys: &expectedLivesys,
+	}
+
+	TestCustomizations := Customizations{
+		Sysconfig: &expectedSysconfig,
+	}
+
+	retSysconfig := TestCustomizations.GetSysconfig()
+
+	assert.Equal(t, &expectedSysconfig, retSysconfig)
 }


### PR DESCRIPTION
This adds partial configuration support for the `sysconfig` stage.