### PR TITLE
iot-commit: do not install weak dependencies

### DIFF
--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -334,6 +334,7 @@ func iotCommitImage(workload workload.Workload,
 	img.OSTreeParent = parentCommit
 	img.OSVersion = t.arch.distro.osVersion
 	img.Filename = t.Filename()
+	img.InstallWeakDeps = false
 
 	return img, nil
 }

--- a/pkg/image/ostree_archive.go
+++ b/pkg/image/ostree_archive.go
@@ -29,12 +29,15 @@ type OSTreeArchive struct {
 
 	OSVersion string
 	Filename  string
+
+	InstallWeakDeps bool
 }
 
 func NewOSTreeArchive(ref string) *OSTreeArchive {
 	return &OSTreeArchive{
-		Base:      NewBase("ostree-archive"),
-		OSTreeRef: ref,
+		Base:            NewBase("ostree-archive"),
+		OSTreeRef:       ref,
+		InstallWeakDeps: true,
 	}
 }
 
@@ -51,6 +54,7 @@ func (img *OSTreeArchive) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.Workload = img.Workload
 	osPipeline.OSTreeParent = img.OSTreeParent
 	osPipeline.OSTreeRef = img.OSTreeRef
+	osPipeline.InstallWeakDeps = img.InstallWeakDeps
 
 	ostreeCommitPipeline := manifest.NewOSTreeCommit(m, buildPipeline, osPipeline, img.OSTreeRef)
 	ostreeCommitPipeline.OSVersion = img.OSVersion

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -164,6 +164,8 @@ type OS struct {
 	OSProduct string
 	OSVersion string
 	OSNick    string
+
+	InstallWeakDeps bool
 }
 
 // NewOS creates a new OS pipeline. build is the build pipeline to use for
@@ -175,9 +177,10 @@ func NewOS(m *Manifest,
 	repos []rpmmd.RepoConfig) *OS {
 	name := "os"
 	p := &OS{
-		Base:     NewBase(m, name, buildPipeline),
-		repos:    filterRepos(repos, name),
-		platform: platform,
+		Base:            NewBase(m, name, buildPipeline),
+		repos:           filterRepos(repos, name),
+		platform:        platform,
+		InstallWeakDeps: true,
 	}
 	buildPipeline.addDependent(p)
 	m.addPipeline(p)
@@ -233,7 +236,7 @@ func (p *OS) getPackageSetChain(Distro) []rpmmd.PackageSet {
 			Include:         append(packages, p.ExtraBasePackages...),
 			Exclude:         p.ExcludeBasePackages,
 			Repositories:    osRepos,
-			InstallWeakDeps: true,
+			InstallWeakDeps: p.InstallWeakDeps,
 		},
 	}
 


### PR DESCRIPTION
Disable the installation of weak dependencies in the OS pipeline by propagating it from the image types down.