### PR TITLE
OpenSCAP autotailoring stage

### DIFF
--- a/internal/oscap/oscap.go
+++ b/internal/oscap/oscap.go
@@ -1,7 +1,11 @@
 package oscap
 
 import (
+	"fmt"
+	"path/filepath"
 	"strings"
+
+	"github.com/osbuild/images/internal/fsnode"
 )
 
 type Profile string
@@ -35,6 +39,9 @@ const (
 	defaultCentos9Datastream string = "/usr/share/xml/scap/ssg/content/ssg-cs9-ds.xml"
 	defaultRHEL8Datastream   string = "/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml"
 	defaultRHEL9Datastream   string = "/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml"
+
+	// tailoring directory path
+	tailoringDirPath string = "/usr/share/xml/osbuild-openscap-data"
 )
 
 func DefaultFedoraDatastream() string {
@@ -69,4 +76,16 @@ func IsProfileAllowed(profile string, allowlist []Profile) bool {
 	}
 
 	return false
+}
+
+func GetTailoringFile(profile string) (string, string, *fsnode.Directory, error) {
+	newProfile := fmt.Sprintf("%s_osbuild_tailoring", profile)
+	path := filepath.Join(tailoringDirPath, "tailoring.xml")
+
+	tailoringDir, err := fsnode.NewDirectory(tailoringDirPath, nil, nil, nil, true)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	return newProfile, path, tailoringDir, nil
 }

--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -107,8 +107,14 @@ type ServicesCustomization struct {
 }
 
 type OpenSCAPCustomization struct {
-	DataStream string `json:"datastream,omitempty" toml:"datastream,omitempty"`
-	ProfileID  string `json:"profile_id,omitempty" toml:"profile_id,omitempty"`
+	DataStream string                           `json:"datastream,omitempty" toml:"datastream,omitempty"`
+	ProfileID  string                           `json:"profile_id,omitempty" toml:"profile_id,omitempty"`
+	Tailoring  *OpenSCAPTailoringCustomizations `json:"tailoring,omitempty" toml:"tailoring,omitempty"`
+}
+
+type OpenSCAPTailoringCustomizations struct {
+	Selected   []string `json:"selected,omitempty" toml:"selected,omitempty"`
+	Unselected []string `json:"unselected,omitempty" toml:"unselected,omitempty"`
 }
 
 type CustomizationError struct {

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -377,6 +377,10 @@ func TestGetOpenSCAPConfig(t *testing.T) {
 	expectedOscap := OpenSCAPCustomization{
 		DataStream: "test-data-stream.xml",
 		ProfileID:  "test_profile",
+		Tailoring: &OpenSCAPTailoringCustomizations{
+			Selected:   []string{"quick_rule"},
+			Unselected: []string{"very_slow_rule"},
+		},
 	}
 
 	TestCustomizations := Customizations{

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -133,22 +133,6 @@ func osCustomizations(
 		osc.SElinux = "targeted"
 	}
 
-	if oscapConfig := c.GetOpenSCAP(); oscapConfig != nil {
-		if t.rpmOstree {
-			panic("unexpected oscap options for ostree image type")
-		}
-		var datastream = oscapConfig.DataStream
-		if datastream == "" {
-			datastream = oscap.DefaultRHEL8Datastream(t.arch.distro.isRHEL())
-		}
-		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(
-			osbuild.OscapConfig{
-				Datastream: datastream,
-				ProfileID:  oscapConfig.ProfileID,
-			},
-		)
-	}
-
 	if t.arch.distro.isRHEL() && options.Facts != nil {
 		osc.FactAPIType = &options.Facts.APIType
 	}
@@ -195,6 +179,49 @@ func osCustomizations(
 
 	for filename, repos := range yumRepos {
 		osc.YUMRepos = append(osc.YUMRepos, osbuild.NewYumReposStageOptions(filename, repos))
+	}
+
+	if oscapConfig := c.GetOpenSCAP(); oscapConfig != nil {
+		if t.rpmOstree {
+			panic("unexpected oscap options for ostree image type")
+		}
+		var datastream = oscapConfig.DataStream
+		if datastream == "" {
+			datastream = oscap.DefaultRHEL8Datastream(t.arch.distro.isRHEL())
+		}
+
+		oscapStageOptions := osbuild.OscapConfig{
+			Datastream: datastream,
+			ProfileID:  oscapConfig.ProfileID,
+		}
+
+		if oscapConfig.Tailoring != nil {
+			newProfile, tailoringFilepath, tailoringDir, err := oscap.GetTailoringFile(oscapConfig.ProfileID)
+			if err != nil {
+				panic(fmt.Sprintf("unexpected error creating tailoring file options: %v", err))
+			}
+
+			tailoringOptions := osbuild.OscapAutotailorConfig{
+				Selected:   oscapConfig.Tailoring.Selected,
+				Unselected: oscapConfig.Tailoring.Unselected,
+				NewProfile: newProfile,
+			}
+
+			osc.OpenSCAPTailorConfig = osbuild.NewOscapAutotailorStageOptions(
+				tailoringFilepath,
+				oscapStageOptions,
+				tailoringOptions,
+			)
+
+			// overwrite the profile id with the new tailoring id
+			oscapStageOptions.ProfileID = newProfile
+			oscapStageOptions.Tailoring = tailoringFilepath
+
+			// add the parent directory for the tailoring file
+			osc.Directories = append(osc.Directories, tailoringDir)
+		}
+
+		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscapStageOptions)
 	}
 
 	osc.ShellInit = imageConfig.ShellInit

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -130,22 +130,6 @@ func osCustomizations(
 		osc.SElinux = "targeted"
 	}
 
-	if oscapConfig := c.GetOpenSCAP(); oscapConfig != nil {
-		if t.rpmOstree {
-			panic("unexpected oscap options for ostree image type")
-		}
-		var datastream = oscapConfig.DataStream
-		if datastream == "" {
-			datastream = oscap.DefaultRHEL9Datastream(t.arch.distro.isRHEL())
-		}
-		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(
-			osbuild.OscapConfig{
-				Datastream: datastream,
-				ProfileID:  oscapConfig.ProfileID,
-			},
-		)
-	}
-
 	if t.arch.distro.isRHEL() && options.Facts != nil {
 		osc.FactAPIType = &options.Facts.APIType
 	}
@@ -192,6 +176,49 @@ func osCustomizations(
 
 	for filename, repos := range yumRepos {
 		osc.YUMRepos = append(osc.YUMRepos, osbuild.NewYumReposStageOptions(filename, repos))
+	}
+
+	if oscapConfig := c.GetOpenSCAP(); oscapConfig != nil {
+		if t.rpmOstree {
+			panic("unexpected oscap options for ostree image type")
+		}
+		var datastream = oscapConfig.DataStream
+		if datastream == "" {
+			datastream = oscap.DefaultRHEL9Datastream(t.arch.distro.isRHEL())
+		}
+
+		oscapStageOptions := osbuild.OscapConfig{
+			Datastream: datastream,
+			ProfileID:  oscapConfig.ProfileID,
+		}
+
+		if oscapConfig.Tailoring != nil {
+			newProfile, tailoringFilepath, tailoringDir, err := oscap.GetTailoringFile(oscapConfig.ProfileID)
+			if err != nil {
+				panic(fmt.Sprintf("unexpected error creating tailoring file options: %v", err))
+			}
+
+			tailoringOptions := osbuild.OscapAutotailorConfig{
+				Selected:   oscapConfig.Tailoring.Selected,
+				Unselected: oscapConfig.Tailoring.Unselected,
+				NewProfile: newProfile,
+			}
+
+			osc.OpenSCAPTailorConfig = osbuild.NewOscapAutotailorStageOptions(
+				tailoringFilepath,
+				oscapStageOptions,
+				tailoringOptions,
+			)
+
+			// overwrite the profile id with the new tailoring id
+			oscapStageOptions.ProfileID = newProfile
+			oscapStageOptions.Tailoring = tailoringFilepath
+
+			// add the parent directory for the tailoring file
+			osc.Directories = append(osc.Directories, tailoringDir)
+		}
+
+		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscapStageOptions)
 	}
 
 	osc.ShellInit = imageConfig.ShellInit

--- a/pkg/osbuild/oscap_autotailor_stage.go
+++ b/pkg/osbuild/oscap_autotailor_stage.go
@@ -1,0 +1,47 @@
+package osbuild
+
+import "fmt"
+
+type OscapAutotailorStageOptions struct {
+	Filepath string                `json:"filepath"`
+	Config   OscapAutotailorConfig `json:"config"`
+}
+type OscapAutotailorConfig struct {
+	OscapConfig
+	NewProfile string   `json:"new_profile"`
+	Selected   []string `json:"selected,omitempty"`
+	Unselected []string `json:"unselected,omitempty"`
+}
+
+func (OscapAutotailorStageOptions) isStageOptions() {}
+
+func (c OscapAutotailorConfig) validate() error {
+	if c.NewProfile == "" {
+		return fmt.Errorf("'new_profile' must be specified")
+	}
+	// reuse the oscap validation
+	return c.OscapConfig.validate()
+}
+
+func NewOscapAutotailorStage(options *OscapAutotailorStageOptions) *Stage {
+	if err := options.Config.validate(); err != nil {
+		panic(err)
+	}
+
+	return &Stage{
+		Type:    "org.osbuild.oscap.autotailor",
+		Options: options,
+	}
+}
+
+func NewOscapAutotailorStageOptions(filepath string, oscapOptions OscapConfig, autotailorOptions OscapAutotailorConfig) *OscapAutotailorStageOptions {
+	return &OscapAutotailorStageOptions{
+		Filepath: filepath,
+		Config: OscapAutotailorConfig{
+			OscapConfig: oscapOptions,
+			NewProfile:  autotailorOptions.NewProfile,
+			Selected:    autotailorOptions.Selected,
+			Unselected:  autotailorOptions.Unselected,
+		},
+	}
+}

--- a/pkg/osbuild/oscap_autotailor_stage_test.go
+++ b/pkg/osbuild/oscap_autotailor_stage_test.go
@@ -1,0 +1,102 @@
+package osbuild
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewOscapAutotailorStage(t *testing.T) {
+	stageOptions := &OscapAutotailorStageOptions{
+		Filepath: "tailoring.xml",
+		Config: OscapAutotailorConfig{
+			OscapConfig: OscapConfig{
+				Datastream: "test_stream",
+				ProfileID:  "test_profile",
+			},
+			NewProfile: "test_profile_osbuild_profile",
+			Selected:   []string{"fast_rule"},
+			Unselected: []string{"slow_rule"},
+		},
+	}
+
+	expectedStage := &Stage{
+		Type:    "org.osbuild.oscap.autotailor",
+		Options: stageOptions,
+	}
+	actualStage := NewOscapAutotailorStage(stageOptions)
+	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestOscapAutotailorStageOptionsValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		options OscapAutotailorStageOptions
+		err     bool
+	}{
+		{
+			name:    "empty-options",
+			options: OscapAutotailorStageOptions{},
+			err:     true,
+		},
+		{
+			name: "empty-datastream",
+			options: OscapAutotailorStageOptions{
+				Config: OscapAutotailorConfig{
+					OscapConfig: OscapConfig{
+
+						ProfileID: "test-profile",
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "empty-profile-id",
+			options: OscapAutotailorStageOptions{
+				Config: OscapAutotailorConfig{
+					OscapConfig: OscapConfig{
+						Datastream: "test-datastream",
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "empty-new-profile-name",
+			options: OscapAutotailorStageOptions{
+				Config: OscapAutotailorConfig{
+					OscapConfig: OscapConfig{
+						ProfileID:  "test-profile",
+						Datastream: "test-datastream",
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "valid-data",
+			options: OscapAutotailorStageOptions{
+				Config: OscapAutotailorConfig{
+					OscapConfig: OscapConfig{
+						ProfileID:  "test-profile",
+						Datastream: "test-datastream",
+					},
+					NewProfile: "test-profile-osbuild-profile",
+				},
+			},
+			err: false,
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err {
+				assert.Errorf(t, tt.options.Config.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)
+				assert.Panics(t, func() { NewOscapAutotailorStage(&tt.options) })
+			} else {
+				assert.NoErrorf(t, tt.options.Config.validate(), "%q returned an error [idx: %d]", tt.name, idx)
+				assert.NotPanics(t, func() { NewOscapAutotailorStage(&tt.options) })
+			}
+		})
+	}
+}

--- a/pkg/osbuild/oscap_remediation_stage.go
+++ b/pkg/osbuild/oscap_remediation_stage.go
@@ -76,6 +76,7 @@ func NewOscapRemediationStageOptions(options OscapConfig) *OscapRemediationStage
 			ProfileID:    options.ProfileID,
 			Datastream:   options.Datastream,
 			DatastreamID: options.DatastreamID,
+			Tailoring:    options.Tailoring,
 			XCCDFID:      options.XCCDFID,
 			BenchmarkID:  options.BenchmarkID,
 			ArfResult:    options.ArfResult,

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -90,5 +90,19 @@
       "edge-container",
       "iot-container"
     ]
+  },
+  "./configs/all-with-oscap.json": {
+    "image-types": [
+      "qcow2"
+    ],
+    "distros": [
+      "rhel-91",
+      "rhel-92",
+      "rhel-87",
+      "rhel-88",
+      "rhel-89",
+      "centos*",
+      "fedora*"
+    ]
   }
 }

--- a/test/configs/all-with-oscap.json
+++ b/test/configs/all-with-oscap.json
@@ -1,0 +1,154 @@
+{
+  "name": "all-with-oscap",
+  "blueprint": {
+    "packages": [
+      {
+        "name": "bash",
+        "version": "*"
+      },
+      {
+        "name": "bluez",
+        "version": "*"
+      }
+    ],
+    "modules": [],
+    "groups": [
+      {
+        "name": "core"
+      }
+    ],
+    "customizations": {
+      "hostname": "my-host",
+      "kernel": {
+        "append": "debug"
+      },
+      "sshkey": [
+        {
+          "user": "user1",
+          "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+        }
+      ],
+      "user": [
+        {
+          "name": "user2",
+          "description": "description 2",
+          "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+          "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+          "home": "/home/home2",
+          "shell": "/bin/sh",
+          "groups": [
+            "group1"
+          ],
+          "uid": 1020,
+          "gid": 1050
+        },
+        {
+          "name": "user3",
+          "uid": 1060,
+          "gid": 1060
+        }
+      ],
+      "group": [
+        {
+          "name": "group1",
+          "gid": 1030
+        },
+        {
+          "name": "group2",
+          "gid": 1050
+        },
+        {
+          "name": "user3",
+          "gid": 1060
+        }
+      ],
+      "timezone": {
+        "timezone": "Europe/London",
+        "ntpservers": [
+          "time.example.com"
+        ]
+      },
+      "locale": {
+        "languages": [
+          "el_CY.UTF-8"
+        ],
+        "keyboard": "dvorak"
+      },
+      "services": {
+        "enabled": [
+          "sshd.socket",
+          "custom.service"
+        ],
+        "disabled": [
+          "bluetooth.service"
+        ]
+      },
+      "filesystem": [
+        {
+          "mountpoint": "/opt",
+          "minsize": 1073741824
+        }
+      ],
+      "directories": [
+        {
+          "path": "/etc/systemd/system/custom.service.d"
+        },
+        {
+          "path": "/etc/custom_dir",
+          "mode": "0770",
+          "user": 1020,
+          "group": 1050
+        }
+      ],
+      "files": [
+        {
+          "path": "/etc/systemd/system/custom.service",
+          "data": "[Unit]\nDescription=Custom service\n\n[Service]\nExecStart=/usr/bin/false\n\n[Install]\nWantedBy=multi-user.target\n"
+        },
+        {
+          "path": "/etc/systemd/system/custom.service.d/override.conf",
+          "data": "[Service]\nExecStart=\nExecStart=/usr/bin/cat /etc/custom_file.txt\n"
+        },
+        {
+          "path": "/etc/custom_file.txt",
+          "data": "image builder is the best",
+          "mode": "0644",
+          "user": "root",
+          "group": "root"
+        },
+        {
+          "path": "/etc/empty_file.txt",
+          "user": 0,
+          "group": 0
+        }
+      ],
+      "repositories": [
+        {
+          "id": "example",
+          "name": "Example repo",
+          "baseurls": [
+            "https://example.com/download/yum"
+          ],
+          "gpgcheck": true,
+          "enabled": true,
+          "repo_gpgcheck": false,
+          "gpgkeys": [
+            "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+          ]
+        }
+      ],
+      "openscap": {
+        "profile_id": "xccdf_org.ssgproject.content_profile_pci-dss",
+        "tailoring": {
+          "selected": [
+            "bind_crypto_policy"
+          ],
+          "unselected": [
+            "rpm_verify_hashes",
+            "enable_fips_mode"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds autotailoring support for openscap customizations.
These customizations allow users to override specific OpenSCAP rules which
are passed to the autotailor stage which is responsible for creating the tailoring
file.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
