### PR TITLE
dependabot: fix groups object format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
       time: "04:00"
     groups:
       go-deps:
-        - "*"  # group all dependency updates into one PR
+        patterns:
+          - "*"  # group all dependency updates into one PR
     open-pull-requests-limit: 1
     rebase-strategy: "auto"


### PR DESCRIPTION
Followup to #33.

The group requires a sub-object called 'patterns'.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups