### PR TITLE
Femove iot-qcow2-image function in Fedora

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -214,7 +214,7 @@ var (
 		defaultSize:         10 * common.GibiByte,
 		rpmOstree:           true,
 		bootable:            true,
-		image:               iotQcow2Image,
+		image:               iotImage,
 		buildPipelines:      []string{"build"},
 		payloadPipelines:    []string{"ostree-deployment", "image", "qcow2"},
 		exports:             []string{"qcow2"},

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -3,7 +3,6 @@ package fedora
 import (
 	"fmt"
 	"math/rand"
-	"strings"
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/fdo"
@@ -542,75 +541,6 @@ func iotImage(workload workload.Workload,
 
 	img.Filename = t.Filename()
 	img.Compression = t.compression
-
-	return img, nil
-}
-
-func iotQcow2Image(workload workload.Workload,
-	t *imageType,
-	customizations *blueprint.Customizations,
-	options distro.ImageOptions,
-	packageSets map[string]rpmmd.PackageSet,
-	containers []container.SourceSpec,
-	rng *rand.Rand) (image.ImageKind, error) {
-
-	commit, err := makeOSTreePayloadCommit(options.OSTree, t.OSTreeRef())
-	if err != nil {
-		return nil, fmt.Errorf("%s: %s", t.Name(), err.Error())
-	}
-	img := image.NewOSTreeDiskImage(commit)
-
-	distro := t.Arch().Distro()
-
-	img.Users = users.UsersFromBP(customizations.GetUsers())
-	img.Groups = users.GroupsFromBP(customizations.GetGroups())
-
-	img.Directories, err = blueprint.DirectoryCustomizationsToFsNodeDirectories(customizations.GetDirectories())
-	if err != nil {
-		return nil, err
-	}
-	img.Files, err = blueprint.FileCustomizationsToFsNodeFiles(customizations.GetFiles())
-	if err != nil {
-		return nil, err
-	}
-
-	img.KernelOptionsAppend = []string{"modprobe.blacklist=vc4"}
-	img.Keyboard = "us"
-	img.Locale = "C.UTF-8"
-
-	// Set sysroot read-only only for Fedora 37+
-	if !common.VersionLessThan(distro.Releasever(), "37") {
-		img.SysrootReadOnly = true
-		img.KernelOptionsAppend = append(img.KernelOptionsAppend, "rw")
-	}
-
-	img.Platform = t.platform
-	img.Workload = workload
-
-	img.Remote = ostree.Remote{
-		Name:        "fedora-iot",
-		URL:         "https://ostree.fedoraproject.org/iot",
-		ContentURL:  "mirrorlist=https://ostree.fedoraproject.org/iot/mirrorlist",
-		GPGKeyPaths: []string{"/etc/pki/rpm-gpg/"},
-	}
-	img.OSName = "fedora-iot"
-
-	if strings.HasPrefix(distro.Name(), "fedora") && !common.VersionLessThan(distro.Releasever(), "38") {
-		img.Ignition = true
-		img.IgnitionPlatform = "qemu"
-	}
-
-	if kopts := customizations.GetKernel(); kopts != nil && kopts.Append != "" {
-		img.KernelOptionsAppend = append(img.KernelOptionsAppend, kopts.Append)
-	}
-
-	pt, err := t.getPartitionTable(customizations.GetFilesystems(), options, rng)
-	if err != nil {
-		return nil, err
-	}
-	img.PartitionTable = pt
-
-	img.Filename = t.Filename()
 
 	return img, nil
 }


### PR DESCRIPTION
The function was added accidentally [1] while rebasing a PR from osbuild-composer [2].  During the rebase, the functionality of iotQcow2Image() was merged with the existing iotImage() function since they share most of their code but the function wasn't removed.

I've confirmed that this has no effect on the image definitions.

[1] 963aba2dddd0fe1385840c23da3ef16d596f0c23
[2] https://github.com/osbuild/images/pull/79