### PR TITLE
Support arbitrary custom mountpoints

### DIFF
--- a/internal/pathpolicy/policies.go
+++ b/internal/pathpolicy/policies.go
@@ -7,7 +7,9 @@ var MountpointPolicies = NewPathPolicies(map[string]PathPolicy{
 	"/var":  {},
 	"/opt":  {},
 	"/srv":  {},
-	"/usr":  {},
+	// NB: any mountpoints under /usr are not supported by systemd fstab
+	// generator in initram before the switch-root, so we don't allow them.
+	"/usr":  {Exact: true},
 	"/app":  {},
 	"/data": {},
 	"/home": {},

--- a/internal/pathpolicy/policies.go
+++ b/internal/pathpolicy/policies.go
@@ -7,6 +7,8 @@ var MountpointPolicies = NewPathPolicies(map[string]PathPolicy{
 	"/var":  {},
 	"/opt":  {},
 	"/srv":  {},
+	// /etc must be on the root filesystem
+	"/etc": {Deny: true},
 	// NB: any mountpoints under /usr are not supported by systemd fstab
 	// generator in initram before the switch-root, so we don't allow them.
 	"/usr":  {Exact: true},
@@ -14,6 +16,22 @@ var MountpointPolicies = NewPathPolicies(map[string]PathPolicy{
 	"/data": {},
 	"/home": {},
 	"/tmp":  {},
+	// API filesystems
+	"/sys":  {Deny: true},
+	"/proc": {Deny: true},
+	"/dev":  {Deny: true},
+	"/run":  {Deny: true},
+	// not allowed due to merged-usr
+	"/bin":   {Deny: true},
+	"/sbin":  {Deny: true},
+	"/lib":   {Deny: true},
+	"/lib64": {Deny: true},
+	// used by ext filesystems
+	"/lost+found": {Deny: true},
+	// used by EFI
+	"/boot/efi": {Deny: true},
+	// used by systemd / ostree
+	"/sysroot": {Deny: true},
 })
 
 // CustomDirectoriesPolicies is a set of default policies for custom directories

--- a/internal/pathpolicy/policies.go
+++ b/internal/pathpolicy/policies.go
@@ -2,20 +2,12 @@ package pathpolicy
 
 // MountpointPolicies is a set of default mountpoint policies used for filesystem customizations
 var MountpointPolicies = NewPathPolicies(map[string]PathPolicy{
-	"/":     {Exact: true},
-	"/boot": {Exact: true},
-	"/var":  {},
-	"/opt":  {},
-	"/srv":  {},
+	"/": {},
 	// /etc must be on the root filesystem
 	"/etc": {Deny: true},
 	// NB: any mountpoints under /usr are not supported by systemd fstab
 	// generator in initram before the switch-root, so we don't allow them.
-	"/usr":  {Exact: true},
-	"/app":  {},
-	"/data": {},
-	"/home": {},
-	"/tmp":  {},
+	"/usr": {Exact: true},
 	// API filesystems
 	"/sys":  {Deny: true},
 	"/proc": {Deny: true},

--- a/internal/pathpolicy/policies_test.go
+++ b/internal/pathpolicy/policies_test.go
@@ -41,12 +41,12 @@ func TestMountpointPolicies(t *testing.T) {
 		{"/srv/www", true},
 
 		{"/usr", true},
-		{"/usr/bin", true},
-		{"/usr/sbin", true},
-		{"/usr/local", true},
-		{"/usr/local/bin", true},
-		{"/usr/lib", true},
-		{"/usr/lib64", true},
+		{"/usr/bin", false},
+		{"/usr/sbin", false},
+		{"/usr/local", false},
+		{"/usr/local/bin", false},
+		{"/usr/lib", false},
+		{"/usr/lib64", false},
 
 		{"/tmp", true},
 		{"/tmp/foo", true},

--- a/internal/pathpolicy/policies_test.go
+++ b/internal/pathpolicy/policies_test.go
@@ -12,22 +12,25 @@ func TestMountpointPolicies(t *testing.T) {
 		{"/", true},
 
 		{"/bin", false},
-		{"/custom", false},
 		{"/dev", false},
 		{"/etc", false},
 		{"/lib", false},
 		{"/lib64", false},
 		{"/lost+found", false},
-		{"/mnt", false},
 		{"/proc", false},
-		{"/root", false},
 		{"/run", false},
 		{"/sbin", false},
 		{"/sys", false},
 		{"/sysroot", false},
 
+		{"/mnt", true},
+		{"/root", true},
+
+		{"/custom", true},
+		{"/custom/dir", true},
+
 		{"/boot", true},
-		{"/boot/dir", false},
+		{"/boot/dir", true},
 		{"/boot/efi", false},
 
 		{"/var", true},

--- a/internal/pathpolicy/policies_test.go
+++ b/internal/pathpolicy/policies_test.go
@@ -1,0 +1,74 @@
+package pathpolicy
+
+import "testing"
+
+func TestMountpointPolicies(t *testing.T) {
+	type testCase struct {
+		path    string
+		allowed bool
+	}
+
+	testCases := []testCase{
+		{"/", true},
+
+		{"/bin", false},
+		{"/custom", false},
+		{"/dev", false},
+		{"/etc", false},
+		{"/lib", false},
+		{"/lib64", false},
+		{"/lost+found", false},
+		{"/mnt", false},
+		{"/proc", false},
+		{"/root", false},
+		{"/run", false},
+		{"/sbin", false},
+		{"/sys", false},
+		{"/sysroot", false},
+
+		{"/boot", true},
+		{"/boot/dir", false},
+		{"/boot/efi", false},
+
+		{"/var", true},
+		{"/var/lib", true},
+		{"/var/log", true},
+
+		{"/opt", true},
+		{"/opt/fancyapp", true},
+
+		{"/srv", true},
+		{"/srv/www", true},
+
+		{"/usr", true},
+		{"/usr/bin", true},
+		{"/usr/sbin", true},
+		{"/usr/local", true},
+		{"/usr/local/bin", true},
+		{"/usr/lib", true},
+		{"/usr/lib64", true},
+
+		{"/tmp", true},
+		{"/tmp/foo", true},
+
+		{"/app", true},
+		{"/app/bin", true},
+
+		{"/data", true},
+		{"/data/foo", true},
+
+		{"/home", true},
+		{"/home/user", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.path, func(t *testing.T) {
+			err := MountpointPolicies.Check(tc.path)
+			if err != nil && tc.allowed {
+				t.Errorf("expected %s to be allowed, but got error: %v", tc.path, err)
+			} else if err == nil && !tc.allowed {
+				t.Errorf("expected %s to be denied, but got no error", tc.path)
+			}
+		})
+	}
+}

--- a/pkg/distro/fedora/distro_test.go
+++ b/pkg/distro/fedora/distro_test.go
@@ -824,42 +824,6 @@ func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 	}
 }
 
-func TestDistro_CustomFileSystemPatternMatching(t *testing.T) {
-	fedoraDistro := fedora.NewF37()
-	bp := blueprint.Blueprint{
-		Customizations: &blueprint.Customizations{
-			Filesystem: []blueprint.FilesystemCustomization{
-				{
-					MinSize:    1024,
-					Mountpoint: "/variable",
-				},
-				{
-					MinSize:    1024,
-					Mountpoint: "/variable/log/audit",
-				},
-			},
-		},
-	}
-	for _, archName := range fedoraDistro.ListArches() {
-		arch, _ := fedoraDistro.GetArch(archName)
-		for _, imgTypeName := range arch.ListImageTypes() {
-			imgType, _ := arch.GetImageType(imgTypeName)
-			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
-			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
-				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
-			} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-qcow2-image" {
-				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services)", imgTypeName))
-			} else if imgTypeName == "iot-installer" || imgTypeName == "iot-simplified-installer" || imgTypeName == "image-installer" {
-				continue
-			} else if imgTypeName == "live-installer" {
-				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for boot ISO image type \"%s\": (allowed: None)", imgTypeName))
-			} else {
-				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/variable\" \"/variable/log/audit\"]")
-			}
-		}
-	}
-}
-
 func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 	fedoraDistro := fedora.NewF37()
 	bp := blueprint.Blueprint{

--- a/pkg/distro/rhel7/distro_test.go
+++ b/pkg/distro/rhel7/distro_test.go
@@ -403,32 +403,6 @@ func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 	}
 }
 
-func TestDistro_CustomFileSystemPatternMatching(t *testing.T) {
-	r7distro := rhel7.New()
-	bp := blueprint.Blueprint{
-		Customizations: &blueprint.Customizations{
-			Filesystem: []blueprint.FilesystemCustomization{
-				{
-					MinSize:    1024,
-					Mountpoint: "/variable",
-				},
-				{
-					MinSize:    1024,
-					Mountpoint: "/variable/log/audit",
-				},
-			},
-		},
-	}
-	for _, archName := range r7distro.ListArches() {
-		arch, _ := r7distro.GetArch(archName)
-		for _, imgTypeName := range arch.ListImageTypes() {
-			imgType, _ := arch.GetImageType(imgTypeName)
-			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
-			assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/variable\" \"/variable/log/audit\"]")
-		}
-	}
-}
-
 func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 	r7distro := rhel7.New()
 	bp := blueprint.Blueprint{

--- a/pkg/distro/rhel8/distro_test.go
+++ b/pkg/distro/rhel8/distro_test.go
@@ -848,44 +848,6 @@ func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 	}
 }
 
-func TestDistro_CustomFileSystemPatternMatching(t *testing.T) {
-	r8distro := rhel8.New()
-	bp := blueprint.Blueprint{
-		Customizations: &blueprint.Customizations{
-			Filesystem: []blueprint.FilesystemCustomization{
-				{
-					MinSize:    1024,
-					Mountpoint: "/variable",
-				},
-				{
-					MinSize:    1024,
-					Mountpoint: "/variable/log/audit",
-				},
-			},
-		},
-	}
-	unsupported := map[string]bool{
-		"edge-installer":            true,
-		"edge-simplified-installer": true,
-		"edge-raw-image":            true,
-		"azure-eap7-rhui":           true,
-	}
-	for _, archName := range r8distro.ListArches() {
-		arch, _ := r8distro.GetArch(archName)
-		for _, imgTypeName := range arch.ListImageTypes() {
-			imgType, _ := arch.GetImageType(imgTypeName)
-			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
-			if imgTypeName == "edge-commit" || imgTypeName == "edge-container" {
-				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
-			} else if unsupported[imgTypeName] {
-				assert.Error(t, err)
-			} else {
-				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/variable\" \"/variable/log/audit\"]")
-			}
-		}
-	}
-}
-
 func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 	r8distro := rhel8.New()
 	bp := blueprint.Blueprint{

--- a/pkg/distro/rhel9/distro_test.go
+++ b/pkg/distro/rhel9/distro_test.go
@@ -811,38 +811,6 @@ func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 	}
 }
 
-func TestDistro_CustomFileSystemPatternMatching(t *testing.T) {
-	r9distro := rhel9.New()
-	bp := blueprint.Blueprint{
-		Customizations: &blueprint.Customizations{
-			Filesystem: []blueprint.FilesystemCustomization{
-				{
-					MinSize:    1024,
-					Mountpoint: "/variable",
-				},
-				{
-					MinSize:    1024,
-					Mountpoint: "/variable/log/audit",
-				},
-			},
-		},
-	}
-	for _, archName := range r9distro.ListArches() {
-		arch, _ := r9distro.GetArch(archName)
-		for _, imgTypeName := range arch.ListImageTypes() {
-			imgType, _ := arch.GetImageType(imgTypeName)
-			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
-			if imgTypeName == "edge-commit" || imgTypeName == "edge-container" {
-				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
-			} else if imgTypeName == "edge-installer" || imgTypeName == "edge-simplified-installer" || imgTypeName == "edge-raw-image" || imgTypeName == "edge-ami" || imgTypeName == "edge-vsphere" {
-				continue
-			} else {
-				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/variable\" \"/variable/log/audit\"]")
-			}
-		}
-	}
-}
-
 func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 	r9distro := rhel9.New()
 	bp := blueprint.Blueprint{


### PR DESCRIPTION
- Add unit test to test specific mountpoint paths against the mountpoint policy. Replace distro-specific unit tests which were testing basically the same thing, but in which distro. This makes little sense, since all distros use the same mountpoint policy.
- Explicitly disallow mountpoints which can't / shouldn't be on a separate partition.
- Relax the mountpoint policy to allow arbitrary custom mountpoints and adjust the unit test accordingly.

Related to https://issues.redhat.com/browse/COMPOSER-2030