### PR TITLE
Ignore /test/data/manifests directory in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ __pycache__
 /containers/config/
 /bin
 /rpmbuild
-
+/test/data/manifests
 /tools/appsre-ansible/inventory


### PR DESCRIPTION
This will prevent accidental inclusion of static manifest generated for testing.