### PR TITLE
Run gitlab CI without waiting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,17 +134,3 @@ jobs:
         # don't check /etc/os-release sourcing, allow useless cats to live inside our codebase, and
         # allow seemingly unreachable commands
         SHELLCHECK_OPTS: -e SC1091 -e SC2002 -e SC2317
-
-  gitlab-ci-helper:
-    name: "Gitlab CI trigger helper"
-    runs-on: ubuntu-latest
-    env:
-      SKIP_CI: ${{ (github.event.pull_request.draft == true || contains(github.event.pull_request.labels.*.name, 'WIP')) && !contains(github.event.pull_request.labels.*.name, 'WIP+test') }}
-    steps:
-      - name: Write PR status
-        run: echo "$SKIP_CI" > SKIP_CI.txt
-      - name: Upload status
-        uses: actions/upload-artifact@v3
-        with:
-          name: PR_STATUS
-          path: SKIP_CI.txt

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -1,10 +1,10 @@
 # inspired by rhinstaller/anaconda
 
-name: Trigger GitLab CI
+name: Start GitLab CI
 
 on:
   workflow_run:
-    workflows: ["GitLab", "Tests"]
+    workflows: ["GitLab"]
     types: [completed]
 
 jobs:


### PR DESCRIPTION
Run gitlab without waiting for the tests workflow to finish. The trigger-gitlab workflow now only depends on the GitLab workflow which just runs the gitlab helper.