### PR TITLE
test: Add PR number to build info and share test caches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,10 @@ check-build-coverage:
   script:
     - apk add -U go python3 gpgme-dev s3cmd
     - ./test/scripts/check-build-coverage ./s3configs/
+  cache:
+    key: testcache
+    paths:
+      - .cache/osbuild-images
 
 finish:
   stage: finish

--- a/test/scripts/check-build-coverage
+++ b/test/scripts/check-build-coverage
@@ -14,8 +14,10 @@ SKIPS = [
 
 def check_build_coverage(cachedir):
     ci_commit = os.environ.get("CI_COMMIT_SHA")
+    ci_branch = os.environ.get("CI_COMMIT_BRANCH")
     tests = set()
     built_now = set()
+    built_pr = set()
     for root, dirs, files in os.walk(cachedir):
         for fname in files:
             _, ext = os.path.splitext(fname)
@@ -31,9 +33,13 @@ def check_build_coverage(cachedir):
 
             commit = build_info["commit"]
             config = build_info["config"]
+            pr = build_info.get("pr")
             if commit == ci_commit:
                 # config was rebuilt in this run: collect and report
                 built_now.add((distro, arch, image, config))
+            if pr is not None and pr == ci_branch:  # make sure we don't print it when both are None
+                # config was rebuilt in this PR (potentially in another run): collect and report
+                built_pr.add((distro, arch, image, config, commit))
 
     all_combos = set()
     for config in testlib.list_images(arches=["x86_64", "aarch64"]):
@@ -45,7 +51,7 @@ def check_build_coverage(cachedir):
         all_combos.add((distro, arch, image))
 
     missing = all_combos - tests
-    return missing, built_now
+    return missing, built_now, built_pr
 
 
 def main():
@@ -55,7 +61,7 @@ def main():
     cachedir = args.cachedir
     testlib.dl_s3_configs(cachedir)
 
-    missing, now = check_build_coverage(cachedir)
+    missing, now, pr = check_build_coverage(cachedir)
 
     if now:
         print("Configurations built in this pipeline")
@@ -64,6 +70,15 @@ def main():
             print(f"✅ {distro} {arch} {image} {config}")
     else:
         print("⭕ No images were built in this pipeline")
+
+    if now:
+        print("Configurations built in this PR")
+        for build in pr:
+            distro, arch, image, config, commit = build
+            commit_url = f"https://github.com/osbuild/images/commit/{commit}"
+            print(f"✅ {distro} {arch} {image} {config} ({commit_url})")
+    else:
+        print("⭕ No images were built in this PR")
 
     if missing:
         print(f"❌ {len(missing)} distro/arch/image combinations have no builds in the cache")

--- a/test/scripts/configure-generators
+++ b/test/scripts/configure-generators
@@ -37,6 +37,10 @@ generate-build-config-{distro}-{arch}:
   artifacts:
     paths:
       - build-config.yml
+  cache:
+    key: testcache
+    paths:
+      - {cache}
 """
 
 TRIGGER_TEMPLATE = """
@@ -69,6 +73,10 @@ generate-ostree-build-config-{distro}-{arch}:
       - build-configs
   needs:
     - image-build-trigger-{distro}-{arch}
+  cache:
+    key: testcache
+    paths:
+      - {cache}
 """
 
 OSTREE_TRIGGER_TEMPLATE = """
@@ -89,6 +97,8 @@ def main():
     images = testlib.list_images(arches=ARCHITECTURES)
     combos = set()
 
+    cache = testlib.TEST_CACHE_ROOT
+
     gen_stage = []
     trigger_stage = []
     ostree_gen_stage = []
@@ -99,10 +109,10 @@ def main():
             continue
 
         combos.add(combo)
-        gen_stage.append(GEN_TEMPLATE.format(distro=img["distro"], arch=img["arch"]))
-        trigger_stage.append(TRIGGER_TEMPLATE.format(distro=img["distro"], arch=img["arch"]))
-        ostree_gen_stage.append(OSTREE_GEN_TEMPLATE.format(distro=img["distro"], arch=img["arch"]))
-        ostree_trigger_stage.append(OSTREE_TRIGGER_TEMPLATE.format(distro=img["distro"], arch=img["arch"]))
+        gen_stage.append(GEN_TEMPLATE.format(distro=img["distro"], arch=img["arch"], cache=cache))
+        trigger_stage.append(TRIGGER_TEMPLATE.format(distro=img["distro"], arch=img["arch"], cache=cache))
+        ostree_gen_stage.append(OSTREE_GEN_TEMPLATE.format(distro=img["distro"], arch=img["arch"], cache=cache))
+        ostree_trigger_stage.append(OSTREE_TRIGGER_TEMPLATE.format(distro=img["distro"], arch=img["arch"], cache=cache))
 
     with open(config_path, "w", encoding="utf-8") as config_file:
         config_file.write(BASE_CONFIG)

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -5,7 +5,7 @@ import pathlib
 import subprocess as sp
 import sys
 
-TEST_CACHE_ROOT = os.path.expanduser("~/.cache/osbuild-images")
+TEST_CACHE_ROOT = ".cache/osbuild-images"
 CONFIGS_PATH = "./test/configs"
 CONFIG_MAP = "./test/config-map.json"
 

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -85,8 +85,8 @@ def list_images(distros=None, arches=None, images=None):
 
 
 def s3_auth_args():
-    s3_key = os.environ.get("V2_AWS_SECRET_ACCESS_KEY")
-    s3_key_id = os.environ.get("V2_AWS_ACCESS_KEY_ID")
+    s3_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    s3_key_id = os.environ.get("AWS_ACCESS_KEY_ID")
     if s3_key and s3_key_id:
         return [f"--access_key={s3_key_id}", f"--secret_key={s3_key}"]
 

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -209,8 +209,11 @@ def filter_builds(manifests, skip_ostree_pull=True):
                 with open(build_info_path) as build_info_fp:
                     dl_config = json.load(build_info_fp)
                 commit = dl_config["commit"]
+                pr = dl_config.get("pr")
                 url = f"https://github.com/osbuild/images/commit/{commit}"
                 print(f"🖼️ Manifest {manifest_fname} was successfully built in commit {commit}\n  {url}")
+                if pr:
+                    print(f"  PR-{pr}: https://github.com/osbuild/images/pull/{pr}")
                 if image_type not in CAN_BOOT_TEST:
                     print(f"  Boot testing for {image_type} is not yet supported")
                     continue

--- a/test/scripts/upload-results
+++ b/test/scripts/upload-results
@@ -24,10 +24,21 @@ def main():
         config_name = config["name"]
 
     build_dir = os.path.join("build", testlib.gen_build_name(distro, arch, image_type, config_name))
+
+    # get the manifest ID to use in the destination path
     manifest_path = os.path.join(build_dir, "manifest.json")
     with open(manifest_path, "r") as manifest_fp:
         manifest_data = json.load(manifest_fp)
     manifest_id = testlib.get_manifest_id(manifest_data)
+
+    # add the PR number (gitlab branch name) to the info.json if available
+    if pr_number := os.environ.get("CI_COMMIT_BRANCH"):
+        info_path = os.path.join(build_dir, "info.json")
+        with open(info_path, "r") as info_fp:
+            build_info = json.load(info_fp)
+        build_info["pr"] = pr_number
+        with open(info_path, "w") as info_fp:
+            json.dump(build_info, info_fp, indent=2)
 
     bucket = os.environ.get("AWS_BUCKET", "image-builder-ci-artifacts")
     s3url = f"s3://{bucket}/images/builds/{distro}/{arch}/{manifest_id}/"


### PR DESCRIPTION
This PR makes two small changes to the test pipelines:
1. Adds the PR number to the build info when a new image is built.  This number is printed when filtering builds to make it easier to determine why image builds are skipped and it's also used to list images build in all pipelines of a given PR in the `check-build-coverage` jobs.  Eventually, we can use this information to add messages to the PR so it's easier to track what is being built by each pipeline run.
2. Puts the rpmmd and build info cache in the working directory and configures build pipeline generators to share that cache.  This should speed up test generation.  It'll be especially good for speeding up depsolving for manifest generation.