### PR TITLE
test_distro: Return a 1GiB default size instead of 0

### DIFF
--- a/pkg/distro/test_distro/distro.go
+++ b/pkg/distro/test_distro/distro.go
@@ -186,7 +186,10 @@ func (t *TestImageType) OSTreeRef() string {
 }
 
 func (t *TestImageType) Size(size uint64) uint64 {
-	return 0
+	if size == 0 {
+		size = 1073741824
+	}
+	return size
 }
 
 func (t *TestImageType) PartitionType() string {


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

Tests using this are all in osbuild-composer, this will be needed for some tests I am currently working on.
