### PR TITLE
FIPS mode support

### DIFF
--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -24,6 +24,7 @@ type Customizations struct {
 	Directories        []DirectoryCustomization  `json:"directories,omitempty" toml:"directories,omitempty"`
 	Files              []FileCustomization       `json:"files,omitempty" toml:"files,omitempty"`
 	Repositories       []RepositoryCustomization `json:"repositories,omitempty" toml:"repositories,omitempty"`
+	FIPS               *bool                     `json:"fips,omitempty" toml:"fips,omitempty"`
 }
 
 type IgnitionCustomization struct {
@@ -312,6 +313,13 @@ func (c *Customizations) GetFDO() *FDOCustomization {
 		return nil
 	}
 	return c.FDO
+}
+
+func (c *Customizations) GetFIPS() bool {
+	if c == nil || c.FIPS == nil {
+		return false
+	}
+	return *c.FIPS
 }
 
 func (c *Customizations) GetOpenSCAP() *OpenSCAPCustomization {

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -49,6 +49,10 @@ func osCustomizations(
 		}
 	}
 
+	if c.GetFIPS() {
+		osc.KernelOptionsAppend = append(osc.KernelOptionsAppend, "fips=1")
+	}
+
 	osc.ExtraBasePackages = osPackageSet.Include
 	osc.ExcludeBasePackages = osPackageSet.Exclude
 	osc.ExtraBaseRepos = osPackageSet.Repositories
@@ -410,6 +414,10 @@ func edgeInstallerImage(workload workload.Workload,
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 
+	if customizations.GetFIPS() {
+		img.KernelOptionsAppend = append(img.KernelOptionsAppend, "fips=1")
+	}
+
 	img.SquashfsCompression = "xz"
 	img.AdditionalDracutModules = []string{"prefixdevname", "prefixdevname-tools"}
 
@@ -449,6 +457,10 @@ func edgeRawImage(workload workload.Workload,
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 
 	img.KernelOptionsAppend = []string{"modprobe.blacklist=vc4"}
+	if customizations.GetFIPS() {
+		img.KernelOptionsAppend = append(img.KernelOptionsAppend, "fips=1")
+	}
+
 	// TODO: move to image config
 	img.Keyboard = "us"
 	img.Locale = "C.UTF-8"
@@ -494,6 +506,9 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 	rawImg.Groups = users.GroupsFromBP(customizations.GetGroups())
 
 	rawImg.KernelOptionsAppend = []string{"modprobe.blacklist=vc4"}
+	if customizations.GetFIPS() {
+		rawImg.KernelOptionsAppend = append(rawImg.KernelOptionsAppend, "fips=1")
+	}
 	rawImg.Keyboard = "us"
 	rawImg.Locale = "C.UTF-8"
 

--- a/pkg/distro/rhel8/imagetype.go
+++ b/pkg/distro/rhel8/imagetype.go
@@ -300,7 +300,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		}
 
 		if t.name == "edge-simplified-installer" {
-			allowed := []string{"InstallationDevice", "FDO", "User", "Group"}
+			allowed := []string{"InstallationDevice", "FDO", "User", "Group", "FIPS"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return warnings, fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
 			}
@@ -327,7 +327,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 				}
 			}
 		} else if t.name == "edge-installer" {
-			allowed := []string{"User", "Group"}
+			allowed := []string{"User", "Group", "FIPS"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return warnings, fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
 			}
@@ -340,7 +340,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 			return warnings, fmt.Errorf("%q images require specifying a URL from which to retrieve the OSTree commit", t.name)
 		}
 
-		allowed := []string{"User", "Group"}
+		allowed := []string{"User", "Group", "FIPS"}
 		if err := customizations.CheckAllowed(allowed...); err != nil {
 			return warnings, fmt.Errorf("unsupported blueprint customizations found for image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
 		}

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -46,6 +46,10 @@ func osCustomizations(
 		osc.KernelOptionsAppend = kernelOptions
 	}
 
+	if c.GetFIPS() {
+		osc.KernelOptionsAppend = append(osc.KernelOptionsAppend, "fips=1")
+	}
+
 	osc.ExtraBasePackages = osPackageSet.Include
 	osc.ExcludeBasePackages = osPackageSet.Exclude
 	osc.ExtraBaseRepos = osPackageSet.Repositories
@@ -438,6 +442,9 @@ func edgeRawImage(workload workload.Workload,
 	if kopts := customizations.GetKernel(); kopts != nil && kopts.Append != "" {
 		img.KernelOptionsAppend = append(img.KernelOptionsAppend, kopts.Append)
 	}
+	if customizations.GetFIPS() {
+		img.KernelOptionsAppend = append(img.KernelOptionsAppend, "fips=1")
+	}
 
 	// TODO: move generation into LiveImage
 	pt, err := t.getPartitionTable(customizations.GetFilesystems(), options, rng)
@@ -506,6 +513,9 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 	// 92+ only
 	if kopts := customizations.GetKernel(); kopts != nil && kopts.Append != "" {
 		rawImg.KernelOptionsAppend = append(rawImg.KernelOptionsAppend, kopts.Append)
+	}
+	if customizations.GetFIPS() {
+		rawImg.KernelOptionsAppend = append(rawImg.KernelOptionsAppend, "fips=1")
 	}
 
 	img := image.NewOSTreeSimplifiedInstaller(rawImg, customizations.InstallationDevice)

--- a/pkg/distro/rhel9/imagetype.go
+++ b/pkg/distro/rhel9/imagetype.go
@@ -305,7 +305,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		}
 
 		if t.name == "edge-simplified-installer" {
-			allowed := []string{"InstallationDevice", "FDO", "Ignition", "Kernel", "User", "Group"}
+			allowed := []string{"InstallationDevice", "FDO", "Ignition", "Kernel", "User", "Group", "FIPS"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return warnings, fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
 			}
@@ -343,7 +343,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 				}
 			}
 		} else if t.name == "edge-installer" {
-			allowed := []string{"User", "Group"}
+			allowed := []string{"User", "Group", "FIPS"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return warnings, fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
 			}
@@ -356,7 +356,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 			return warnings, fmt.Errorf("%q images require specifying a URL from which to retrieve the OSTree commit", t.name)
 		}
 
-		allowed := []string{"Ignition", "Kernel", "User", "Group"}
+		allowed := []string{"Ignition", "Kernel", "User", "Group", "FIPS"}
 		if err := customizations.CheckAllowed(allowed...); err != nil {
 			return warnings, fmt.Errorf("unsupported blueprint customizations found for image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
 		}

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -35,6 +35,7 @@ type AnacondaOSTreeInstaller struct {
 
 	Filename string
 
+	KernelOptionsAppend       []string
 	AdditionalDracutModules   []string
 	AdditionalAnacondaModules []string
 	AdditionalDrivers         []string
@@ -100,6 +101,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	bootTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
 	bootTreePipeline.ISOLabel = isoLabel
 	bootTreePipeline.KernelOpts = []string{fmt.Sprintf("inst.stage2=hd:LABEL=%s", isoLabel), fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", isoLabel, kspath)}
+	bootTreePipeline.KernelOpts = append(bootTreePipeline.KernelOpts, img.KernelOptionsAppend...)
 
 	// enable ISOLinux on x86_64 only
 	isoLinuxEnabled := img.Platform.GetArch() == platform.ARCH_X86_64

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -742,6 +742,13 @@ func (p *OS) serialize() osbuild.Pipeline {
 		}))
 	}
 
+	if osbuild.ContainsFIPSKernelOption(p.KernelOptionsAppend) {
+		fipsStage := osbuild.NewFIPSStage(&osbuild.FIPSStageOptions{
+			BootCfg: false,
+		})
+		pipeline.AddStage(fipsStage)
+	}
+
 	if p.SElinux != "" {
 		pipeline.AddStage(osbuild.NewSELinuxStage(&osbuild.SELinuxStageOptions{
 			FileContexts:     fmt.Sprintf("etc/selinux/%s/contexts/files/file_contexts", p.SElinux),

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -344,6 +344,14 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 		pipeline.AddStage(systemdStage)
 	}
 
+	if osbuild.ContainsFIPSKernelOption(p.KernelOptionsAppend) {
+		fipsStage := osbuild.NewFIPSStage(&osbuild.FIPSStageOptions{
+			BootCfg: false,
+		})
+		fipsStage.MountOSTree(p.osName, commit.Ref, 0)
+		pipeline.AddStage(fipsStage)
+	}
+
 	pipeline.AddStage(osbuild.NewOSTreeSelinuxStage(
 		&osbuild.OSTreeSelinuxStageOptions{
 			Deployment: osbuild.OSTreeDeployment{

--- a/pkg/osbuild/disk.go
+++ b/pkg/osbuild/disk.go
@@ -117,7 +117,18 @@ func GenImageKernelOptions(pt *disk.PartitionTable) []string {
 		case *disk.LUKSContainer:
 			karg := "luks.uuid=" + ent.UUID
 			cmdline = append(cmdline, karg)
+		case *disk.Filesystem:
+			if ent.Mountpoint == "/boot" {
+				if label := ent.Label; label != "" {
+					karg := "boot=LABEL=" + label
+					cmdline = append(cmdline, karg)
+				} else if uuid := ent.UUID; uuid != "" {
+					karg := "boot=UID=" + uuid
+					cmdline = append(cmdline, karg)
+				}
+			}
 		}
+
 		return nil
 	}
 

--- a/pkg/osbuild/fips_stage.go
+++ b/pkg/osbuild/fips_stage.go
@@ -1,0 +1,28 @@
+package osbuild
+
+import (
+	"strings"
+)
+
+type FIPSStageOptions struct {
+	BootCfg bool `json:"boot_cfg"`
+}
+
+func (FIPSStageOptions) isStageOptions() {}
+
+// NewFIPSStage creates FIPSStage
+func NewFIPSStage(options *FIPSStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.fips",
+		Options: options,
+	}
+}
+
+func ContainsFIPSKernelOption(kernelOpts []string) bool {
+	for _, kernelOption := range kernelOpts {
+		if strings.Contains(kernelOption, "fips=1") {
+			return true
+		}
+	}
+	return false
+}

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -37,6 +37,11 @@
       "edge-simplified-installer"
     ]
   },
+  "./configs/edge-ostree-pull-device-fips.json": {
+    "image-types": [
+      "edge-simplified-installer"
+    ]
+  },
   "./configs/edge-ostree-pull-empty.json": {
     "image-types": [
       "edge-installer",
@@ -44,7 +49,19 @@
       "edge-vsphere"
     ]
   },
+ "./configs/edge-ostree-pull-empty-fips.json": {
+    "image-types": [
+      "edge-installer",
+      "edge-raw-image",
+      "edge-vsphere"
+    ]
+  },
   "./configs/edge-ostree-pull-user.json": {
+    "image-types": [
+      "edge-ami"
+    ]
+  },
+  "./configs/edge-ostree-pull-user-fips.json": {
     "image-types": [
       "edge-ami"
     ]
@@ -57,6 +74,11 @@
   "./configs/embed-containers.json": {
     "image-types": [
       "edge-commit"
+    ]
+  },
+  "./configs/fips.json": {
+    "image-types": [
+      "edge-container"
     ]
   },
   "./configs/empty.json": {

--- a/test/configs/edge-ostree-pull-device-fips.json
+++ b/test/configs/edge-ostree-pull-device-fips.json
@@ -1,0 +1,16 @@
+{
+  "name": "edge-ostree-pull-device-fips",
+  "blueprint": {
+    "customizations": {
+      "fips": true,
+      "installation_device": "/dev/vda"
+    }
+  },
+  "ostree": {
+    "url": "http://example.com/repo"
+  },
+  "depends": {
+    "image-type": "edge-container",
+    "config": "fips.json"
+  }
+}

--- a/test/configs/edge-ostree-pull-empty-fips.json
+++ b/test/configs/edge-ostree-pull-empty-fips.json
@@ -1,0 +1,15 @@
+{
+  "name": "edge-ostree-pull-empty-fips",
+  "blueprint": {
+    "customizations": {
+        "fips": true
+    }
+  },
+  "ostree": {
+    "url": "http://example.com/repo"
+  },
+  "depends": {
+    "image-type": "edge-container",
+    "config": "fips.json"
+  }
+}

--- a/test/configs/edge-ostree-pull-user-fips.json
+++ b/test/configs/edge-ostree-pull-user-fips.json
@@ -1,0 +1,24 @@
+{
+  "name": "edge-ostree-pull-user-fips",
+  "blueprint": {
+    "customizations": {
+      "fips": true,
+      "user": [
+        {
+          "groups": [
+            "wheel"
+          ],
+          "key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPDyeUyVWvuSSOdrikiDWgNoCz0oYP4Ir68jJecn+XYc github.com/osbuild/images",
+          "name": "osbuild"
+        }
+      ]
+    }
+  },
+  "depends": {
+    "config": "empty.json",
+    "image-type": "edge-container"
+  },
+  "ostree": {
+    "url": "http://example.com/repo"
+  }
+}

--- a/test/configs/fips.json
+++ b/test/configs/fips.json
@@ -1,0 +1,8 @@
+{
+  "name": "fips",
+  "blueprint": {
+    "customizations": {
+      "fips": true
+    }
+  }
+}


### PR DESCRIPTION
Enables system FIPS mode at build time by defining a new 'fips' blueprint 
customization. Depends on osbuild/osbuild/pull/1423

- blueprint(fips): add FIPS blueprint
- distro(rhel): enable FIPS customization for edge images
- distro(rhel): add required kernel cmdline for FIPS customization
- image(anaconda): allow additional kernel cmdline options
- osbuild(stages): Add the new FIPS stage
- manifest(fips): enable FIPS stage
- osbuild(fips): add 'boot' kernel cmdline option in FIPS mode
- test(fips): add tests for FIPS enabled edge images
