### PR TITLE
feat: enable FIPS for edge-installer with BIOS

### DIFF
--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -129,6 +129,9 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	isoTreePipeline.OSTreeCommitSource = &img.Commit
 	isoTreePipeline.ISOLinux = isoLinuxEnabled
+	if img.FIPS {
+		isoTreePipeline.KernelOpts = append(isoTreePipeline.KernelOpts, "fips=1")
+	}
 
 	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, isoLabel)
 	isoPipeline.SetFilename(img.Filename)


### PR DESCRIPTION
Enable FIPS mode setup for the edge-installer when
booted in legacy BIOS mode.

Signed-off-by: Miguel Martín <mmartinv@redhat.com>
