### PR TITLE
test: ignore stage ordering for distro-arch jobs

### DIFF
--- a/test/generators/configure-generators
+++ b/test/generators/configure-generators
@@ -47,6 +47,8 @@ image-build-trigger-{distro}-{arch}:
       - artifact: build-config.yml
         job: generate-build-config-{distro}-{arch}
     strategy: depend
+  needs:
+    - generate-build-config-{distro}-{arch}
 """
 
 OSTREE_GEN_TEMPLATE = """
@@ -65,6 +67,8 @@ generate-ostree-build-config-{distro}-{arch}:
     paths:
       - build-config.yml
       - build-configs
+  needs:
+    - image-build-trigger-{distro}-{arch}
 """
 
 OSTREE_TRIGGER_TEMPLATE = """
@@ -75,6 +79,8 @@ image-build-ostree-trigger-{distro}-{arch}:
       - artifact: build-config.yml
         job: generate-ostree-build-config-{distro}-{arch}
     strategy: depend
+  needs:
+    - generate-ostree-build-config-{distro}-{arch}
 """
 
 


### PR DESCRIPTION
Using the 'needs' keyword [1], a job will start as soon as its dependency is done, without waiting for the whole previous stage to finish.  This means that build jobs will start as soon as the corresponding generate jobs are done (i.e. for the same distro-arch), ostree-generators will run as soon as the corresponding build jobs are done, and ostree-build jobs will run as soon as the corresponding ostree-generators are done.

This might speed up execution in cases where one generator job takes longer than usual, for whatever reason, and ends up not generating any builds, whereas another generator job finishes early and does generate builds.

[1] https://docs.gitlab.com/ee/ci/yaml/index.html#needs