### PR TITLE
RHEL9: Add packages for dracut modules explicitly (don't rely on weak dependencies)

### DIFF
--- a/pkg/distro/rhel9/bare_metal.go
+++ b/pkg/distro/rhel9/bare_metal.go
@@ -133,6 +133,20 @@ func installerPackageSet(t *imageType) rpmmd.PackageSet {
 		},
 	}
 
+	ps = ps.Append(rpmmd.PackageSet{
+		// Extra packages that are required by the dracut stage of all installers.
+		// These are weak deps of other packages in the list above, but lets be
+		// explicit about what we need and not rely on the weak deps. Relying
+		// on hard-dependencies for other modules is OK for now.
+		//
+		// TODO: add these dynamically based on the modules enabled by each
+		// pipeline.
+		Include: []string{
+			"mdadm",
+			"nss-softokn",
+		},
+	})
+
 	switch t.arch.Name() {
 	case platform.ARCH_X86_64.String():
 		ps = ps.Append(rpmmd.PackageSet{


### PR DESCRIPTION
For installers (both Anaconda and CoreOS) on RHEL 9, we define a couple of dracut modules that rely on packages that are pulled in as weak dependencies of other packages in the installer package set.  Let's define these explicitly instead.
For other packages that are required by other modules, let's still rely on package "hard" dependencies that are already defined.

In the future, we should derive the required packages dynamically from the dracut modules defined in the pipeline.

I've verified this works by applying the following patch and building installers:
```diff
diff --git a/pkg/manifest/anaconda_installer.go b/pkg/manifest/anaconda_installer.go
index 0d5c10037..2719d76b6 100644
--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -149,7 +149,7 @@ func (p *AnacondaInstaller) getPackageSetChain(Distro) []rpmmd.PackageSet {
 			Include:         append(packages, p.ExtraPackages...),
 			Exclude:         p.ExcludePackages,
 			Repositories:    append(p.repos, p.ExtraRepos...),
-			InstallWeakDeps: true,
+			InstallWeakDeps: false,
 		},
 	}
 }
diff --git a/pkg/manifest/coreos_installer.go b/pkg/manifest/coreos_installer.go
index 0f0f2b5d6..321083be3 100644
--- a/pkg/manifest/coreos_installer.go
+++ b/pkg/manifest/coreos_installer.go
@@ -128,7 +128,7 @@ func (p *CoreOSInstaller) getPackageSetChain(Distro) []rpmmd.PackageSet {
 			Include:         append(packages, p.ExtraPackages...),
 			Exclude:         p.ExcludePackages,
 			Repositories:    append(p.repos, p.ExtraRepos...),
-			InstallWeakDeps: true,
+			InstallWeakDeps: false,
 		},
 	}
 }
```

Applying the same patch on (current) `main` and building an installer should fail at the dracut stage.

This is not an issue on RHEL 8 and Fedora.  The package sets for installers include packages with hard dependencies on the modules.