### PR TITLE
Test/all-customizations: add more custom mountpoints

### DIFF
--- a/test/configs/all-customizations.json
+++ b/test/configs/all-customizations.json
@@ -85,8 +85,40 @@
       },
       "filesystem": [
         {
+          "mountpoint": "/home",
+          "minsize": 2147483648
+        },
+        {
+          "mountpoint": "/home/shadowman",
+          "minsize": "500MiB"
+        },
+        {
+          "mountpoint": "/foo",
+          "minsize": "1GiB"
+        },
+        {
+          "mountpoint": "/usr",
+          "minsize": "4GiB"
+        },
+        {
           "mountpoint": "/opt",
-          "minsize": 1073741824
+          "minsize": "1GiB"
+        },
+        {
+          "mountpoint": "/media",
+          "minsize": "1GiB"
+        },
+        {
+          "mountpoint": "/root",
+          "minsize": "1GiB"
+        },
+        {
+          "mountpoint": "/srv",
+          "minsize": "1GiB"
+        },
+        {
+          "mountpoint": "/mnt",
+          "minsize": "1GiB"
         }
       ],
       "directories": [


### PR DESCRIPTION
Modify the `all-customization.json` image config to generate testing manifests with more comprehensive list of custom (and arbitrary) mountpoints.