### PR TITLE
Deny additional mountpoint paths symlinked to /run

### DIFF
--- a/internal/pathpolicy/policies.go
+++ b/internal/pathpolicy/policies.go
@@ -24,6 +24,10 @@ var MountpointPolicies = NewPathPolicies(map[string]PathPolicy{
 	"/boot/efi": {Deny: true},
 	// used by systemd / ostree
 	"/sysroot": {Deny: true},
+	// symlink to ../run which is on tmpfs
+	"/var/run": {Deny: true},
+	// symlink to ../run/lock which is on tmpfs
+	"/var/lock": {Deny: true},
 })
 
 // CustomDirectoriesPolicies is a set of default policies for custom directories

--- a/internal/pathpolicy/policies_test.go
+++ b/internal/pathpolicy/policies_test.go
@@ -36,6 +36,9 @@ func TestMountpointPolicies(t *testing.T) {
 		{"/var", true},
 		{"/var/lib", true},
 		{"/var/log", true},
+		{"/var/tmp", true},
+		{"/var/run", false},
+		{"/var/lock", false},
 
 		{"/opt", true},
 		{"/opt/fancyapp", true},


### PR DESCRIPTION
SSIA