### PR TITLE
CI: separate test caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
+.cache
 
 .vscode
 .DS_Store

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,11 +41,11 @@ check-build-coverage:
     PYTHONUNBUFFERED: 1
   script:
     - apk add -U go python3 gpgme-dev s3cmd
-    - ./test/scripts/check-build-coverage ./s3configs/
+    - ./test/scripts/check-build-coverage .cache/osbuild-images/builds/
   cache:
-    key: testcache
+    key: buildinfo
     paths:
-      - .cache/osbuild-images
+      - .cache/osbuild-images/builds
 
 finish:
   stage: finish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,6 +57,7 @@ check-build-coverage:
     PYTHONUNBUFFERED: 1
   script:
     - apk add -U go python3 gpgme-dev s3cmd
+    - ./test/scripts/dl-build-info .cache/osbuild-images/builds/
     - ./test/scripts/check-build-coverage .cache/osbuild-images/builds/
   cache:
     key: buildinfo

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,13 @@ cache-init:
     PYTHONUNBUFFERED: 1
   script:
     - apk add -U python3 s3cmd
+    - ls -la
+    - mkdir -p .cache/osbuild-images/builds
+    - find .cache/osbuild-images/builds -type f | wc -l
+    - du -hs .cache/osbuild-images/builds
     - ./test/scripts/dl-build-info .cache/osbuild-images/builds/
+    - find .cache/osbuild-images/builds -type f | wc -l
+    - du -hs .cache/osbuild-images/builds
   cache:
     key: buildinfo
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,22 @@ init:
   script:
     - schutzbot/update_github_status.sh start
 
+cache-init:
+  # pull configs from s3 and update the gitlab cache for the rest of the
+  # pipeline
+  stage: init
+  image: alpine:latest
+  variables:
+    PYTHONUNBUFFERED: 1
+  script:
+    - apk add -U python3 s3cmd
+    - ./test/scripts/dl-build-info .cache/osbuild-images/builds/
+  cache:
+    key: buildinfo
+    paths:
+      - .cache/osbuild-images/builds
+    policy: pull-push
+
 configure-generators:
   stage: gen
   image: alpine:latest
@@ -46,6 +62,7 @@ check-build-coverage:
     key: buildinfo
     paths:
       - .cache/osbuild-images/builds
+    policy: pull-push
 
 finish:
   stage: finish

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -72,7 +72,8 @@
   },
   "./configs/kernel-debug.json": {
     "image-types": [
-      "iot-commit"
+      "iot-commit",
+      "qcow2"
     ]
   },
   "./configs/edge-ostree-pull-device.json": {

--- a/test/scripts/check-build-coverage
+++ b/test/scripts/check-build-coverage
@@ -56,10 +56,9 @@ def check_build_coverage(cachedir):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("cachedir", type=str, help="path to download the build test cache")
+    parser.add_argument("cachedir", type=str, help="path to existing build cache")
     args = parser.parse_args()
     cachedir = args.cachedir
-    testlib.dl_s3_configs(cachedir)
 
     missing, now, pr = check_build_coverage(cachedir)
 

--- a/test/scripts/configure-generators
+++ b/test/scripts/configure-generators
@@ -30,6 +30,11 @@ generate-build-config-{distro}-{arch}:
     RUNNER: aws/fedora-38-{arch}
     INTERNAL_NETWORK: "true"
   script:
+    - ls -la
+    - mkdir -p .cache/osbuild-images/builds
+    - find .cache/osbuild-images/builds -type f | wc -l
+    - du -hs .cache/osbuild-images/builds
+
     - sudo ./schutzbot/setup-osbuild-repo
     - sudo dnf -y install go python3 gpgme-devel s3cmd
       osbuild osbuild-luks2 osbuild-lvm2 osbuild-ostree osbuild-selinux

--- a/test/scripts/configure-generators
+++ b/test/scripts/configure-generators
@@ -38,9 +38,12 @@ generate-build-config-{distro}-{arch}:
     paths:
       - build-config.yml
   cache:
-    key: testcache
-    paths:
-      - {cache}
+    - key: buildinfo
+      paths:
+        - {cache}/builds
+    - key: rpmmd
+      paths:
+        - {cache}/rpmmd
 """
 
 TRIGGER_TEMPLATE = """
@@ -74,9 +77,12 @@ generate-ostree-build-config-{distro}-{arch}:
   needs:
     - image-build-trigger-{distro}-{arch}
   cache:
-    key: testcache
-    paths:
-      - {cache}
+    - key: buildinfo
+      paths:
+        - {cache}/builds
+    - key: rpmmd
+      paths:
+        - {cache}/rpmmd
 """
 
 OSTREE_TRIGGER_TEMPLATE = """

--- a/test/scripts/configure-generators
+++ b/test/scripts/configure-generators
@@ -41,9 +41,11 @@ generate-build-config-{distro}-{arch}:
     - key: buildinfo
       paths:
         - {cache}/builds
+      policy: pull
     - key: rpmmd
       paths:
         - {cache}/rpmmd
+      policy: pull-push
 """
 
 TRIGGER_TEMPLATE = """
@@ -80,9 +82,11 @@ generate-ostree-build-config-{distro}-{arch}:
     - key: buildinfo
       paths:
         - {cache}/builds
+      policy: pull
     - key: rpmmd
       paths:
         - {cache}/rpmmd
+      policy: pull-push
 """
 
 OSTREE_TRIGGER_TEMPLATE = """

--- a/test/scripts/dl-build-info
+++ b/test/scripts/dl-build-info
@@ -9,7 +9,7 @@ def main():
     parser.add_argument("cachedir", type=str, help="path to download the build test cache")
     args = parser.parse_args()
     cachedir = args.cachedir
-    testlib.dl_s3_configs(cachedir)
+    testlib.dl_build_info(cachedir)
 
 
 if __name__ == "__main__":

--- a/test/scripts/dl-build-info
+++ b/test/scripts/dl-build-info
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+import argparse
+
+import imgtestlib as testlib
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("cachedir", type=str, help="path to download the build test cache")
+    args = parser.parse_args()
+    cachedir = args.cachedir
+    testlib.dl_s3_configs(cachedir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -234,6 +234,14 @@ def filter_builds(manifests, skip_ostree_pull=True):
         print("⚠️ Errors:")
         print("\n".join(errors))
 
+    for build_request in build_requests:
+        distro = build_request["distro"]
+        arch = build_request["arch"]
+        image_type = build_request["image-type"]
+        config = build_request["config"]
+        config_name = config["name"]
+        print(f"🛠️ Adding build for {distro}/{arch}/{image_type}/{config_name}")
+
     return build_requests
 
 

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -93,7 +93,7 @@ def s3_auth_args():
     return []
 
 
-def dl_s3_configs(destination):
+def dl_build_info(destination):
     """
     Downloads all the configs from the s3 bucket.
     """
@@ -173,11 +173,8 @@ def filter_builds(manifests, skip_ostree_pull=True):
     Returns a list of build requests for the manifests that have no matching config in the test build cache.
     """
     print(f"⚙️ Filtering {len(manifests)} build configurations")
-    dl_path = os.path.join(TEST_CACHE_ROOT, "builds/")
-    os.makedirs(dl_path, exist_ok=True)
+    build_info_root = os.path.join(TEST_CACHE_ROOT, "builds/")
     build_requests = []
-
-    dl_s3_configs(dl_path)
 
     errors = []
 
@@ -200,8 +197,8 @@ def filter_builds(manifests, skip_ostree_pull=True):
         build_request["manifest-checksum"] = manifest_id
 
         # check if the hash_fname exists in the synced directory
-        dl_config_dir = os.path.join(dl_path, distro, arch)
-        build_info_path = os.path.join(dl_config_dir, manifest_id, "info.json")
+        distro_arch_dir = os.path.join(build_info_root, distro, arch)
+        build_info_path = os.path.join(distro_arch_dir, manifest_id, "info.json")
 
         # check if the id_fname exists in the synced directory
         if os.path.exists(build_info_path):

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -173,7 +173,7 @@ def filter_builds(manifests, skip_ostree_pull=True):
     Returns a list of build requests for the manifests that have no matching config in the test build cache.
     """
     print(f"⚙️ Filtering {len(manifests)} build configurations")
-    dl_path = os.path.join(TEST_CACHE_ROOT, "s3configs", "builds/")
+    dl_path = os.path.join(TEST_CACHE_ROOT, "builds/")
     os.makedirs(dl_path, exist_ok=True)
     build_requests = []
 


### PR DESCRIPTION
Separate the two types of info in the test cache and control them separately.

The `rpmmd` cache is only set on the build config generators that generate manifests.
The `buildinfo` cache is set up at the beginning of the pipeline.  The build config generators that use it for filtering never download the data and instead use the cache directly.
In the final step, the `check-build-coverage` job downloads the build info again to get any new files created by build jobs and updates the gitlab CI cache for later pipelines.