### PR TITLE
test: Use last stage ID as manifest ID

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,6 +45,7 @@ generate-build-config:
     INTERNAL_NETWORK: "true"
   script:
     - sudo dnf -y install go python3 gpgme-devel s3cmd
+      osbuild osbuild-luks2 osbuild-lvm2 osbuild-ostree osbuild-selinux
     - ./test/cases/generate-build-config build-config.yml
   artifacts:
     paths:

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -109,8 +109,7 @@ func loadConfig(path string) buildConfig {
 	return conf
 }
 
-func loadConfigMap() configMap {
-	configPath := "./test/config-map.json"
+func loadConfigMap(configPath string) configMap {
 	fp, err := os.Open(configPath)
 	if err != nil {
 		panic(fmt.Sprintf("failed to open config map %q: %s", configPath, err.Error()))
@@ -511,13 +510,14 @@ func u(s string) string {
 
 func main() {
 	// common args
-	var outputDir, cacheRoot string
+	var outputDir, cacheRoot, configPath string
 	var nWorkers int
 	var metadata bool
 	flag.StringVar(&outputDir, "output", "test/data/manifests/", "manifest store directory")
 	flag.IntVar(&nWorkers, "workers", 16, "number of workers to run concurrently")
 	flag.StringVar(&cacheRoot, "cache", "/tmp/rpmmd", "rpm metadata cache directory")
 	flag.BoolVar(&metadata, "metadata", true, "store metadata in the file")
+	flag.StringVar(&configPath, "config", "test/config-map.json", "configuration file mapping image types to configs")
 
 	// content args
 	var packages, containers, commits bool
@@ -544,7 +544,7 @@ func main() {
 		"commits":    commits,
 	}
 
-	configs := loadConfigMap()
+	configs := loadConfigMap(configPath)
 
 	if err := os.MkdirAll(outputDir, 0770); err != nil {
 		panic(fmt.Sprintf("failed to create target directory: %s", err.Error()))

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -154,7 +154,7 @@ func makeManifestJob(
 	metadata bool,
 ) manifestJob {
 	distroName := distribution.Name()
-	filename := fmt.Sprintf("%s-%s-%s-%s-boot.json", u(distroName), u(archName), u(imgType.Name()), u(name))
+	filename := fmt.Sprintf("%s-%s-%s-%s.json", u(distroName), u(archName), u(imgType.Name()), u(name))
 	cacheDir := filepath.Join(cacheRoot, archName+distribution.Name())
 
 	options := distro.ImageOptions{Size: 0}

--- a/test/cases/build-image.sh
+++ b/test/cases/build-image.sh
@@ -5,6 +5,7 @@
 set -euxo pipefail
 
 distro="${1}"
+arch=$(uname -m)
 imgtype="${2}"
 config="${3}"
 
@@ -19,11 +20,16 @@ echo "Build finished!!"
 
 echo "Registering successful build in S3"
 
+u() {
+    echo "${1}" | tr - _
+}
+
+
 config_name=$(jq -r .name "${config}")
-manifest=(./build/*/manifest.json)  # there should only be one
+builddir="./build/$(u "${distro}")-$(u "${arch}")-$(u "${imgtype}")-$(u "${config_name}")"
+manifest="${builddir}/manifest.json"
 manifest_hash=$(sha256sum "${manifest[0]}" | awk '{ print $1 }')
 
-arch=$(uname -m)
 osbuild_ver=$(osbuild --version)
 
 # TODO: Include osbuild commit hash

--- a/test/cases/build-image.sh
+++ b/test/cases/build-image.sh
@@ -28,19 +28,21 @@ u() {
 config_name=$(jq -r .name "${config}")
 builddir="./build/$(u "${distro}")-$(u "${arch}")-$(u "${imgtype}")-$(u "${config_name}")"
 manifest="${builddir}/manifest.json"
-manifest_hash=$(sha256sum "${manifest[0]}" | awk '{ print $1 }')
+
+# calculate manifest ID based on hash of concatenated stage IDs
+manifest_id=$(osbuild --inspect "${manifest}" | jq -r '.pipelines[-1].stages[-1].id')
 
 osbuild_ver=$(osbuild --version)
 
 # TODO: Include osbuild commit hash
-filename="${manifest_hash}.json"
+filename="${manifest_id}.json"
 cat << EOF > "${filename}"
 {
   "distro": "${distro}",
   "arch": "${arch}",
   "image-type": "${imgtype}",
   "config": "${config_name}",
-  "manifest-checksum": "${manifest_hash}",
+  "manifest-checksum": "${manifest_id}",
   "obuild-version": "${osbuild_ver}",
   "commit": "${CI_COMMIT_SHA}"
 }

--- a/test/cases/generate-build-config
+++ b/test/cases/generate-build-config
@@ -74,7 +74,7 @@ NullBuild:
 
 
 def runcmd(cmd):
-    print(f"Running: {' '.join(cmd)}")
+    print(f"Running: {' '.join(cmd)}", flush=True)
     job = sp.run(cmd, capture_output=True)
     if job.returncode > 0:
         print(f"Command failed: {cmd}")

--- a/test/cases/generate-build-config
+++ b/test/cases/generate-build-config
@@ -218,8 +218,6 @@ def filter_builds(manifest_dir):
                         f"Config: {distro}/{arch}/{image_type}/{config_name}\n"
                 ))
 
-        print("Adding build request")
-        print(build_request)
         build_requests.append(build_request)
 
     print("Config filtering done!\n")

--- a/test/cases/generate-build-config
+++ b/test/cases/generate-build-config
@@ -270,12 +270,11 @@ def main():
 
     check_config_names()
 
+    manifest_dir = os.path.join(TEST_CACHE_ROOT, "manifests")
+    generate_manifests(manifest_dir)
+    build_requests = filter_builds(manifest_dir)
+
     with open(config_path, "w") as config_file:
-
-        manifest_dir = os.path.join(TEST_CACHE_ROOT, "manifests")
-        generate_manifests(manifest_dir)
-        build_requests = filter_builds(manifest_dir)
-
         if len(build_requests) == 0:
             print("No manifest changes detected. Generating null config.")
             config_file.write(NULL_CONFIG)

--- a/test/cases/generate-build-config
+++ b/test/cases/generate-build-config
@@ -32,6 +32,12 @@ SKIPS = [
     "iot-simplified-installer",
 ]
 
+# ostree containers are pushed to the CI registry to be reused by dependants
+OSTREE_CONTAINERS = [
+    "iot-container",
+    "edge-container"
+]
+
 # base and terraform bits copied from main .gitlab-ci.yml
 # needed for status reporting and defining the runners
 BASE_CONFIG = """
@@ -59,7 +65,9 @@ BASE_CONFIG = """
 JOB_TEMPLATE = """
 build/{distro}/{arch}/{image_type}/{config_name}:
   stage: test
-  script: ./test/cases/build-image.sh "{distro}" "{image_type}" "{config}"
+  script: |
+    ./test/cases/build-image.sh "{distro}" "{image_type}" "{config}"
+    {extra_commands}
   extends: .terraform
   variables:
     RUNNER: aws/fedora-38-{arch}
@@ -186,6 +194,9 @@ def filter_builds(manifest_dir):
         image_type = build_request["image-type"]
         filename = manifest_hash + ".json"
 
+        # add manifest checksum to build request
+        build_request["manifest-checksum"] = manifest_hash
+
         if image_type in SKIPS:
             continue
 
@@ -225,6 +236,10 @@ def list_images():
     return json.loads(out)
 
 
+def u(s):
+    return s.replace("-", "_")
+
+
 def generate_configs(build_requests, pipeline_file):
     print(f"Generating dynamic pipelines for {len(build_requests)} builds")
     for build in build_requests:
@@ -232,11 +247,22 @@ def generate_configs(build_requests, pipeline_file):
         arch = build["arch"]
         image_type = build["image-type"]
         config = build["config"]
+        man_checksum = build["manifest-checksum"]
 
         config_name = config["name"]
+
+        extra_cmds = []
+        if image_type in OSTREE_CONTAINERS:
+            # push to container registry and label with checksum
+            build_name = f"{u(distro)}-{u(arch)}-{u(image_type)}-{u(config_name)}"
+            # NOTE: the artifact path and filename depend on the names in the manifest
+            container_path = f"./build/{build_name}/container/container.tar"
+            extra_cmds.append(f'./tools/ci/push-container.sh "{container_path}" "{build_name}:build-{man_checksum}"')
+
         config_path = os.path.join(CONFIGS_PATH, config_name+".json")
         pipeline_file.write(JOB_TEMPLATE.format(distro=distro, arch=arch, image_type=image_type,
                                                 config_name=config_name, config=config_path,
+                                                extra_commands="\n".join(extra_cmds),
                                                 internal="true" if "rhel" in distro else "false"))
     print("DONE!")
 

--- a/test/cases/generate-build-config
+++ b/test/cases/generate-build-config
@@ -81,9 +81,8 @@ NullBuild:
 """
 
 
-def runcmd(cmd):
-    print(f"Running: {' '.join(cmd)}", flush=True)
-    job = sp.run(cmd, capture_output=True)
+def runcmd(cmd, stdin=None):
+    job = sp.run(cmd, input=stdin, capture_output=True)
     if job.returncode > 0:
         print(f"Command failed: {cmd}")
         if job.stdout:
@@ -116,11 +115,13 @@ def check_config_names():
 
 def generate_manifests(outputdir):
     arches_arg = ",".join(ARCHITECTURES)
-    out, err = runcmd(["go", "run", "./cmd/gen-manifests",
-                       "-cache", os.path.join(TEST_CACHE_ROOT, "rpmmd"),
-                       "-output", outputdir,
-                       "-workers", "100",
-                       "-arches", arches_arg])
+    cmd = ["go", "run", "./cmd/gen-manifests",
+           "-cache", os.path.join(TEST_CACHE_ROOT, "rpmmd"),
+           "-output", outputdir,
+           "-workers", "100",
+           "-arches", arches_arg]
+    print(f"Running: {' '.join(cmd)}", flush=True)
+    out, err = runcmd(cmd)
 
     # print stderr in case there were errors or warnings about skipped configurations
     # but filter out the annoying ones
@@ -169,6 +170,26 @@ def serialise(data):
     return serialised.replace("<", r"\u003c").replace(">", r"\u003e")
 
 
+def get_manifest_id(manifest_data):
+    md = json.dumps(manifest_data).encode()
+    out, _ = runcmd(["osbuild", "--inspect", "-"], stdin=md)
+    data = json.loads(out)
+    # last stage ID depends on all previous stage IDs, so we can use it as a manifest ID
+    return data["pipelines"][-1]["stages"][-1]["id"]
+
+
+def resync_s3_configs(source):
+    s3url = f"{S3_BUCKET}/{S3_PREFIX}/"
+    print(f"Uploading configs to {s3url}")
+    job = sp.run(["s3cmd", *s3_auth_args(), "sync", "--no-delete-removed", "--skip-existing", source, s3url],
+                 capture_output=True)
+    ok = job.returncode == 0
+    if not ok:
+        print(f"Failed to sync contents of {s3url}:")
+        print(job.stderr.decode())
+    return ok
+
+
 def filter_builds(manifest_dir):
     print("Filtering build configurations")
     dl_path = os.path.join(TEST_CACHE_ROOT, "s3configs")
@@ -181,30 +202,59 @@ def filter_builds(manifest_dir):
 
     for manifest_file in os.listdir(manifest_dir):
         manifest_path = os.path.join(manifest_dir, manifest_file)
+
+        # generate old-style manifest hash for now
+        # TODO: remove after conversion
         with open(manifest_path) as manifest_fp:
             data = json.load(manifest_fp)
 
         manifest_data = data["manifest"]
-        build_request = data["build-request"]
+
+        # generate manifest id based on concatenated stage IDs calculated from osbuild
+        manifest_id = get_manifest_id(manifest_data)
+        id_fname = manifest_id + ".json"
+
         manifest_serialised = serialise(manifest_data)
         manifest_hash = hashlib.sha256(manifest_serialised.encode()).hexdigest()
+        hash_fname = manifest_hash + ".json"
 
+        build_request = data["build-request"]
         distro = build_request["distro"]
         arch = build_request["arch"]
         image_type = build_request["image-type"]
-        filename = manifest_hash + ".json"
 
-        # add manifest checksum to build request
-        build_request["manifest-checksum"] = manifest_hash
+        # add manifest id to build request
+        build_request["manifest-checksum"] = manifest_id
 
         if image_type in SKIPS:
             continue
 
-        # check if the file exists in the synced directory
-        dl_config_path = os.path.join(dl_path, "builds", distro, arch, filename)
-        if os.path.exists(dl_config_path):
+        # check if the hash_fname exists in the synced directory
+        dl_config_dir = os.path.join(dl_path, "builds", distro, arch)
+        hash_config_path = os.path.join(dl_config_dir, hash_fname)
+        id_config_path = os.path.join(dl_config_dir, id_fname)
+
+        # TODO: remove after conversion
+        if os.path.exists(hash_config_path):
             try:
-                with open(dl_config_path) as dl_config_fp:
+                with open(hash_config_path) as dl_config_fp:
+                    dl_config = json.load(dl_config_fp)
+                commit = dl_config["commit"]
+                print(f"Manifest {manifest_file} was successfully built in commit {commit}")
+                # rename file in local s3 dir to new naming scheme
+                os.rename(hash_config_path, id_config_path)
+                continue
+            except json.JSONDecodeError as jd:
+                config_name = build_request["config"]["name"]
+                errors.append((
+                        f"failed to parse {hash_config_path}\n"
+                        f"{jd.msg}\n"
+                ))
+
+        # check if the id_fname exists in the synced directory
+        if os.path.exists(id_config_path):
+            try:
+                with open(id_config_path) as dl_config_fp:
                     dl_config = json.load(dl_config_fp)
                 commit = dl_config["commit"]
                 print(f"Manifest {manifest_file} was successfully built in commit {commit}")
@@ -212,7 +262,7 @@ def filter_builds(manifest_dir):
             except json.JSONDecodeError as jd:
                 config_name = build_request["config"]["name"]
                 errors.append((
-                        f"failed to parse {dl_config_path}\n"
+                        f"failed to parse {id_config_path}\n"
                         f"{jd.msg}\n"
                         "Scheduling config for rebuild\n"
                         f"Config: {distro}/{arch}/{image_type}/{config_name}\n"
@@ -225,6 +275,9 @@ def filter_builds(manifest_dir):
         # print errors at the end so they're visible
         print("Errors:")
         print("\n".join(errors))
+
+    print("Syncing new files to s3 build cache")
+    resync_s3_configs(dl_path)
     return build_requests
 
 

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -3,7 +3,7 @@
     "./test/configs/empty.json"
   ],
   "edge-ami": [
-    "./test/configs/ostree-deploy.json"
+    "./test/configs/ostree-example.json"
   ],
   "edge-commit": [
     "./test/configs/ostree.json",
@@ -14,19 +14,19 @@
     "./test/configs/embed-containers-2.json"
   ],
   "edge-installer": [
-    "./test/configs/ostree-deploy.json"
+    "./test/configs/ostree-example.json"
   ],
   "edge-raw-image": [
-    "./test/configs/ostree-deploy.json"
+    "./test/configs/ostree-example.json"
   ],
   "edge-simplified-installer": [
     "./test/configs/ostree-device.json"
   ],
   "edge-vsphere": [
-    "./test/configs/ostree-deploy.json"
+    "./test/configs/ostree-example.json"
   ],
   "iot-ami": [
-    "./test/configs/ostree-deploy.json"
+    "./test/configs/ostree-example.json"
   ],
   "iot-commit": [
     "./test/configs/kernel-debug.json"
@@ -36,10 +36,10 @@
     "./test/configs/iot-customizations-full.json"
   ],
   "iot-installer": [
-    "./test/configs/ostree-deploy.json"
+    "./test/configs/ostree-example.json"
   ],
   "iot-raw-image": [
-    "./test/configs/ostree-deploy.json"
+    "./test/configs/ostree-example.json"
   ],
   "iot-simplified-installer": [
     "./test/configs/ostree-device.json"

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -10,6 +10,7 @@
     "./test/configs/embed-containers.json"
   ],
   "edge-container": [
+    "./test/configs/empty.json",
     "./test/configs/ostree.json",
     "./test/configs/embed-containers-2.json"
   ],
@@ -32,6 +33,7 @@
     "./test/configs/kernel-debug.json"
   ],
   "iot-container": [
+    "./test/configs/empty.json",
     "./test/configs/ostree.json",
     "./test/configs/iot-customizations-full.json"
   ],

--- a/test/configs/ostree-example.json
+++ b/test/configs/ostree-example.json
@@ -1,5 +1,5 @@
 {
-  "name": "ostree-deploy",
+  "name": "ostree-example",
   "ostree": {
     "ref": "test/fedora/iot",
     "url": "http://fedora.example.com/repo"

--- a/test/configs/ostree.json
+++ b/test/configs/ostree.json
@@ -1,6 +1,6 @@
 {
   "name": "ostree",
   "ostree": {
-    "ref": "test/fedora/iot"
+    "ref": "osbuild/images/ostree/test"
   }
 }

--- a/tools/ci/push-container.sh
+++ b/tools/ci/push-container.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Push a container to the CI registry
+
+set -euo pipefail
+
+archive="${1}"
+name="${2}"
+
+
+sudo dnf install -y podman
+podman login -u "${CI_REGISTRY_USER}" -p "${CI_JOB_TOKEN}" "${CI_REGISTRY}"
+
+# pull into local registry
+container_name="${CI_REGISTRY}/${CI_PROJECT_PATH}/${name}"
+image_id=$(podman pull "oci-archive:${archive}")
+echo "Tagging ${image_id} -> ${container_name}"
+podman tag "${image_id}" "${container_name}"
+echo "Pushing ${container_name}"
+podman push "${container_name}"


### PR DESCRIPTION
The biggest change for this PR is the change in the way we calculate the manifest ID for our test build cache.
Instead of hashing the manifest contents, use the last stage ID computed from osbuild --inspect.  This has the following advantages:
- It is not affected by formatting (indentation, newlines).
- It is not affected by content URLs when the content is the same.  For example, an ostree commit from a different URL will not affect the stage IDs if the content hash is the same.

This gets around an issue we were going to face when generating manifests from local ostree containers when the IP address or port of the local container changes.  It also lets us stop worrying about the exact format of the manifest file when comparing.

For now, the build config generator checks for both filenames (hash-based and stage-id-based) in the build cache from s3.  This is temporary until all or most files in the build cache are updated to the new filenames.  The script renames and syncs back with the new filename any file it finds that matches the old way of computing the manifest checksum.

Other improvements and changes:
- gen-manifests can now resolve ostree commits with --commits flag (mocks the resolution by default)
- gen-manifests can now mock the resolution of packages (depsolve) and containers with --packages=false and --containers=false respectively (does not mock the resolution by default)
- ostree container image types (iot-container and edge-container) are pushed to the gitlab registry for the project.  These will be used to test installer and raw image builds (followup PR).