### PR TITLE
Enable system FIPS mode for Edge Images

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-38": {
     "dependencies": {
       "osbuild": {
-        "commit": "61da6124edee4f9735d50a412d5ecc16c8eec674"
+        "commit": "f3d740aaf8531e55b99632f579f2fae13f1511b7"
       }
     },
     "repos": [

--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -24,6 +24,7 @@ type Customizations struct {
 	Directories        []DirectoryCustomization  `json:"directories,omitempty" toml:"directories,omitempty"`
 	Files              []FileCustomization       `json:"files,omitempty" toml:"files,omitempty"`
 	Repositories       []RepositoryCustomization `json:"repositories,omitempty" toml:"repositories,omitempty"`
+	FIPS               *bool                     `json:"fips,omitempty" toml:"fips,omitempty"`
 }
 
 type IgnitionCustomization struct {
@@ -355,4 +356,11 @@ func (c *Customizations) GetRepositories() ([]RepositoryCustomization, error) {
 	}
 
 	return c.Repositories, nil
+}
+
+func (c *Customizations) GetFIPS() bool {
+	if c == nil || c.FIPS == nil {
+		return false
+	}
+	return *c.FIPS
 }

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -404,6 +404,7 @@ func edgeRawImage(workload workload.Workload,
 
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
+	img.FIPS = customizations.GetFIPS()
 
 	// The kernel options defined on the image type are usually handled in
 	// osCustomiztions() but ostree images don't use OSCustomizations, so we
@@ -468,6 +469,7 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 
 	rawImg.Users = users.UsersFromBP(customizations.GetUsers())
 	rawImg.Groups = users.GroupsFromBP(customizations.GetGroups())
+	rawImg.FIPS = customizations.GetFIPS()
 
 	rawImg.KernelOptionsAppend = []string{"modprobe.blacklist=vc4"}
 	rawImg.Keyboard = "us"

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -382,6 +382,7 @@ func edgeInstallerImage(workload workload.Workload,
 	img.OSName = "rhel"
 	img.OSVersion = d.osVersion
 	img.Release = fmt.Sprintf("%s %s", d.product, d.osVersion)
+	img.FIPS = customizations.GetFIPS()
 
 	img.Filename = t.Filename()
 

--- a/pkg/distro/rhel9/imagetype.go
+++ b/pkg/distro/rhel9/imagetype.go
@@ -343,7 +343,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 				}
 			}
 		} else if t.name == "edge-installer" {
-			allowed := []string{"User", "Group"}
+			allowed := []string{"User", "Group", "FIPS"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return warnings, fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
 			}

--- a/pkg/distro/rhel9/imagetype.go
+++ b/pkg/distro/rhel9/imagetype.go
@@ -305,7 +305,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		}
 
 		if t.name == "edge-simplified-installer" {
-			allowed := []string{"InstallationDevice", "FDO", "Ignition", "Kernel", "User", "Group"}
+			allowed := []string{"InstallationDevice", "FDO", "Ignition", "Kernel", "User", "Group", "FIPS"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return warnings, fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
 			}
@@ -356,7 +356,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 			return warnings, fmt.Errorf("%q images require specifying a URL from which to retrieve the OSTree commit", t.name)
 		}
 
-		allowed := []string{"Ignition", "Kernel", "User", "Group"}
+		allowed := []string{"Ignition", "Kernel", "User", "Group", "FIPS"}
 		if err := customizations.CheckAllowed(allowed...); err != nil {
 			return warnings, fmt.Errorf("unsupported blueprint customizations found for image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
 		}

--- a/pkg/image/ostree_disk.go
+++ b/pkg/image/ostree_disk.go
@@ -45,6 +45,8 @@ type OSTreeDiskImage struct {
 
 	Directories []*fsnode.Directory
 	Files       []*fsnode.File
+
+	FIPS bool
 }
 
 func NewOSTreeDiskImage(commit ostree.SourceSpec) *OSTreeDiskImage {

--- a/pkg/image/ostree_disk.go
+++ b/pkg/image/ostree_disk.go
@@ -66,6 +66,7 @@ func baseRawOstreeImage(img *OSTreeDiskImage, m *manifest.Manifest, buildPipelin
 	osPipeline.SysrootReadOnly = img.SysrootReadOnly
 	osPipeline.Directories = img.Directories
 	osPipeline.Files = img.Files
+	osPipeline.FIPS = img.FIPS
 
 	// other image types (e.g. live) pass the workload to the pipeline.
 	osPipeline.EnabledServices = img.Workload.GetServices()

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -53,6 +53,8 @@ type OSTreeDeployment struct {
 
 	EnabledServices  []string
 	DisabledServices []string
+
+	FIPS bool
 }
 
 // NewOSTreeDeployment creates a pipeline for an ostree deployment from a
@@ -158,6 +160,11 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 			"ignition.platform.id="+p.ignitionPlatform,
 			"$ignition_firstboot",
 		)
+	}
+
+	if p.FIPS {
+		kernelOpts = append(kernelOpts, osbuild.GenFIPSKernelOptions(p.PartitionTable)...)
+		p.Files = append(p.Files, osbuild.GenFIPSFiles()...)
 	}
 
 	pipeline.AddStage(osbuild.NewOSTreeDeployStage(
@@ -296,6 +303,13 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 		localeStage := osbuild.NewLocaleStage(options)
 		localeStage.MountOSTree(p.osName, commit.Ref, 0)
 		pipeline.AddStage(localeStage)
+	}
+
+	if p.FIPS {
+		for _, stage := range osbuild.GenFIPSStages() {
+			stage.MountOSTree(p.osName, commit.Ref, 0)
+			pipeline.AddStage(stage)
+		}
 	}
 
 	grubOptions := osbuild.NewGrub2StageOptionsUnified(p.PartitionTable,

--- a/pkg/osbuild/fips.go
+++ b/pkg/osbuild/fips.go
@@ -1,0 +1,43 @@
+package osbuild
+
+import (
+	"os"
+
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/fsnode"
+	"github.com/osbuild/images/pkg/disk"
+)
+
+func GenFIPSKernelOptions(pt *disk.PartitionTable) []string {
+	cmdline := make([]string, 0)
+	cmdline = append(cmdline, "fips=1")
+	if bootMnt := pt.FindMountable("/boot"); bootMnt != nil {
+		boot := bootMnt.GetFSSpec()
+		if label := boot.Label; label != "" {
+			karg := "boot=LABEL=" + label
+			cmdline = append(cmdline, karg)
+		} else if uuid := boot.UUID; uuid != "" {
+			karg := "boot=UUID=" + uuid
+			cmdline = append(cmdline, karg)
+		}
+	}
+	return cmdline
+}
+
+func GenFIPSFiles() (files []*fsnode.File) {
+	file, _ := fsnode.NewFile("/etc/system-fips", common.ToPtr(os.FileMode(0644)),
+		"root", "root", []byte("# FIPS module installation complete\n"))
+	files = append(files, file)
+	return
+}
+
+func GenFIPSStages() (stages []*Stage) {
+	stages = []*Stage{
+		NewUpdateCryptoPoliciesStage(
+			&UpdateCryptoPoliciesStageOptions{
+				Policy: "FIPS",
+			}),
+	}
+	stages = append(stages, GenFileNodesStages(GenFIPSFiles())...)
+	return
+}

--- a/pkg/osbuild/update_crypto_policies_stage.go
+++ b/pkg/osbuild/update_crypto_policies_stage.go
@@ -1,0 +1,14 @@
+package osbuild
+
+type UpdateCryptoPoliciesStageOptions struct {
+	Policy string `json:"policy"`
+}
+
+func (UpdateCryptoPoliciesStageOptions) isStageOptions() {}
+
+func NewUpdateCryptoPoliciesStage(options *UpdateCryptoPoliciesStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.update-crypto-policies",
+		Options: options,
+	}
+}

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -37,7 +37,27 @@
       "edge-simplified-installer"
     ]
   },
+  "./configs/edge-ostree-pull-device-fips.json": {
+    "distros": [
+      "rhel-93",
+      "rhel-94"
+    ],
+    "image-types": [
+      "edge-simplified-installer"
+    ]
+  },
   "./configs/edge-ostree-pull-empty.json": {
+    "image-types": [
+      "edge-installer",
+      "edge-raw-image",
+      "edge-vsphere"
+    ]
+  },
+ "./configs/edge-ostree-pull-fips.json": {
+    "distros": [
+      "rhel-93",
+      "rhel-94"
+    ],
     "image-types": [
       "edge-installer",
       "edge-raw-image",
@@ -49,6 +69,16 @@
       "edge-ami"
     ]
   },
+  "./configs/edge-ostree-pull-user-fips.json": {
+    "distros": [
+      "rhel-93",
+      "rhel-94"
+    ],
+    "image-types": [
+      "edge-ami"
+    ]
+  },
+
   "./configs/embed-containers-2.json": {
     "image-types": [
       "edge-container"

--- a/test/configs/edge-ostree-pull-device-fips.json
+++ b/test/configs/edge-ostree-pull-device-fips.json
@@ -1,0 +1,16 @@
+{
+  "name": "edge-ostree-pull-device-fips",
+  "blueprint": {
+    "customizations": {
+      "fips": true,
+      "installation_device": "/dev/vda"
+    }
+  },
+  "ostree": {
+    "url": "http://example.com/repo"
+  },
+  "depends": {
+    "image-type": "edge-container",
+    "config": "empty.json"
+  }
+}

--- a/test/configs/edge-ostree-pull-fips.json
+++ b/test/configs/edge-ostree-pull-fips.json
@@ -1,0 +1,15 @@
+{
+  "name": "edge-ostree-pull-fips",
+  "blueprint": {
+    "customizations": {
+      "fips": true
+    }
+  },
+  "ostree": {
+    "url": "http://example.com/repo"
+  },
+  "depends": {
+    "image-type": "edge-container",
+    "config": "empty.json"
+  }
+}

--- a/test/configs/edge-ostree-pull-user-fips.json
+++ b/test/configs/edge-ostree-pull-user-fips.json
@@ -1,0 +1,24 @@
+{
+  "name": "edge-ostree-pull-user-fips",
+  "blueprint": {
+    "customizations": {
+      "fips": true,
+      "user": [
+        {
+          "groups": [
+            "wheel"
+          ],
+          "key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNebAh6SjpAn8wB53K4695cGnHGuCtl4RdaX3futZgJUultHyzeYHnzMO7d4++qnRL+Rworew62LKP560uvtncc= github.com/osbuild/images",
+          "name": "osbuild"
+        }
+      ]
+    }
+  },
+  "depends": {
+    "config": "empty.json",
+    "image-type": "edge-container"
+  },
+  "ostree": {
+    "url": "http://example.com/repo"
+  }
+}

--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -31,7 +31,7 @@ def get_aws_config():
 def create_ssh_key():
     with TemporaryDirectory() as tmpdir:
         keypath = os.path.join(tmpdir, "testkey")
-        if ci_priv_key := os.environ.get("CI_PRIV_SSH_KEY"):
+        if ci_priv_key := os.environ.get("CI_PRIV_SSH_KEY_2"):
             # running in CI: use key from env
             with open(keypath, "w") as keyfile:
                 keyfile.write(ci_priv_key + "\n")
@@ -45,7 +45,7 @@ def create_ssh_key():
                 pubkeyfile.write(pubkey)
         else:
             # create an ssh key pair with empty password
-            cmd = ["ssh-keygen", "-N", "", "-f", keypath]
+            cmd = ["ssh-keygen", "-t", "ecdsa", "-b", "256", "-m", "pem", "-N", "", "-f", keypath]
             runcmd(cmd)
 
         yield keypath, keypath + ".pub"


### PR DESCRIPTION
Defines a new `fips` blueprint customization to enable the system FIPS mode on the generated images.

Enables `fips` blueprint customization support for the following images: 
- Edge images based on OSTree deployments:
   - `edge-raw-image`
   - `edge-simplified-installer`
   - `edge-vsphere`
   - `edge-ami`
- Edge images based on the Anaconda OSTree installer:
  -  `edge-installer`

Depends on osbuild/osbuild/pull/1443
