### PR TITLE
OSBuild result: improve readability of the text format

### DIFF
--- a/pkg/osbuild/result.go
+++ b/pkg/osbuild/result.go
@@ -147,10 +147,10 @@ func (res *Result) Write(writer io.Writer) error {
 	sort.Strings(pipelineNames)
 
 	for _, pipelineName := range pipelineNames {
-		fmt.Fprintf(writer, "Pipeline %s\n", pipelineName)
+		fmt.Fprintf(writer, "Pipeline: %s\n", pipelineName)
 		pipelineMD := res.Metadata[pipelineName]
 		for _, stage := range res.Log[pipelineName] {
-			fmt.Fprintf(writer, "Stage %s\n", stage.Type)
+			fmt.Fprintf(writer, "Stage: %s\n", stage.Type)
 			fmt.Fprintf(writer, "Output:\n%s\n", stage.Output)
 
 			// print structured stage metadata if available
@@ -164,8 +164,8 @@ func (res *Result) Write(writer io.Writer) error {
 						return err
 					}
 				}
-				fmt.Fprint(writer, "\n")
 			}
+			fmt.Fprint(writer, "\n")
 		}
 	}
 

--- a/pkg/osbuild/result_test.go
+++ b/pkg/osbuild/result_test.go
@@ -285,8 +285,8 @@ func TestWrite(t *testing.T) {
 	var b bytes.Buffer
 	assert.NoError(result.Write(&b))
 	expectedOutput :=
-		`Pipeline build
-Stage org.osbuild.rpm
+		`Pipeline: build
+Stage: org.osbuild.rpm
 Output:
 <rpm stage output>
 Metadata:
@@ -305,16 +305,17 @@ Metadata:
   ]
 }
 
-Stage org.osbuild.selinux
+Stage: org.osbuild.selinux
 Output:
 <selinux stage output>
 
-Pipeline final-pipeline
-Stage org.osbuild.qcow2
+Pipeline: final-pipeline
+Stage: org.osbuild.qcow2
 Output:
 assmelber the image
-Pipeline os
-Stage org.osbuild.rpm
+
+Pipeline: os
+Stage: org.osbuild.rpm
 Output:
 <os rpm stage output>
 Metadata:


### PR DESCRIPTION
I would find it nicer if the pipeline and stage names would be separated by a colon in the text format of osbuild output, instead of e.g.:

```
Pipeline build
Stage org.osbuild.rpm
Output:
[/usr/lib/tmpfiles.d/journal-nocow.conf:26] Failed to resolve specifier: uninitialized /etc detected, skipping
All rules containing unresolvable specifiers will be skipped.
...
```

In addition, ensure that there is a newline after each stage results are printed, regardless if there were any metadata to print. This change ensures that each stage results are visually separated by one newline.

The text format is now uploaded to Koji builds, therefore I'm trying to make it a bit easier to read.