### PR TITLE
github: Merge dependabot PRs as a proper bot account

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,7 +1,7 @@
 # Taken from https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#common-dependabot-automations
 
 name: Dependabot auto-approve and auto-merge
-on: pull_request
+on: pull_request_target
 
 permissions: write-all
 
@@ -14,10 +14,10 @@ jobs:
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN}}
 
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN}}


### PR DESCRIPTION
Currently, we merge these PRs as the default GitHub Actions bot account.
However, I'm fairly sure that this bot account cannot spawn new actions
as a protection against recursive actions. Thus, the merge train will
fail because no actions will be spawned for it since the train was
created by the default bot.

This commit uses the Schutzbot's token in order to create the merge
train. This should allow GitHub to create the neccessary workflows when
Schutzbot auto-merges the PR.

Since secrets are not available on pull_request workflows, I changed
the trigger to pull_request_target. This shouldn't have any other
effects on the workflow.