### PR TITLE
gen-manifest: add a shortcut option for providing single image config

### DIFF
--- a/test/scripts/generate-ostree-build-config
+++ b/test/scripts/generate-ostree-build-config
@@ -94,7 +94,7 @@ def gen_dependency_manifests(config_map, distro, arch, outputdir):
                "-output", outputdir,
                "-workers", "100",
                "-images", ",".join(gen_image_types),
-               "-config", tmpfile.name,
+               "-config-map", tmpfile.name,
                "-arches", arch]
         if distro:
             cmd.extend(["-distros", distro])
@@ -143,7 +143,7 @@ def gen_image_manifests(config_map, configs, distro, arch, outputdir):
                "-cache", os.path.join(testlib.TEST_CACHE_ROOT, "rpmmd"),
                "-output", outputdir,
                "-workers", "100",
-               "-config", config_map_path,
+               "-config-map", config_map_path,
                "-commits=true",  # resolve ostree commit sources
                "-skip-noconfig",  # skip configs that aren't in the config-map
                "-arches", arch]


### PR DESCRIPTION
The gen-manifest accepts an image config map via the `-config` option,
which is good for CI and testing purposes.

However, imagine a situation when:
- you are making changes to code in the repository which affects
  generated manifests,
- you want to use a custom image config to test these changes and
  generate manifests to build them using osbuild

In this case, one can filter out distro / arch / image type using the
`gen-manifest` CLI options, instead of creating the image config map.
Passing an ad-hoc image config to `gen-manifests` on the CLI to use for
all image types and filtering what gets generated using the CLI options
is IMO much nicer (or easier to use) for development, than the current
approach (which involves basically creating two JSON files and editing
one of them each time one wants to use a different image config).

Change the behavior of the original `-config` option to accept a
single image config which will be used for all image types / distros /
arches. Note that this will almost certainly fail for some images, but
the intention of this option is to be used for development and together
with filtering options such as `-distros`, `-arches` and `-image-types`.

The original option is now available under a new name `-config-map`,
which is better aligned with what it does.

Example use:
```
$ go run cmd/gen-manifests/* -distros fedora-38 -images minimal-raw -arches x86_64 -config test-fs-customizations.json
```