### PR TITLE
Fix implicit memory aliasing in for loops

### DIFF
--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -140,14 +140,15 @@ func main() {
 	}
 
 	repos := make([]rpmmd.RepoConfig, len(composeRequest.Repositories))
-	for i, repo := range composeRequest.Repositories {
+	for idx := range composeRequest.Repositories {
+		repo := composeRequest.Repositories[idx]
 		repoName := repo.Name
 		if repoName == "" {
-			repoName = fmt.Sprintf("repo-%d", i)
+			repoName = fmt.Sprintf("repo-%d", idx)
 		}
 		repoId := repo.Id
 		if repoId == "" {
-			repoId = fmt.Sprintf("repo-%d", i)
+			repoId = fmt.Sprintf("repo-%d", idx)
 		}
 		var urls []string
 		if repo.BaseURL != "" {
@@ -158,7 +159,7 @@ func main() {
 			keys = []string{repo.GPGKey}
 		}
 
-		repos[i] = rpmmd.RepoConfig{
+		repos[idx] = rpmmd.RepoConfig{
 			Id:           repoId,
 			Name:         repoName,
 			BaseURLs:     urls,

--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -211,10 +211,11 @@ func (c *Customizations) GetUsers() []UserCustomization {
 
 	// prepend sshkey for backwards compat (overridden by users)
 	if len(c.SSHKey) > 0 {
-		for _, c := range c.SSHKey {
+		for idx := range c.SSHKey {
+			keyc := c.SSHKey[idx]
 			users = append(users, UserCustomization{
-				Name: c.User,
-				Key:  &c.Key,
+				Name: keyc.User,
+				Key:  &keyc.Key,
 			})
 		}
 	}

--- a/pkg/osbuild/cloud_init_stage_test.go
+++ b/pkg/osbuild/cloud_init_stage_test.go
@@ -74,7 +74,8 @@ func TestCloudInitStage_NewStage_Invalid(t *testing.T) {
 			},
 		},
 	}
-	for idx, tt := range tests {
+	for idx := range tests {
+		tt := tests[idx]
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Panics(t, func() { NewCloudInitStage(&tt.options) }, "NewCloudInitStage didn't panic, but it should [idx: %d]", idx)
 		})

--- a/pkg/osbuild/dnf_automatic_config_stage_test.go
+++ b/pkg/osbuild/dnf_automatic_config_stage_test.go
@@ -66,7 +66,8 @@ func TestDNFAutomaticConfigStageOptionsValidate(t *testing.T) {
 			err: false,
 		},
 	}
-	for idx, tt := range tests {
+	for idx := range tests {
+		tt := tests[idx]
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.err {
 				assert.Errorf(t, tt.options.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)

--- a/pkg/osbuild/dnf_config_stage_test.go
+++ b/pkg/osbuild/dnf_config_stage_test.go
@@ -123,7 +123,8 @@ func TestDNFConfigValidate(t *testing.T) {
 			false,
 		},
 	}
-	for _, test := range tests {
+	for idx := range tests {
+		test := tests[idx]
 		if test.valid {
 			require.NotPanics(t, func() { NewDNFConfigStage(&test.options) })
 		} else {

--- a/pkg/osbuild/gcp_guest_agent_conf_stage_test.go
+++ b/pkg/osbuild/gcp_guest_agent_conf_stage_test.go
@@ -50,7 +50,8 @@ func TestNewGcpGuestAgentConfigOptionsValidate(t *testing.T) {
 			err: false,
 		},
 	}
-	for idx, tt := range tests {
+	for idx := range tests {
+		tt := tests[idx]
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.err {
 				assert.Errorf(t, tt.options.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)

--- a/pkg/osbuild/modprobe_stage_test.go
+++ b/pkg/osbuild/modprobe_stage_test.go
@@ -64,7 +64,8 @@ func TestModprobeStageOptionsValidate(t *testing.T) {
 			err: false,
 		},
 	}
-	for idx, tt := range tests {
+	for idx := range tests {
+		tt := tests[idx]
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.err {
 				assert.Errorf(t, tt.options.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)

--- a/pkg/osbuild/oscap_autotailor_stage_test.go
+++ b/pkg/osbuild/oscap_autotailor_stage_test.go
@@ -88,7 +88,8 @@ func TestOscapAutotailorStageOptionsValidate(t *testing.T) {
 			err: false,
 		},
 	}
-	for idx, tt := range tests {
+	for idx := range tests {
+		tt := tests[idx]
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.err {
 				assert.Errorf(t, tt.options.Config.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)

--- a/pkg/osbuild/oscap_remediation_stage_test.go
+++ b/pkg/osbuild/oscap_remediation_stage_test.go
@@ -71,7 +71,8 @@ func TestOscapRemediationStageOptionsValidate(t *testing.T) {
 			err: false,
 		},
 	}
-	for idx, tt := range tests {
+	for idx := range tests {
+		tt := tests[idx]
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.err {
 				assert.Errorf(t, tt.options.Config.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)

--- a/pkg/osbuild/sshd_config_stage_test.go
+++ b/pkg/osbuild/sshd_config_stage_test.go
@@ -95,7 +95,8 @@ func TestSshdConfigStageOptionsValidate(t *testing.T) {
 		},
 	}
 
-	for idx, tt := range tests {
+	for idx := range tests {
+		tt := tests[idx]
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.err {
 				assert.Errorf(t, tt.options.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)

--- a/pkg/osbuild/systemd_journald_stage_test.go
+++ b/pkg/osbuild/systemd_journald_stage_test.go
@@ -44,7 +44,8 @@ func TestSystemdJournaldStage_ValidateInvalid(t *testing.T) {
 			},
 		},
 	}
-	for idx, te := range tests {
+	for idx := range tests {
+		te := tests[idx]
 		t.Run(te.name, func(t *testing.T) {
 			assert.Errorf(t, te.options.validate(), "%q didn't return an error [idx: %d]", te.name, idx)
 			assert.Panics(t, func() { NewSystemdJournaldStage(&te.options) })

--- a/pkg/osbuild/tar_stage_test.go
+++ b/pkg/osbuild/tar_stage_test.go
@@ -64,7 +64,8 @@ func TestTarStageOptionsValidate(t *testing.T) {
 			err: false,
 		},
 	}
-	for idx, tt := range tests {
+	for idx := range tests {
+		tt := tests[idx]
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.err {
 				assert.Errorf(t, tt.options.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)

--- a/pkg/osbuild/yum_config_stage_test.go
+++ b/pkg/osbuild/yum_config_stage_test.go
@@ -103,7 +103,8 @@ func TestYumConfigValidate(t *testing.T) {
 			true,
 		},
 	}
-	for _, test := range tests {
+	for idx := range tests {
+		test := tests[idx]
 		if test.valid {
 			require.NotPanics(t, func() { NewYumConfigStage(&test.options) })
 		} else {

--- a/pkg/osbuild/yum_repos_stage_test.go
+++ b/pkg/osbuild/yum_repos_stage_test.go
@@ -174,7 +174,8 @@ func TestYumReposStageOptionsValidate(t *testing.T) {
 			err: false,
 		},
 	}
-	for idx, tt := range tests {
+	for idx := range tests {
+		tt := tests[idx]
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.err {
 				assert.Errorf(t, tt.options.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)

--- a/pkg/rpmmd/repository.go
+++ b/pkg/rpmmd/repository.go
@@ -245,7 +245,8 @@ func loadRepositoriesFromFile(filename string) (map[string][]RepoConfig, error) 
 	}
 
 	for arch, repos := range reposMap {
-		for _, repo := range repos {
+		for idx := range repos {
+			repo := repos[idx]
 			var urls []string
 			if repo.BaseURL != "" {
 				urls = []string{repo.BaseURL}


### PR DESCRIPTION
Fix all instances of gosec G601: Implicit memory aliasing in for loop.

(cherry picked from commit 9a445e6af94e209a786695b315cc9adf8f2e383c)