### PR TITLE
devcontainer: update to work for images

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,33 +1,25 @@
-FROM fedora:36
+FROM fedora:38
 
 # Install:
 #  - a few packages for convenient usage
-#  - RPM tooling
 #  - the go compiler
-#  - weldr-client to use the weldr API
-#  - builddep to be able to pull in requirements from .spec
+#  - gpgme-devel
+#  - osbuild
 RUN dnf install -y \
     fish \
     fd-find \
     ripgrep \
     jq \
-    fedora-packager \
-    rpmdevtools \
-    go-srpm-macros \
     go \
-    weldr-client \
+    gpgme-devel \
     osbuild \
     osbuild-lvm2 \
     osbuild-luks2 \
     osbuild-ostree \
-    osbuild-tools \
-    'dnf-command(builddep)'
+    osbuild-tools
 # install the language server
 RUN go install -v golang.org/x/tools/gopls@latest
 RUN go install -v github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest
 RUN go install -v github.com/ramya-rao-a/go-outline@latest
 RUN go install -v github.com/go-delve/delve/cmd/dlv@latest
 RUN go install -v honnef.co/go/tools/cmd/staticcheck@latest
-COPY ./osbuild-composer.spec /tmp/osbuild-composer.spec
-RUN dnf builddep /tmp/osbuild-composer.spec -y
-RUN rm /tmp/osbuild-composer.spec

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "composer",
+  "name": "images",
   "build": {
     "dockerfile": "Dockerfile",
     "context": ".."
@@ -11,7 +11,6 @@
     "--privileged"
   ],
   "extensions": [
-    "laurenttreguier.rpm-spec",
     "golang.Go",
     "GitHub.vscode-pull-request-github"
   ]


### PR DESCRIPTION
There is no rpm for images, so we drop all rpm related bits. This also means we need to include the `gpgme-devel` dependency explicitly.

Update the container from f36 to f38.