### PR TITLE
Enable test retries (1 retrry)

### DIFF
--- a/test/generators/imgtestlib.py
+++ b/test/generators/imgtestlib.py
@@ -32,6 +32,7 @@ BASE_CONFIG = """
   after_script:
     - schutzbot/update_github_status.sh update || true
   interruptible: true
+  retry: 1
   tags:
     - terraform
 


### PR DESCRIPTION
It seems the tests and the specifically the test case generators aren't as stable as I thought.  Some network flakiness can occur at times and they probably went unnoticed before due to the retries, making it look like it was all stable.

This reverts commit dd14277c09d257661441bf7c8297ba84bae56e29.