### PR TITLE
simplified-installer/fedora: extend rootlv size

### DIFF
--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -350,7 +350,7 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 						Description: "built with lvm2 and osbuild",
 						LogicalVolumes: []disk.LVMLogicalVolume{
 							{
-								Size: 2569 * common.MebiByte,
+								Size: 8 * common.GibiByte,
 								Name: "rootlv",
 								Payload: &disk.Filesystem{
 									Type:         "ext4",
@@ -420,7 +420,7 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 						Description: "built with lvm2 and osbuild",
 						LogicalVolumes: []disk.LVMLogicalVolume{
 							{
-								Size: 2569 * common.MebiByte,
+								Size: 8 * common.GibiByte,
 								Name: "rootlv",
 								Payload: &disk.Filesystem{
 									Type:         "ext4",


### PR DESCRIPTION
This PR fixes [#3529](https://github.com/osbuild/osbuild-composer/issues/3529) , and extends the `iotSimplifiedInstallerPartitionTables` `rootlv` to 8GiB. 