### PR TITLE
Edge remove hybrid boot

### DIFF
--- a/pkg/distro/rhel8/distro.go
+++ b/pkg/distro/rhel8/distro.go
@@ -251,21 +251,23 @@ func newDistro(name string, minor int) *distribution {
 		amiImgTypeX86_64(rd),
 	)
 
+	x86FirmwarePackages := []string{
+		"microcode_ctl", // ??
+		"iwl1000-firmware",
+		"iwl100-firmware",
+		"iwl105-firmware",
+		"iwl135-firmware",
+		"iwl2000-firmware",
+		"iwl2030-firmware",
+		"iwl3160-firmware",
+		"iwl5000-firmware",
+		"iwl5150-firmware",
+		"iwl6050-firmware",
+	}
+
 	bareMetalX86Platform := &platform.X86{
 		BasePlatform: platform.BasePlatform{
-			FirmwarePackages: []string{
-				"microcode_ctl", // ??
-				"iwl1000-firmware",
-				"iwl100-firmware",
-				"iwl105-firmware",
-				"iwl135-firmware",
-				"iwl2000-firmware",
-				"iwl2030-firmware",
-				"iwl3160-firmware",
-				"iwl5000-firmware",
-				"iwl5150-firmware",
-				"iwl6050-firmware",
-			},
+			FirmwarePackages: x86FirmwarePackages,
 		},
 		BIOS:       true,
 		UEFIVendor: rd.vendor,
@@ -273,10 +275,21 @@ func newDistro(name string, minor int) *distribution {
 
 	x86_64.addImageTypes(
 		bareMetalX86Platform,
+		imageInstaller(),
+	)
+
+	edgeX86Platform := &platform.X86{
+		BasePlatform: platform.BasePlatform{
+			FirmwarePackages: x86FirmwarePackages,
+		},
+		UEFIVendor: rd.vendor,
+	}
+
+	x86_64.addImageTypes(
+		edgeX86Platform,
 		edgeOCIImgType(rd),
 		edgeCommitImgType(rd),
 		edgeInstallerImgType(rd),
-		imageInstaller(),
 	)
 
 	gceX86Platform := &platform.X86{
@@ -437,7 +450,7 @@ func newDistro(name string, minor int) *distribution {
 			// image types only available on 8.6 and later on RHEL
 			// These edge image types require FDO which aren't available on older versions
 			x86_64.addImageTypes(
-				bareMetalX86Platform,
+				edgeX86Platform,
 				edgeRawImgType(),
 			)
 
@@ -490,7 +503,7 @@ func newDistro(name string, minor int) *distribution {
 		rd.addArches(s390x)
 	} else {
 		x86_64.addImageTypes(
-			bareMetalX86Platform,
+			edgeX86Platform,
 			edgeRawImgType(),
 		)
 

--- a/pkg/distro/rhel8/edge.go
+++ b/pkg/distro/rhel8/edge.go
@@ -163,7 +163,7 @@ func minimalRawImgType(rd distribution) imageType {
 		buildPipelines:      []string{"build"},
 		payloadPipelines:    []string{"os", "image", "xz"},
 		exports:             []string{"xz"},
-		basePartitionTables: defaultBasePartitionTables,
+		basePartitionTables: minimalRawBasePartitionTable,
 	}
 	return it
 }

--- a/pkg/distro/rhel8/partition_tables.go
+++ b/pkg/distro/rhel8/partition_tables.go
@@ -299,12 +299,6 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     1 * common.MebiByte,
-				Bootable: true,
-				Type:     disk.BIOSBootPartitionGUID,
-				UUID:     disk.BIOSBootPartitionUUID,
-			},
-			{
 				Size: 127 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
@@ -418,6 +412,73 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 						FSTabFreq:    0,
 						FSTabPassNo:  0,
 					},
+				},
+			},
+		},
+	},
+}
+
+var minimalRawBasePartitionTable = distro.BasePartitionTableMap{
+	platform.ARCH_X86_64.String(): disk.PartitionTable{
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []disk.Partition{
+			{
+				Size: 100 * common.MebiByte,
+				Type: disk.EFISystemPartitionGUID,
+				UUID: disk.EFISystemPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "vfat",
+					UUID:         disk.EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 2 * common.GibiByte,
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.RootPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "xfs",
+					Label:        "root",
+					Mountpoint:   "/",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+		},
+	},
+	platform.ARCH_AARCH64.String(): disk.PartitionTable{
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []disk.Partition{
+			{
+				Size: 100 * common.MebiByte,
+				Type: disk.EFISystemPartitionGUID,
+				UUID: disk.EFISystemPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "vfat",
+					UUID:         disk.EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 2 * common.GibiByte,
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.RootPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "xfs",
+					Label:        "root",
+					Mountpoint:   "/",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
 				},
 			},
 		},

--- a/pkg/distro/rhel9/distro.go
+++ b/pkg/distro/rhel9/distro.go
@@ -293,31 +293,42 @@ func newDistro(name string, minor int) *distribution {
 		mkGCEImageType(rd.isRHEL()),
 	)
 
+	x86FirmwarePackages := []string{
+		"microcode_ctl", // ??
+		"iwl1000-firmware",
+		"iwl100-firmware",
+		"iwl105-firmware",
+		"iwl135-firmware",
+		"iwl2000-firmware",
+		"iwl2030-firmware",
+		"iwl3160-firmware",
+		"iwl5000-firmware",
+		"iwl5150-firmware",
+		"iwl6050-firmware",
+	}
+
 	x86_64.addImageTypes(
 		&platform.X86{
 			BasePlatform: platform.BasePlatform{
-				FirmwarePackages: []string{
-					"microcode_ctl", // ??
-					"iwl1000-firmware",
-					"iwl100-firmware",
-					"iwl105-firmware",
-					"iwl135-firmware",
-					"iwl2000-firmware",
-					"iwl2030-firmware",
-					"iwl3160-firmware",
-					"iwl5000-firmware",
-					"iwl5150-firmware",
-					"iwl6050-firmware",
-				},
+				FirmwarePackages: x86FirmwarePackages,
 			},
 			BIOS:       true,
+			UEFIVendor: rd.vendor,
+		},
+		imageInstaller,
+	)
+
+	x86_64.addImageTypes(
+		&platform.X86{
+			BasePlatform: platform.BasePlatform{
+				FirmwarePackages: x86FirmwarePackages,
+			},
 			UEFIVendor: rd.vendor,
 		},
 		edgeOCIImgType,
 		edgeCommitImgType,
 		edgeInstallerImgType,
 		edgeRawImgType,
-		imageInstaller,
 		edgeAMIImgType,
 	)
 
@@ -326,7 +337,6 @@ func newDistro(name string, minor int) *distribution {
 			BasePlatform: platform.BasePlatform{
 				ImageFormat: platform.FORMAT_VMDK,
 			},
-			BIOS:       true,
 			UEFIVendor: rd.vendor,
 		},
 		edgeVsphereImgType,
@@ -337,7 +347,6 @@ func newDistro(name string, minor int) *distribution {
 			BasePlatform: platform.BasePlatform{
 				ImageFormat: platform.FORMAT_RAW,
 			},
-			BIOS:       false,
 			UEFIVendor: rd.vendor,
 		},
 		edgeSimplifiedInstallerImgType,

--- a/pkg/distro/rhel9/edge.go
+++ b/pkg/distro/rhel9/edge.go
@@ -326,12 +326,6 @@ var (
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
-					Size:     1 * common.MebiByte, // 1MB
-					Bootable: true,
-					Type:     disk.BIOSBootPartitionGUID,
-					UUID:     disk.BIOSBootPartitionUUID,
-				},
-				{
 					Size: 127 * common.MebiByte, // 127 MB
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,


### PR DESCRIPTION
Remove hybrid boot and all the legacy BIOS partitions from Edge images as UEFI is the only supported boot mechanism.  