### PR TITLE
Minimal image builds

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -67,6 +67,7 @@ type crBlueprint struct {
 	Containers     []blueprint.Container     `json:"containers,omitempty"`
 	Customizations *blueprint.Customizations `json:"customizations,omitempty"`
 	Distro         string                    `json:"distro,omitempty"`
+	Minimal        bool                      `json:"minimal,omitempty"`
 }
 
 type BuildConfig struct {

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -73,6 +73,7 @@ type crBlueprint struct {
 	Containers     []blueprint.Container     `json:"containers,omitempty"`
 	Customizations *blueprint.Customizations `json:"customizations,omitempty"`
 	Distro         string                    `json:"distro,omitempty"`
+	Minimal        bool                      `json:"minimal,omitempty"`
 }
 
 type buildRequest struct {

--- a/internal/environment/azure.go
+++ b/internal/environment/azure.go
@@ -5,9 +5,18 @@ type Azure struct {
 }
 
 func (p *Azure) GetPackages() []string {
-	return []string{"WALinuxAgent"}
+	return []string{
+		"cloud-init",
+		"WALinuxAgent",
+	}
 }
 
 func (p *Azure) GetServices() []string {
-	return []string{"waagent"}
+	return []string{
+		"cloud-init.service",
+		"cloud-config.service",
+		"cloud-final.service",
+		"cloud-init-local.service",
+		"waagent",
+	}
 }

--- a/internal/environment/ec2.go
+++ b/internal/environment/ec2.go
@@ -9,5 +9,10 @@ func (p *EC2) GetPackages() []string {
 }
 
 func (p *EC2) GetServices() []string {
-	return []string{"cloud-init.service"}
+	return []string{
+		"cloud-init.service",
+		"cloud-config.service",
+		"cloud-final.service",
+		"cloud-init-local.service",
+	}
 }

--- a/internal/environment/kvm.go
+++ b/internal/environment/kvm.go
@@ -1,0 +1,21 @@
+package environment
+
+type KVM struct {
+	BaseEnvironment
+}
+
+func (e *KVM) GetPackages() []string {
+	return []string{
+		"cloud-init",
+		"qemu-guest-agent",
+	}
+}
+
+func (e *KVM) GetServices() []string {
+	return []string{
+		"cloud-init.service",
+		"cloud-config.service",
+		"cloud-final.service",
+		"cloud-init-local.service",
+	}
+}

--- a/pkg/blueprint/blueprint.go
+++ b/pkg/blueprint/blueprint.go
@@ -14,14 +14,6 @@ type Blueprint struct {
 	Distro         string          `json:"distro" toml:"distro"`
 }
 
-type Change struct {
-	Commit    string    `json:"commit" toml:"commit"`
-	Message   string    `json:"message" toml:"message"`
-	Revision  *int      `json:"revision" toml:"revision"`
-	Timestamp string    `json:"timestamp" toml:"timestamp"`
-	Blueprint Blueprint `json:"-" toml:"-"`
-}
-
 // A Package specifies an RPM package.
 type Package struct {
 	Name    string `json:"name" toml:"name"`

--- a/pkg/blueprint/blueprint.go
+++ b/pkg/blueprint/blueprint.go
@@ -12,6 +12,7 @@ type Blueprint struct {
 	Containers     []Container     `json:"containers,omitempty" toml:"containers,omitempty"`
 	Customizations *Customizations `json:"customizations,omitempty" toml:"customizations"`
 	Distro         string          `json:"distro" toml:"distro"`
+	Minimal        bool            `json:"minimal" toml:"minimal"`
 }
 
 // A Package specifies an RPM package.

--- a/pkg/blueprint/blueprint.go
+++ b/pkg/blueprint/blueprint.go
@@ -12,7 +12,9 @@ type Blueprint struct {
 	Containers     []Container     `json:"containers,omitempty" toml:"containers,omitempty"`
 	Customizations *Customizations `json:"customizations,omitempty" toml:"customizations"`
 	Distro         string          `json:"distro" toml:"distro"`
-	Minimal        bool            `json:"minimal" toml:"minimal"`
+
+	// EXPERIMENTAL
+	Minimal bool `json:"minimal" toml:"minimal"`
 }
 
 // A Package specifies an RPM package.

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -233,20 +233,15 @@ var (
 	}
 
 	qcow2ImgType = imageType{
-		name:     "qcow2",
-		filename: "disk.qcow2",
-		mimeType: "application/x-qemu-disk",
+		name:        "qcow2",
+		filename:    "disk.qcow2",
+		mimeType:    "application/x-qemu-disk",
+		environment: &environment.KVM{},
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: qcow2CommonPackageSet,
 		},
 		defaultImageConfig: &distro.ImageConfig{
 			DefaultTarget: common.ToPtr("multi-user.target"),
-			EnabledServices: []string{
-				"cloud-init.service",
-				"cloud-config.service",
-				"cloud-final.service",
-				"cloud-init-local.service",
-			},
 		},
 		kernelOptions:       cloudKernelOptions,
 		bootable:            true,

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -247,6 +247,10 @@ func diskImage(workload workload.Workload,
 	img.Environment = t.environment
 	img.Workload = workload
 	img.Compression = t.compression
+	if bp.Minimal {
+		// Disable weak dependencies if the 'minimal' option is enabled
+		img.InstallWeakDeps = common.ToPtr(false)
+	}
 	// TODO: move generation into LiveImage
 	pt, err := t.getPartitionTable(bp.Customizations.GetFilesystems(), options, rng)
 	if err != nil {

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -235,7 +235,7 @@ func osCustomizations(
 
 func diskImage(workload workload.Workload,
 	t *imageType,
-	customizations *blueprint.Customizations,
+	bp *blueprint.Blueprint,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
@@ -243,12 +243,12 @@ func diskImage(workload workload.Workload,
 
 	img := image.NewDiskImage()
 	img.Platform = t.platform
-	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, customizations)
+	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, bp.Customizations)
 	img.Environment = t.environment
 	img.Workload = workload
 	img.Compression = t.compression
 	// TODO: move generation into LiveImage
-	pt, err := t.getPartitionTable(customizations.GetFilesystems(), options, rng)
+	pt, err := t.getPartitionTable(bp.Customizations.GetFilesystems(), options, rng)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +261,7 @@ func diskImage(workload workload.Workload,
 
 func containerImage(workload workload.Workload,
 	t *imageType,
-	c *blueprint.Customizations,
+	bp *blueprint.Blueprint,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
@@ -269,7 +269,7 @@ func containerImage(workload workload.Workload,
 	img := image.NewBaseContainer()
 
 	img.Platform = t.platform
-	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, c)
+	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, bp.Customizations)
 	img.Environment = t.environment
 	img.Workload = workload
 
@@ -280,7 +280,7 @@ func containerImage(workload workload.Workload,
 
 func liveInstallerImage(workload workload.Workload,
 	t *imageType,
-	customizations *blueprint.Customizations,
+	bp *blueprint.Blueprint,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
@@ -307,7 +307,7 @@ func liveInstallerImage(workload workload.Workload,
 
 func imageInstallerImage(workload workload.Workload,
 	t *imageType,
-	customizations *blueprint.Customizations,
+	bp *blueprint.Blueprint,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
@@ -327,6 +327,7 @@ func imageInstallerImage(workload workload.Workload,
 	}
 	img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, "org.fedoraproject.Anaconda.Modules.Users")
 
+	customizations := bp.Customizations
 	img.Platform = t.platform
 	img.Workload = workload
 	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, customizations)
@@ -351,7 +352,7 @@ func imageInstallerImage(workload workload.Workload,
 
 func iotCommitImage(workload workload.Workload,
 	t *imageType,
-	customizations *blueprint.Customizations,
+	bp *blueprint.Blueprint,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
@@ -363,7 +364,7 @@ func iotCommitImage(workload workload.Workload,
 	d := t.arch.distro
 
 	img.Platform = t.platform
-	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, customizations)
+	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, bp.Customizations)
 	if !common.VersionLessThan(d.Releasever(), "38") {
 		// see https://github.com/ostreedev/ostree/issues/2840
 		img.OSCustomizations.Presets = []osbuild.Preset{
@@ -393,7 +394,7 @@ func iotCommitImage(workload workload.Workload,
 
 func iotContainerImage(workload workload.Workload,
 	t *imageType,
-	customizations *blueprint.Customizations,
+	bp *blueprint.Blueprint,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
@@ -403,7 +404,7 @@ func iotContainerImage(workload workload.Workload,
 	img := image.NewOSTreeContainer(commitRef)
 	d := t.arch.distro
 	img.Platform = t.platform
-	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, customizations)
+	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, bp.Customizations)
 	if !common.VersionLessThan(d.Releasever(), "38") {
 		// see https://github.com/ostreedev/ostree/issues/2840
 		img.OSCustomizations.Presets = []osbuild.Preset{
@@ -434,7 +435,7 @@ func iotContainerImage(workload workload.Workload,
 
 func iotInstallerImage(workload workload.Workload,
 	t *imageType,
-	customizations *blueprint.Customizations,
+	bp *blueprint.Blueprint,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
@@ -449,6 +450,7 @@ func iotInstallerImage(workload workload.Workload,
 
 	img := image.NewAnacondaOSTreeInstaller(commit)
 
+	customizations := bp.Customizations
 	img.Platform = t.platform
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
 	img.Users = users.UsersFromBP(customizations.GetUsers())
@@ -475,7 +477,7 @@ func iotInstallerImage(workload workload.Workload,
 
 func iotImage(workload workload.Workload,
 	t *imageType,
-	customizations *blueprint.Customizations,
+	bp *blueprint.Blueprint,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
@@ -489,6 +491,7 @@ func iotImage(workload workload.Workload,
 
 	distro := t.Arch().Distro()
 
+	customizations := bp.Customizations
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 
@@ -551,7 +554,7 @@ func iotImage(workload workload.Workload,
 
 func iotSimplifiedInstallerImage(workload workload.Workload,
 	t *imageType,
-	customizations *blueprint.Customizations,
+	bp *blueprint.Blueprint,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
@@ -563,6 +566,7 @@ func iotSimplifiedInstallerImage(workload workload.Workload,
 	}
 	rawImg := image.NewOSTreeDiskImage(commit)
 
+	customizations := bp.Customizations
 	rawImg.Users = users.UsersFromBP(customizations.GetUsers())
 	rawImg.Groups = users.GroupsFromBP(customizations.GetGroups())
 

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -174,8 +174,11 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 	// of the same name from the distro and arch
 	staticPackageSets := make(map[string]rpmmd.PackageSet)
 
-	for name, getter := range t.packageSets {
-		staticPackageSets[name] = getter(t)
+	// don't add any static packages if Minimal was selected
+	if !bp.Minimal {
+		for name, getter := range t.packageSets {
+			staticPackageSets[name] = getter(t)
+		}
 	}
 
 	// amend with repository information and collect payload repos

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -21,7 +21,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-type imageFunc func(workload workload.Workload, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, packageSets map[string]rpmmd.PackageSet, containers []container.SourceSpec, rng *rand.Rand) (image.ImageKind, error)
+type imageFunc func(workload workload.Workload, t *imageType, bp *blueprint.Blueprint, options distro.ImageOptions, packageSets map[string]rpmmd.PackageSet, containers []container.SourceSpec, rng *rand.Rand) (image.ImageKind, error)
 
 type packageSetFunc func(t *imageType) rpmmd.PackageSet
 
@@ -222,7 +222,7 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 	/* #nosec G404 */
 	rng := rand.New(source)
 
-	img, err := t.image(w, t, bp.Customizations, options, staticPackageSets, containerSources, rng)
+	img, err := t.image(w, t, bp, options, staticPackageSets, containerSources, rng)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/image/disk.go
+++ b/pkg/image/disk.go
@@ -32,6 +32,10 @@ type DiskImage struct {
 	OSProduct string
 	OSVersion string
 	OSNick    string
+
+	// InstallWeakDeps enables installation of weak dependencies for packages
+	// that are statically defined for the payload pipeline of the image.
+	InstallWeakDeps *bool
 }
 
 func NewDiskImage() *DiskImage {
@@ -57,6 +61,9 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.OSProduct = img.OSProduct
 	osPipeline.OSVersion = img.OSVersion
 	osPipeline.OSNick = img.OSNick
+	if img.InstallWeakDeps != nil {
+		osPipeline.InstallWeakDeps = *img.InstallWeakDeps
+	}
 
 	rawImagePipeline := manifest.NewRawImage(buildPipeline, osPipeline)
 	rawImagePipeline.PartTool = img.PartTool

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -167,6 +167,9 @@ type OS struct {
 	OSVersion string
 	OSNick    string
 
+	// InstallWeakDeps enables installation of weak dependencies for packages
+	// that are statically defined for the pipeline.
+	// Defaults to True.
 	InstallWeakDeps bool
 }
 

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -105,5 +105,21 @@
       "centos*",
       "fedora*"
     ]
+  },
+  "./configs/minimal.json": {
+    "image-types": [
+      "qcow2"
+    ],
+    "distros": [
+      "fedora*"
+    ]
+  },
+  "./configs/minimal-pkgs.json": {
+    "image-types": [
+      "qcow2"
+    ],
+    "distros": [
+      "fedora*"
+    ]
   }
 }

--- a/test/configs/minimal-pkgs.json
+++ b/test/configs/minimal-pkgs.json
@@ -1,0 +1,14 @@
+{
+  "name": "minimal-pkgs",
+  "blueprint": {
+    "minimal": true,
+    "packages": [
+      {
+        "name": "tmux"
+      },
+      {
+        "name": "vim-enhanced"
+      }
+    ]
+  }
+}

--- a/test/configs/minimal.json
+++ b/test/configs/minimal.json
@@ -1,0 +1,6 @@
+{
+  "name": "minimal",
+  "blueprint": {
+    "minimal": true
+  }
+}


### PR DESCRIPTION
This PR adds a new feature to the build configuration called `minimal` which affects payload packages in two ways:
- It ignores any statically defined packages for an image type (the packages defined on `ImageType.packageSets`).
- It disables weak dependencies for all payload packages.

The option therefore creates a **minimal** image where the packages installed are only the ones required to boot the image and provide basic functionality according to Platform (for firmware and bootloader configuration for example) and the Environment (`cloud-init` for cloud environment for example), removing any packages from an image type that are added purely by policy.

For the qcow2 (and its derivatives), the enabled services have been removed from the base image type configuration and moved to the respective environments: EC2 (ami), Azure (vhd), and KVM (new env for qcow2).

---

**THIS IS AN EXPERIMENTAL FEATURE**

I don't intend for this to be exposed in osbuild-composer just yet.  It's currently enabled only in Fedora.  I tested locally a minimal build of Fedora 38 x86_64 qcow2 and it works.  It shrinks the image from 500 MiB to 300 MiB, and reduces the package count from 453 to 215.

I'd like to get this in even if untested to have it as a proof of concept.
I intend for this to address a very common feature request which is the removal of base packages from image types.  Instead of allowing package exclusion, a minimal image with weak dependencies disabled should allow users to add just the packages they **want** while the platform and environment define the packages they **need**.  This will become even more powerful when we let users define the platform and environment directly.  If (when) we introduce a null environment, and make it user-configurable, a user would be able to build a minimal qcow2 (as enabled in this PR) and also remove `cloud-init`, which is defined in the new KVM environment.