### PR TITLE
distro/fedora: align the vhd image to the official version

### DIFF
--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -11,13 +11,12 @@ import (
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-func qcow2CommonPackageSet(t *imageType) rpmmd.PackageSet {
+func cloudBaseSet(t *imageType) rpmmd.PackageSet {
 	return rpmmd.PackageSet{
 		Include: []string{
 			"@Fedora Cloud Server",
 			"chrony", // not mentioned in the kickstart, anaconda pulls it when setting the timezone
 			"langpacks-en",
-			"qemu-guest-agent",
 		},
 		Exclude: []string{
 			"dracut-config-rescue",
@@ -29,25 +28,22 @@ func qcow2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 	}
 }
 
+func qcow2CommonPackageSet(t *imageType) rpmmd.PackageSet {
+	return cloudBaseSet(t).Append(
+		rpmmd.PackageSet{
+			Include: []string{
+				"qemu-guest-agent",
+			},
+		})
+}
+
 func vhdCommonPackageSet(t *imageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			"@core",
-			"chrony",
-			"langpacks-en",
-			"net-tools",
-			"ntfsprogs",
-			"libxcrypt-compat",
-			"initscripts",
-			"glibc-all-langpacks",
-		},
-		Exclude: []string{
-			"dracut-config-rescue",
-			"geolite2-city",
-			"geolite2-country",
-			"zram-generator-defaults",
-		},
-	}
+	return cloudBaseSet(t).Append(
+		rpmmd.PackageSet{
+			Include: []string{
+				"WALinuxAgent",
+			},
+		})
 }
 
 func vmdkCommonPackageSet(t *imageType) rpmmd.PackageSet {


### PR DESCRIPTION
I took the kickstart from Fedora and reimplemented it here. This should fix a lot of issues like missing cloud-init. Since the kickstart for azure is inheriting the kickstart from the base cloud image, I did the same thing in our code to mimic that.

See
https://pagure.io/fedora-kickstarts/blob/58c856ae882a93362f025b4efae143fbd778edc9/f/fedora-cloud-base-azure.ks