### PR TITLE
Enables 'fdo.di_mfg_string_type_mac_iface' variable passing

### DIFF
--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -45,8 +45,9 @@ type FDOCustomization struct {
 	DiunPubKeyInsecure     string `json:"diun_pub_key_insecure,omitempty" toml:"diun_pub_key_insecure,omitempty"`
 	// This is the output of:
 	// echo "sha256:$(openssl x509 -fingerprint -sha256 -noout -in diun_cert.pem | cut -d"=" -f2 | sed 's/://g')"
-	DiunPubKeyHash      string `json:"diun_pub_key_hash,omitempty" toml:"diun_pub_key_hash,omitempty"`
-	DiunPubKeyRootCerts string `json:"diun_pub_key_root_certs,omitempty" toml:"diun_pub_key_root_certs,omitempty"`
+	DiunPubKeyHash          string `json:"diun_pub_key_hash,omitempty" toml:"diun_pub_key_hash,omitempty"`
+	DiunPubKeyRootCerts     string `json:"diun_pub_key_root_certs,omitempty" toml:"diun_pub_key_root_certs,omitempty"`
+	DiMfgStringTypeMacIface string `json:"di_mfg_string_type_mac_iface,omitempty" toml:"di_mfg_string_type_mac_iface,omitempty"`
 }
 
 type KernelCustomization struct {

--- a/pkg/customizations/fdo/fdo.go
+++ b/pkg/customizations/fdo/fdo.go
@@ -3,10 +3,11 @@ package fdo
 import "github.com/osbuild/images/pkg/blueprint"
 
 type Options struct {
-	ManufacturingServerURL string
-	DiunPubKeyInsecure     string
-	DiunPubKeyHash         string
-	DiunPubKeyRootCerts    string
+	ManufacturingServerURL  string
+	DiunPubKeyInsecure      string
+	DiunPubKeyHash          string
+	DiunPubKeyRootCerts     string
+	DiMfgStringTypeMacIface string
 }
 
 func FromBP(bpFDO blueprint.FDOCustomization) *Options {

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -127,6 +127,9 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 		if img.FDO.DiunPubKeyRootCerts != "" {
 			kernelOpts = append(kernelOpts, "fdo.diun_pub_key_root_certs=/fdo_diun_pub_key_root_certs.pem")
 		}
+		if img.FDO.DiMfgStringTypeMacIface != "" {
+			kernelOpts = append(kernelOpts, "fdo.di_mfg_string_type_mac_iface="+img.FDO.DiMfgStringTypeMacIface)
+		}
 	}
 
 	bootTreePipeline.KernelOpts = kernelOpts


### PR DESCRIPTION
Makes necessary changes for 'fdo.di_mfg_string_type_mac_iface' variable to be passed to manufacturing-client.service when the manufacturing-client is run via the simplified-installer.