### PR TITLE
Store images in S3 after building

### DIFF
--- a/test/cases/build-image.sh
+++ b/test/cases/build-image.sh
@@ -9,13 +9,13 @@ arch=$(uname -m)
 imgtype="${2}"
 config="${3}"
 
-echo "Building image ${distro}/${imgtype} using config ${config}"
+echo "👷 Building image ${distro}/${imgtype} using config ${config}"
 cat "${config}"  # print the config for logging
 sudo go run ./cmd/build -output ./build -distro "${distro}" -image "${imgtype}" -config "${config}"
 
-echo "Build finished!!"
+echo "✅ Build finished!!"
 
-echo "Registering successful build in S3"
+echo "☁️ Registering successful build in S3"
 
 u() {
     echo "${1}" | tr - _
@@ -50,7 +50,9 @@ EOF
 
 s3url="s3://image-builder-ci-artifacts/images/builds/${distro}/${arch}/${manifest_id}/"
 
-echo "Uploading ${builddir} to ${s3url}"
+echo "⬆️ Uploading ${builddir} to ${s3url}"
 AWS_SECRET_ACCESS_KEY="$V2_AWS_SECRET_ACCESS_KEY" \
 AWS_ACCESS_KEY_ID="$V2_AWS_ACCESS_KEY_ID" \
 s3cmd --acl-private put --recursive "${builddir}/" "${s3url}"
+
+echo "✅ DONE!!"

--- a/test/generators/check-build-coverage
+++ b/test/generators/check-build-coverage
@@ -49,7 +49,7 @@ def main():
 
     missing = check_build_coverage(cachedir)
     if missing:
-        print(f"{len(missing)} distro/arch/image combinations have no builds in the cache")
+        print(f"❌ {len(missing)} distro/arch/image combinations have no builds in the cache")
         for idx, m in enumerate(missing, start=1):
             print(f" {idx:3d}: " + "/".join(m))
         sys.exit(1)

--- a/test/generators/generate-build-config
+++ b/test/generators/generate-build-config
@@ -31,6 +31,11 @@ def generate_manifests(outputdir, distro, arch):
     Generate all manifest using the default config map and return a dictionary mapping each manifest file to the
     manifest data and its ID.
     """
+    target = arch
+    if distro:
+        target = distro + "/" + arch
+
+    print(f"🗒️ Generating all manifests using the default config map for {target}")
     cmd = ["go", "run", "./cmd/gen-manifests",
            "-cache", os.path.join(testlib.TEST_CACHE_ROOT, "rpmmd"),
            "-output", outputdir,
@@ -38,7 +43,8 @@ def generate_manifests(outputdir, distro, arch):
            "-arches", arch]
     if distro:
         cmd.extend(["-distros", distro])
-    print(f"Running: {' '.join(cmd)}")
+
+    print("⌨️" + " ".join(cmd))
     out, err = testlib.runcmd(cmd)
 
     # print stderr in case there were errors or warnings about skipped configurations
@@ -51,12 +57,12 @@ def generate_manifests(outputdir, distro, arch):
             continue
         print(line)
 
-    print("Manifest generation done!\n")
+    print("✅ Manifest generation done!\n")
     return testlib.read_manifests(outputdir)
 
 
 def generate_configs(build_requests, pipeline_file):
-    print(f"Generating dynamic pipelines for {len(build_requests)} builds")
+    print(f"🧪 Generating dynamic pipelines for {len(build_requests)} builds")
     for build in build_requests:
         distro = build["distro"]
         arch = build["arch"]
@@ -79,7 +85,7 @@ def generate_configs(build_requests, pipeline_file):
                                                 config_name=config_name, config=config_path,
                                                 container_push=container_push_cmd,
                                                 internal="true" if "rhel" in distro else "false"))
-    print("DONE!")
+    print("✅ DONE!")
 
 
 def main():
@@ -98,7 +104,7 @@ def main():
 
     with open(config_path, "w") as config_file:
         if len(build_requests) == 0:
-            print("No manifest changes detected. Generating null config.")
+            print("⚫ No manifest changes detected. Generating null config.")
             config_file.write(testlib.NULL_CONFIG)
             return
 

--- a/test/generators/generate-ostree-build-config
+++ b/test/generators/generate-ostree-build-config
@@ -57,7 +57,11 @@ def gen_dependency_manifests(config_map, distro, arch, outputdir):
 
     Returns a dictionary mapping manifest file name (without path) to the manifest data and its ID.
     """
-    print("Generating manifests for dependencies")
+    target = arch
+    if distro:
+        target = distro + "/" + arch
+
+    print(f"🗒️ Generating manifests for dependencies for {target}")
     dep_config_map: dict = {}  # config map for the dependencies
     gen_image_types = set()  # set of all the image types to generate manifests for
 
@@ -91,7 +95,7 @@ def gen_dependency_manifests(config_map, distro, arch, outputdir):
                "-arches", arch]
         if distro:
             cmd.extend(["-distros", distro])
-        print(" ".join(cmd))
+        print("⌨️" + " ".join(cmd))
         out, err = testlib.runcmd(cmd)
 
     # print stderr in case there were errors or warnings about skipped configurations
@@ -104,7 +108,7 @@ def gen_dependency_manifests(config_map, distro, arch, outputdir):
             continue
         print(line)
 
-    print("Manifest generation done!\n")
+    print("✅ Manifest generation done!\n")
     return testlib.read_manifests(outputdir)
 
 
@@ -116,6 +120,11 @@ def gen_image_manifests(config_map, configs, distro, arch, outputdir):
 
     Returns a dictionary mapping manifest file name (without path) to the manifest data and its ID.
     """
+    target = arch
+    if distro:
+        target = distro + "/" + arch
+
+    print(f"🗒️ Generating manifests for ostree-based images for {target}")
     with TemporaryDirectory() as tmpdir:
         # write each config to a separate file
         for config in configs.values():
@@ -137,7 +146,7 @@ def gen_image_manifests(config_map, configs, distro, arch, outputdir):
                "-arches", arch]
         if distro:
             cmd.extend(["-distros", distro])
-        print(" ".join(cmd))
+        print("⌨️" + " ".join(cmd))
         out, err = testlib.runcmd(cmd)
 
     # print stderr in case there were errors or warnings about skipped configurations
@@ -150,7 +159,7 @@ def gen_image_manifests(config_map, configs, distro, arch, outputdir):
             continue
         print(line)
 
-    print("Manifest generation done!\n")
+    print("✅ Manifest generation done!\n")
     return testlib.read_manifests(outputdir)
 
 
@@ -248,20 +257,20 @@ def setup_dependencies(manifests, config_map, distro, arch):
 
     try:
         for container, port in container_ports.items():
-            print(f"Starting container {container} {port}")
+            print(f"📦 Starting container {container} {port}")
             cont_id, _ = testlib.runcmd(["podman", "run", "-d", "--rm", f"-p{port}:8080", container])
             container_ids.append(cont_id.strip().decode())
 
         yield new_config_map, new_configs
     finally:
-        print("Stopping containers")
-        print("\n".join(container_ids))
-        for cont_id in container_ids:
-            testlib.runcmd(["podman", "stop", cont_id])
+        if container_ids:
+            print("📦 Stopping containers")
+            out, _ = testlib.runcmd(["podman", "stop", " ".join(container_ids)])
+            print(out.decode())
 
 
 def generate_configs(build_requests, pull_configs, pipeline_file, configs_dir):
-    print(f"Generating dynamic pipelines for {len(build_requests)} builds")
+    print(f"🧪 Generating dynamic pipelines for {len(build_requests)} builds")
     os.makedirs(configs_dir, exist_ok=True)
     for build in build_requests:
         distro = build["distro"]
@@ -286,7 +295,7 @@ def generate_configs(build_requests, pull_configs, pipeline_file, configs_dir):
                                                 config_name=config_name, config=build_config_path,
                                                 start_container=container_cmd,
                                                 internal="true" if "rhel" in distro else "false"))
-    print("DONE!")
+    print("✅ DONE!")
 
 
 def main():
@@ -315,7 +324,7 @@ def main():
 
     with open(config_path, "w") as config_file:
         if len(build_requests) == 0:
-            print("No manifest changes detected. Generating null config.")
+            print("⚫ No manifest changes detected. Generating null config.")
             config_file.write(testlib.NULL_CONFIG)
             return
 

--- a/test/generators/imgtestlib.py
+++ b/test/generators/imgtestlib.py
@@ -56,7 +56,7 @@ NullBuild:
 def runcmd(cmd, stdin=None):
     job = sp.run(cmd, input=stdin, capture_output=True)
     if job.returncode > 0:
-        print(f"Command failed: {cmd}")
+        print(f"❌ Command failed: {cmd}")
         if job.stdout:
             print(job.stdout.decode())
         if job.stderr:
@@ -96,7 +96,7 @@ def dl_s3_configs(destination):
     """
     s3url = f"{S3_BUCKET}/{S3_PREFIX}/"
 
-    print(f"Downloading configs from {s3url}")
+    print(f"⬇️ Downloading configs from {s3url}")
     # only download info.json (exclude everything, then include) files, otherwise we get manifests and whole images
     job = sp.run(["s3cmd", *s3_auth_args(), "sync",
                   "--exclude=*",
@@ -106,7 +106,7 @@ def dl_s3_configs(destination):
                  capture_output=True)
     ok = job.returncode == 0
     if not ok:
-        print(f"Failed to sync contents of {s3url}:")
+        print(f"⚠️ Failed to sync contents of {s3url}:")
         print(job.stderr.decode())
     return ok
 
@@ -139,7 +139,7 @@ def check_config_names():
             bad_configs.append(str(file))
 
     if bad_configs:
-        print("ERROR: The following test configs have names that don't match their filenames.")
+        print("☠️ ERROR: The following test configs have names that don't match their filenames.")
         print("\n".join(bad_configs))
         print("This will produce incorrect test generation and results.")
         print("Aborting.")
@@ -151,7 +151,7 @@ def read_manifests(path):
     Read all manifests in the given path, calculate their IDs, and return a dictionary mapping each filename to the data
     and its ID.
     """
-    print(f"Reading manifests in {path}")
+    print(f"📖 Reading manifests in {path}")
     manifests = {}
     for manifest_fname in os.listdir(path):
         manifest_path = os.path.join(path, manifest_fname)
@@ -161,7 +161,7 @@ def read_manifests(path):
             "data": manifest_data,
             "id": get_manifest_id(manifest_data["manifest"]),
         }
-    print("Done")
+    print("✅ Done")
     return manifests
 
 
@@ -169,7 +169,7 @@ def filter_builds(manifests, skip_ostree_pull=True):
     """
     Returns a list of build requests for the manifests that have no matching config in the test build cache.
     """
-    print(f"Filtering {len(manifests)} build configurations")
+    print(f"⚙️ Filtering {len(manifests)} build configurations")
     dl_path = os.path.join(TEST_CACHE_ROOT, "s3configs", "builds/")
     os.makedirs(dl_path, exist_ok=True)
     build_requests = []
@@ -190,7 +190,7 @@ def filter_builds(manifests, skip_ostree_pull=True):
 
         # check if the config specifies an ostree URL and skip it if requested
         if skip_ostree_pull and config.get("ostree", {}).get("url"):
-            print(f"Skipping {distro}/{arch}/{image_type}/{config_name} (ostree dependency)")
+            print(f"🦘 Skipping {distro}/{arch}/{image_type}/{config_name} (ostree dependency)")
             continue
 
         # add manifest id to build request
@@ -207,7 +207,7 @@ def filter_builds(manifests, skip_ostree_pull=True):
                     dl_config = json.load(build_info_fp)
                 commit = dl_config["commit"]
                 url = f"https://github.com/osbuild/images/commit/{commit}"
-                print(f"Manifest {manifest_fname} was successfully built in commit {commit}\n  {url}")
+                print(f"🖼️ Manifest {manifest_fname} was successfully built in commit {commit}\n  {url}")
                 continue
             except json.JSONDecodeError as jd:
                 errors.append((
@@ -219,10 +219,10 @@ def filter_builds(manifests, skip_ostree_pull=True):
 
         build_requests.append(build_request)
 
-    print("Config filtering done!\n")
+    print("✅ Config filtering done!\n")
     if errors:
         # print errors at the end so they're visible
-        print("Errors:")
+        print("⚠️ Errors:")
         print("\n".join(errors))
 
     return build_requests


### PR DESCRIPTION
In addition to the build info, also store the manifest and the actual image by uploading the whole build directory to s3.
We should start using these images for further testing in other projects, like osbuild-composer and maybe to bring back image info in manifest-db without needing to rebuild every time.

This PR will cause a rebuild of all image types since the build cache directory structure is changing.