### PR TITLE
OpenSCAP results compression

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -38,6 +38,9 @@ const (
 
 	// Added kernel command line options for ami, qcow2, openstack, vhd and vmdk types
 	cloudKernelOptions = "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+
+	// location for saving openscap remediation data
+	oscapDataDir = "/oscap_data"
 )
 
 var (

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -165,6 +165,16 @@ func osCustomizations(
 		if t.rpmOstree {
 			panic("unexpected oscap options for ostree image type")
 		}
+
+		// although the osbuild stage will create this directory,
+		// it's probably better to ensure that it is created here
+		dataDirNode, err := fsnode.NewDirectory(oscapDataDir, nil, nil, nil, true)
+		if err != nil {
+			panic("unexpected error creating OpenSCAP data directory")
+		}
+
+		osc.Directories = append(osc.Directories, dataDirNode)
+
 		var datastream = oscapConfig.DataStream
 		if datastream == "" {
 			datastream = oscap.DefaultFedoraDatastream()
@@ -202,7 +212,7 @@ func osCustomizations(
 			osc.Directories = append(osc.Directories, tailoringDir)
 		}
 
-		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscapStageOptions)
+		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscapDataDir, oscapStageOptions)
 	}
 
 	osc.ShellInit = imageConfig.ShellInit

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -182,14 +182,15 @@ func osCustomizations(
 			}
 
 			tailoringOptions := osbuild.OscapAutotailorConfig{
+				NewProfile: newProfile,
+				Datastream: datastream,
+				ProfileID:  oscapConfig.ProfileID,
 				Selected:   oscapConfig.Tailoring.Selected,
 				Unselected: oscapConfig.Tailoring.Unselected,
-				NewProfile: newProfile,
 			}
 
 			osc.OpenSCAPTailorConfig = osbuild.NewOscapAutotailorStageOptions(
 				tailoringFilepath,
-				oscapStageOptions,
 				tailoringOptions,
 			)
 

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -181,8 +181,9 @@ func osCustomizations(
 		}
 
 		oscapStageOptions := osbuild.OscapConfig{
-			Datastream: datastream,
-			ProfileID:  oscapConfig.ProfileID,
+			Datastream:  datastream,
+			ProfileID:   oscapConfig.ProfileID,
+			Compression: true,
 		}
 
 		if oscapConfig.Tailoring != nil {

--- a/pkg/distro/rhel7/distro.go
+++ b/pkg/distro/rhel7/distro.go
@@ -22,6 +22,9 @@ const (
 
 	// blueprint package set name
 	blueprintPkgsKey = "blueprint"
+
+	// location for saving openscap remediation data
+	oscapDataDir = "/oscap_data"
 )
 
 // RHEL-based OS image configuration defaults

--- a/pkg/distro/rhel7/images.go
+++ b/pkg/distro/rhel7/images.go
@@ -133,8 +133,9 @@ func osCustomizations(
 		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(
 			oscapDataDir,
 			osbuild.OscapConfig{
-				Datastream: oscapConfig.DataStream,
-				ProfileID:  oscapConfig.ProfileID,
+				Datastream:  oscapConfig.DataStream,
+				ProfileID:   oscapConfig.ProfileID,
+				Compression: true,
 			},
 		)
 	}

--- a/pkg/distro/rhel7/images.go
+++ b/pkg/distro/rhel7/images.go
@@ -131,6 +131,7 @@ func osCustomizations(
 
 	if oscapConfig := c.GetOpenSCAP(); oscapConfig != nil {
 		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(
+			oscapDataDir,
 			osbuild.OscapConfig{
 				Datastream: oscapConfig.DataStream,
 				ProfileID:  oscapConfig.ProfileID,

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -202,8 +202,9 @@ func osCustomizations(
 		}
 
 		oscapStageOptions := osbuild.OscapConfig{
-			Datastream: datastream,
-			ProfileID:  oscapConfig.ProfileID,
+			Datastream:  datastream,
+			ProfileID:   oscapConfig.ProfileID,
+			Compression: true,
 		}
 
 		if oscapConfig.Tailoring != nil {

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -186,6 +186,16 @@ func osCustomizations(
 		if t.rpmOstree {
 			panic("unexpected oscap options for ostree image type")
 		}
+
+		// although the osbuild stage will create this directory,
+		// it's probably better to ensure that it is created here
+		dataDirNode, err := fsnode.NewDirectory(oscapDataDir, nil, nil, nil, true)
+		if err != nil {
+			panic("unexpected error creating OpenSCAP data directory")
+		}
+
+		osc.Directories = append(osc.Directories, dataDirNode)
+
 		var datastream = oscapConfig.DataStream
 		if datastream == "" {
 			datastream = oscap.DefaultRHEL8Datastream(t.arch.distro.isRHEL())
@@ -223,7 +233,7 @@ func osCustomizations(
 			osc.Directories = append(osc.Directories, tailoringDir)
 		}
 
-		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscapStageOptions)
+		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscapDataDir, oscapStageOptions)
 	}
 
 	osc.ShellInit = imageConfig.ShellInit

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -203,14 +203,15 @@ func osCustomizations(
 			}
 
 			tailoringOptions := osbuild.OscapAutotailorConfig{
+				NewProfile: newProfile,
+				Datastream: datastream,
+				ProfileID:  oscapConfig.ProfileID,
 				Selected:   oscapConfig.Tailoring.Selected,
 				Unselected: oscapConfig.Tailoring.Unselected,
-				NewProfile: newProfile,
 			}
 
 			osc.OpenSCAPTailorConfig = osbuild.NewOscapAutotailorStageOptions(
 				tailoringFilepath,
-				oscapStageOptions,
 				tailoringOptions,
 			)
 

--- a/pkg/distro/rhel8/imagetype.go
+++ b/pkg/distro/rhel8/imagetype.go
@@ -37,6 +37,9 @@ const (
 
 	// blueprint package set name
 	blueprintPkgsKey = "blueprint"
+
+	// location for saving openscap remediation data
+	oscapDataDir = "/oscap_data"
 )
 
 type imageFunc func(workload workload.Workload, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, packageSets map[string]rpmmd.PackageSet, containers []container.SourceSpec, rng *rand.Rand) (image.ImageKind, error)

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -183,6 +183,16 @@ func osCustomizations(
 		if t.rpmOstree {
 			panic("unexpected oscap options for ostree image type")
 		}
+
+		// although the osbuild stage will create this directory,
+		// it's probably better to ensure that it is created here
+		dataDirNode, err := fsnode.NewDirectory(oscapDataDir, nil, nil, nil, true)
+		if err != nil {
+			panic("unexpected error creating OpenSCAP data directory")
+		}
+
+		osc.Directories = append(osc.Directories, dataDirNode)
+
 		var datastream = oscapConfig.DataStream
 		if datastream == "" {
 			datastream = oscap.DefaultRHEL9Datastream(t.arch.distro.isRHEL())
@@ -220,7 +230,7 @@ func osCustomizations(
 			osc.Directories = append(osc.Directories, tailoringDir)
 		}
 
-		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscapStageOptions)
+		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscapDataDir, oscapStageOptions)
 	}
 
 	osc.ShellInit = imageConfig.ShellInit

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -199,8 +199,9 @@ func osCustomizations(
 		}
 
 		oscapStageOptions := osbuild.OscapConfig{
-			Datastream: datastream,
-			ProfileID:  oscapConfig.ProfileID,
+			Datastream:  datastream,
+			ProfileID:   oscapConfig.ProfileID,
+			Compression: true,
 		}
 
 		if oscapConfig.Tailoring != nil {

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -200,14 +200,15 @@ func osCustomizations(
 			}
 
 			tailoringOptions := osbuild.OscapAutotailorConfig{
+				NewProfile: newProfile,
+				Datastream: datastream,
+				ProfileID:  oscapConfig.ProfileID,
 				Selected:   oscapConfig.Tailoring.Selected,
 				Unselected: oscapConfig.Tailoring.Unselected,
-				NewProfile: newProfile,
 			}
 
 			osc.OpenSCAPTailorConfig = osbuild.NewOscapAutotailorStageOptions(
 				tailoringFilepath,
-				oscapStageOptions,
 				tailoringOptions,
 			)
 

--- a/pkg/distro/rhel9/imagetype.go
+++ b/pkg/distro/rhel9/imagetype.go
@@ -40,6 +40,9 @@ const (
 
 	// blueprint package set name
 	blueprintPkgsKey = "blueprint"
+
+	// location for saving openscap remediation data
+	oscapDataDir = "/oscap_data"
 )
 
 type imageFunc func(workload workload.Workload, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, packageSets map[string]rpmmd.PackageSet, containers []container.SourceSpec, rng *rand.Rand) (image.ImageKind, error)

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -220,7 +220,7 @@ func (p *OS) getPackageSetChain(Distro) []rpmmd.PackageSet {
 	}
 
 	if p.OpenSCAPConfig != nil {
-		packages = append(packages, "openscap-scanner", "scap-security-guide")
+		packages = append(packages, "openscap-scanner", "scap-security-guide", "xz")
 	}
 
 	// Make sure the right packages are included for subscriptions

--- a/pkg/osbuild/oscap_autotailor_stage.go
+++ b/pkg/osbuild/oscap_autotailor_stage.go
@@ -6,9 +6,11 @@ type OscapAutotailorStageOptions struct {
 	Filepath string                `json:"filepath"`
 	Config   OscapAutotailorConfig `json:"config"`
 }
+
 type OscapAutotailorConfig struct {
-	OscapConfig
 	NewProfile string   `json:"new_profile"`
+	Datastream string   `json:"datastream" toml:"datastream"`
+	ProfileID  string   `json:"profile_id" toml:"profile_id"`
 	Selected   []string `json:"selected,omitempty"`
 	Unselected []string `json:"unselected,omitempty"`
 }
@@ -16,11 +18,16 @@ type OscapAutotailorConfig struct {
 func (OscapAutotailorStageOptions) isStageOptions() {}
 
 func (c OscapAutotailorConfig) validate() error {
+	if c.Datastream == "" {
+		return fmt.Errorf("'datastream' must be specified")
+	}
+	if c.ProfileID == "" {
+		return fmt.Errorf("'profile_id' must be specified")
+	}
 	if c.NewProfile == "" {
 		return fmt.Errorf("'new_profile' must be specified")
 	}
-	// reuse the oscap validation
-	return c.OscapConfig.validate()
+	return nil
 }
 
 func NewOscapAutotailorStage(options *OscapAutotailorStageOptions) *Stage {
@@ -34,14 +41,15 @@ func NewOscapAutotailorStage(options *OscapAutotailorStageOptions) *Stage {
 	}
 }
 
-func NewOscapAutotailorStageOptions(filepath string, oscapOptions OscapConfig, autotailorOptions OscapAutotailorConfig) *OscapAutotailorStageOptions {
+func NewOscapAutotailorStageOptions(filepath string, autotailorOptions OscapAutotailorConfig) *OscapAutotailorStageOptions {
 	return &OscapAutotailorStageOptions{
 		Filepath: filepath,
 		Config: OscapAutotailorConfig{
-			OscapConfig: oscapOptions,
-			NewProfile:  autotailorOptions.NewProfile,
-			Selected:    autotailorOptions.Selected,
-			Unselected:  autotailorOptions.Unselected,
+			NewProfile: autotailorOptions.NewProfile,
+			Datastream: autotailorOptions.Datastream,
+			ProfileID:  autotailorOptions.ProfileID,
+			Selected:   autotailorOptions.Selected,
+			Unselected: autotailorOptions.Unselected,
 		},
 	}
 }

--- a/pkg/osbuild/oscap_autotailor_stage_test.go
+++ b/pkg/osbuild/oscap_autotailor_stage_test.go
@@ -10,10 +10,8 @@ func TestNewOscapAutotailorStage(t *testing.T) {
 	stageOptions := &OscapAutotailorStageOptions{
 		Filepath: "tailoring.xml",
 		Config: OscapAutotailorConfig{
-			OscapConfig: OscapConfig{
-				Datastream: "test_stream",
-				ProfileID:  "test_profile",
-			},
+			Datastream: "test_stream",
+			ProfileID:  "test_profile",
 			NewProfile: "test_profile_osbuild_profile",
 			Selected:   []string{"fast_rule"},
 			Unselected: []string{"slow_rule"},
@@ -43,10 +41,7 @@ func TestOscapAutotailorStageOptionsValidate(t *testing.T) {
 			name: "empty-datastream",
 			options: OscapAutotailorStageOptions{
 				Config: OscapAutotailorConfig{
-					OscapConfig: OscapConfig{
-
-						ProfileID: "test-profile",
-					},
+					ProfileID: "test-profile",
 				},
 			},
 			err: true,
@@ -55,9 +50,7 @@ func TestOscapAutotailorStageOptionsValidate(t *testing.T) {
 			name: "empty-profile-id",
 			options: OscapAutotailorStageOptions{
 				Config: OscapAutotailorConfig{
-					OscapConfig: OscapConfig{
-						Datastream: "test-datastream",
-					},
+					Datastream: "test-datastream",
 				},
 			},
 			err: true,
@@ -66,10 +59,8 @@ func TestOscapAutotailorStageOptionsValidate(t *testing.T) {
 			name: "empty-new-profile-name",
 			options: OscapAutotailorStageOptions{
 				Config: OscapAutotailorConfig{
-					OscapConfig: OscapConfig{
-						ProfileID:  "test-profile",
-						Datastream: "test-datastream",
-					},
+					ProfileID:  "test-profile",
+					Datastream: "test-datastream",
 				},
 			},
 			err: true,
@@ -78,10 +69,8 @@ func TestOscapAutotailorStageOptionsValidate(t *testing.T) {
 			name: "valid-data",
 			options: OscapAutotailorStageOptions{
 				Config: OscapAutotailorConfig{
-					OscapConfig: OscapConfig{
-						ProfileID:  "test-profile",
-						Datastream: "test-datastream",
-					},
+					ProfileID:  "test-profile",
+					Datastream: "test-datastream",
 					NewProfile: "test-profile-osbuild-profile",
 				},
 			},

--- a/pkg/osbuild/oscap_remediation_stage.go
+++ b/pkg/osbuild/oscap_remediation_stage.go
@@ -28,6 +28,7 @@ type OscapConfig struct {
 	HtmlReport   string              `json:"html_report,omitempty" toml:"html_report,omitempty"`
 	VerboseLog   string              `json:"verbose_log,omitempty" toml:"verbose_log,omitempty"`
 	VerboseLevel OscapVerbosityLevel `json:"verbose_level,omitempty" toml:"verbose_level,omitempty"`
+	Compression  bool                `json:"compress_results,omitempty" toml:"compress_results,omitempty"`
 }
 
 func (OscapRemediationStageOptions) isStageOptions() {}
@@ -85,6 +86,7 @@ func NewOscapRemediationStageOptions(dataDir string, options OscapConfig) *Oscap
 			HtmlReport:   options.HtmlReport,
 			VerboseLog:   options.VerboseLog,
 			VerboseLevel: options.VerboseLevel,
+			Compression:  options.Compression,
 		},
 	}
 }

--- a/pkg/osbuild/oscap_remediation_stage.go
+++ b/pkg/osbuild/oscap_remediation_stage.go
@@ -15,6 +15,7 @@ type OscapRemediationStageOptions struct {
 	DataDir string      `json:"data_dir,omitempty"`
 	Config  OscapConfig `json:"config"`
 }
+
 type OscapConfig struct {
 	Datastream   string              `json:"datastream" toml:"datastream"`
 	ProfileID    string              `json:"profile_id" toml:"profile_id"`
@@ -23,7 +24,7 @@ type OscapConfig struct {
 	BenchmarkID  string              `json:"benchmark_id,omitempty" toml:"benchmark_id,omitempty"`
 	Tailoring    string              `json:"tailoring,omitempty" toml:"tailoring,omitempty"`
 	TailoringID  string              `json:"tailoring_id,omitempty" toml:"tailoring_id,omitempty"`
-	ArfResult    string              `json:"arf_result,omitempty" toml:"arf_result,omitempty"`
+	ArfResult    string              `json:"arf_results,omitempty" toml:"arf_results,omitempty"`
 	HtmlReport   string              `json:"html_report,omitempty" toml:"html_report,omitempty"`
 	VerboseLog   string              `json:"verbose_log,omitempty" toml:"verbose_log,omitempty"`
 	VerboseLevel OscapVerbosityLevel `json:"verbose_level,omitempty" toml:"verbose_level,omitempty"`

--- a/pkg/osbuild/oscap_remediation_stage.go
+++ b/pkg/osbuild/oscap_remediation_stage.go
@@ -71,8 +71,9 @@ func NewOscapRemediationStage(options *OscapRemediationStageOptions) *Stage {
 	}
 }
 
-func NewOscapRemediationStageOptions(options OscapConfig) *OscapRemediationStageOptions {
+func NewOscapRemediationStageOptions(dataDir string, options OscapConfig) *OscapRemediationStageOptions {
 	return &OscapRemediationStageOptions{
+		DataDir: dataDir,
 		Config: OscapConfig{
 			ProfileID:    options.ProfileID,
 			Datastream:   options.Datastream,

--- a/pkg/osbuild/oscap_remediation_stage_test.go
+++ b/pkg/osbuild/oscap_remediation_stage_test.go
@@ -66,6 +66,7 @@ func TestOscapRemediationStageOptionsValidate(t *testing.T) {
 					Datastream:   "test-datastream",
 					ProfileID:    "test-profile",
 					VerboseLevel: "INFO",
+					Compression:  true,
 				},
 			},
 			err: false,


### PR DESCRIPTION
The OpenSCAP remediation stage has been reworked to operate in three
stages:
1. Scan the filesystem tree and save results 
2. Generate the remediation script 
3. Run the offline remediation.

Steps one and two both require a data directory for the output that is then used by the next step. This PR creates the necessary config options and enables compression for the results file, since the file could be potentially quite large.
