### PR TITLE
rhel9: GCE: Add correct grub2 tools for UEFI platforms

### DIFF
--- a/pkg/distro/rhel9/gce.go
+++ b/pkg/distro/rhel9/gce.go
@@ -235,7 +235,8 @@ func gceCommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"chrony",
 			"timedatex",
 			// EFI
-			"grub2-tools-efi",
+			"grub2-tools",
+			"grub2-tools-minimal",
 			"firewalld", // not pulled in any more as on RHEL-8
 		},
 		Exclude: []string{


### PR DESCRIPTION
The grub2-tools-efi package is actually contains tools just for booting Linux on x86 EFI Apple Macs, they're three tools that are uesd for the Mac bless process. The actually useful UEFI tools for normal platforms are contained in the minimal and main tools package so ensure we have the right ones in place for GCE images.