### PR TITLE
wsl: don't exclude file package

### DIFF
--- a/pkg/distro/rhel8/ubi.go
+++ b/pkg/distro/rhel8/ubi.go
@@ -90,7 +90,6 @@ func ubiCommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"elfutils-debuginfod-client",
 			"fedora-release",
 			"fedora-repos",
-			"file",
 			"fontpackages-filesystem",
 			"gawk-all-langpacks",
 			"gettext",


### PR DESCRIPTION
When insights-client is included, the file exclusion prevents python3-magic being installed, which is a dependency of insights-client.


---

without the file exclude, insights-client (and rhc) install just fine.