### PR TITLE
update to go 1.19

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,10 +66,10 @@ jobs:
     name: "⌨ Lint"
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18
+      - name: Set up Go 1.19
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.19
         id: go
 
       - name: Check out code into the Go module directory
@@ -96,10 +96,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
-      - name: Set up Go 1.18
+      - name: Set up Go 1.19
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.19
         id: go
 
       - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/images
 
-go 1.18
+go 1.19
 
 exclude github.com/mattn/go-sqlite3 v2.0.3+incompatible
 

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION=1.18.9
+GO_VERSION=1.19.11
 GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
 
 # this is the official way to get a different version of golang


### PR DESCRIPTION
UBI and the oldest supported Fedora (37) now all have go 1.19, so we are
 cleared to switch.

