### PR TITLE
test: filter on architecture as well when generating config map of dependencies

### DIFF
--- a/test/scripts/generate-ostree-build-config
+++ b/test/scripts/generate-ostree-build-config
@@ -33,9 +33,10 @@ def read_config_map():
         return json.load(config_map_file)
 
 
-def configs_with_deps(configs, distro=None):
+def configs_with_deps(configs, distro=None, arch=None):
     """
     Return a config map with only the config files that have dependencies.
+    Filter on distro and arch if specified.
     """
     with_deps: dict[str, str] = {}
     config_map_dir = os.path.abspath(os.path.dirname(testlib.CONFIG_MAP))
@@ -46,8 +47,13 @@ def configs_with_deps(configs, distro=None):
             data = json.load(config_file)
         if not data.get("depends"):
             continue
-        config_distro = filters.get("distros", [])
-        if config_distro and distro and distro not in config_distro:
+
+        # filter on distro and arch
+        distro_filters = filters.get("distros", [])
+        if distro_filters and distro and distro not in distro_filters:
+            continue
+        arch_filters = filters.get("arches", [])
+        if arch_filters and arch and arch not in arch_filters:
             continue
 
         with_deps[config_path] = filters
@@ -320,7 +326,7 @@ def main():
 
     testlib.check_config_names()
 
-    config_map = configs_with_deps(read_config_map(), distro)  # filtered config map: only configs with deps
+    config_map = configs_with_deps(read_config_map(), distro, arch)  # filtered config map: only configs with deps
 
     with TemporaryDirectory() as cache_root:
         dep_manifest_dir = os.path.join(cache_root, "dependencies")

--- a/test/scripts/generate-ostree-build-config
+++ b/test/scripts/generate-ostree-build-config
@@ -226,10 +226,10 @@ def setup_dependencies(manifests, config_map, distro, arch):
                                             images=filters.get("image-types"))
 
         for image_config in image_configs:
-            distro = image_config["distro"]
-            arch = image_config["arch"]
-            image_type = image_config["image-type"]
-            dep_build_name = testlib.gen_build_name(distro, arch, dep_image_type, dep_config_name)
+            ic_distro = image_config["distro"]
+            ic_arch = image_config["arch"]
+            ic_image_type = image_config["image-type"]
+            dep_build_name = testlib.gen_build_name(ic_distro, ic_arch, dep_image_type, dep_config_name)
             manifest_id = manifests[dep_build_name + ".json"]["id"]
             container = f"{testlib.REGISTRY}/{dep_build_name}:build-{manifest_id}"
 
@@ -249,7 +249,7 @@ def setup_dependencies(manifests, config_map, distro, arch):
                 "ostree": {
                     "url": f"http://localhost:{port}/repo",
                     # get the ref from the current config, or compute the default if unset
-                    "ref": config_data.get("ostree", {}).get("ref", default_ref(distro, arch)),
+                    "ref": config_data.get("ostree", {}).get("ref", default_ref(ic_distro, ic_arch)),
                 },
                 "blueprint": config_data.get("blueprint"),
             }
@@ -262,9 +262,9 @@ def setup_dependencies(manifests, config_map, distro, arch):
 
             config_fname = config_name + ".json"
             new_filters = new_config_map.get(config_fname, {"distros": [], "arches": [], "image-types": []})
-            new_filters["distros"].append(distro)
-            new_filters["arches"].append(arch)
-            new_filters["image-types"].append(image_type)
+            new_filters["distros"].append(ic_distro)
+            new_filters["arches"].append(ic_arch)
+            new_filters["image-types"].append(ic_image_type)
             new_config_map[config_fname] = new_filters
 
     try:


### PR DESCRIPTION
Following up from #260, this PR also filters the config map on the architecture.