### PR TITLE
pathpolicy: `/root` for `CustomFilesPolicy`

### DIFF
--- a/internal/pathpolicy/policies.go
+++ b/internal/pathpolicy/policies.go
@@ -24,6 +24,7 @@ var CustomDirectoriesPolicies = NewPathPolicies(map[string]PathPolicy{
 var CustomFilesPolicies = NewPathPolicies(map[string]PathPolicy{
 	"/":           {Deny: true},
 	"/etc":        {},
+	"/root":       {},
 	"/etc/fstab":  {Deny: true},
 	"/etc/shadow": {Deny: true},
 	"/etc/passwd": {Deny: true},


### PR DESCRIPTION
Allow writing to `/root` and subdirectories in file customizations. This is necessary to support building the KDE live image in a blueprints-defined way. This image wants to write GTK theme configuration into `/root`.