### PR TITLE
Run tests on merge_group event for merge queues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+  # for merge queue
+  merge_group:
 
 jobs:
   unit-tests:


### PR DESCRIPTION
Enables actions to run when a merge_group even is triggered, which is used for merge queues.

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

The gitlab CI branch will be named the same as the github branch (`gh-readonly-queue/{base_branch}`), which is descriptive enough, so we don't need a special condition for it in the PR naming of the gitlab CI branch
https://github.com/osbuild/images/blob/2f38765b301f5197dbe3906c990dfffcf91f87ba/.github/workflows/trigger-gitlab.yml#L47-L53