### PR TITLE
Support checksums for ostree parents when building ostree commits

### DIFF
--- a/pkg/distro/rhel8/distro_test.go
+++ b/pkg/distro/rhel8/distro_test.go
@@ -489,11 +489,11 @@ func TestDistro_ManifestError(t *testing.T) {
 			if imgTypeName == "edge-commit" || imgTypeName == "edge-container" {
 				assert.EqualError(t, err, "kernel boot parameter customizations are not supported for ostree types")
 			} else if imgTypeName == "edge-raw-image" {
-				assert.EqualError(t, err, "edge raw images require specifying a URL from which to retrieve the OSTree commit")
+				assert.EqualError(t, err, fmt.Sprintf("%q images require specifying a URL from which to retrieve the OSTree commit", imgTypeName))
 			} else if imgTypeName == "edge-installer" || imgTypeName == "edge-simplified-installer" {
-				assert.EqualError(t, err, fmt.Sprintf("boot ISO image type \"%s\" requires specifying a URL from which to retrieve the OSTree commit", imgTypeName))
+				assert.EqualError(t, err, fmt.Sprintf("boot ISO image type %q requires specifying a URL from which to retrieve the OSTree commit", imgTypeName))
 			} else if imgTypeName == "azure-eap7-rhui" {
-				assert.EqualError(t, err, fmt.Sprintf("image type \"%s\" does not support customizations", imgTypeName))
+				assert.EqualError(t, err, fmt.Sprintf("image type %q does not support customizations", imgTypeName))
 			} else {
 				assert.NoError(t, err)
 			}

--- a/pkg/distro/rhel9/imagetype.go
+++ b/pkg/distro/rhel9/imagetype.go
@@ -19,7 +19,6 @@ import (
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/image"
 	"github.com/osbuild/images/pkg/manifest"
-	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -282,19 +281,16 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		return warnings, fmt.Errorf("embedding containers is not supported for %s on %s", t.name, t.arch.distro.name)
 	}
 
-	ostreeURL := ""
 	if options.OSTree != nil {
-		if options.OSTree.ParentRef != "" && options.OSTree.URL == "" {
-			// specifying parent ref also requires URL
-			return nil, ostree.NewParameterComboError("ostree parent ref specified, but no URL to retrieve it")
+		if err := options.OSTree.Validate(); err != nil {
+			return nil, err
 		}
-		ostreeURL = options.OSTree.URL
 	}
 
 	if t.bootISO && t.rpmOstree {
 		// ostree-based ISOs require a URL from which to pull a payload commit
-		if ostreeURL == "" {
-			return warnings, fmt.Errorf("boot ISO image type %q requires specifying a URL from which to retrieve the OSTree commit", t.name)
+		if options.OSTree == nil || options.OSTree.URL == "" {
+			return nil, fmt.Errorf("boot ISO image type %q requires specifying a URL from which to retrieve the OSTree commit", t.name)
 		}
 
 		if t.name == "edge-simplified-installer" {
@@ -345,7 +341,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 
 	if t.name == "edge-raw-image" || t.name == "edge-ami" || t.name == "edge-vsphere" {
 		// ostree-based bootable images require a URL from which to pull a payload commit
-		if ostreeURL == "" {
+		if options.OSTree == nil || options.OSTree.URL == "" {
 			return warnings, fmt.Errorf("%q images require specifying a URL from which to retrieve the OSTree commit", t.name)
 		}
 

--- a/pkg/ostree/errors.go
+++ b/pkg/ostree/errors.go
@@ -18,7 +18,7 @@ func NewResolveRefError(msg string, args ...interface{}) ResolveRefError {
 	return ResolveRefError{msg: fmt.Sprintf(msg, args...)}
 }
 
-// InvalidParamsError is returned when a parameter is invalid (e.g., malformed
+// RefError is returned when a parameter is invalid (e.g., malformed
 // or contains illegal characters).
 type RefError struct {
 	msg string

--- a/pkg/ostree/ostree.go
+++ b/pkg/ostree/ostree.go
@@ -109,7 +109,7 @@ func ResolveRef(location, ref string, consumerCerts bool, subs *rhsm.Subscriptio
 		if ca != nil {
 			caCertPEM, err := os.ReadFile(*ca)
 			if err != nil {
-				return "", NewResolveRefError("error adding rhsm certificates when resolving ref")
+				return "", NewResolveRefError("error adding rhsm certificates when resolving ref: %s", err)
 			}
 			roots := x509.NewCertPool()
 			ok := roots.AppendCertsFromPEM(caCertPEM)
@@ -121,7 +121,7 @@ func ResolveRef(location, ref string, consumerCerts bool, subs *rhsm.Subscriptio
 
 		cert, err := tls.LoadX509KeyPair(subs.Consumer.ConsumerCert, subs.Consumer.ConsumerKey)
 		if err != nil {
-			return "", NewResolveRefError("error adding rhsm certificates when resolving ref")
+			return "", NewResolveRefError("error adding rhsm certificates when resolving ref: %s", err)
 		}
 		tlsConf.Certificates = []tls.Certificate{cert}
 
@@ -137,7 +137,7 @@ func ResolveRef(location, ref string, consumerCerts bool, subs *rhsm.Subscriptio
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
-		return "", NewResolveRefError("error adding rhsm certificates when resolving ref")
+		return "", NewResolveRefError("error preparing ostree resolve request: %s", err)
 	}
 
 	resp, err := client.Do(req)

--- a/pkg/ostree/ostree_test.go
+++ b/pkg/ostree/ostree_test.go
@@ -55,12 +55,12 @@ func TestOstreeResolveRef(t *testing.T) {
 		Subs *rhsm.Subscriptions
 	}
 	srvConfs := []srvConfig{
-		srvConfig{
+		{
 			Srv:  srv,
 			RHSM: false,
 			Subs: nil,
 		},
-		srvConfig{
+		{
 			Srv:  srv2,
 			RHSM: true,
 			Subs: subs,

--- a/pkg/ostree/ostree_test.go
+++ b/pkg/ostree/ostree_test.go
@@ -118,3 +118,99 @@ func TestVerifyRef(t *testing.T) {
 		assert.Equal(t, expOut, verifyRef(in), in)
 	}
 }
+
+func TestValidate(t *testing.T) {
+
+	type testCase struct {
+		options ImageOptions
+		valid   bool
+	}
+
+	cases := map[string]testCase{
+		"empty": {
+			options: ImageOptions{
+				ImageRef:   "",
+				ParentRef:  "",
+				URL:        "",
+				ContentURL: "",
+			},
+			valid: true,
+		},
+		"fedora-ref-valid": {
+			options: ImageOptions{
+				ImageRef:   "fedora/39/x86_64/iot",
+				ParentRef:  "",
+				URL:        "",
+				ContentURL: "",
+			},
+			valid: true,
+		},
+		"fedora-ref-invalid": {
+			options: ImageOptions{
+				ImageRef:   "fedora/39/x86_64/ιοτ",
+				ParentRef:  "",
+				URL:        "",
+				ContentURL: "",
+			},
+			valid: false,
+		},
+		"fedora-parent-valid": {
+			options: ImageOptions{
+				ImageRef:   "fedora/39/x86_64/iot",
+				ParentRef:  "fedora/39/x86_64/iot",
+				URL:        "https://repo.example.com",
+				ContentURL: "",
+			},
+			valid: true,
+		},
+		"fedora-parent-invalid": {
+			options: ImageOptions{
+				ImageRef:   "fedora/39/x86_64/iot",
+				ParentRef:  "-bad",
+				URL:        "https://repo.example.com",
+				ContentURL: "",
+			},
+			valid: false,
+		},
+		"parent-without-url": {
+			options: ImageOptions{
+				ParentRef:  "parent/ref/without/a/URL",
+				ContentURL: "",
+			},
+			valid: false,
+		},
+		"bad-url": {
+			options: ImageOptions{
+				URL:        "this-is-not-a-url",
+				ContentURL: "",
+			},
+			valid: false,
+		},
+		"bad-content-url": {
+			options: ImageOptions{
+				ContentURL: "http;;//where-is-my-shift-key.com",
+			},
+			valid: false,
+		},
+		"checksum-ref": {
+			options: ImageOptions{
+				ImageRef: "c70e4ceff1726cb986eafd0230e2e1b0e5ebe590d0498a9f7c370c8ec3797deb",
+			},
+			valid: false,
+		},
+		"checksum-parent": {
+			options: ImageOptions{
+				ImageRef:  "the-ref",
+				ParentRef: "c70e4ceff1726cb986eafd0230e2e1b0e5ebe590d0498a9f7c370c8ec3797deb",
+			},
+			valid: false,
+		},
+	}
+
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, testCase.valid, testCase.options.Validate() == nil)
+		})
+	}
+
+}

--- a/pkg/ostree/ostree_test.go
+++ b/pkg/ostree/ostree_test.go
@@ -115,6 +115,6 @@ func TestVerifyRef(t *testing.T) {
 	}
 
 	for in, expOut := range cases {
-		assert.Equal(t, expOut, VerifyRef(in), in)
+		assert.Equal(t, expOut, verifyRef(in), in)
 	}
 }


### PR DESCRIPTION
If a ref to be resolved is already a checksum, just copy it to the checksum field and don't resolve.  This is only valid for parent refs.  Image refs that look like checksums will be caught by a new Validate() function.

Supporting checksums for parent refs means that users can specify a parent ostree commit that is not the head of a branch.

Resolves COMPOSER-1976

See also https://github.com/osbuild/osbuild-composer/issues/3107