### PR TITLE
Add iot-simplified-installer and iot-qcow2 image types to Fedora

### DIFF
--- a/cmd/osbuild-playground/my-container.go
+++ b/cmd/osbuild-playground/my-container.go
@@ -57,7 +57,7 @@ func (img *MyContainer) InstantiateManifest(m *manifest.Manifest,
 	os.OSCustomizations.Timezone = "UTC"
 
 	// create an OCI container containing the OS tree created above
-	container := manifest.NewOCIContainer(m, build, os)
+	container := manifest.NewOCIContainer(build, os)
 	artifact := container.Export()
 
 	return artifact, nil

--- a/cmd/osbuild-playground/my-image.go
+++ b/cmd/osbuild-playground/my-image.go
@@ -50,7 +50,7 @@ func (img *MyImage) InstantiateManifest(m *manifest.Manifest,
 	os.KernelName = "kernel" // use the default fedora kernel
 
 	// create a raw image containing the OS tree created above
-	raw := manifest.NewRawImage(m, build, os)
+	raw := manifest.NewRawImage(build, os)
 	artifact := raw.Export()
 
 	return artifact, nil

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -33,7 +33,7 @@ func TestImageType_PackageSetsChains(t *testing.T) {
 
 					// set up bare minimum args for image type
 					var customizations *blueprint.Customizations
-					if imageType.Name() == "edge-simplified-installer" {
+					if imageType.Name() == "edge-simplified-installer" || imageType.Name() == "iot-simplified-installer" {
 						customizations = &blueprint.Customizations{
 							InstallationDevice: "/dev/null",
 						}
@@ -108,7 +108,7 @@ func TestImageTypePipelineNames(t *testing.T) {
 
 					// set up bare minimum args for image type
 					var customizations *blueprint.Customizations
-					if imageType.Name() == "edge-simplified-installer" {
+					if imageType.Name() == "edge-simplified-installer" || imageType.Name() == "iot-simplified-installer" {
 						customizations = &blueprint.Customizations{
 							InstallationDevice: "/dev/null",
 						}
@@ -430,7 +430,7 @@ func TestPipelineRepositories(t *testing.T) {
 
 							// set up bare minimum args for image type
 							var customizations *blueprint.Customizations
-							if imageType.Name() == "edge-simplified-installer" {
+							if imageType.Name() == "edge-simplified-installer" || imageType.Name() == "iot-simplified-installer" {
 								customizations = &blueprint.Customizations{
 									InstallationDevice: "/dev/null",
 								}

--- a/pkg/distro/distro_test_common/distro_test_common.go
+++ b/pkg/distro/distro_test_common/distro_test_common.go
@@ -76,6 +76,7 @@ func TestDistro_KernelOption(t *testing.T, d distro.Distro) {
 		"edge-simplified-installer": true,
 		"edge-vsphere":              true,
 		"iot-installer":             true,
+		"iot-qcow2-image":           true,
 		"iot-raw-image":             true,
 		"iot-simplified-installer":  true,
 
@@ -174,6 +175,7 @@ func TestDistro_OSTreeOptions(t *testing.T, d distro.Distro) {
 		"edge-simplified-installer": true,
 		"iot-ami":                   true,
 		"iot-installer":             true,
+		"iot-qcow2-image":           true,
 		"iot-raw-image":             true,
 		"iot-simplified-installer":  true,
 	}

--- a/pkg/distro/distro_test_common/distro_test_common.go
+++ b/pkg/distro/distro_test_common/distro_test_common.go
@@ -70,13 +70,14 @@ func TestDistro_KernelOption(t *testing.T, d distro.Distro) {
 		// Ostree installers and raw images download a payload to embed or
 		// deploy.  The kernel is part of the payload so it doesn't appear in
 		// the image type's package lists.
-		"iot-installer":             true,
-		"edge-installer":            true,
-		"edge-simplified-installer": true,
-		"iot-raw-image":             true,
-		"edge-raw-image":            true,
 		"edge-ami":                  true,
+		"edge-installer":            true,
+		"edge-raw-image":            true,
+		"edge-simplified-installer": true,
 		"edge-vsphere":              true,
+		"iot-installer":             true,
+		"iot-raw-image":             true,
+		"iot-simplified-installer":  true,
 
 		// the tar image type is a minimal image type which is not expected to
 		// be usable without a blueprint (see commit 83a63aaf172f556f6176e6099ffaa2b5357b58f5).

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -203,6 +203,24 @@ var (
 		requiredPartitionSizes: map[string]uint64{},
 	}
 
+	iotQcow2ImgType = imageType{
+		name:        "iot-qcow2-image",
+		filename:    "image.qcow2",
+		mimeType:    "application/x-qemu-disk",
+		packageSets: map[string]packageSetFunc{},
+		defaultImageConfig: &distro.ImageConfig{
+			Locale: common.ToPtr("en_US.UTF-8"),
+		},
+		defaultSize:         10 * common.GibiByte,
+		rpmOstree:           true,
+		bootable:            true,
+		image:               iotQcow2Image,
+		buildPipelines:      []string{"build"},
+		payloadPipelines:    []string{"ostree-deployment", "image", "qcow2"},
+		exports:             []string{"qcow2"},
+		basePartitionTables: iotBasePartitionTables,
+	}
+
 	qcow2ImgType = imageType{
 		name:     "qcow2",
 		filename: "disk.qcow2",
@@ -650,7 +668,16 @@ func newDistro(version int) distro.Distro {
 		},
 		iotRawImgType,
 	)
-
+	x86_64.addImageTypes(
+		&platform.X86{
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_QCOW2,
+			},
+			BIOS:       false,
+			UEFIVendor: "fedora",
+		},
+		iotQcow2ImgType,
+	)
 	aarch64.addImageTypes(
 		&platform.Aarch64{
 			UEFIVendor: "fedora",
@@ -668,8 +695,9 @@ func newDistro(version int) distro.Distro {
 				QCOW2Compat: "1.1",
 			},
 		},
-		qcow2ImgType,
+		iotQcow2ImgType,
 		ociImgType,
+		qcow2ImgType,
 	)
 	aarch64.addImageTypes(
 		&platform.Aarch64{

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -797,10 +797,17 @@ func newDistro(version int) distro.Distro {
 				BasePlatform: platform.BasePlatform{
 					ImageFormat: platform.FORMAT_RAW,
 					FirmwarePackages: []string{
-						"biosdevname",
+						"grub2-efi-x64-cdboot",
+						"grub2-pc",
+						"grub2-pc-modules",
+						"grub2-tools",
+						"grub2-tools-extra",
+						"grub2-tools-minimal",
 						"iwlwifi-dvm-firmware",
 						"iwlwifi-mvm-firmware",
 						"microcode_ctl",
+						"syslinux",
+						"syslinux-nonlinux",
 					},
 				},
 				BIOS:       false,
@@ -812,9 +819,14 @@ func newDistro(version int) distro.Distro {
 			&platform.Aarch64{
 				BasePlatform: platform.BasePlatform{
 					FirmwarePackages: []string{
-						"uboot-images-armv8",
-						"bcm283x-firmware",
 						"arm-image-installer",
+						"bcm283x-firmware",
+						"grub2-efi-aa64",
+						"grub2-efi-aa64-cdboot",
+						"grub2-tools",
+						"grub2-tools-extra",
+						"grub2-tools-minimal",
+						"uboot-images-armv8",
 					},
 				},
 				UEFIVendor: "fedora",

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -175,7 +175,7 @@ var (
 		buildPipelines:      []string{"build"},
 		payloadPipelines:    []string{"ostree-deployment", "image", "xz", "coi-tree", "efiboot-tree", "bootiso-tree", "bootiso"},
 		exports:             []string{"bootiso"},
-		basePartitionTables: iotBasePartitionTables,
+		basePartitionTables: iotSimplifiedInstallerPartitionTables,
 	}
 
 	iotRawImgType = imageType{

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -191,7 +191,7 @@ var (
 		defaultSize:         4 * common.GibiByte,
 		rpmOstree:           true,
 		bootable:            true,
-		image:               iotRawImage,
+		image:               iotImage,
 		buildPipelines:      []string{"build"},
 		payloadPipelines:    []string{"ostree-deployment", "image", "xz"},
 		exports:             []string{"xz"},

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -157,6 +157,27 @@ var (
 		exports:          []string{"bootiso"},
 	}
 
+	iotSimplifiedInstallerImgType = imageType{
+		name:     "iot-simplified-installer",
+		filename: "simplified-installer.iso",
+		mimeType: "application/x-iso9660-image",
+		packageSets: map[string]packageSetFunc{
+			installerPkgsKey: iotSimplifiedInstallerPackageSet,
+		},
+		defaultImageConfig: &distro.ImageConfig{
+			EnabledServices: iotServices,
+		},
+		defaultSize:         10 * common.GibiByte,
+		rpmOstree:           true,
+		bootable:            true,
+		bootISO:             true,
+		image:               iotSimplifiedInstallerImage,
+		buildPipelines:      []string{"build"},
+		payloadPipelines:    []string{"ostree-deployment", "image", "xz", "coi-tree", "efiboot-tree", "bootiso-tree", "bootiso"},
+		exports:             []string{"bootiso"},
+		basePartitionTables: iotBasePartitionTables,
+	}
+
 	iotRawImgType = imageType{
 		name:        "iot-raw-image",
 		nameAliases: []string{"fedora-iot-raw-image"},
@@ -629,6 +650,7 @@ func newDistro(version int) distro.Distro {
 		},
 		iotRawImgType,
 	)
+
 	aarch64.addImageTypes(
 		&platform.Aarch64{
 			UEFIVendor: "fedora",
@@ -674,10 +696,10 @@ func newDistro(version int) distro.Distro {
 			},
 			UEFIVendor: "fedora",
 		},
-		iotCommitImgType,
-		iotOCIImgType,
-		iotInstallerImgType,
 		imageInstallerImgType,
+		iotCommitImgType,
+		iotInstallerImgType,
+		iotOCIImgType,
 		liveInstallerImgType,
 	)
 	aarch64.addImageTypes(
@@ -739,6 +761,39 @@ func newDistro(version int) distro.Distro {
 		},
 		minimalrawImgType,
 	)
+
+	if !common.VersionLessThan(rd.Releasever(), "38") {
+		// iot simplified installer was introduced in F38
+		x86_64.addImageTypes(
+			&platform.X86{
+				BasePlatform: platform.BasePlatform{
+					ImageFormat: platform.FORMAT_RAW,
+					FirmwarePackages: []string{
+						"biosdevname",
+						"iwlwifi-dvm-firmware",
+						"iwlwifi-mvm-firmware",
+						"microcode_ctl",
+					},
+				},
+				BIOS:       false,
+				UEFIVendor: "fedora",
+			},
+			iotSimplifiedInstallerImgType,
+		)
+		aarch64.addImageTypes(
+			&platform.Aarch64{
+				BasePlatform: platform.BasePlatform{
+					FirmwarePackages: []string{
+						"uboot-images-armv8",
+						"bcm283x-firmware",
+						"arm-image-installer",
+					},
+				},
+				UEFIVendor: "fedora",
+			},
+			iotSimplifiedInstallerImgType,
+		)
+	}
 
 	rd.addArches(x86_64, aarch64)
 	return &rd

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -604,18 +604,10 @@ func newDistro(version int) distro.Distro {
 		&platform.X86{
 			BasePlatform: platform.BasePlatform{
 				FirmwarePackages: []string{
-					"microcode_ctl", // ??
-					"iwl1000-firmware",
-					"iwl100-firmware",
-					"iwl105-firmware",
-					"iwl135-firmware",
-					"iwl2000-firmware",
-					"iwl2030-firmware",
-					"iwl3160-firmware",
-					"iwl5000-firmware",
-					"iwl5150-firmware",
-					"iwl6000-firmware",
-					"iwl6050-firmware",
+					"biosdevname",
+					"iwlwifi-dvm-firmware",
+					"iwlwifi-mvm-firmware",
+					"microcode_ctl",
 				},
 			},
 			BIOS:       true,
@@ -674,9 +666,10 @@ func newDistro(version int) distro.Distro {
 		&platform.Aarch64{
 			BasePlatform: platform.BasePlatform{
 				FirmwarePackages: []string{
-					"uboot-images-armv8", // ??
-					"bcm283x-firmware",
 					"arm-image-installer", // ??
+					"bcm283x-firmware",
+					"iwl7260-firmware",
+					"uboot-images-armv8", // ??
 				},
 			},
 			UEFIVendor: "fedora",

--- a/pkg/distro/fedora/distro_test.go
+++ b/pkg/distro/fedora/distro_test.go
@@ -330,6 +330,7 @@ func TestImageType_Name(t *testing.T) {
 				"iot-commit",
 				"iot-container",
 				"iot-installer",
+				"iot-qcow2-image",
 				"iot-raw-image",
 				"live-installer",
 				"minimal-raw",
@@ -355,6 +356,7 @@ func TestImageType_Name(t *testing.T) {
 				"iot-commit",
 				"iot-container",
 				"iot-installer",
+				"iot-qcow2-image",
 				"iot-raw-image",
 				"minimal-raw",
 				"oci",
@@ -492,7 +494,7 @@ func TestDistro_ManifestError(t *testing.T) {
 				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for boot ISO image type \"%s\": (allowed: User, Group)", imgTypeName))
 			} else if imgTypeName == "live-installer" {
 				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for boot ISO image type \"%s\": (allowed: None)", imgTypeName))
-			} else if imgTypeName == "iot-raw-image" {
+			} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-qcow2-image" {
 				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services)", imgTypeName))
 			} else {
 				assert.NoError(t, err)
@@ -516,6 +518,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"iot-commit",
 				"iot-container",
 				"iot-installer",
+				"iot-qcow2-image",
 				"iot-raw-image",
 				"live-installer",
 				"minimal-raw",
@@ -542,6 +545,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"iot-commit",
 				"iot-container",
 				"iot-installer",
+				"iot-qcow2-image",
 				"iot-raw-image",
 				"live-installer",
 				"minimal-raw",
@@ -653,7 +657,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
 			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
-			} else if imgTypeName == "iot-raw-image" {
+			} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-qcow2-image" {
 				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services)", imgTypeName))
 			} else if imgTypeName == "iot-installer" || imgTypeName == "iot-simplified-installer" || imgTypeName == "image-installer" {
 				continue
@@ -685,7 +689,7 @@ func TestDistro_TestRootMountPoint(t *testing.T) {
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
 			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
-			} else if imgTypeName == "iot-raw-image" {
+			} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-qcow2-image" {
 				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services)", imgTypeName))
 			} else if imgTypeName == "iot-installer" || imgTypeName == "iot-simplified-installer" || imgTypeName == "image-installer" {
 				continue
@@ -829,7 +833,7 @@ func TestDistro_CustomFileSystemPatternMatching(t *testing.T) {
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
 			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
-			} else if imgTypeName == "iot-raw-image" {
+			} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-qcow2-image" {
 				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services)", imgTypeName))
 			} else if imgTypeName == "iot-installer" || imgTypeName == "iot-simplified-installer" || imgTypeName == "image-installer" {
 				continue
@@ -861,7 +865,7 @@ func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
 			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
-			} else if imgTypeName == "iot-raw-image" {
+			} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-qcow2-image" {
 				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services)", imgTypeName))
 			} else if imgTypeName == "iot-installer" || imgTypeName == "iot-simplified-installer" || imgTypeName == "image-installer" {
 				continue

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -452,6 +452,10 @@ func iotRawImage(workload workload.Workload,
 		img.SysrootReadOnly = true
 	}
 
+	if !common.VersionLessThan(distro.Releasever(), "38") {
+		img.Ignition = true
+	}
+
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -372,6 +372,10 @@ func iotCommitImage(workload workload.Workload,
 				Name:  "coreos-ignition-write-issues.service",
 				State: osbuild.StateEnable,
 			},
+			{
+				Name:  "fdo-client-linuxapp.service",
+				State: osbuild.StateEnable,
+			},
 		}
 	}
 	img.Environment = t.environment
@@ -406,6 +410,10 @@ func iotContainerImage(workload workload.Workload,
 			},
 			{
 				Name:  "coreos-ignition-write-issues.service",
+				State: osbuild.StateEnable,
+			},
+			{
+				Name:  "fdo-client-linuxapp.service",
 				State: osbuild.StateEnable,
 			},
 		}

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -447,12 +447,7 @@ func iotRawImage(workload workload.Workload,
 
 	img := image.NewOSTreeRawImage(commit)
 
-	// Set sysroot read-only only for Fedora 37+
 	distro := t.Arch().Distro()
-	if !common.VersionLessThan(distro.Releasever(), "37") {
-		img.SysrootReadOnly = true
-	}
-
 	if !common.VersionLessThan(distro.Releasever(), "38") {
 		img.Ignition = true
 	}
@@ -469,11 +464,15 @@ func iotRawImage(workload workload.Workload,
 		return nil, err
 	}
 
-	// "rw" kernel option is required when /sysroot is mounted read-only to
-	// keep stateful parts of the filesystem writeable (/var/ and /etc)
-	img.KernelOptionsAppend = []string{"modprobe.blacklist=vc4", "rw"}
+	img.KernelOptionsAppend = []string{"modprobe.blacklist=vc4"}
 	img.Keyboard = "us"
 	img.Locale = "C.UTF-8"
+
+	// Set sysroot read-only only for Fedora 37+
+	if !common.VersionLessThan(distro.Releasever(), "37") {
+		img.SysrootReadOnly = true
+		img.KernelOptionsAppend = append(img.KernelOptionsAppend, "rw")
+	}
 
 	img.Platform = t.platform
 	img.Workload = workload
@@ -485,6 +484,14 @@ func iotRawImage(workload workload.Workload,
 		GPGKeyPaths: []string{"/etc/pki/rpm-gpg/"},
 	}
 	img.OSName = "fedora-iot"
+
+	if bpIgnition := customizations.GetIgnition(); bpIgnition != nil && bpIgnition.FirstBoot != nil && bpIgnition.FirstBoot.ProvisioningURL != "" {
+		img.KernelOptionsAppend = append(img.KernelOptionsAppend, "ignition.config.url="+bpIgnition.FirstBoot.ProvisioningURL)
+	}
+
+	if kopts := customizations.GetKernel(); kopts != nil && kopts.Append != "" {
+		img.KernelOptionsAppend = append(img.KernelOptionsAppend, kopts.Append)
+	}
 
 	// TODO: move generation into LiveImage
 	pt, err := t.getPartitionTable(customizations.GetFilesystems(), options, rng)
@@ -519,12 +526,13 @@ func iotSimplifiedInstallerImage(workload workload.Workload,
 	rawImg.Users = users.UsersFromBP(customizations.GetUsers())
 	rawImg.Groups = users.GroupsFromBP(customizations.GetGroups())
 
-	// "rw" kernel option is required when /sysroot is mounted read-only to
-	// keep stateful parts of the filesystem writeable (/var/ and /etc)
-	rawImg.KernelOptionsAppend = []string{"modprobe.blacklist=vc4", "rw"}
+	rawImg.KernelOptionsAppend = []string{"modprobe.blacklist=vc4"}
 	rawImg.Keyboard = "us"
 	rawImg.Locale = "C.UTF-8"
-	rawImg.SysrootReadOnly = true
+	if !common.VersionLessThan(t.arch.distro.osVersion, "38") {
+		rawImg.SysrootReadOnly = true
+		rawImg.KernelOptionsAppend = append(rawImg.KernelOptionsAppend, "rw")
+	}
 
 	rawImg.Platform = t.platform
 	rawImg.Workload = workload

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -5,6 +5,8 @@ import (
 	"math/rand"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/fdo"
+	"github.com/osbuild/images/internal/ignition"
 	"github.com/osbuild/images/internal/oscap"
 	"github.com/osbuild/images/internal/users"
 	"github.com/osbuild/images/internal/workload"
@@ -493,6 +495,88 @@ func iotRawImage(workload workload.Workload,
 
 	img.Filename = t.Filename()
 	img.Compression = t.compression
+
+	return img, nil
+}
+
+func iotSimplifiedInstallerImage(workload workload.Workload,
+	t *imageType,
+	customizations *blueprint.Customizations,
+	options distro.ImageOptions,
+	packageSets map[string]rpmmd.PackageSet,
+	containers []container.SourceSpec,
+	rng *rand.Rand) (image.ImageKind, error) {
+
+	commit, err := makeOSTreePayloadCommit(options.OSTree, t.OSTreeRef())
+	if err != nil {
+		return nil, fmt.Errorf("%s: %s", t.Name(), err.Error())
+	}
+	rawImg := image.NewOSTreeRawImage(commit)
+	if !common.VersionLessThan(t.arch.distro.osVersion, "38") {
+		rawImg.Ignition = true
+	}
+
+	rawImg.Users = users.UsersFromBP(customizations.GetUsers())
+	rawImg.Groups = users.GroupsFromBP(customizations.GetGroups())
+
+	// "rw" kernel option is required when /sysroot is mounted read-only to
+	// keep stateful parts of the filesystem writeable (/var/ and /etc)
+	rawImg.KernelOptionsAppend = []string{"modprobe.blacklist=vc4", "rw"}
+	rawImg.Keyboard = "us"
+	rawImg.Locale = "C.UTF-8"
+	rawImg.SysrootReadOnly = true
+
+	rawImg.Platform = t.platform
+	rawImg.Workload = workload
+	rawImg.Remote = ostree.Remote{
+		Name:       "fedora-iot",
+		URL:        options.OSTree.URL,
+		ContentURL: options.OSTree.ContentURL,
+	}
+	rawImg.OSName = "fedora"
+
+	// TODO: move generation into LiveImage
+	pt, err := t.getPartitionTable(customizations.GetFilesystems(), options, rng)
+	if err != nil {
+		return nil, err
+	}
+	rawImg.PartitionTable = pt
+
+	rawImg.Filename = t.Filename()
+
+	if bpIgnition := customizations.GetIgnition(); bpIgnition != nil && bpIgnition.FirstBoot != nil && bpIgnition.FirstBoot.ProvisioningURL != "" {
+		rawImg.KernelOptionsAppend = append(rawImg.KernelOptionsAppend, "ignition.config.url="+bpIgnition.FirstBoot.ProvisioningURL)
+	}
+
+	if kopts := customizations.GetKernel(); kopts != nil && kopts.Append != "" {
+		rawImg.KernelOptionsAppend = append(rawImg.KernelOptionsAppend, kopts.Append)
+	}
+
+	img := image.NewOSTreeSimplifiedInstaller(rawImg, customizations.InstallationDevice)
+	img.ExtraBasePackages = packageSets[installerPkgsKey]
+	// img.Workload = workload
+	img.Platform = t.platform
+	img.Filename = t.Filename()
+	if bpFDO := customizations.GetFDO(); bpFDO != nil {
+		img.FDO = fdo.FromBP(*bpFDO)
+	}
+	// ignition configs from blueprint
+	if bpIgnition := customizations.GetIgnition(); bpIgnition != nil {
+		if bpIgnition.Embedded != nil {
+			var err error
+			img.IgnitionEmbedded, err = ignition.EmbeddedOptionsFromBP(*bpIgnition.Embedded)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	d := t.arch.distro
+	img.ISOLabelTempl = d.isolabelTmpl
+	img.Product = d.product
+	img.Variant = "iot"
+	img.OSName = "fedora"
+	img.OSVersion = d.osVersion
 
 	return img, nil
 }

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -464,11 +464,8 @@ func iotRawImage(workload workload.Workload,
 	img.Keyboard = "us"
 	img.Locale = "C.UTF-8"
 
-	// Set sysroot read-only only for Fedora 37+
-	if !common.VersionLessThan(distro.Releasever(), "37") {
-		img.SysrootReadOnly = true
-		img.KernelOptionsAppend = append(img.KernelOptionsAppend, "rw")
-	}
+	img.SysrootReadOnly = true
+	img.KernelOptionsAppend = append(img.KernelOptionsAppend, "rw")
 
 	img.Platform = t.platform
 	img.Workload = workload

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -3,7 +3,6 @@ package fedora
 import (
 	"fmt"
 	"math/rand"
-	"strings"
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/oscap"
@@ -311,7 +310,7 @@ func imageInstallerImage(workload workload.Workload,
 
 	// Enable anaconda-webui for Fedora > 38
 	distro := t.Arch().Distro()
-	if strings.HasPrefix(distro.Name(), "fedora") && !common.VersionLessThan(distro.Releasever(), "38") {
+	if !common.VersionLessThan(distro.Releasever(), "38") {
 		img.AdditionalAnacondaModules = []string{
 			"org.fedoraproject.Anaconda.Modules.Security",
 			"org.fedoraproject.Anaconda.Modules.Timezone",
@@ -448,7 +447,7 @@ func iotRawImage(workload workload.Workload,
 
 	// Set sysroot read-only only for Fedora 37+
 	distro := t.Arch().Distro()
-	if strings.HasPrefix(distro.Name(), "fedora") && !common.VersionLessThan(distro.Releasever(), "37") {
+	if !common.VersionLessThan(distro.Releasever(), "37") {
 		img.SysrootReadOnly = true
 	}
 

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -257,7 +257,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		}
 	}
 
-	if t.name == "iot-raw-image" {
+	if t.name == "iot-raw-image" || t.name == "iot-qcow2-image" {
 		allowed := []string{"User", "Group", "Directories", "Files", "Services"}
 		if err := customizations.CheckAllowed(allowed...); err != nil {
 			return nil, fmt.Errorf("unsupported blueprint customizations found for image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -265,10 +265,48 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		// TODO: consider additional checks, such as those in "edge-simplified-installer" in RHEL distros
 	}
 
-	// BootISO's have limited support for customizations.
+	// BootISOs have limited support for customizations.
 	// TODO: Support kernel name selection for image-installer
 	if t.bootISO {
-		if t.name == "iot-installer" || t.name == "image-installer" {
+		if t.name == "iot-simplified-installer" {
+			allowed := []string{"InstallationDevice", "FDO", "Ignition", "Kernel"}
+			if err := customizations.CheckAllowed(allowed...); err != nil {
+				return nil, fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
+			}
+			if customizations.GetInstallationDevice() == "" {
+				return nil, fmt.Errorf("boot ISO image type %q requires specifying an installation device to install to", t.name)
+			}
+
+			// FDO is optional, but when specified has some restrictions
+			if customizations.GetFDO() != nil {
+				if customizations.GetFDO().ManufacturingServerURL == "" {
+					return nil, fmt.Errorf("boot ISO image type %q requires specifying FDO.ManufacturingServerURL configuration to install to when using FDO", t.name)
+				}
+				var diunSet int
+				if customizations.GetFDO().DiunPubKeyHash != "" {
+					diunSet++
+				}
+				if customizations.GetFDO().DiunPubKeyInsecure != "" {
+					diunSet++
+				}
+				if customizations.GetFDO().DiunPubKeyRootCerts != "" {
+					diunSet++
+				}
+				if diunSet != 1 {
+					return nil, fmt.Errorf("boot ISO image type %q requires specifying one of [FDO.DiunPubKeyHash,FDO.DiunPubKeyInsecure,FDO.DiunPubKeyRootCerts] configuration to install to when using FDO", t.name)
+				}
+			}
+
+			// ignition is optional, we might be using FDO
+			if customizations.GetIgnition() != nil {
+				if customizations.GetIgnition().Embedded != nil && customizations.GetIgnition().FirstBoot != nil {
+					return nil, fmt.Errorf("both ignition embedded and firstboot configurations found")
+				}
+				if customizations.GetIgnition().FirstBoot != nil && customizations.GetIgnition().FirstBoot.ProvisioningURL == "" {
+					return nil, fmt.Errorf("ignition.firstboot requires a provisioning url")
+				}
+			}
+		} else if t.name == "iot-installer" || t.name == "image-installer" {
 			allowed := []string{"User", "Group"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return nil, fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -269,7 +269,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 	// TODO: Support kernel name selection for image-installer
 	if t.bootISO {
 		if t.name == "iot-simplified-installer" {
-			allowed := []string{"InstallationDevice", "FDO", "Ignition", "Kernel"}
+			allowed := []string{"InstallationDevice", "FDO", "Ignition", "Kernel", "User", "Group"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return nil, fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
 			}

--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -542,3 +542,54 @@ func minimalrpmPackageSet(t *imageType) rpmmd.PackageSet {
 		},
 	}
 }
+
+func iotSimplifiedInstallerPackageSet(t *imageType) rpmmd.PackageSet {
+	// common installer packages
+	ps := installerPackageSet(t)
+
+	ps = ps.Append(rpmmd.PackageSet{
+		Include: []string{
+			"attr",
+			"basesystem",
+			"binutils",
+			"bsdtar",
+			"clevis-dracut",
+			"clevis-luks",
+			"cloud-utils-growpart",
+			"coreos-installer",
+			"coreos-installer-dracut",
+			"coreutils",
+			"device-mapper-multipath",
+			"dnsmasq",
+			"dosfstools",
+			"dracut-live",
+			"e2fsprogs",
+			"fcoe-utils",
+			"fdo-init",
+			"fedora-logos",
+			"gdisk",
+			"gzip",
+			"ima-evm-utils",
+			"iproute",
+			"iptables",
+			"iputils",
+			"iscsi-initiator-utils",
+			"keyutils",
+			"lldpad",
+			"lvm2",
+			"mdadm",
+			"nss-softokn",
+			"passwd",
+			"policycoreutils",
+			"policycoreutils-python-utils",
+			"procps-ng",
+			"rootfiles",
+			"setools-console",
+			"sudo",
+			"traceroute",
+			"util-linux",
+		},
+	})
+
+	return ps
+}

--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -180,7 +180,10 @@ func iotCommitPackageSet(t *imageType) rpmmd.PackageSet {
 	if !common.VersionLessThan(t.arch.distro.osVersion, "38") {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
-				"fdo-client", // added in F38
+				"fdo-client",
+				"fdo-owner-cli",
+				"ignition-edge",
+				"ssh-key-dir",
 			},
 		})
 	}

--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -13,13 +13,13 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     1 * common.MebiByte, // 1MB
+				Size:     1 * common.MebiByte,
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 200 * common.MebiByte, // 200 MB
+				Size: 200 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -33,7 +33,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 500 * common.MebiByte, // 500 MB
+				Size: 500 * common.MebiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -46,7 +46,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * common.GibiByte, // 2GiB
+				Size: 2 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -65,7 +65,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size: 200 * common.MebiByte, // 200 MB
+				Size: 200 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -79,7 +79,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 500 * common.MebiByte, // 500 MB
+				Size: 500 * common.MebiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -92,7 +92,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * common.GibiByte, // 2GiB
+				Size: 2 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -114,7 +114,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size: 501 * common.MebiByte, // 501 MiB
+				Size: 501 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -128,7 +128,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 1 * common.GibiByte, // 1 GiB
+				Size: 1 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -141,7 +141,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2569 * common.MebiByte, // 2.5 GiB
+				Size: 2569 * common.MebiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -160,7 +160,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "dos",
 		Partitions: []disk.Partition{
 			{
-				Size:     501 * common.MebiByte, // 501 MiB
+				Size:     501 * common.MebiByte,
 				Type:     "06",
 				Bootable: true,
 				Payload: &disk.Filesystem{
@@ -174,7 +174,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 1 * common.GibiByte, // 1 GiB
+				Size: 1 * common.GibiByte,
 				Type: "83",
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
@@ -186,7 +186,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2569 * common.MebiByte, // 2.5 GiB
+				Size: 2569 * common.MebiByte,
 				Type: "83",
 				Payload: &disk.Filesystem{
 					Type:         "ext4",

--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -200,3 +200,146 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 		},
 	},
 }
+
+var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
+	platform.ARCH_X86_64.String(): disk.PartitionTable{
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []disk.Partition{
+			{
+				Size: 501 * common.MebiByte,
+				Type: disk.EFISystemPartitionGUID,
+				UUID: disk.EFISystemPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "vfat",
+					UUID:         disk.EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					Label:        "EFI-SYSTEM",
+					FSTabOptions: "umask=0077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 1 * common.GibiByte,
+				Type: disk.XBootLDRPartitionGUID,
+				UUID: disk.FilesystemDataUUID,
+				Payload: &disk.Filesystem{
+					Type:         "ext4",
+					Mountpoint:   "/boot",
+					Label:        "boot",
+					FSTabOptions: "defaults",
+					FSTabFreq:    1,
+					FSTabPassNo:  1,
+				},
+			},
+			{
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.RootPartitionUUID,
+				Payload: &disk.LUKSContainer{
+					Label:      "crypt_root",
+					Cipher:     "cipher_null",
+					Passphrase: "osbuild",
+					PBKDF: disk.Argon2id{
+						Memory:      32,
+						Iterations:  4,
+						Parallelism: 1,
+					},
+					Clevis: &disk.ClevisBind{
+						Pin:              "null",
+						Policy:           "{}",
+						RemovePassphrase: true,
+					},
+					Payload: &disk.LVMVolumeGroup{
+						Name:        "rootvg",
+						Description: "built with lvm2 and osbuild",
+						LogicalVolumes: []disk.LVMLogicalVolume{
+							{
+								Size: 2569 * common.MebiByte,
+								Name: "rootlv",
+								Payload: &disk.Filesystem{
+									Type:         "ext4",
+									Label:        "root",
+									Mountpoint:   "/",
+									FSTabOptions: "defaults",
+									FSTabFreq:    0,
+									FSTabPassNo:  0,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	platform.ARCH_AARCH64.String(): disk.PartitionTable{
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []disk.Partition{
+			{
+				Size: 501 * common.MebiByte,
+				Type: disk.EFISystemPartitionGUID,
+				UUID: disk.EFISystemPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "vfat",
+					UUID:         disk.EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					Label:        "EFI-SYSTEM",
+					FSTabOptions: "umask=0077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 1 * common.GibiByte,
+				Type: disk.XBootLDRPartitionGUID,
+				UUID: disk.FilesystemDataUUID,
+				Payload: &disk.Filesystem{
+					Type:         "ext4",
+					Mountpoint:   "/boot",
+					Label:        "boot",
+					FSTabOptions: "defaults",
+					FSTabFreq:    1,
+					FSTabPassNo:  1,
+				},
+			},
+			{
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.RootPartitionUUID,
+				Payload: &disk.LUKSContainer{
+					Label:      "crypt_root",
+					Cipher:     "cipher_null",
+					Passphrase: "osbuild",
+					PBKDF: disk.Argon2id{
+						Memory:      32,
+						Iterations:  4,
+						Parallelism: 1,
+					},
+					Clevis: &disk.ClevisBind{
+						Pin:              "null",
+						Policy:           "{}",
+						RemovePassphrase: true,
+					},
+					Payload: &disk.LVMVolumeGroup{
+						Name:        "rootvg",
+						Description: "built with lvm2 and osbuild",
+						LogicalVolumes: []disk.LVMLogicalVolume{
+							{
+								Size: 2569 * common.MebiByte,
+								Name: "rootlv",
+								Payload: &disk.Filesystem{
+									Type:         "ext4",
+									Label:        "root",
+									Mountpoint:   "/",
+									FSTabOptions: "defaults",
+									FSTabFreq:    0,
+									FSTabPassNo:  0,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}

--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -273,13 +273,13 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 		},
 	},
 	platform.ARCH_AARCH64.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		UUID: "0xc1748067",
+		Type: "dos",
 		Partitions: []disk.Partition{
 			{
-				Size: 501 * common.MebiByte,
-				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
+				Size:     501 * common.MebiByte,
+				Type:     "06",
+				Bootable: true,
 				Payload: &disk.Filesystem{
 					Type:         "vfat",
 					UUID:         disk.EFIFilesystemUUID,

--- a/pkg/distro/rhel7/partition_tables.go
+++ b/pkg/distro/rhel7/partition_tables.go
@@ -7,21 +7,19 @@ import (
 	"github.com/osbuild/images/pkg/platform"
 )
 
-// ////////// Partition table //////////
-
 var defaultBasePartitionTables = distro.BasePartitionTableMap{
 	platform.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     1 * common.MebiByte, // 1MB
+				Size:     1 * common.MebiByte,
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 200 * common.MebiByte, // 200 MB
+				Size: 200 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -35,7 +33,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 500 * common.MebiByte, // 500 MB
+				Size: 500 * common.MebiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -48,7 +46,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * common.GibiByte, // 2GiB
+				Size: 2 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -439,7 +439,7 @@ func edgeRawImage(workload workload.Workload,
 		return nil, fmt.Errorf("%s: %s", t.Name(), err.Error())
 	}
 
-	img := image.NewOSTreeRawImage(commit)
+	img := image.NewOSTreeDiskImage(commit)
 
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
@@ -484,7 +484,7 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 		return nil, fmt.Errorf("%s: %s", t.Name(), err.Error())
 	}
 
-	rawImg := image.NewOSTreeRawImage(commit)
+	rawImg := image.NewOSTreeDiskImage(commit)
 
 	rawImg.Users = users.UsersFromBP(customizations.GetUsers())
 	rawImg.Groups = users.GroupsFromBP(customizations.GetGroups())

--- a/pkg/distro/rhel8/partition_tables.go
+++ b/pkg/distro/rhel8/partition_tables.go
@@ -32,7 +32,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * common.GibiByte, // 2 GiB
+				Size: 2 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -64,7 +64,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * common.GibiByte, // 2 GiB
+				Size: 2 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -88,7 +88,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				Bootable: true,
 			},
 			{
-				Size: 2 * common.GibiByte, // 2 GiB
+				Size: 2 * common.GibiByte,
 				Payload: &disk.Filesystem{
 					Type:         "xfs",
 					Mountpoint:   "/",
@@ -104,7 +104,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "dos",
 		Partitions: []disk.Partition{
 			{
-				Size:     2 * common.GibiByte, // 2 GiB
+				Size:     2 * common.GibiByte,
 				Bootable: true,
 				Payload: &disk.Filesystem{
 					Type:         "xfs",
@@ -233,7 +233,7 @@ var ec2LegacyBasePartitionTables = distro.BasePartitionTableMap{
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 2 * common.GibiByte, // 2 GiB
+				Size: 2 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -277,7 +277,7 @@ var ec2LegacyBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * common.GibiByte, // 2 GiB
+				Size: 2 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -305,7 +305,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 127 * common.MebiByte, // 127 MB
+				Size: 127 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -319,7 +319,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 384 * common.MebiByte, // 384 MB
+				Size: 384 * common.MebiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -332,7 +332,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * common.GibiByte, // 2 GiB
+				Size: 2 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.LUKSContainer{
@@ -366,7 +366,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size: 127 * common.MebiByte, // 127 MB
+				Size: 127 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -380,7 +380,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 384 * common.MebiByte, // 384 MB
+				Size: 384 * common.MebiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -393,7 +393,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * common.GibiByte, // 2 GiB
+				Size: 2 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.LUKSContainer{

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -396,13 +396,7 @@ func edgeRawImage(workload workload.Workload,
 	if err != nil {
 		return nil, fmt.Errorf("%s: %s", t.Name(), err.Error())
 	}
-
 	img := image.NewOSTreeDiskImage(commit)
-
-	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || t.arch.distro.osVersion == "9-stream" {
-		img.Ignition = true
-		img.IgnitionPlatform = "metal"
-	}
 
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
@@ -415,6 +409,14 @@ func edgeRawImage(workload workload.Workload,
 		img.KernelOptionsAppend = append(img.KernelOptionsAppend, "rw")
 	}
 
+	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || t.arch.distro.osVersion == "9-stream" {
+		img.Ignition = true
+		img.IgnitionPlatform = "metal"
+		if bpIgnition := customizations.GetIgnition(); bpIgnition != nil && bpIgnition.FirstBoot != nil && bpIgnition.FirstBoot.ProvisioningURL != "" {
+			img.KernelOptionsAppend = append(img.KernelOptionsAppend, "ignition.config.url="+bpIgnition.FirstBoot.ProvisioningURL)
+		}
+	}
+
 	img.Platform = t.platform
 	img.Workload = workload
 	img.Remote = ostree.Remote{
@@ -424,11 +426,6 @@ func edgeRawImage(workload workload.Workload,
 	}
 	img.OSName = "redhat"
 
-	if bpIgnition := customizations.GetIgnition(); bpIgnition != nil && bpIgnition.FirstBoot != nil && bpIgnition.FirstBoot.ProvisioningURL != "" {
-		img.KernelOptionsAppend = append(img.KernelOptionsAppend, "ignition.config.url="+bpIgnition.FirstBoot.ProvisioningURL)
-	}
-
-	// 92+ only
 	if kopts := customizations.GetKernel(); kopts != nil && kopts.Append != "" {
 		img.KernelOptionsAppend = append(img.KernelOptionsAppend, kopts.Append)
 	}
@@ -458,12 +455,7 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 	if err != nil {
 		return nil, fmt.Errorf("%s: %s", t.Name(), err.Error())
 	}
-
 	rawImg := image.NewOSTreeDiskImage(commit)
-	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || t.arch.distro.osVersion == "9-stream" {
-		rawImg.Ignition = true
-		rawImg.IgnitionPlatform = "metal"
-	}
 
 	rawImg.Users = users.UsersFromBP(customizations.GetUsers())
 	rawImg.Groups = users.GroupsFromBP(customizations.GetGroups())
@@ -485,6 +477,14 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 	}
 	rawImg.OSName = "redhat"
 
+	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || t.arch.distro.osVersion == "9-stream" {
+		rawImg.Ignition = true
+		rawImg.IgnitionPlatform = "metal"
+		if bpIgnition := customizations.GetIgnition(); bpIgnition != nil && bpIgnition.FirstBoot != nil && bpIgnition.FirstBoot.ProvisioningURL != "" {
+			rawImg.KernelOptionsAppend = append(rawImg.KernelOptionsAppend, "ignition.config.url="+bpIgnition.FirstBoot.ProvisioningURL)
+		}
+	}
+
 	// TODO: move generation into LiveImage
 	pt, err := t.getPartitionTable(customizations.GetFilesystems(), options, rng)
 	if err != nil {
@@ -493,10 +493,6 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 	rawImg.PartitionTable = pt
 
 	rawImg.Filename = t.Filename()
-
-	if bpIgnition := customizations.GetIgnition(); bpIgnition != nil && bpIgnition.FirstBoot != nil && bpIgnition.FirstBoot.ProvisioningURL != "" {
-		rawImg.KernelOptionsAppend = append(rawImg.KernelOptionsAppend, "ignition.config.url="+bpIgnition.FirstBoot.ProvisioningURL)
-	}
 
 	// 92+ only
 	if kopts := customizations.GetKernel(); kopts != nil && kopts.Append != "" {

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -406,8 +406,6 @@ func edgeRawImage(workload workload.Workload,
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 
-	// "rw" kernel option is required when /sysroot is mounted read-only to
-	// keep stateful parts of the filesystem writeable (/var/ and /etc)
 	img.KernelOptionsAppend = []string{"modprobe.blacklist=vc4"}
 	img.Keyboard = "us"
 	img.Locale = "C.UTF-8"
@@ -468,8 +466,6 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 	rawImg.Users = users.UsersFromBP(customizations.GetUsers())
 	rawImg.Groups = users.GroupsFromBP(customizations.GetGroups())
 
-	// "rw" kernel option is required when /sysroot is mounted read-only to
-	// keep stateful parts of the filesystem writeable (/var/ and /etc)
 	rawImg.KernelOptionsAppend = []string{"modprobe.blacklist=vc4"}
 	rawImg.Keyboard = "us"
 	rawImg.Locale = "C.UTF-8"

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -397,7 +397,7 @@ func edgeRawImage(workload workload.Workload,
 		return nil, fmt.Errorf("%s: %s", t.Name(), err.Error())
 	}
 
-	img := image.NewOSTreeRawImage(commit)
+	img := image.NewOSTreeDiskImage(commit)
 
 	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || t.arch.distro.osVersion == "9-stream" {
 		img.Ignition = true
@@ -459,7 +459,7 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 		return nil, fmt.Errorf("%s: %s", t.Name(), err.Error())
 	}
 
-	rawImg := image.NewOSTreeRawImage(commit)
+	rawImg := image.NewOSTreeDiskImage(commit)
 	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || t.arch.distro.osVersion == "9-stream" {
 		rawImg.Ignition = true
 		rawImg.IgnitionPlatform = "metal"

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -401,6 +401,7 @@ func edgeRawImage(workload workload.Workload,
 
 	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || t.arch.distro.osVersion == "9-stream" {
 		img.Ignition = true
+		img.IgnitionPlatform = "metal"
 	}
 
 	img.Users = users.UsersFromBP(customizations.GetUsers())
@@ -461,6 +462,7 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 	rawImg := image.NewOSTreeRawImage(commit)
 	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || t.arch.distro.osVersion == "9-stream" {
 		rawImg.Ignition = true
+		rawImg.IgnitionPlatform = "metal"
 	}
 
 	rawImg.Users = users.UsersFromBP(customizations.GetUsers())

--- a/pkg/distro/rhel9/partition_tables.go
+++ b/pkg/distro/rhel9/partition_tables.go
@@ -13,13 +13,13 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     1 * common.MebiByte, // 1MB
+				Size:     1 * common.MebiByte,
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 200 * common.MebiByte, // 200 MB
+				Size: 200 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -33,7 +33,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 500 * common.MebiByte, // 500 MB
+				Size: 500 * common.MebiByte,
 				Type: disk.XBootLDRPartitionGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -46,7 +46,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * common.GibiByte, // 2GiB
+				Size: 2 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -65,7 +65,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size: 200 * common.MebiByte, // 200 MB
+				Size: 200 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -79,7 +79,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 500 * common.MebiByte, // 500 MB
+				Size: 500 * common.MebiByte,
 				Type: disk.XBootLDRPartitionGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -92,7 +92,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * common.GibiByte, // 2GiB
+				Size: 2 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -116,7 +116,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				Bootable: true,
 			},
 			{
-				Size: 500 * common.MebiByte, // 500 MB
+				Size: 500 * common.MebiByte,
 				Payload: &disk.Filesystem{
 					Type:         "xfs",
 					Mountpoint:   "/boot",
@@ -127,7 +127,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * common.GibiByte, // 2GiB
+				Size: 2 * common.GibiByte,
 				Payload: &disk.Filesystem{
 					Type:         "xfs",
 					Mountpoint:   "/",
@@ -143,7 +143,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "dos",
 		Partitions: []disk.Partition{
 			{
-				Size: 500 * common.MebiByte, // 500 MB
+				Size: 500 * common.MebiByte,
 				Payload: &disk.Filesystem{
 					Type:         "xfs",
 					Mountpoint:   "/boot",
@@ -154,7 +154,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size:     2 * common.GibiByte, // 2GiB
+				Size:     2 * common.GibiByte,
 				Bootable: true,
 				Payload: &disk.Filesystem{
 					Type:         "xfs",

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -82,7 +82,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	// TODO: replace isoLabelTmpl with more high-level properties
 	isoLabel := fmt.Sprintf(img.ISOLabelTempl, img.Platform.GetArch())
 
-	rootfsImagePipeline := manifest.NewISORootfsImg(m, buildPipeline, livePipeline)
+	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, livePipeline)
 	rootfsImagePipeline.Size = 8 * common.GibiByte
 
 	bootTreePipeline := manifest.NewEFIBootTree(m, buildPipeline, img.Product, img.OSVersion)
@@ -104,12 +104,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	// enable ISOLinux on x86_64 only
 	isoLinuxEnabled := img.Platform.GetArch() == platform.ARCH_X86_64
 
-	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(m,
-		buildPipeline,
-		livePipeline,
-		rootfsImagePipeline,
-		bootTreePipeline,
-		isoLabel)
+	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(buildPipeline, livePipeline, rootfsImagePipeline, bootTreePipeline)
 	isoTreePipeline.PartitionTable = rootfsPartitionTable
 	isoTreePipeline.Release = img.Release
 	isoTreePipeline.OSName = img.OSName
@@ -117,7 +112,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.KernelOpts = kernelOpts
 	isoTreePipeline.ISOLinux = isoLinuxEnabled
 
-	isoPipeline := manifest.NewISO(m, buildPipeline, isoTreePipeline, isoLabel)
+	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, isoLabel)
 	isoPipeline.SetFilename(img.Filename)
 	isoPipeline.ISOLinux = isoLinuxEnabled
 

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -118,7 +118,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.ISOLinux = isoLinuxEnabled
 
 	isoPipeline := manifest.NewISO(m, buildPipeline, isoTreePipeline, isoLabel)
-	isoPipeline.Filename = img.Filename
+	isoPipeline.SetFilename(img.Filename)
 	isoPipeline.ISOLinux = isoLinuxEnabled
 
 	artifact := isoPipeline.Export()

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -91,7 +91,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	// TODO: replace isoLabelTmpl with more high-level properties
 	isoLabel := fmt.Sprintf(img.ISOLabelTempl, img.Platform.GetArch())
 
-	rootfsImagePipeline := manifest.NewISORootfsImg(m, buildPipeline, anacondaPipeline)
+	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)
 	rootfsImagePipeline.Size = 4 * common.GibiByte
 
 	bootTreePipeline := manifest.NewEFIBootTree(m, buildPipeline, img.Product, img.OSVersion)
@@ -103,12 +103,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	// enable ISOLinux on x86_64 only
 	isoLinuxEnabled := img.Platform.GetArch() == platform.ARCH_X86_64
 
-	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(m,
-		buildPipeline,
-		anacondaPipeline,
-		rootfsImagePipeline,
-		bootTreePipeline,
-		isoLabel)
+	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(buildPipeline, anacondaPipeline, rootfsImagePipeline, bootTreePipeline)
 	isoTreePipeline.PartitionTable = rootfsPartitionTable
 	isoTreePipeline.Release = img.Release
 	isoTreePipeline.OSName = img.OSName
@@ -124,7 +119,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.OSTreeCommitSource = &img.Commit
 	isoTreePipeline.ISOLinux = isoLinuxEnabled
 
-	isoPipeline := manifest.NewISO(m, buildPipeline, isoTreePipeline, isoLabel)
+	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, isoLabel)
 	isoPipeline.SetFilename(img.Filename)
 	isoPipeline.ISOLinux = isoLinuxEnabled
 	artifact := isoPipeline.Export()

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -125,7 +125,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.ISOLinux = isoLinuxEnabled
 
 	isoPipeline := manifest.NewISO(m, buildPipeline, isoTreePipeline, isoLabel)
-	isoPipeline.Filename = img.Filename
+	isoPipeline.SetFilename(img.Filename)
 	isoPipeline.ISOLinux = isoLinuxEnabled
 	artifact := isoPipeline.Export()
 

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -157,7 +157,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.ISOLinux = isoLinuxEnabled
 
 	isoPipeline := manifest.NewISO(m, buildPipeline, isoTreePipeline, isoLabel)
-	isoPipeline.Filename = img.Filename
+	isoPipeline.SetFilename(img.Filename)
 	isoPipeline.ISOLinux = isoLinuxEnabled
 
 	artifact := isoPipeline.Export()

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -111,7 +111,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	// TODO: replace isoLabelTmpl with more high-level properties
 	isoLabel := fmt.Sprintf(img.ISOLabelTempl, img.Platform.GetArch())
 
-	rootfsImagePipeline := manifest.NewISORootfsImg(m, buildPipeline, anacondaPipeline)
+	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)
 	rootfsImagePipeline.Size = 4 * common.GibiByte
 
 	bootTreePipeline := manifest.NewEFIBootTree(m, buildPipeline, img.Product, img.OSVersion)
@@ -134,12 +134,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	// enable ISOLinux on x86_64 only
 	isoLinuxEnabled := img.Platform.GetArch() == platform.ARCH_X86_64
 
-	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(m,
-		buildPipeline,
-		anacondaPipeline,
-		rootfsImagePipeline,
-		bootTreePipeline,
-		isoLabel)
+	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(buildPipeline, anacondaPipeline, rootfsImagePipeline, bootTreePipeline)
 	isoTreePipeline.PartitionTable = rootfsPartitionTable
 	isoTreePipeline.Release = img.Release
 	isoTreePipeline.OSName = img.OSName
@@ -156,7 +151,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.KernelOpts = img.AdditionalKernelOpts
 	isoTreePipeline.ISOLinux = isoLinuxEnabled
 
-	isoPipeline := manifest.NewISO(m, buildPipeline, isoTreePipeline, isoLabel)
+	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, isoLabel)
 	isoPipeline.SetFilename(img.Filename)
 	isoPipeline.ISOLinux = isoLinuxEnabled
 

--- a/pkg/image/archive.go
+++ b/pkg/image/archive.go
@@ -39,7 +39,7 @@ func (img *Archive) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.Environment = img.Environment
 	osPipeline.Workload = img.Workload
 
-	tarPipeline := manifest.NewTar(m, buildPipeline, &osPipeline.Base, "archive")
+	tarPipeline := manifest.NewTar(buildPipeline, osPipeline, "archive")
 	tarPipeline.SetFilename(img.Filename)
 	artifact := tarPipeline.Export()
 

--- a/pkg/image/archive.go
+++ b/pkg/image/archive.go
@@ -40,7 +40,7 @@ func (img *Archive) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.Workload = img.Workload
 
 	tarPipeline := manifest.NewTar(m, buildPipeline, &osPipeline.Base, "archive")
-	tarPipeline.Filename = img.Filename
+	tarPipeline.SetFilename(img.Filename)
 	artifact := tarPipeline.Export()
 
 	return artifact, nil

--- a/pkg/image/container.go
+++ b/pkg/image/container.go
@@ -40,7 +40,7 @@ func (img *BaseContainer) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.Workload = img.Workload
 
 	ociPipeline := manifest.NewOCIContainer(m, buildPipeline, osPipeline)
-	ociPipeline.Filename = img.Filename
+	ociPipeline.SetFilename(img.Filename)
 	artifact := ociPipeline.Export()
 
 	return artifact, nil

--- a/pkg/image/container.go
+++ b/pkg/image/container.go
@@ -39,7 +39,7 @@ func (img *BaseContainer) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.Environment = img.Environment
 	osPipeline.Workload = img.Workload
 
-	ociPipeline := manifest.NewOCIContainer(m, buildPipeline, osPipeline)
+	ociPipeline := manifest.NewOCIContainer(buildPipeline, osPipeline)
 	ociPipeline.SetFilename(img.Filename)
 	artifact := ociPipeline.Export()
 

--- a/pkg/image/disk.go
+++ b/pkg/image/disk.go
@@ -58,7 +58,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.OSVersion = img.OSVersion
 	osPipeline.OSNick = img.OSNick
 
-	imagePipeline := manifest.NewRawImage(m, buildPipeline, osPipeline)
+	imagePipeline := manifest.NewRawImage(buildPipeline, osPipeline)
 	imagePipeline.PartTool = img.PartTool
 
 	var artifact *artifact.Artifact
@@ -79,7 +79,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 		artifactPipeline = qcow2Pipeline
 		artifact = qcow2Pipeline.Export()
 	case platform.FORMAT_VHD:
-		vpcPipeline := manifest.NewVPC(m, buildPipeline, imagePipeline)
+		vpcPipeline := manifest.NewVPC(buildPipeline, imagePipeline)
 		if img.Compression == "" {
 			vpcPipeline.SetFilename(img.Filename)
 		}
@@ -87,16 +87,16 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 		artifactPipeline = vpcPipeline
 		artifact = vpcPipeline.Export()
 	case platform.FORMAT_VMDK:
-		vmdkPipeline := manifest.NewVMDK(m, buildPipeline, imagePipeline, nil)
+		vmdkPipeline := manifest.NewVMDK(buildPipeline, imagePipeline)
 		if img.Compression == "" {
 			vmdkPipeline.SetFilename(img.Filename)
 		}
 		artifactPipeline = vmdkPipeline
 		artifact = vmdkPipeline.Export()
 	case platform.FORMAT_OVA:
-		vmdkPipeline := manifest.NewVMDK(m, buildPipeline, imagePipeline, nil)
-		ovfPipeline := manifest.NewOVF(m, buildPipeline, vmdkPipeline)
-		artifactPipeline := manifest.NewTar(m, buildPipeline, ovfPipeline, "archive")
+		vmdkPipeline := manifest.NewVMDK(buildPipeline, imagePipeline)
+		ovfPipeline := manifest.NewOVF(buildPipeline, vmdkPipeline)
+		artifactPipeline := manifest.NewTar(buildPipeline, ovfPipeline, "archive")
 		artifactPipeline.Format = osbuild.TarArchiveFormatUstar
 		artifactPipeline.RootNode = osbuild.TarRootNodeOmit
 		artifactPipeline.SetFilename(img.Filename)
@@ -105,7 +105,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 		// NOTE(akoutsou): temporary workaround; filename required for GCP
 		// TODO: define internal raw filename on image type
 		imagePipeline.SetFilename("disk.raw")
-		archivePipeline := manifest.NewTar(m, buildPipeline, imagePipeline, "archive")
+		archivePipeline := manifest.NewTar(buildPipeline, imagePipeline, "archive")
 		archivePipeline.Format = osbuild.TarArchiveFormatOldgnu
 		archivePipeline.RootNode = osbuild.TarRootNodeOmit
 		// these are required to successfully import the image to GCP

--- a/pkg/image/disk.go
+++ b/pkg/image/disk.go
@@ -71,7 +71,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 		artifactPipeline = imagePipeline
 		artifact = imagePipeline.Export()
 	case platform.FORMAT_QCOW2:
-		qcow2Pipeline := manifest.NewQCOW2(m, buildPipeline, imagePipeline)
+		qcow2Pipeline := manifest.NewQCOW2(buildPipeline, imagePipeline)
 		if img.Compression == "" {
 			qcow2Pipeline.SetFilename(img.Filename)
 		}
@@ -119,7 +119,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 
 	switch img.Compression {
 	case "xz":
-		xzPipeline := manifest.NewXZ(m, buildPipeline, artifactPipeline)
+		xzPipeline := manifest.NewXZ(buildPipeline, artifactPipeline)
 		xzPipeline.SetFilename(img.Filename)
 		artifact = xzPipeline.Export()
 	case "":

--- a/pkg/image/disk.go
+++ b/pkg/image/disk.go
@@ -66,14 +66,14 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 	switch img.Platform.GetImageFormat() {
 	case platform.FORMAT_RAW:
 		if img.Compression == "" {
-			imagePipeline.Filename = img.Filename
+			imagePipeline.SetFilename(img.Filename)
 		}
 		artifactPipeline = imagePipeline
 		artifact = imagePipeline.Export()
 	case platform.FORMAT_QCOW2:
 		qcow2Pipeline := manifest.NewQCOW2(m, buildPipeline, imagePipeline)
 		if img.Compression == "" {
-			qcow2Pipeline.Filename = img.Filename
+			qcow2Pipeline.SetFilename(img.Filename)
 		}
 		qcow2Pipeline.Compat = img.Platform.GetQCOW2Compat()
 		artifactPipeline = qcow2Pipeline
@@ -81,7 +81,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 	case platform.FORMAT_VHD:
 		vpcPipeline := manifest.NewVPC(m, buildPipeline, imagePipeline)
 		if img.Compression == "" {
-			vpcPipeline.Filename = img.Filename
+			vpcPipeline.SetFilename(img.Filename)
 		}
 		vpcPipeline.ForceSize = img.ForceSize
 		artifactPipeline = vpcPipeline
@@ -89,7 +89,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 	case platform.FORMAT_VMDK:
 		vmdkPipeline := manifest.NewVMDK(m, buildPipeline, imagePipeline, nil)
 		if img.Compression == "" {
-			vmdkPipeline.Filename = img.Filename
+			vmdkPipeline.SetFilename(img.Filename)
 		}
 		artifactPipeline = vmdkPipeline
 		artifact = vmdkPipeline.Export()
@@ -99,12 +99,12 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 		artifactPipeline := manifest.NewTar(m, buildPipeline, ovfPipeline, "archive")
 		artifactPipeline.Format = osbuild.TarArchiveFormatUstar
 		artifactPipeline.RootNode = osbuild.TarRootNodeOmit
-		artifactPipeline.Filename = img.Filename
+		artifactPipeline.SetFilename(img.Filename)
 		artifact = artifactPipeline.Export()
 	case platform.FORMAT_GCE:
 		// NOTE(akoutsou): temporary workaround; filename required for GCP
 		// TODO: define internal raw filename on image type
-		imagePipeline.Filename = "disk.raw"
+		imagePipeline.SetFilename("disk.raw")
 		archivePipeline := manifest.NewTar(m, buildPipeline, imagePipeline, "archive")
 		archivePipeline.Format = osbuild.TarArchiveFormatOldgnu
 		archivePipeline.RootNode = osbuild.TarRootNodeOmit
@@ -112,7 +112,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 		archivePipeline.ACLs = common.ToPtr(false)
 		archivePipeline.SELinux = common.ToPtr(false)
 		archivePipeline.Xattrs = common.ToPtr(false)
-		archivePipeline.Filename = img.Filename // filename extension will determine compression
+		archivePipeline.SetFilename(img.Filename) // filename extension will determine compression
 	default:
 		panic("invalid image format for image kind")
 	}
@@ -120,7 +120,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 	switch img.Compression {
 	case "xz":
 		xzPipeline := manifest.NewXZ(m, buildPipeline, artifactPipeline)
-		xzPipeline.Filename = img.Filename
+		xzPipeline.SetFilename(img.Filename)
 		artifact = xzPipeline.Export()
 	case "":
 		// do nothing

--- a/pkg/image/ostree_archive.go
+++ b/pkg/image/ostree_archive.go
@@ -56,10 +56,10 @@ func (img *OSTreeArchive) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.OSTreeRef = img.OSTreeRef
 	osPipeline.InstallWeakDeps = img.InstallWeakDeps
 
-	ostreeCommitPipeline := manifest.NewOSTreeCommit(m, buildPipeline, osPipeline, img.OSTreeRef)
+	ostreeCommitPipeline := manifest.NewOSTreeCommit(buildPipeline, osPipeline, img.OSTreeRef)
 	ostreeCommitPipeline.OSVersion = img.OSVersion
 
-	tarPipeline := manifest.NewTar(m, buildPipeline, &ostreeCommitPipeline.Base, "commit-archive")
+	tarPipeline := manifest.NewTar(buildPipeline, ostreeCommitPipeline, "commit-archive")
 	tarPipeline.SetFilename(img.Filename)
 	artifact := tarPipeline.Export()
 

--- a/pkg/image/ostree_archive.go
+++ b/pkg/image/ostree_archive.go
@@ -60,7 +60,7 @@ func (img *OSTreeArchive) InstantiateManifest(m *manifest.Manifest,
 	ostreeCommitPipeline.OSVersion = img.OSVersion
 
 	tarPipeline := manifest.NewTar(m, buildPipeline, &ostreeCommitPipeline.Base, "commit-archive")
-	tarPipeline.Filename = img.Filename
+	tarPipeline.SetFilename(img.Filename)
 	artifact := tarPipeline.Export()
 
 	return artifact, nil

--- a/pkg/image/ostree_container.go
+++ b/pkg/image/ostree_container.go
@@ -54,7 +54,7 @@ func (img *OSTreeContainer) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.OSTreeRef = img.OSTreeRef
 	osPipeline.OSTreeParent = img.OSTreeParent
 
-	commitPipeline := manifest.NewOSTreeCommit(m, buildPipeline, osPipeline, img.OSTreeRef)
+	commitPipeline := manifest.NewOSTreeCommit(buildPipeline, osPipeline, img.OSTreeRef)
 	commitPipeline.OSVersion = img.OSVersion
 
 	nginxConfigPath := "/etc/nginx.conf"
@@ -69,7 +69,7 @@ func (img *OSTreeContainer) InstantiateManifest(m *manifest.Manifest,
 		listenPort)
 	serverPipeline.Language = img.ContainerLanguage
 
-	containerPipeline := manifest.NewOCIContainer(m, buildPipeline, serverPipeline)
+	containerPipeline := manifest.NewOCIContainer(buildPipeline, serverPipeline)
 	containerPipeline.Cmd = []string{"nginx", "-c", nginxConfigPath}
 	containerPipeline.ExposedPorts = []string{listenPort}
 	containerPipeline.SetFilename(img.Filename)

--- a/pkg/image/ostree_container.go
+++ b/pkg/image/ostree_container.go
@@ -72,7 +72,7 @@ func (img *OSTreeContainer) InstantiateManifest(m *manifest.Manifest,
 	containerPipeline := manifest.NewOCIContainer(m, buildPipeline, serverPipeline)
 	containerPipeline.Cmd = []string{"nginx", "-c", nginxConfigPath}
 	containerPipeline.ExposedPorts = []string{listenPort}
-	containerPipeline.Filename = img.Filename
+	containerPipeline.SetFilename(img.Filename)
 	artifact := containerPipeline.Export()
 
 	return artifact, nil

--- a/pkg/image/ostree_raw.go
+++ b/pkg/image/ostree_raw.go
@@ -64,7 +64,7 @@ func ostreeCompressedImagePipelines(img *OSTreeRawImage, m *manifest.Manifest, b
 }
 
 func baseRawOstreeImage(img *OSTreeRawImage, m *manifest.Manifest, buildPipeline *manifest.Build) *manifest.RawOSTreeImage {
-	osPipeline := manifest.NewOSTreeDeployment(m, buildPipeline, img.CommitSource, img.OSName, img.Ignition, img.IgnitionPlatform, img.Platform)
+	osPipeline := manifest.NewOSTreeDeployment(buildPipeline, m, img.CommitSource, img.OSName, img.Ignition, img.IgnitionPlatform, img.Platform)
 	osPipeline.PartitionTable = img.PartitionTable
 	osPipeline.Remote = img.Remote
 	osPipeline.KernelOptionsAppend = img.KernelOptionsAppend
@@ -80,7 +80,7 @@ func baseRawOstreeImage(img *OSTreeRawImage, m *manifest.Manifest, buildPipeline
 	osPipeline.EnabledServices = img.Workload.GetServices()
 	osPipeline.DisabledServices = img.Workload.GetDisabledServices()
 
-	return manifest.NewRawOStreeImage(m, buildPipeline, img.Platform, osPipeline)
+	return manifest.NewRawOStreeImage(buildPipeline, osPipeline, img.Platform)
 }
 
 func (img *OSTreeRawImage) InstantiateManifest(m *manifest.Manifest,
@@ -97,7 +97,7 @@ func (img *OSTreeRawImage) InstantiateManifest(m *manifest.Manifest,
 			panic(fmt.Sprintf("no compression is allowed with VMDK format for %q", img.name))
 		}
 		ostreeBase := baseRawOstreeImage(img, m, buildPipeline)
-		vmdkPipeline := manifest.NewVMDK(m, buildPipeline, nil, ostreeBase)
+		vmdkPipeline := manifest.NewVMDK(buildPipeline, ostreeBase)
 		vmdkPipeline.SetFilename(img.Filename)
 		art = vmdkPipeline.Export()
 	default:

--- a/pkg/image/ostree_raw.go
+++ b/pkg/image/ostree_raw.go
@@ -39,9 +39,9 @@ type OSTreeRawImage struct {
 
 	Filename string
 
-	Compression string
-
-	Ignition bool
+	Ignition         bool
+	IgnitionPlatform string
+	Compression      string
 
 	Directories []*fsnode.Directory
 	Files       []*fsnode.File
@@ -64,7 +64,7 @@ func ostreeCompressedImagePipelines(img *OSTreeRawImage, m *manifest.Manifest, b
 }
 
 func baseRawOstreeImage(img *OSTreeRawImage, m *manifest.Manifest, buildPipeline *manifest.Build) *manifest.RawOSTreeImage {
-	osPipeline := manifest.NewOSTreeDeployment(m, buildPipeline, img.CommitSource, img.OSName, img.Ignition, img.Platform)
+	osPipeline := manifest.NewOSTreeDeployment(m, buildPipeline, img.CommitSource, img.OSName, img.Ignition, img.IgnitionPlatform, img.Platform)
 	osPipeline.PartitionTable = img.PartitionTable
 	osPipeline.Remote = img.Remote
 	osPipeline.KernelOptionsAppend = img.KernelOptionsAppend

--- a/pkg/image/ostree_raw.go
+++ b/pkg/image/ostree_raw.go
@@ -57,7 +57,7 @@ func NewOSTreeRawImage(commit ostree.SourceSpec) *OSTreeRawImage {
 func ostreeCompressedImagePipelines(img *OSTreeRawImage, m *manifest.Manifest, buildPipeline *manifest.Build) *manifest.XZ {
 	imagePipeline := baseRawOstreeImage(img, m, buildPipeline)
 
-	xzPipeline := manifest.NewXZ(m, buildPipeline, imagePipeline)
+	xzPipeline := manifest.NewXZ(buildPipeline, imagePipeline)
 	xzPipeline.SetFilename(img.Filename)
 
 	return xzPipeline

--- a/pkg/image/ostree_raw.go
+++ b/pkg/image/ostree_raw.go
@@ -58,7 +58,7 @@ func ostreeCompressedImagePipelines(img *OSTreeRawImage, m *manifest.Manifest, b
 	imagePipeline := baseRawOstreeImage(img, m, buildPipeline)
 
 	xzPipeline := manifest.NewXZ(m, buildPipeline, imagePipeline)
-	xzPipeline.Filename = img.Filename
+	xzPipeline.SetFilename(img.Filename)
 
 	return xzPipeline
 }
@@ -98,7 +98,7 @@ func (img *OSTreeRawImage) InstantiateManifest(m *manifest.Manifest,
 		}
 		ostreeBase := baseRawOstreeImage(img, m, buildPipeline)
 		vmdkPipeline := manifest.NewVMDK(m, buildPipeline, nil, ostreeBase)
-		vmdkPipeline.Filename = img.Filename
+		vmdkPipeline.SetFilename(img.Filename)
 		art = vmdkPipeline.Export()
 	default:
 		switch img.Compression {
@@ -107,7 +107,7 @@ func (img *OSTreeRawImage) InstantiateManifest(m *manifest.Manifest,
 			art = ostreeCompressed.Export()
 		case "":
 			ostreeBase := baseRawOstreeImage(img, m, buildPipeline)
-			ostreeBase.Filename = img.Filename
+			ostreeBase.SetFilename(img.Filename)
 			art = ostreeBase.Export()
 		default:
 			panic(fmt.Sprintf("unsupported compression type %q on %q", img.Compression, img.name))

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -79,7 +79,9 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	// create the raw image
 	img.rawImage.Filename = rawImageFilename
-	rawImage := ostreeCompressedImagePipelines(img.rawImage, m, buildPipeline)
+
+	// image in simplified installer is always compressed
+	compressedImage := ostreeCompressedImagePipelines(img.rawImage, m, buildPipeline)
 
 	coiPipeline := manifest.NewCoreOSInstaller(m,
 		buildPipeline,
@@ -149,7 +151,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	isoTreePipeline := manifest.NewCoreOSISOTree(m,
 		buildPipeline,
-		rawImage,
+		compressedImage,
 		coiPipeline,
 		bootTreePipeline,
 		isoLabel)

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -75,13 +75,11 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	buildPipeline := manifest.NewBuild(m, runner, repos)
 	buildPipeline.Checkpoint()
 
-	rawImageFilename := "image.raw.xz"
-
-	// create the raw image
-	img.rawImage.Filename = rawImageFilename
+	imageFilename := "image.raw.xz"
 
 	// image in simplified installer is always compressed
-	compressedImage := ostreeCompressedImagePipelines(img.rawImage, m, buildPipeline)
+	compressedImage := manifest.NewXZ(buildPipeline, baseRawOstreeImage(img.rawImage, m, buildPipeline))
+	compressedImage.SetFilename(imageFilename)
 
 	coiPipeline := manifest.NewCoreOSInstaller(m,
 		buildPipeline,
@@ -111,7 +109,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 		"coreos.inst.crypt_root=1",
 		"coreos.inst.isoroot=" + isoLabel,
 		"coreos.inst.install_dev=" + img.installDevice,
-		fmt.Sprintf("coreos.inst.image_file=/run/media/iso/%s", rawImageFilename),
+		fmt.Sprintf("coreos.inst.image_file=/run/media/iso/%s", imageFilename),
 		"coreos.inst.insecure",
 	}
 
@@ -153,7 +151,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.KernelOpts = kernelOpts
 	isoTreePipeline.PartitionTable = rootfsPartitionTable
 	isoTreePipeline.OSName = img.OSName
-	isoTreePipeline.PayloadPath = fmt.Sprintf("/%s", rawImageFilename)
+	isoTreePipeline.PayloadPath = fmt.Sprintf("/%s", imageFilename)
 	isoTreePipeline.ISOLinux = isoLinuxEnabled
 
 	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, isoLabel)

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -149,19 +149,14 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	// enable ISOLinux on x86_64 only
 	isoLinuxEnabled := img.Platform.GetArch() == platform.ARCH_X86_64
 
-	isoTreePipeline := manifest.NewCoreOSISOTree(m,
-		buildPipeline,
-		compressedImage,
-		coiPipeline,
-		bootTreePipeline,
-		isoLabel)
+	isoTreePipeline := manifest.NewCoreOSISOTree(buildPipeline, compressedImage, coiPipeline, bootTreePipeline)
 	isoTreePipeline.KernelOpts = kernelOpts
 	isoTreePipeline.PartitionTable = rootfsPartitionTable
 	isoTreePipeline.OSName = img.OSName
 	isoTreePipeline.PayloadPath = fmt.Sprintf("/%s", rawImageFilename)
 	isoTreePipeline.ISOLinux = isoLinuxEnabled
 
-	isoPipeline := manifest.NewISO(m, buildPipeline, isoTreePipeline, isoLabel)
+	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, isoLabel)
 	isoPipeline.SetFilename(img.Filename)
 	isoPipeline.ISOLinux = isoLinuxEnabled
 

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -162,7 +162,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.ISOLinux = isoLinuxEnabled
 
 	isoPipeline := manifest.NewISO(m, buildPipeline, isoTreePipeline, isoLabel)
-	isoPipeline.Filename = img.Filename
+	isoPipeline.SetFilename(img.Filename)
 	isoPipeline.ISOLinux = isoLinuxEnabled
 
 	artifact := isoPipeline.Export()

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -21,7 +21,7 @@ type OSTreeSimplifiedInstaller struct {
 	Base
 
 	// Raw image that will be created and embedded
-	rawImage *OSTreeRawImage
+	rawImage *OSTreeDiskImage
 
 	Platform         platform.Platform
 	OSCustomizations manifest.OSCustomizations
@@ -60,7 +60,7 @@ type OSTreeSimplifiedInstaller struct {
 	AdditionalDracutModules []string
 }
 
-func NewOSTreeSimplifiedInstaller(rawImage *OSTreeRawImage, installDevice string) *OSTreeSimplifiedInstaller {
+func NewOSTreeSimplifiedInstaller(rawImage *OSTreeDiskImage, installDevice string) *OSTreeSimplifiedInstaller {
 	return &OSTreeSimplifiedInstaller{
 		Base:          NewBase("ostree-simplified-installer"),
 		rawImage:      rawImage,

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -367,7 +367,7 @@ func dracutStageOptions(kernelVer string, biosdevname bool, additionalModules []
 	}
 }
 
-func (p *AnacondaInstaller) GetPlatform() platform.Platform {
+func (p *AnacondaInstaller) Platform() platform.Platform {
 	return p.platform
 }
 

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -55,25 +55,22 @@ type AnacondaInstallerISOTree struct {
 	ISOLinux bool
 }
 
-func NewAnacondaInstallerISOTree(m *Manifest,
-	buildPipeline *Build,
-	anacondaPipeline *AnacondaInstaller,
-	rootfsPipeline *ISORootfsImg,
-	bootTreePipeline *EFIBootTree,
-	isoLabel string) *AnacondaInstallerISOTree {
+func NewAnacondaInstallerISOTree(buildPipeline *Build, anacondaPipeline *AnacondaInstaller, rootfsPipeline *ISORootfsImg, bootTreePipeline *EFIBootTree) *AnacondaInstallerISOTree {
 
+	// the three pipelines should all belong to the same manifest
+	if anacondaPipeline.Manifest() != rootfsPipeline.Manifest() ||
+		anacondaPipeline.Manifest() != bootTreePipeline.Manifest() {
+		panic("pipelines from different manifests")
+	}
 	p := &AnacondaInstallerISOTree{
-		Base:             NewBase(m, "bootiso-tree", buildPipeline),
+		Base:             NewBase(anacondaPipeline.Manifest(), "bootiso-tree", buildPipeline),
 		anacondaPipeline: anacondaPipeline,
 		rootfsPipeline:   rootfsPipeline,
 		bootTreePipeline: bootTreePipeline,
-		isoLabel:         isoLabel,
+		isoLabel:         bootTreePipeline.ISOLabel,
 	}
 	buildPipeline.addDependent(p)
-	if anacondaPipeline.Base.manifest != m {
-		panic("anaconda pipeline from different manifest")
-	}
-	m.addPipeline(p)
+	anacondaPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/coi_iso_tree.go
+++ b/pkg/manifest/coi_iso_tree.go
@@ -35,25 +35,27 @@ type CoreOSISOTree struct {
 	KernelOpts []string
 }
 
-func NewCoreOSISOTree(m *Manifest,
+func NewCoreOSISOTree(
 	buildPipeline *Build,
 	payloadPipeline *XZ,
 	coiPipeline *CoreOSInstaller,
-	bootTreePipeline *EFIBootTree,
-	isoLabel string) *CoreOSISOTree {
+	bootTreePipeline *EFIBootTree) *CoreOSISOTree {
+
+	// the three pipelines should all belong to the same manifest
+	if payloadPipeline.Manifest() != coiPipeline.Manifest() ||
+		payloadPipeline.Manifest() != bootTreePipeline.Manifest() {
+		panic("pipelines from different manifests")
+	}
 
 	p := &CoreOSISOTree{
-		Base:             NewBase(m, "bootiso-tree", buildPipeline),
+		Base:             NewBase(coiPipeline.Manifest(), "bootiso-tree", buildPipeline),
 		payloadPipeline:  payloadPipeline,
 		coiPipeline:      coiPipeline,
 		bootTreePipeline: bootTreePipeline,
-		isoLabel:         isoLabel,
+		isoLabel:         bootTreePipeline.ISOLabel,
 	}
 	buildPipeline.addDependent(p)
-	if coiPipeline.Base.manifest != m {
-		panic("anaconda pipeline from different manifest")
-	}
-	m.addPipeline(p)
+	coiPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/coi_iso_tree.go
+++ b/pkg/manifest/coi_iso_tree.go
@@ -64,12 +64,12 @@ func (p *CoreOSISOTree) serialize() osbuild.Pipeline {
 		&osbuild.CopyStageOptions{
 			Paths: []osbuild.CopyStagePath{
 				{
-					From: fmt.Sprintf("input://file/%s", p.payloadPipeline.Filename),
+					From: fmt.Sprintf("input://file/%s", p.payloadPipeline.Filename()),
 					To:   fmt.Sprintf("tree://%s", p.PayloadPath),
 				},
 			},
 		},
-		osbuild.NewXzStageInputs(osbuild.NewFilesInputPipelineObjectRef(p.payloadPipeline.Name(), p.payloadPipeline.Filename, nil)),
+		osbuild.NewXzStageInputs(osbuild.NewFilesInputPipelineObjectRef(p.payloadPipeline.Name(), p.payloadPipeline.Filename(), nil)),
 	))
 
 	if p.coiPipeline.Ignition != nil {

--- a/pkg/manifest/commit.go
+++ b/pkg/manifest/commit.go
@@ -16,20 +16,14 @@ type OSTreeCommit struct {
 // NewOSTreeCommit creates a new OSTree commit pipeline. The
 // treePipeline is the tree representing the content of the commit.
 // ref is the ref to create the commit under.
-func NewOSTreeCommit(m *Manifest,
-	buildPipeline *Build,
-	treePipeline *OS,
-	ref string) *OSTreeCommit {
+func NewOSTreeCommit(buildPipeline *Build, treePipeline *OS, ref string) *OSTreeCommit {
 	p := &OSTreeCommit{
-		Base:         NewBase(m, "ostree-commit", buildPipeline),
+		Base:         NewBase(treePipeline.Manifest(), "ostree-commit", buildPipeline),
 		treePipeline: treePipeline,
 		ref:          ref,
 	}
-	if treePipeline.Base.manifest != m {
-		panic("tree pipeline from different manifest")
-	}
 	buildPipeline.addDependent(p)
-	m.addPipeline(p)
+	treePipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/commit_server_tree.go
+++ b/pkg/manifest/commit_server_tree.go
@@ -149,6 +149,6 @@ func chmodStageOptions(path, mode string, recursive bool) *osbuild.ChmodStageOpt
 	}
 }
 
-func (p *OSTreeCommitServer) GetPlatform() platform.Platform {
+func (p *OSTreeCommitServer) Platform() platform.Platform {
 	return p.platform
 }

--- a/pkg/manifest/coreos_installer.go
+++ b/pkg/manifest/coreos_installer.go
@@ -66,8 +66,10 @@ func NewCoreOSInstaller(m *Manifest,
 	return p
 }
 
-// TODO: refactor - what is required to boot and what to build, and
-// do they all belong in this pipeline?
+// TODO: refactor:
+// - what is required to boot and what to build?
+// - do they all belong in this pipeline?
+// - should these be moved to the platform for the image type?
 func (p *CoreOSInstaller) getBootPackages() []string {
 	packages := []string{
 		"grub2-tools",
@@ -76,6 +78,11 @@ func (p *CoreOSInstaller) getBootPackages() []string {
 		"efibootmgr",
 	}
 
+	packages = append(packages, p.platform.GetPackages()...)
+
+	// TODO: Move these to the platform?
+	// For Fedora, this will add a lot of duplicates, but we also add them here
+	// for RHEL and CentOS.
 	switch p.platform.GetArch() {
 	case platform.ARCH_X86_64:
 		packages = append(packages,
@@ -95,6 +102,10 @@ func (p *CoreOSInstaller) getBootPackages() []string {
 		)
 	default:
 		panic(fmt.Sprintf("unsupported arch: %s", p.platform.GetArch()))
+	}
+
+	if p.Biosdevname {
+		packages = append(packages, "biosdevname")
 	}
 
 	return packages

--- a/pkg/manifest/coreos_installer.go
+++ b/pkg/manifest/coreos_installer.go
@@ -185,6 +185,6 @@ func (p *CoreOSInstaller) serialize() osbuild.Pipeline {
 	return pipeline
 }
 
-func (p *CoreOSInstaller) GetPlatform() platform.Platform {
+func (p *CoreOSInstaller) Platform() platform.Platform {
 	return p.platform
 }

--- a/pkg/manifest/iso.go
+++ b/pkg/manifest/iso.go
@@ -24,18 +24,15 @@ func (p *ISO) SetFilename(filename string) {
 	p.filename = filename
 }
 
-func NewISO(m *Manifest,
-	buildPipeline *Build,
-	treePipeline Pipeline,
-	isoLabel string) *ISO {
+func NewISO(buildPipeline *Build, treePipeline Pipeline, isoLabel string) *ISO {
 	p := &ISO{
-		Base:         NewBase(m, "bootiso", buildPipeline),
+		Base:         NewBase(treePipeline.Manifest(), "bootiso", buildPipeline),
 		treePipeline: treePipeline,
 		filename:     "image.iso",
 		isoLabel:     isoLabel,
 	}
 	buildPipeline.addDependent(p)
-	m.addPipeline(p)
+	treePipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/iso.go
+++ b/pkg/manifest/iso.go
@@ -10,10 +10,18 @@ import (
 type ISO struct {
 	Base
 	ISOLinux bool
-	Filename string
+	filename string
 
 	treePipeline Pipeline
 	isoLabel     string
+}
+
+func (p ISO) Filename() string {
+	return p.filename
+}
+
+func (p *ISO) SetFilename(filename string) {
+	p.filename = filename
 }
 
 func NewISO(m *Manifest,
@@ -23,7 +31,7 @@ func NewISO(m *Manifest,
 	p := &ISO{
 		Base:         NewBase(m, "bootiso", buildPipeline),
 		treePipeline: treePipeline,
-		Filename:     "image.iso",
+		filename:     "image.iso",
 		isoLabel:     isoLabel,
 	}
 	buildPipeline.addDependent(p)
@@ -41,8 +49,8 @@ func (p *ISO) getBuildPackages(Distro) []string {
 func (p *ISO) serialize() osbuild.Pipeline {
 	pipeline := p.Base.serialize()
 
-	pipeline.AddStage(osbuild.NewXorrisofsStage(xorrisofsStageOptions(p.Filename, p.isoLabel, p.ISOLinux), p.treePipeline.Name()))
-	pipeline.AddStage(osbuild.NewImplantisomd5Stage(&osbuild.Implantisomd5StageOptions{Filename: p.Filename}))
+	pipeline.AddStage(osbuild.NewXorrisofsStage(xorrisofsStageOptions(p.Filename(), p.isoLabel, p.ISOLinux), p.treePipeline.Name()))
+	pipeline.AddStage(osbuild.NewImplantisomd5Stage(&osbuild.Implantisomd5StageOptions{Filename: p.Filename()}))
 
 	return pipeline
 }
@@ -71,5 +79,5 @@ func xorrisofsStageOptions(filename, isolabel string, isolinux bool) *osbuild.Xo
 func (p *ISO) Export() *artifact.Artifact {
 	p.Base.export = true
 	mimeType := "application/x-iso9660-image"
-	return artifact.New(p.Name(), p.Filename, &mimeType)
+	return artifact.New(p.Name(), p.Filename(), &mimeType)
 }

--- a/pkg/manifest/iso_rootfs.go
+++ b/pkg/manifest/iso_rootfs.go
@@ -14,13 +14,13 @@ type ISORootfsImg struct {
 	installerPipeline Pipeline
 }
 
-func NewISORootfsImg(m *Manifest, buildPipeline *Build, installerPipeline Pipeline) *ISORootfsImg {
+func NewISORootfsImg(buildPipeline *Build, installerPipeline Pipeline) *ISORootfsImg {
 	p := &ISORootfsImg{
-		Base:              NewBase(m, "rootfs-image", buildPipeline),
+		Base:              NewBase(installerPipeline.Manifest(), "rootfs-image", buildPipeline),
 		installerPipeline: installerPipeline,
 	}
 	buildPipeline.addDependent(p)
-	m.addPipeline(p)
+	installerPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/oci_container.go
+++ b/pkg/manifest/oci_container.go
@@ -24,19 +24,14 @@ func (p *OCIContainer) SetFilename(filename string) {
 	p.filename = filename
 }
 
-func NewOCIContainer(m *Manifest,
-	buildPipeline *Build,
-	treePipeline TreePipeline) *OCIContainer {
+func NewOCIContainer(buildPipeline *Build, treePipeline TreePipeline) *OCIContainer {
 	p := &OCIContainer{
-		Base:         NewBase(m, "container", buildPipeline),
+		Base:         NewBase(treePipeline.Manifest(), "container", buildPipeline),
 		treePipeline: treePipeline,
 		filename:     "oci-archive.tar",
 	}
-	if treePipeline.Manifest() != m {
-		panic("tree pipeline from different manifest")
-	}
 	buildPipeline.addDependent(p)
-	m.addPipeline(p)
+	treePipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/oci_container.go
+++ b/pkg/manifest/oci_container.go
@@ -32,7 +32,7 @@ func NewOCIContainer(m *Manifest,
 		treePipeline: treePipeline,
 		filename:     "oci-archive.tar",
 	}
-	if treePipeline.GetManifest() != m {
+	if treePipeline.Manifest() != m {
 		panic("tree pipeline from different manifest")
 	}
 	buildPipeline.addDependent(p)
@@ -44,7 +44,7 @@ func (p *OCIContainer) serialize() osbuild.Pipeline {
 	pipeline := p.Base.serialize()
 
 	options := &osbuild.OCIArchiveStageOptions{
-		Architecture: p.treePipeline.GetPlatform().GetArch().String(),
+		Architecture: p.treePipeline.Platform().GetArch().String(),
 		Filename:     p.Filename(),
 		Config: &osbuild.OCIArchiveConfig{
 			Cmd:          p.Cmd,

--- a/pkg/manifest/oci_container.go
+++ b/pkg/manifest/oci_container.go
@@ -9,20 +9,28 @@ import (
 // tree created by another Pipeline.
 type OCIContainer struct {
 	Base
-	Filename     string
+	filename     string
 	Cmd          []string
 	ExposedPorts []string
 
-	treePipeline Tree
+	treePipeline TreePipeline
+}
+
+func (p OCIContainer) Filename() string {
+	return p.filename
+}
+
+func (p *OCIContainer) SetFilename(filename string) {
+	p.filename = filename
 }
 
 func NewOCIContainer(m *Manifest,
 	buildPipeline *Build,
-	treePipeline Tree) *OCIContainer {
+	treePipeline TreePipeline) *OCIContainer {
 	p := &OCIContainer{
 		Base:         NewBase(m, "container", buildPipeline),
 		treePipeline: treePipeline,
-		Filename:     "oci-archive.tar",
+		filename:     "oci-archive.tar",
 	}
 	if treePipeline.GetManifest() != m {
 		panic("tree pipeline from different manifest")
@@ -37,7 +45,7 @@ func (p *OCIContainer) serialize() osbuild.Pipeline {
 
 	options := &osbuild.OCIArchiveStageOptions{
 		Architecture: p.treePipeline.GetPlatform().GetArch().String(),
-		Filename:     p.Filename,
+		Filename:     p.Filename(),
 		Config: &osbuild.OCIArchiveConfig{
 			Cmd:          p.Cmd,
 			ExposedPorts: p.ExposedPorts,
@@ -57,5 +65,5 @@ func (p *OCIContainer) getBuildPackages(Distro) []string {
 func (p *OCIContainer) Export() *artifact.Artifact {
 	p.Base.export = true
 	mimeType := "application/x-tar"
-	return artifact.New(p.Name(), p.Filename, &mimeType)
+	return artifact.New(p.Name(), p.Filename(), &mimeType)
 }

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -797,7 +797,7 @@ func usersFirstBootOptions(users []users.User) *osbuild.FirstBootStageOptions {
 	return options
 }
 
-func (p *OS) GetPlatform() platform.Platform {
+func (p *OS) Platform() platform.Platform {
 	return p.platform
 }
 

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -123,6 +123,7 @@ type OSCustomizations struct {
 	WSLConfig            *osbuild.WSLConfStageOptions
 	LeapSecTZ            *string
 	FactAPIType          *facts.APIType
+	Presets              []osbuild.Preset
 
 	Subscription *subscription.ImageOptions
 	RHSMConfig   map[subscription.RHSMStatus]*osbuild.RHSMStageOptions
@@ -730,6 +731,12 @@ func (p *OS) serialize() osbuild.Pipeline {
 	// hardened image
 	if p.OpenSCAPConfig != nil {
 		pipeline.AddStage(osbuild.NewOscapRemediationStage(p.OpenSCAPConfig))
+	}
+
+	if len(p.Presets) != 0 {
+		pipeline.AddStage(osbuild.NewSystemdPresetStage(&osbuild.SystemdPresetStageOptions{
+			Presets: p.Presets,
+		}))
 	}
 
 	if p.SElinux != "" {

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -57,8 +57,8 @@ type OSTreeDeployment struct {
 
 // NewOSTreeDeployment creates a pipeline for an ostree deployment from a
 // commit.
-func NewOSTreeDeployment(m *Manifest,
-	buildPipeline *Build,
+func NewOSTreeDeployment(buildPipeline *Build,
+	m *Manifest,
 	commit ostree.SourceSpec,
 	osName string,
 	ignition bool,

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -45,6 +45,9 @@ type OSTreeDeployment struct {
 	// Whether ignition is in use or not
 	ignition bool
 
+	// Specifies the ignition platform to use
+	ignitionPlatform string
+
 	Directories []*fsnode.Directory
 	Files       []*fsnode.File
 
@@ -59,14 +62,16 @@ func NewOSTreeDeployment(m *Manifest,
 	commit ostree.SourceSpec,
 	osName string,
 	ignition bool,
+	ignitionPlatform string,
 	platform platform.Platform) *OSTreeDeployment {
 
 	p := &OSTreeDeployment{
-		Base:         NewBase(m, "ostree-deployment", buildPipeline),
-		commitSource: commit,
-		osName:       osName,
-		platform:     platform,
-		ignition:     ignition,
+		Base:             NewBase(m, "ostree-deployment", buildPipeline),
+		commitSource:     commit,
+		osName:           osName,
+		platform:         platform,
+		ignition:         ignition,
+		ignitionPlatform: ignitionPlatform,
 	}
 	buildPipeline.addDependent(p)
 	m.addPipeline(p)
@@ -145,9 +150,12 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 	kernelOpts = append(kernelOpts, p.KernelOptionsAppend...)
 
 	if p.ignition {
+		if p.ignitionPlatform == "" {
+			panic("ignition is enabled but ignition platform ID is not set")
+		}
 		kernelOpts = append(kernelOpts,
 			"coreos.no_persist_ip", // users cannot add connections as we don't have a live iso, this prevents connections to bleed into the system from the ign initrd
-			"ignition.platform.id=metal",
+			"ignition.platform.id="+p.ignitionPlatform,
 			"$ignition_firstboot",
 		)
 	}

--- a/pkg/manifest/ovf.go
+++ b/pkg/manifest/ovf.go
@@ -46,7 +46,7 @@ func (p *OVF) serialize() osbuild.Pipeline {
 	))
 
 	pipeline.AddStage(osbuild.NewOVFStage(&osbuild.OVFStageOptions{
-		Vmdk: p.imgPipeline.Filename,
+		Vmdk: p.imgPipeline.Filename(),
 	}))
 
 	return pipeline

--- a/pkg/manifest/ovf.go
+++ b/pkg/manifest/ovf.go
@@ -14,18 +14,13 @@ type OVF struct {
 }
 
 // NewOVF creates a new OVF pipeline. imgPipeline is the pipeline producing the vmdk image.
-func NewOVF(m *Manifest,
-	buildPipeline *Build,
-	imgPipeline *VMDK) *OVF {
+func NewOVF(buidPipeline *Build, imgPipeline *VMDK) *OVF {
 	p := &OVF{
-		Base:        NewBase(m, "ovf", buildPipeline),
+		Base:        NewBase(imgPipeline.Manifest(), "ovf", buidPipeline),
 		imgPipeline: imgPipeline,
 	}
-	if imgPipeline.Base.manifest != m {
-		panic("live image pipeline from different manifest")
-	}
-	buildPipeline.addDependent(p)
-	m.addPipeline(p)
+	buidPipeline.addDependent(p)
+	imgPipeline.Manifest().addPipeline(p)
 	return p
 }
 
@@ -36,7 +31,7 @@ func (p *OVF) serialize() osbuild.Pipeline {
 	pipeline.AddStage(osbuild.NewCopyStageSimple(
 		&osbuild.CopyStageOptions{
 			Paths: []osbuild.CopyStagePath{
-				osbuild.CopyStagePath{
+				{
 					From: fmt.Sprintf("input://%s/%s", inputName, p.imgPipeline.Export().Filename()),
 					To:   "tree:///",
 				},

--- a/pkg/manifest/pipeline.go
+++ b/pkg/manifest/pipeline.go
@@ -176,8 +176,16 @@ func (p Base) serialize() osbuild.Pipeline {
 	return pipeline
 }
 
-type Tree interface {
+// TreePipeline is any pipeline that produces a directory tree.
+type TreePipeline interface {
 	Name() string
 	GetManifest() *Manifest
 	GetPlatform() platform.Platform
+}
+
+// FilePipeline is any pipeline that produces a single file (typically an image file).
+type FilePipeline interface {
+	Pipeline
+	Filename() string
+	SetFilename(fname string)
 }

--- a/pkg/manifest/pipeline.go
+++ b/pkg/manifest/pipeline.go
@@ -191,6 +191,7 @@ func (p Base) serialize() osbuild.Pipeline {
 type TreePipeline interface {
 	Name() string
 	Manifest() *Manifest
+	BuildPipeline() *Build
 	Platform() platform.Platform
 }
 

--- a/pkg/manifest/pipeline.go
+++ b/pkg/manifest/pipeline.go
@@ -23,6 +23,13 @@ type Pipeline interface {
 	// Export this tree of this pipeline as an artifact when osbuild is called.
 	Export() *artifact.Artifact
 
+	// BuildPipeline returns a reference to the pipeline that creates the build
+	// root for this pipeline. For build pipelines, it should return nil.
+	BuildPipeline() *Build
+
+	// Manifest returns a reference to the Manifest which this Pipeline belongs to.
+	Manifest() *Manifest
+
 	getCheckpoint() bool
 
 	getExport() bool
@@ -95,7 +102,11 @@ func (p Base) getExport() bool {
 	return p.export
 }
 
-func (p Base) GetManifest() *Manifest {
+func (p Base) BuildPipeline() *Build {
+	return p.build
+}
+
+func (p Base) Manifest() *Manifest {
 	return p.manifest
 }
 
@@ -179,8 +190,8 @@ func (p Base) serialize() osbuild.Pipeline {
 // TreePipeline is any pipeline that produces a directory tree.
 type TreePipeline interface {
 	Name() string
-	GetManifest() *Manifest
-	GetPlatform() platform.Platform
+	Manifest() *Manifest
+	Platform() platform.Platform
 }
 
 // FilePipeline is any pipeline that produces a single file (typically an image file).

--- a/pkg/manifest/qcow2.go
+++ b/pkg/manifest/qcow2.go
@@ -8,10 +8,18 @@ import (
 // A QCOW2 turns a raw image file into qcow2 image.
 type QCOW2 struct {
 	Base
-	Filename string
+	filename string
 	Compat   string
 
 	imgPipeline *RawImage
+}
+
+func (p QCOW2) Filename() string {
+	return p.filename
+}
+
+func (p *QCOW2) SetFilename(filename string) {
+	p.filename = filename
 }
 
 // NewQCOW2 createsa new QCOW2 pipeline. imgPipeline is the pipeline producing the
@@ -23,7 +31,7 @@ func NewQCOW2(m *Manifest,
 	p := &QCOW2{
 		Base:        NewBase(m, "qcow2", buildPipeline),
 		imgPipeline: imgPipeline,
-		Filename:    "image.qcow2",
+		filename:    "image.qcow2",
 	}
 	if imgPipeline.Base.manifest != m {
 		panic("live image pipeline from different manifest")
@@ -37,12 +45,12 @@ func (p *QCOW2) serialize() osbuild.Pipeline {
 	pipeline := p.Base.serialize()
 
 	pipeline.AddStage(osbuild.NewQEMUStage(
-		osbuild.NewQEMUStageOptions(p.Filename,
+		osbuild.NewQEMUStageOptions(p.Filename(),
 			osbuild.QEMUFormatQCOW2,
 			osbuild.QCOW2Options{
 				Compat: p.Compat,
 			}),
-		osbuild.NewQemuStagePipelineFilesInputs(p.imgPipeline.Name(), p.imgPipeline.Filename),
+		osbuild.NewQemuStagePipelineFilesInputs(p.imgPipeline.Name(), p.imgPipeline.Filename()),
 	))
 
 	return pipeline
@@ -55,5 +63,5 @@ func (p *QCOW2) getBuildPackages(Distro) []string {
 func (p *QCOW2) Export() *artifact.Artifact {
 	p.Base.export = true
 	mimeType := "application/x-qemu-disk"
-	return artifact.New(p.Name(), p.Filename, &mimeType)
+	return artifact.New(p.Name(), p.Filename(), &mimeType)
 }

--- a/pkg/manifest/qcow2.go
+++ b/pkg/manifest/qcow2.go
@@ -11,7 +11,7 @@ type QCOW2 struct {
 	filename string
 	Compat   string
 
-	imgPipeline *RawImage
+	imgPipeline FilePipeline
 }
 
 func (p QCOW2) Filename() string {
@@ -25,19 +25,14 @@ func (p *QCOW2) SetFilename(filename string) {
 // NewQCOW2 createsa new QCOW2 pipeline. imgPipeline is the pipeline producing the
 // raw image. The pipeline name is the name of the new pipeline. Filename is the name
 // of the produced qcow2 image.
-func NewQCOW2(m *Manifest,
-	buildPipeline *Build,
-	imgPipeline *RawImage) *QCOW2 {
+func NewQCOW2(buildPipeline *Build, imgPipeline FilePipeline) *QCOW2 {
 	p := &QCOW2{
-		Base:        NewBase(m, "qcow2", buildPipeline),
+		Base:        NewBase(imgPipeline.Manifest(), "qcow2", buildPipeline),
 		imgPipeline: imgPipeline,
 		filename:    "image.qcow2",
 	}
-	if imgPipeline.Base.manifest != m {
-		panic("live image pipeline from different manifest")
-	}
 	buildPipeline.addDependent(p)
-	m.addPipeline(p)
+	imgPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/raw.go
+++ b/pkg/manifest/raw.go
@@ -23,20 +23,15 @@ func (p *RawImage) SetFilename(filename string) {
 	p.filename = filename
 }
 
-func NewRawImage(m *Manifest,
-	buildPipeline *Build,
-	treePipeline *OS) *RawImage {
+func NewRawImage(buildPipeline *Build, treePipeline *OS) *RawImage {
 	p := &RawImage{
-		Base:         NewBase(m, "image", buildPipeline),
+		Base:         NewBase(treePipeline.Manifest(), "image", buildPipeline),
 		treePipeline: treePipeline,
 		filename:     "disk.img",
 	}
 	buildPipeline.addDependent(p)
-	if treePipeline.Base.manifest != m {
-		panic("tree pipeline from different manifest")
-	}
 	p.PartTool = osbuild.PTSfdisk // default; can be changed after initialisation
-	m.addPipeline(p)
+	treePipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/raw_ostree.go
+++ b/pkg/manifest/raw_ostree.go
@@ -25,21 +25,15 @@ func (p *RawOSTreeImage) SetFilename(filename string) {
 	p.filename = filename
 }
 
-func NewRawOStreeImage(m *Manifest,
-	buildPipeline *Build,
-	platform platform.Platform,
-	treePipeline *OSTreeDeployment) *RawOSTreeImage {
+func NewRawOStreeImage(buildPipeline *Build, treePipeline *OSTreeDeployment, platform platform.Platform) *RawOSTreeImage {
 	p := &RawOSTreeImage{
-		Base:         NewBase(m, "image", buildPipeline),
+		Base:         NewBase(treePipeline.Manifest(), "image", buildPipeline),
 		treePipeline: treePipeline,
 		filename:     "disk.img",
 		platform:     platform,
 	}
 	buildPipeline.addDependent(p)
-	if treePipeline.Base.manifest != m {
-		panic("tree pipeline from different manifest")
-	}
-	m.addPipeline(p)
+	treePipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/raw_ostree.go
+++ b/pkg/manifest/raw_ostree.go
@@ -13,8 +13,16 @@ import (
 type RawOSTreeImage struct {
 	Base
 	treePipeline *OSTreeDeployment
-	Filename     string
+	filename     string
 	platform     platform.Platform
+}
+
+func (p RawOSTreeImage) Filename() string {
+	return p.filename
+}
+
+func (p *RawOSTreeImage) SetFilename(filename string) {
+	p.filename = filename
 }
 
 func NewRawOStreeImage(m *Manifest,
@@ -24,7 +32,7 @@ func NewRawOStreeImage(m *Manifest,
 	p := &RawOSTreeImage{
 		Base:         NewBase(m, "image", buildPipeline),
 		treePipeline: treePipeline,
-		Filename:     "disk.img",
+		filename:     "disk.img",
 		platform:     platform,
 	}
 	buildPipeline.addDependent(p)
@@ -57,12 +65,12 @@ func (p *RawOSTreeImage) serialize() osbuild.Pipeline {
 		panic("no partition table in live image")
 	}
 
-	for _, stage := range osbuild.GenImagePrepareStages(pt, p.Filename, osbuild.PTSfdisk) {
+	for _, stage := range osbuild.GenImagePrepareStages(pt, p.Filename(), osbuild.PTSfdisk) {
 		pipeline.AddStage(stage)
 	}
 
 	inputName := "root-tree"
-	treeCopyOptions, treeCopyDevices, treeCopyMounts := osbuild.GenCopyFSTreeOptions(inputName, p.treePipeline.Name(), p.Filename, pt)
+	treeCopyOptions, treeCopyDevices, treeCopyMounts := osbuild.GenCopyFSTreeOptions(inputName, p.treePipeline.Name(), p.Filename(), pt)
 	treeCopyInputs := osbuild.NewPipelineTreeInputs(inputName, p.treePipeline.Name())
 
 	pipeline.AddStage(osbuild.NewCopyStage(treeCopyOptions, treeCopyInputs, treeCopyDevices, treeCopyMounts))
@@ -71,7 +79,7 @@ func (p *RawOSTreeImage) serialize() osbuild.Pipeline {
 	if len(bootFiles) > 0 {
 		// we ignore the bootcopyoptions as they contain a full tree copy instead we make our own, we *do* still want all the other
 		// information such as mountpoints and devices
-		_, bootCopyDevices, bootCopyMounts := osbuild.GenCopyFSTreeOptions(inputName, p.treePipeline.Name(), p.Filename, pt)
+		_, bootCopyDevices, bootCopyMounts := osbuild.GenCopyFSTreeOptions(inputName, p.treePipeline.Name(), p.Filename(), pt)
 		bootCopyOptions := &osbuild.CopyStageOptions{}
 
 		commit := p.treePipeline.ostreeSpecs[0]
@@ -91,12 +99,12 @@ func (p *RawOSTreeImage) serialize() osbuild.Pipeline {
 		pipeline.AddStage(osbuild.NewCopyStage(bootCopyOptions, bootCopyInputs, bootCopyDevices, bootCopyMounts))
 	}
 
-	for _, stage := range osbuild.GenImageFinishStages(pt, p.Filename) {
+	for _, stage := range osbuild.GenImageFinishStages(pt, p.Filename()) {
 		pipeline.AddStage(stage)
 	}
 
 	if grubLegacy := p.treePipeline.platform.GetBIOSPlatform(); grubLegacy != "" {
-		pipeline.AddStage(osbuild.NewGrub2InstStage(osbuild.NewGrub2InstStageOption(p.Filename, pt, grubLegacy)))
+		pipeline.AddStage(osbuild.NewGrub2InstStage(osbuild.NewGrub2InstStageOption(p.Filename(), pt, grubLegacy)))
 	}
 
 	return pipeline
@@ -104,5 +112,5 @@ func (p *RawOSTreeImage) serialize() osbuild.Pipeline {
 
 func (p *RawOSTreeImage) Export() *artifact.Artifact {
 	p.Base.export = true
-	return artifact.New(p.Name(), p.Filename, nil)
+	return artifact.New(p.Name(), p.Filename(), nil)
 }

--- a/pkg/manifest/tar.go
+++ b/pkg/manifest/tar.go
@@ -30,17 +30,14 @@ func (p *Tar) SetFilename(filename string) {
 // NewTar creates a new TarPipeline. The inputPipeline represents the
 // filesystem tree which will be the contents of the tar file. The pipelinename
 // is the name of the pipeline. The filename is the name of the output tar file.
-func NewTar(m *Manifest,
-	buildPipeline *Build,
-	inputPipeline Pipeline,
-	pipelinename string) *Tar {
+func NewTar(buildPipeline *Build, inputPipeline Pipeline, pipelinename string) *Tar {
 	p := &Tar{
-		Base:          NewBase(m, pipelinename, buildPipeline),
+		Base:          NewBase(inputPipeline.Manifest(), pipelinename, buildPipeline),
 		inputPipeline: inputPipeline,
 		filename:      "image.tar",
 	}
 	buildPipeline.addDependent(p)
-	m.addPipeline(p)
+	inputPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/tar.go
+++ b/pkg/manifest/tar.go
@@ -8,7 +8,7 @@ import (
 // A Tar represents the contents of another pipeline in a tar file
 type Tar struct {
 	Base
-	Filename string
+	filename string
 
 	Format   osbuild.TarArchiveFormat
 	RootNode osbuild.TarRootNode
@@ -17,6 +17,14 @@ type Tar struct {
 	Xattrs   *bool
 
 	inputPipeline Pipeline
+}
+
+func (p Tar) Filename() string {
+	return p.filename
+}
+
+func (p *Tar) SetFilename(filename string) {
+	p.filename = filename
 }
 
 // NewTar creates a new TarPipeline. The inputPipeline represents the
@@ -29,7 +37,7 @@ func NewTar(m *Manifest,
 	p := &Tar{
 		Base:          NewBase(m, pipelinename, buildPipeline),
 		inputPipeline: inputPipeline,
-		Filename:      "image.tar",
+		filename:      "image.tar",
 	}
 	buildPipeline.addDependent(p)
 	m.addPipeline(p)
@@ -40,7 +48,7 @@ func (p *Tar) serialize() osbuild.Pipeline {
 	pipeline := p.Base.serialize()
 
 	tarOptions := &osbuild.TarStageOptions{
-		Filename: p.Filename,
+		Filename: p.Filename(),
 		Format:   p.Format,
 		ACLs:     p.ACLs,
 		SELinux:  p.SELinux,
@@ -60,5 +68,5 @@ func (p *Tar) getBuildPackages(Distro) []string {
 func (p *Tar) Export() *artifact.Artifact {
 	p.Base.export = true
 	mimeType := "application/x-tar"
-	return artifact.New(p.Name(), p.Filename, &mimeType)
+	return artifact.New(p.Name(), p.Filename(), &mimeType)
 }

--- a/pkg/manifest/vmdk.go
+++ b/pkg/manifest/vmdk.go
@@ -8,9 +8,17 @@ import (
 // A VMDK turns a raw image file or a raw ostree image file into vmdk image.
 type VMDK struct {
 	Base
-	Filename string
+	filename string
 
 	imgPipeline Pipeline
+}
+
+func (p VMDK) Filename() string {
+	return p.filename
+}
+
+func (p *VMDK) SetFilename(filename string) {
+	p.filename = filename
 }
 
 // NewVMDK creates a new VMDK pipeline. imgPipeline is the pipeline producing the
@@ -28,7 +36,7 @@ func NewVMDK(m *Manifest,
 		p = &VMDK{
 			Base:        NewBase(m, "vmdk", buildPipeline),
 			imgPipeline: imgPipeline,
-			Filename:    "image.vmdk",
+			filename:    "image.vmdk",
 		}
 		if imgPipeline.Base.manifest != m {
 			panic("live image pipeline from different manifest")
@@ -37,7 +45,7 @@ func NewVMDK(m *Manifest,
 		p = &VMDK{
 			Base:        NewBase(m, "vmdk", buildPipeline),
 			imgPipeline: imgOstreePipeline,
-			Filename:    "image.vmdk",
+			filename:    "image.vmdk",
 		}
 		if imgOstreePipeline.Base.manifest != m {
 			panic("live image pipeline from different manifest")
@@ -52,7 +60,7 @@ func (p *VMDK) serialize() osbuild.Pipeline {
 	pipeline := p.Base.serialize()
 
 	pipeline.AddStage(osbuild.NewQEMUStage(
-		osbuild.NewQEMUStageOptions(p.Filename, osbuild.QEMUFormatVMDK, osbuild.VMDKOptions{
+		osbuild.NewQEMUStageOptions(p.Filename(), osbuild.QEMUFormatVMDK, osbuild.VMDKOptions{
 			Subformat: osbuild.VMDKSubformatStreamOptimized,
 		}),
 		osbuild.NewQemuStagePipelineFilesInputs(p.imgPipeline.Name(), p.imgPipeline.Export().Filename()),
@@ -68,5 +76,5 @@ func (p *VMDK) getBuildPackages(Distro) []string {
 func (p *VMDK) Export() *artifact.Artifact {
 	p.Base.export = true
 	mimeType := "application/x-vmdk"
-	return artifact.New(p.Name(), p.Filename, &mimeType)
+	return artifact.New(p.Name(), p.Filename(), &mimeType)
 }

--- a/pkg/manifest/vmdk.go
+++ b/pkg/manifest/vmdk.go
@@ -25,34 +25,14 @@ func (p *VMDK) SetFilename(filename string) {
 // raw image. imgOstreePipeline is the pipeline producing the raw ostree image.
 // Either imgPipeline or imgOStreePipeline are required, but not both at the same time.
 // Filename is the name of the produced image.
-func NewVMDK(m *Manifest,
-	buildPipeline *Build,
-	imgPipeline *RawImage, imgOstreePipeline *RawOSTreeImage) *VMDK {
-	if imgPipeline != nil && imgOstreePipeline != nil {
-		panic("NewVMDK requires either RawImage or RawOSTreeImage")
-	}
-	var p *VMDK
-	if imgPipeline != nil {
-		p = &VMDK{
-			Base:        NewBase(m, "vmdk", buildPipeline),
-			imgPipeline: imgPipeline,
-			filename:    "image.vmdk",
-		}
-		if imgPipeline.Base.manifest != m {
-			panic("live image pipeline from different manifest")
-		}
-	} else {
-		p = &VMDK{
-			Base:        NewBase(m, "vmdk", buildPipeline),
-			imgPipeline: imgOstreePipeline,
-			filename:    "image.vmdk",
-		}
-		if imgOstreePipeline.Base.manifest != m {
-			panic("live image pipeline from different manifest")
-		}
+func NewVMDK(buildPipeline *Build, imgPipeline FilePipeline) *VMDK {
+	p := &VMDK{
+		Base:        NewBase(imgPipeline.Manifest(), "vmdk", buildPipeline),
+		imgPipeline: imgPipeline,
+		filename:    "image.vmdk",
 	}
 	buildPipeline.addDependent(p)
-	m.addPipeline(p)
+	imgPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/vpc.go
+++ b/pkg/manifest/vpc.go
@@ -8,11 +8,19 @@ import (
 // A VPC turns a raw image file into qemu-based image format, such as qcow2.
 type VPC struct {
 	Base
-	Filename string
+	filename string
 
 	ForceSize *bool
 
 	imgPipeline *RawImage
+}
+
+func (p VPC) Filename() string {
+	return p.filename
+}
+
+func (p *VPC) SetFilename(filename string) {
+	p.filename = filename
 }
 
 // NewVPC createsa new Qemu pipeline. imgPipeline is the pipeline producing the
@@ -24,7 +32,7 @@ func NewVPC(m *Manifest,
 	p := &VPC{
 		Base:        NewBase(m, "vpc", buildPipeline),
 		imgPipeline: imgPipeline,
-		Filename:    "image.vhd",
+		filename:    "image.vhd",
 	}
 	if imgPipeline.Base.manifest != m {
 		panic("live image pipeline from different manifest")
@@ -40,8 +48,8 @@ func (p *VPC) serialize() osbuild.Pipeline {
 	formatOptions := osbuild.VPCOptions{ForceSize: p.ForceSize}
 
 	pipeline.AddStage(osbuild.NewQEMUStage(
-		osbuild.NewQEMUStageOptions(p.Filename, osbuild.QEMUFormatVPC, formatOptions),
-		osbuild.NewQemuStagePipelineFilesInputs(p.imgPipeline.Name(), p.imgPipeline.Filename),
+		osbuild.NewQEMUStageOptions(p.Filename(), osbuild.QEMUFormatVPC, formatOptions),
+		osbuild.NewQemuStagePipelineFilesInputs(p.imgPipeline.Name(), p.imgPipeline.Filename()),
 	))
 
 	return pipeline
@@ -54,5 +62,5 @@ func (p *VPC) getBuildPackages(Distro) []string {
 func (p *VPC) Export() *artifact.Artifact {
 	p.Base.export = true
 	mimeType := "application/x-vhd"
-	return artifact.New(p.Name(), p.Filename, &mimeType)
+	return artifact.New(p.Name(), p.Filename(), &mimeType)
 }

--- a/pkg/manifest/vpc.go
+++ b/pkg/manifest/vpc.go
@@ -26,19 +26,14 @@ func (p *VPC) SetFilename(filename string) {
 // NewVPC createsa new Qemu pipeline. imgPipeline is the pipeline producing the
 // raw image. The pipeline name is the name of the new pipeline. Filename is the name
 // of the produced image.
-func NewVPC(m *Manifest,
-	buildPipeline *Build,
-	imgPipeline *RawImage) *VPC {
+func NewVPC(buildPipeline *Build, imgPipeline *RawImage) *VPC {
 	p := &VPC{
-		Base:        NewBase(m, "vpc", buildPipeline),
+		Base:        NewBase(imgPipeline.Manifest(), "vpc", buildPipeline),
 		imgPipeline: imgPipeline,
 		filename:    "image.vhd",
 	}
-	if imgPipeline.Base.manifest != m {
-		panic("live image pipeline from different manifest")
-	}
 	buildPipeline.addDependent(p)
-	m.addPipeline(p)
+	imgPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/xz.go
+++ b/pkg/manifest/xz.go
@@ -23,16 +23,14 @@ func (p *XZ) SetFilename(filename string) {
 
 // NewXZ creates a new XZ pipeline. imgPipeline is the pipeline producing the
 // raw image that will be xz compressed.
-func NewXZ(m *Manifest,
-	buildPipeline *Build,
-	imgPipeline Pipeline) *XZ {
+func NewXZ(buildPipeline *Build, imgPipeline Pipeline) *XZ {
 	p := &XZ{
-		Base:        NewBase(m, "xz", buildPipeline),
+		Base:        NewBase(imgPipeline.Manifest(), "xz", buildPipeline),
 		filename:    "image.xz",
 		imgPipeline: imgPipeline,
 	}
 	buildPipeline.addDependent(p)
-	m.addPipeline(p)
+	imgPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/xz.go
+++ b/pkg/manifest/xz.go
@@ -8,9 +8,17 @@ import (
 // The XZ pipeline compresses a raw image file using xz.
 type XZ struct {
 	Base
-	Filename string
+	filename string
 
 	imgPipeline Pipeline
+}
+
+func (p XZ) Filename() string {
+	return p.filename
+}
+
+func (p *XZ) SetFilename(filename string) {
+	p.filename = filename
 }
 
 // NewXZ creates a new XZ pipeline. imgPipeline is the pipeline producing the
@@ -20,7 +28,7 @@ func NewXZ(m *Manifest,
 	imgPipeline Pipeline) *XZ {
 	p := &XZ{
 		Base:        NewBase(m, "xz", buildPipeline),
-		Filename:    "image.xz",
+		filename:    "image.xz",
 		imgPipeline: imgPipeline,
 	}
 	buildPipeline.addDependent(p)
@@ -32,7 +40,7 @@ func (p *XZ) serialize() osbuild.Pipeline {
 	pipeline := p.Base.serialize()
 
 	pipeline.AddStage(osbuild.NewXzStage(
-		osbuild.NewXzStageOptions(p.Filename),
+		osbuild.NewXzStageOptions(p.Filename()),
 		osbuild.NewXzStageInputs(osbuild.NewFilesInputPipelineObjectRef(p.imgPipeline.Name(), p.imgPipeline.Export().Filename(), nil)),
 	))
 
@@ -46,5 +54,5 @@ func (p *XZ) getBuildPackages(Distro) []string {
 func (p *XZ) Export() *artifact.Artifact {
 	p.Base.export = true
 	mimeType := "application/xz"
-	return artifact.New(p.Name(), p.Filename, &mimeType)
+	return artifact.New(p.Name(), p.Filename(), &mimeType)
 }

--- a/pkg/manifest/xz.go
+++ b/pkg/manifest/xz.go
@@ -10,7 +10,7 @@ type XZ struct {
 	Base
 	filename string
 
-	imgPipeline Pipeline
+	imgPipeline FilePipeline
 }
 
 func (p XZ) Filename() string {
@@ -23,7 +23,7 @@ func (p *XZ) SetFilename(filename string) {
 
 // NewXZ creates a new XZ pipeline. imgPipeline is the pipeline producing the
 // raw image that will be xz compressed.
-func NewXZ(buildPipeline *Build, imgPipeline Pipeline) *XZ {
+func NewXZ(buildPipeline *Build, imgPipeline FilePipeline) *XZ {
 	p := &XZ{
 		Base:        NewBase(imgPipeline.Manifest(), "xz", buildPipeline),
 		filename:    "image.xz",

--- a/pkg/osbuild/systemd_preset_stage.go
+++ b/pkg/osbuild/systemd_preset_stage.go
@@ -1,0 +1,38 @@
+package osbuild
+
+import "fmt"
+
+type SystemdPresetStageOptions struct {
+	Presets []Preset `json:"presets,omitempty"`
+}
+
+type PresetState string
+
+const (
+	StateEnable  PresetState = "enable"
+	StateDisable PresetState = "disable"
+)
+
+type Preset struct {
+	Name  string      `json:"name,omitempty"`
+	State PresetState `json:"state,omitempty"`
+}
+
+func (SystemdPresetStageOptions) isStageOptions() {}
+
+func NewSystemdPresetStage(options *SystemdPresetStageOptions) *Stage {
+	if err := options.validate(); err != nil {
+		panic(err)
+	}
+	return &Stage{
+		Type:    "org.osbuild.systemd.preset",
+		Options: options,
+	}
+}
+
+func (o SystemdPresetStageOptions) validate() error {
+	if len(o.Presets) == 0 {
+		return fmt.Errorf("at least one preset is required")
+	}
+	return nil
+}

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -66,6 +66,7 @@
     "image-types": [
       "iot-ami",
       "iot-installer",
+      "iot-qcow2-image",
       "iot-raw-image"
     ]
   },


### PR DESCRIPTION
_Migration of https://github.com/osbuild/osbuild-composer/pull/3282._

Adds new image types to Fedora:
- iot-simplified-installer (F38+)
- iot-qcow2-image

This PR also introduces a new interface, `FilePipeline`, which is implemented by pipelines that produce a single file (typically an image file, but it could be any single file).  Pipelines that work on single files (like `XZ`, `QCOW2`, `VMDK`) can now take any `FilePipeline` as input.