### PR TITLE
resolver: Always return results sorted by Digest

### DIFF
--- a/pkg/container/resolver.go
+++ b/pkg/container/resolver.go
@@ -3,6 +3,7 @@ package container
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -78,6 +79,9 @@ func (r *Resolver) Finish() ([]Spec, error) {
 		detail := strings.Join(errs, "; ")
 		return specs, fmt.Errorf("failed to resolve container: %s", detail)
 	}
+
+	// Return a stable result, sorted by Digest
+	sort.Slice(specs, func(i, j int) bool { return specs[i].Digest < specs[j].Digest })
 
 	return specs, nil
 }

--- a/pkg/container/resolver_test.go
+++ b/pkg/container/resolver_test.go
@@ -2,7 +2,6 @@ package container_test
 
 import (
 	"fmt"
-	"sort"
 	"testing"
 	"time"
 
@@ -11,14 +10,6 @@ import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/container"
 )
-
-type lessCompare func(i, j int) bool
-
-func makeSpecSorter(specs []container.Spec) lessCompare {
-	return func(i, j int) bool {
-		return specs[i].Digest < specs[j].Digest
-	}
-}
 
 func TestResolver(t *testing.T) {
 
@@ -59,9 +50,6 @@ func TestResolver(t *testing.T) {
 		assert.NoError(t, err)
 		want[i] = spec
 	}
-
-	sort.Slice(have, makeSpecSorter(have))
-	sort.Slice(want, makeSpecSorter(want))
 
 	assert.ElementsMatch(t, have, want)
 }


### PR DESCRIPTION
The output of the resolver can be inconsistent. This causes problems with the diff-manifest CI script because consecutive runs on the same code may have different outputs, causing a false manifest diff error from Schutzbot.

The tests was already sorting by Digest, so move that up into Finished() and remove the sort from the test. Now the results will always be in a consistent order.


This pull request includes:

- [X] adequate testing for the new functionality or fixed issue
- [X] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
