### PR TITLE
fedora: exclude sdubby

### DIFF
--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -434,6 +434,7 @@ func liveInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 			"fcoe-utils",
 			"gfs2-utils",
 			"reiserfs-utils",
+			"sdubby",
 		},
 	}
 


### PR DESCRIPTION
`sdubby` conflicts with `grubby` and was excluded in fedora-kickstarts for the live image.