### PR TITLE
remove greenboot-default-health-check rpm

### DIFF
--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -111,7 +111,6 @@ func iotCommitPackageSet(t *imageType) rpmmd.PackageSet {
 			"glibc-minimal-langpack",
 			"gnupg2",
 			"greenboot",
-			"greenboot-default-health-checks",
 			"gzip",
 			"hostname",
 			"ignition",

--- a/pkg/distro/rhel8/edge.go
+++ b/pkg/distro/rhel8/edge.go
@@ -270,7 +270,6 @@ func edgeCommitPackageSet(t *imageType) rpmmd.PackageSet {
 			Include: []string{
 				"fdo-client",
 				"fdo-owner-cli",
-				"greenboot-default-health-checks",
 				"sos",
 			},
 		})

--- a/pkg/distro/rhel9/edge.go
+++ b/pkg/distro/rhel9/edge.go
@@ -547,7 +547,6 @@ func edgeCommitPackageSet(t *imageType) rpmmd.PackageSet {
 			"clevis-dracut",
 			"clevis-luks",
 			"greenboot",
-			"greenboot-default-health-checks",
 			"fdo-client",
 			"fdo-owner-cli",
 			"sos",

--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -614,7 +614,6 @@
         - assert:
             that:
               - "'greenboot-0' in result_greenboot_packages.stdout"
-              - "'greenboot-default-health-checks' in result_greenboot_packages.stdout"
             fail_msg: "Some of greenboot and its related packages are not installed"
             success_msg: "All greenboot and its related packages are installed"
       always:

--- a/test/data/ansible/check_ostree_nort.yaml
+++ b/test/data/ansible/check_ostree_nort.yaml
@@ -333,7 +333,6 @@
         - assert:
             that:
               - "'greenboot-0' in result_greenboot_packages.stdout"
-              - "'greenboot-default-health-checks' in result_greenboot_packages.stdout"
             fail_msg: "Some of greenboot and its related packages are not installed"
             success_msg: "All greenboot and its related packages are installed"
       always:


### PR DESCRIPTION
greenboot-health-checks scripts provided by default is contradicting with some of the edge use cases, like usb installation with no network connectivity.Need to make the scripts more resilient  that can cater to generic use-cases before adding them as mandatory package.