### PR TITLE
packages: propagate excludes for installers

### DIFF
--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -58,6 +58,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 		img.OSVersion)
 
 	livePipeline.ExtraPackages = img.ExtraBasePackages.Include
+	livePipeline.ExcludePackages = img.ExtraBasePackages.Exclude
 
 	livePipeline.Variant = img.Variant
 	livePipeline.Biosdevname = (img.Platform.GetArch() == platform.ARCH_X86_64)

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -63,6 +63,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 		img.Product,
 		img.OSVersion)
 	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include
+	anacondaPipeline.ExcludePackages = img.ExtraBasePackages.Exclude
 	anacondaPipeline.ExtraRepos = img.ExtraBasePackages.Repositories
 	anacondaPipeline.Users = img.Users
 	anacondaPipeline.Groups = img.Groups

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -75,6 +75,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 		img.OSVersion)
 
 	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include
+	anacondaPipeline.ExcludePackages = img.ExtraBasePackages.Exclude
 	anacondaPipeline.ExtraRepos = img.ExtraBasePackages.Repositories
 	anacondaPipeline.Users = img.Users
 	anacondaPipeline.Groups = img.Groups

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -89,6 +89,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 		img.Product,
 		img.OSVersion)
 	coiPipeline.ExtraPackages = img.ExtraBasePackages.Include
+	coiPipeline.ExcludePackages = img.ExtraBasePackages.Exclude
 	coiPipeline.ExtraRepos = img.ExtraBasePackages.Repositories
 	coiPipeline.FDO = img.FDO
 	coiPipeline.Ignition = img.IgnitionEmbedded

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -30,9 +30,10 @@ type AnacondaInstaller struct {
 	// manifest.
 	Type AnacondaInstallerType
 
-	// Packages to install in addition to the ones required by the
+	// Packages to install and/or exclude in addition to the ones required by the
 	// pipeline.
-	ExtraPackages []string
+	ExtraPackages   []string
+	ExcludePackages []string
 
 	// Extra repositories to install packages from
 	ExtraRepos []rpmmd.RepoConfig
@@ -146,6 +147,7 @@ func (p *AnacondaInstaller) getPackageSetChain(Distro) []rpmmd.PackageSet {
 	return []rpmmd.PackageSet{
 		{
 			Include:         append(packages, p.ExtraPackages...),
+			Exclude:         p.ExcludePackages,
 			Repositories:    append(p.repos, p.ExtraRepos...),
 			InstallWeakDeps: true,
 		},

--- a/pkg/manifest/coreos_installer.go
+++ b/pkg/manifest/coreos_installer.go
@@ -15,9 +15,10 @@ import (
 type CoreOSInstaller struct {
 	Base
 
-	// Packages to install in addition to the ones required by the
+	// Packages to install or exclude in addition to the ones required by the
 	// pipeline.
-	ExtraPackages []string
+	ExtraPackages   []string
+	ExcludePackages []string
 
 	// Extra repositories to install packages from
 	ExtraRepos []rpmmd.RepoConfig
@@ -125,6 +126,7 @@ func (p *CoreOSInstaller) getPackageSetChain(Distro) []rpmmd.PackageSet {
 	return []rpmmd.PackageSet{
 		{
 			Include:         append(packages, p.ExtraPackages...),
+			Exclude:         p.ExcludePackages,
 			Repositories:    append(p.repos, p.ExtraRepos...),
 			InstallWeakDeps: true,
 		},


### PR DESCRIPTION
Installers use `installerPkgsKey` to propagate packages necessary for the installer environment. This didn't send through excluded packages leading to depsolve failures on Fedora 40 where both `sdubby` and `grubby` are selected; but `sdubby` conflicts and should be excluded.