### PR TITLE
osbuild.OSBuildVersion: return version without trailing newline

### DIFF
--- a/pkg/osbuild/osbuild-exec.go
+++ b/pkg/osbuild/osbuild-exec.go
@@ -98,5 +98,8 @@ func OSBuildVersion() (string, error) {
 	}
 
 	// osbuild --version prints the version in the form of "osbuild VERSION". Extract the version.
-	return strings.TrimPrefix(stdoutBuffer.String(), "osbuild "), nil
+	version := strings.TrimPrefix(stdoutBuffer.String(), "osbuild ")
+	// Remove the trailing newline.
+	version = strings.TrimSpace(version)
+	return version, nil
 }


### PR DESCRIPTION
The version string returned by the `OSBuildVersion()` function contained a trailing newline. Ensure that it is removed.