### PR TITLE
generate-ostree-build-config: fix a wrong object access

### DIFF
--- a/test/generators/generate-ostree-build-config
+++ b/test/generators/generate-ostree-build-config
@@ -281,7 +281,7 @@ def generate_configs(build_requests, pull_configs, container_configs, pipeline_f
         config_name = config["name"]
 
         # generate script line to pull and start container
-        container = container_configs[config_name]["container"]
+        container = container_configs[config_name]
 
         # write the config to the artifacts directory
         build_config_path = os.path.join(configs_dir, config_name + ".json")


### PR DESCRIPTION
Cherry pick from https://github.com/osbuild/images/pull/98.  The Fedora 40 PR might take a while to get merged because new distros and their repos often have issues, so let's get this fix in quickly on its own.