### PR TITLE
distro: fix kernel options for Fedora Azure image

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -276,7 +276,7 @@ var (
 				"loadmodules.service",
 			},
 		},
-		kernelOptions:       defaultKernelOptions,
+		kernelOptions:       cloudKernelOptions,
 		bootable:            true,
 		defaultSize:         2 * common.GibiByte,
 		image:               diskImage,


### PR DESCRIPTION
During rebase of 3d3649014465603f700cfe4191edcc39ddb64514, this change was missed due to 3d8388edf8c5e7f5b62ef0b5f7d1c7314e7eb2ed.