### PR TITLE
Enable / disable services also using presets for OSTree deployment images if Ignition is used.

### DIFF
--- a/pkg/osbuild/systemd_preset_stage.go
+++ b/pkg/osbuild/systemd_preset_stage.go
@@ -36,3 +36,21 @@ func (o SystemdPresetStageOptions) validate() error {
 	}
 	return nil
 }
+
+// GenServicesPresetStage creates a new systemd preset stage for the given
+// list of services to enable and disable.
+func GenServicesPresetStage(enabled, disabled []string) *Stage {
+	if len(enabled) == 0 && len(disabled) == 0 {
+		return nil
+	}
+
+	presets := make([]Preset, 0, len(enabled)+len(disabled))
+	for _, name := range enabled {
+		presets = append(presets, Preset{Name: name, State: StateEnable})
+	}
+	for _, name := range disabled {
+		presets = append(presets, Preset{Name: name, State: StateDisable})
+	}
+
+	return NewSystemdPresetStage(&SystemdPresetStageOptions{Presets: presets})
+}

--- a/pkg/osbuild/systemd_preset_stage_test.go
+++ b/pkg/osbuild/systemd_preset_stage_test.go
@@ -1,0 +1,63 @@
+package osbuild
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenServicesPresetStage(t *testing.T) {
+	type TestCase struct {
+		Name          string
+		Enabled       []string
+		Disabled      []string
+		ExpectedStage *Stage
+	}
+
+	tests := []TestCase{
+		{
+			Name:          "empty",
+			ExpectedStage: nil,
+		},
+		{
+			Name:    "enabled-only",
+			Enabled: []string{"foo.service", "bar.service"},
+			ExpectedStage: NewSystemdPresetStage(&SystemdPresetStageOptions{
+				Presets: []Preset{
+					{Name: "foo.service", State: StateEnable},
+					{Name: "bar.service", State: StateEnable},
+				},
+			}),
+		},
+		{
+			Name:     "disabled-only",
+			Disabled: []string{"foo.service", "bar.service"},
+			ExpectedStage: NewSystemdPresetStage(&SystemdPresetStageOptions{
+				Presets: []Preset{
+					{Name: "foo.service", State: StateDisable},
+					{Name: "bar.service", State: StateDisable},
+				},
+			}),
+		},
+		{
+			Name:     "enabled-and-disabled",
+			Enabled:  []string{"foo.service", "bar.service"},
+			Disabled: []string{"baz.service", "bob.service"},
+			ExpectedStage: NewSystemdPresetStage(&SystemdPresetStageOptions{
+				Presets: []Preset{
+					{Name: "foo.service", State: StateEnable},
+					{Name: "bar.service", State: StateEnable},
+					{Name: "baz.service", State: StateDisable},
+					{Name: "bob.service", State: StateDisable},
+				},
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			actualStage := GenServicesPresetStage(tt.Enabled, tt.Disabled)
+			assert.Equal(t, tt.ExpectedStage, actualStage)
+		})
+	}
+}


### PR DESCRIPTION
Extend the `OSTreeDeployment` pipeline implementation to enable / disable services also using systemd presets in case Ignition is being used.

The pipeline already enables / disables services using the Systemd stage, which calls `systemctl`, but on some systems (since Fedora 37), Systemd will reset all enabled / disabled services based on system presets on first boot. This is not a problem for our images in general, since they contain fake machine-id, which makes systemd think that the system is not booting for the first time. This is however not the case when Ignition is being used, since it signals to systemd to treat the first boot as an actual first boot.

Enabling systemd services using `systemctl` is still kept in the pipeline, since the end result will be the same even if services are enabled / disabled multiple times via different means.

Related to:
- https://github.com/osbuild/osbuild-composer/pull/3634
- https://fedoraproject.org/wiki/Changes/Preset_All_Systemd_Units_on_First_Boot