### PR TITLE
test: fix script paths for ostree builds

### DIFF
--- a/test/scripts/generate-ostree-build-config
+++ b/test/scripts/generate-ostree-build-config
@@ -15,7 +15,8 @@ build/{distro}/{arch}/{image_type}/{config_name}:
       osbuild osbuild-luks2 osbuild-lvm2 osbuild-ostree osbuild-selinux
       s3cmd podman
     - {start_container}
-    - ./test/scripts/build-image.sh "{distro}" "{image_type}" "{config}"
+    - ./test/scripts/build-image "{distro}" "{image_type}" "{config}"
+    - ./test/scripts/upload-results "{distro}" "{image_type}" "{config}"
   extends: .terraform
   variables:
     RUNNER: aws/fedora-38-{arch}


### PR DESCRIPTION
The ostree build tests are currently broken.

This is the same change made for the non-ostree tests in 1dac638e4796da5b7feeda1e87a5b5fef3750a34.  The ostree test config generation was missed in PR #188.