### PR TITLE
osbuild: rework device mount names handling

### DIFF
--- a/pkg/osbuild/copy_stage.go
+++ b/pkg/osbuild/copy_stage.go
@@ -2,6 +2,7 @@ package osbuild
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 
 	"github.com/osbuild/images/pkg/disk"
@@ -86,6 +87,13 @@ func GenCopyFSTreeOptions(inputName, inputPipeline, filename string, pt *disk.Pa
 
 		// update devices map with new elements from stageDevices
 		for devName := range stageDevices {
+			if existingDevice, exists := devices[devName]; exists {
+				// It is usual that the a device is generated twice for the same Entity e.g. LVM VG, which is OK.
+				// Therefore fail only if a device with the same name is generated for two different Entities.
+				if !reflect.DeepEqual(existingDevice, stageDevices[devName]) {
+					panic(fmt.Sprintf("the device name %q has been generated for two different devices", devName))
+				}
+			}
 			devices[devName] = stageDevices[devName]
 		}
 		return nil

--- a/pkg/osbuild/device.go
+++ b/pkg/osbuild/device.go
@@ -153,7 +153,7 @@ func deviceName(p disk.Entity) string {
 
 	switch payload := p.(type) {
 	case disk.Mountable:
-		return pathdot(payload.GetMountpoint())
+		return pathEscape(payload.GetMountpoint())
 	case *disk.LUKSContainer:
 		return "luks-" + payload.UUID[:4]
 	case *disk.LVMVolumeGroup:
@@ -206,12 +206,21 @@ func getDevices(path []disk.Entity, filename string, lockLoopback bool) (map[str
 	return do, parent
 }
 
-func pathdot(path string) string {
-	if path == "/" {
-		return "root"
+// pathEscape implements similar path escaping as used by systemd-escape
+// https://github.com/systemd/systemd/blob/c57ff6230e4e199d40f35a356e834ba99f3f8420/src/basic/unit-name.c#L389
+func pathEscape(path string) string {
+	if len(path) == 0 || path == "/" {
+		return "-"
 	}
 
-	path = strings.TrimLeft(path, "/")
+	path = strings.Trim(path, "/")
 
-	return strings.ReplaceAll(path, "/", ".")
+	escapeChars := func(s, char string) string {
+		return strings.ReplaceAll(s, char, fmt.Sprintf("\\x%x", char[0]))
+	}
+
+	path = escapeChars(path, "\\")
+	path = escapeChars(path, "-")
+
+	return strings.ReplaceAll(path, "/", "-")
 }

--- a/pkg/osbuild/device.go
+++ b/pkg/osbuild/device.go
@@ -157,7 +157,7 @@ func deviceName(p disk.Entity) string {
 	case *disk.LUKSContainer:
 		return "luks-" + payload.UUID[:4]
 	case *disk.LVMVolumeGroup:
-		return payload.Name + "vg"
+		return payload.Name
 	case *disk.LVMLogicalVolume:
 		return payload.Name
 	}

--- a/pkg/osbuild/device_test.go
+++ b/pkg/osbuild/device_test.go
@@ -140,3 +140,29 @@ func TestGenDeviceFinishStagesOrderWithLVMClevisBind(t *testing.T) {
 	// followed by "org.osbuild.luks2.remove-key"
 	assert.Equal("org.osbuild.luks2.remove-key", luks.Type)
 }
+
+func TestPathEscape(t *testing.T) {
+	testCases := []struct {
+		path     string
+		expected string
+	}{
+		{"", "-"},
+		{"/", "-"},
+		{"/root", "root"},
+		{"/root/", "root"},
+		{"/home/shadowman", "home-shadowman"},
+		{"/home/s.o.s", "home-s.o.s"},
+		{"/path/to/dir", "path-to-dir"},
+		{"/path/with\\backslash", "path-with\\x5cbackslash"},
+		{"/path-with-dash", "path\\x2dwith\\x2ddash"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.path, func(t *testing.T) {
+			result := pathEscape(tc.path)
+			if result != tc.expected {
+				t.Errorf("pathEscape(%q) = %q; expected %q", tc.path, result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The ability to create arbitrary mountpoints under the filesystem root revealed an issue in the code generating device names for mount options of osbuild stages. Specifically, it would generate the same device name for `/` and `/root` mountpoints. Moreover, other places were making assumptions which should not be relied on, e.g.:

- `GenCopyFSTreeOptions()` could happily replace existing device mount with a different device, but the same name.
- `GenCopyFSTreeOptions()` expected that the mount name for entity with `/` mountpoint will be always called `root`.
- `RawOSTreeImage.serialize()` expected that the mount name for entity with `/` mountpoint will be always called `root`.

Remove these assumptions from the code and explicitly check for device name conflicts.

Rework the function escaping mountpoint paths to use a similar algorithm as `systemd-escape`. This will assure that it will produce different escaped path for different paths,  but still the same escaped path if the path did not change.

As a minor change, change the osbuild code handling LVM to not append `vg` to LVM VG names, but use it as is. This is consistent with how LVM LV names are handled. All partition table definitions and code converting PT to LVM always use `rootvg` as the name got the root LVM VG. Which previously resulted in the VG having name `rootvgvg`.