### PR TITLE
Group dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,5 +18,8 @@ updates:
     schedule:
       interval: "daily"
       time: "04:00"
-    open-pull-requests-limit: 5
-    rebase-strategy: "disabled"
+    groups:
+      go-deps:
+        - "*"  # group all dependency updates into one PR
+    open-pull-requests-limit: 1
+    rebase-strategy: "auto"


### PR DESCRIPTION
- Group all updates into one PR.
- Limit to one PR at a time (since they're grouped).
- Automatically rebase when needed.