### PR TITLE
Add URL to commit when printing build cache info

### DIFF
--- a/test/generators/imgtestlib.py
+++ b/test/generators/imgtestlib.py
@@ -201,7 +201,8 @@ def filter_builds(manifests, skip_ostree_pull=True):
                 with open(id_config_path) as dl_config_fp:
                     dl_config = json.load(dl_config_fp)
                 commit = dl_config["commit"]
-                print(f"Manifest {manifest_fname} was successfully built in commit {commit}")
+                url = f"https://github.com/osbuild/images/commit/{commit}"
+                print(f"Manifest {manifest_fname} was successfully built in commit {commit}\n  {url}")
                 continue
             except json.JSONDecodeError as jd:
                 errors.append((


### PR DESCRIPTION
Adds a clickable URL in the job log to the commit when an image configuration was built.