### PR TITLE
pkg/arch: split arch from pkg/platform

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/distro"
@@ -341,7 +341,7 @@ func main() {
 		fail(fmt.Sprintf("invalid or unsupported distribution: %q", distroName))
 	}
 
-	archName := common.CurrentArch()
+	archName := arch.Current().String()
 	arch, err := distribution.GetArch(archName)
 	if err != nil {
 		fail(fmt.Sprintf("invalid arch name %q for distro %q: %s\n", archName, distroName, err.Error()))

--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/distro"
 	rhel "github.com/osbuild/images/pkg/distro/rhel8"
 	"github.com/osbuild/images/pkg/dnfjson"
 	"github.com/osbuild/images/pkg/ostree"
-	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -85,22 +85,22 @@ func TestDepsolvePackageSets(t *testing.T) {
 
 	// Set up temporary directory for rpm/dnf cache
 	dir := t.TempDir()
-	solver := dnfjson.NewSolver(cs9.ModulePlatformID(), cs9.Releasever(), platform.ARCH_X86_64.String(), cs9.Name(), dir)
+	solver := dnfjson.NewSolver(cs9.ModulePlatformID(), cs9.Releasever(), arch.ARCH_X86_64.String(), cs9.Name(), dir)
 
 	repos, err := rpmmd.LoadRepositories([]string{repoDir}, cs9.Name())
 	require.NoErrorf(t, err, "Failed to LoadRepositories %v", cs9.Name())
-	x86Repos, ok := repos[platform.ARCH_X86_64.String()]
-	require.Truef(t, ok, "failed to get %q repos for %q", platform.ARCH_X86_64.String(), cs9.Name())
+	x86Repos, ok := repos[arch.ARCH_X86_64.String()]
+	require.Truef(t, ok, "failed to get %q repos for %q", arch.ARCH_X86_64.String(), cs9.Name())
 
-	x86Arch, err := cs9.GetArch(platform.ARCH_X86_64.String())
-	require.Nilf(t, err, "failed to get %q arch of %q distro", platform.ARCH_X86_64.String(), cs9.Name())
+	x86Arch, err := cs9.GetArch(arch.ARCH_X86_64.String())
+	require.Nilf(t, err, "failed to get %q arch of %q distro", arch.ARCH_X86_64.String(), cs9.Name())
 
 	qcow2ImageTypeName := "qcow2"
 	qcow2Image, err := x86Arch.GetImageType(qcow2ImageTypeName)
-	require.Nilf(t, err, "failed to get %q image type of %q/%q distro/arch", qcow2ImageTypeName, cs9.Name(), platform.ARCH_X86_64.String())
+	require.Nilf(t, err, "failed to get %q image type of %q/%q distro/arch", qcow2ImageTypeName, cs9.Name(), arch.ARCH_X86_64.String())
 
 	manifestSource, _, err := qcow2Image.Manifest(&blueprint.Blueprint{Packages: []blueprint.Package{{Name: "bind"}}}, distro.ImageOptions{}, x86Repos, 0)
-	require.Nilf(t, err, "failed to initialise manifest for %q image type of %q/%q distro/arch", qcow2ImageTypeName, cs9.Name(), platform.ARCH_X86_64.String())
+	require.Nilf(t, err, "failed to initialise manifest for %q image type of %q/%q distro/arch", qcow2ImageTypeName, cs9.Name(), arch.ARCH_X86_64.String())
 	imagePkgSets := manifestSource.GetPackageSetChains()
 
 	gotPackageSpecsSets := make(map[string][]rpmmd.PackageSpec, len(imagePkgSets))

--- a/cmd/osbuild-playground/main.go
+++ b/cmd/osbuild-playground/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distroregistry"
 	"github.com/osbuild/images/pkg/image"
@@ -42,7 +42,7 @@ func main() {
 	var distroArg string
 	flag.StringVar(&distroArg, "distro", "host", "distro to build from")
 	var archArg string
-	flag.StringVar(&archArg, "arch", common.CurrentArch(), "architecture to build for")
+	flag.StringVar(&archArg, "arch", arch.Current().String(), "architecture to build for")
 	var imageTypeArg string
 	flag.StringVar(&imageTypeArg, "type", "my-container", "image type to build")
 	flag.Parse()

--- a/internal/boot/aws.go
+++ b/internal/boot/aws.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"github.com/osbuild/images/internal/cloud/awscloud"
-	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 )
 
 type awsCredentials struct {
@@ -97,7 +97,7 @@ func UploadImageToAWS(c *awsCredentials, imagePath string, imageName string) err
 	if err != nil {
 		return fmt.Errorf("cannot upload the image: %v", err)
 	}
-	_, _, err = uploader.Register(imageName, c.Bucket, imageName, nil, common.CurrentArch(), nil)
+	_, _, err = uploader.Register(imageName, c.Bucket, imageName, nil, arch.Current().String(), nil)
 	if err != nil {
 		return fmt.Errorf("cannot register the image: %v", err)
 	}

--- a/internal/boot/context-managers.go
+++ b/internal/boot/context-managers.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/osbuild/images/cmd/osbuild-image-tests/constants"
 	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/arch"
 )
 
 // WithNetworkNamespace provides the function f with a new network namespace
@@ -111,7 +111,7 @@ func WithBootedQemuImage(image string, ns NetNS, f func() error) error {
 		}
 
 		var qemuCmd *exec.Cmd
-		if common.CurrentArch() == "x86_64" {
+		if common.CurrentArch() == arch.ARCH_X86_64.String() {
 			hostDistroName, _, _, err := common.GetHostDistroName()
 			if err != nil {
 				return fmt.Errorf("cannot determing the current distro: %v", err)
@@ -136,7 +136,7 @@ func WithBootedQemuImage(image string, ns NetNS, f func() error) error {
 				"-nographic",
 				image,
 			)
-		} else if common.CurrentArch() == platform.ARCH_AARCH64.String() {
+		} else if common.CurrentArch() == arch.ARCH_AARCH64.String() {
 			// This command does not use KVM as I was unable to make it work in Beaker,
 			// once we have machines that can use KVM, enable it to make it faster
 			qemuCmd = ns.NamespacedCommand(

--- a/internal/boot/context-managers.go
+++ b/internal/boot/context-managers.go
@@ -111,7 +111,7 @@ func WithBootedQemuImage(image string, ns NetNS, f func() error) error {
 		}
 
 		var qemuCmd *exec.Cmd
-		if common.CurrentArch() == arch.ARCH_X86_64.String() {
+		if arch.IsX86_64() {
 			hostDistroName, _, _, err := common.GetHostDistroName()
 			if err != nil {
 				return fmt.Errorf("cannot determing the current distro: %v", err)
@@ -136,7 +136,7 @@ func WithBootedQemuImage(image string, ns NetNS, f func() error) error {
 				"-nographic",
 				image,
 			)
-		} else if common.CurrentArch() == arch.ARCH_AARCH64.String() {
+		} else if arch.IsAarch64() {
 			// This command does not use KVM as I was unable to make it work in Beaker,
 			// once we have machines that can use KVM, enable it to make it faster
 			qemuCmd = ns.NamespacedCommand(

--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -4,27 +4,10 @@ import (
 	"fmt"
 	"io"
 	"regexp"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
 )
-
-var RuntimeGOARCH = runtime.GOARCH
-
-func CurrentArch() string {
-	if RuntimeGOARCH == "amd64" {
-		return "x86_64"
-	} else if RuntimeGOARCH == "arm64" {
-		return "aarch64"
-	} else if RuntimeGOARCH == "ppc64le" {
-		return "ppc64le"
-	} else if RuntimeGOARCH == "s390x" {
-		return "s390x"
-	} else {
-		panic("unsupported architecture")
-	}
-}
 
 func PanicOnError(err error) {
 	if err != nil {

--- a/internal/common/helpers_test.go
+++ b/internal/common/helpers_test.go
@@ -8,41 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCurrentArchAMD64(t *testing.T) {
-	origRuntimeGOARCH := RuntimeGOARCH
-	defer func() { RuntimeGOARCH = origRuntimeGOARCH }()
-	RuntimeGOARCH = "amd64"
-	assert.Equal(t, "x86_64", CurrentArch())
-}
-
-func TestCurrentArchARM64(t *testing.T) {
-	origRuntimeGOARCH := RuntimeGOARCH
-	defer func() { RuntimeGOARCH = origRuntimeGOARCH }()
-	RuntimeGOARCH = "arm64"
-	assert.Equal(t, "aarch64", CurrentArch())
-}
-
-func TestCurrentArchPPC64LE(t *testing.T) {
-	origRuntimeGOARCH := RuntimeGOARCH
-	defer func() { RuntimeGOARCH = origRuntimeGOARCH }()
-	RuntimeGOARCH = "ppc64le"
-	assert.Equal(t, "ppc64le", CurrentArch())
-}
-
-func TestCurrentArchS390X(t *testing.T) {
-	origRuntimeGOARCH := RuntimeGOARCH
-	defer func() { RuntimeGOARCH = origRuntimeGOARCH }()
-	RuntimeGOARCH = "s390x"
-	assert.Equal(t, "s390x", CurrentArch())
-}
-
-func TestCurrentArchUnsupported(t *testing.T) {
-	origRuntimeGOARCH := RuntimeGOARCH
-	defer func() { RuntimeGOARCH = origRuntimeGOARCH }()
-	RuntimeGOARCH = "UKNOWN"
-	assert.PanicsWithValue(t, "unsupported architecture", func() { CurrentArch() })
-}
-
 func TestPanicOnError(t *testing.T) {
 	err := errors.New("Error message")
 	assert.PanicsWithValue(t, err, func() { PanicOnError(err) })

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -18,7 +18,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
-	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -244,7 +244,7 @@ func GenerateCIArtifactName(prefix string) (string, error) {
 		return "", fmt.Errorf("The environment variables must specify BRANCH_NAME, BUILD_ID, and DISTRO_CODE")
 	}
 
-	arch := common.CurrentArch()
+	arch := arch.Current().String()
 
 	return fmt.Sprintf("%s%s-%s-%s-%s", prefix, distroCode, arch, branchName, buildId), nil
 }

--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -1,5 +1,9 @@
 package arch
 
+import (
+	"runtime"
+)
+
 type Arch uint64
 
 const ( // architecture enum
@@ -22,4 +26,37 @@ func (a Arch) String() string {
 	default:
 		panic("invalid architecture")
 	}
+}
+
+var runtimeGOARCH = runtime.GOARCH
+
+func Current() Arch {
+	switch runtimeGOARCH {
+	case "amd64":
+		return ARCH_X86_64
+	case "arm64":
+		return ARCH_AARCH64
+	case "ppc64le":
+		return ARCH_PPC64LE
+	case "s390x":
+		return ARCH_S390X
+	default:
+		panic("unsupported architecture")
+	}
+}
+
+func IsX86_64() bool {
+	return Current() == ARCH_X86_64
+}
+
+func IsAarch64() bool {
+	return Current() == ARCH_AARCH64
+}
+
+func IsPPC() bool {
+	return Current() == ARCH_PPC64LE
+}
+
+func IsS390x() bool {
+	return Current() == ARCH_S390X
 }

--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -1,0 +1,25 @@
+package arch
+
+type Arch uint64
+
+const ( // architecture enum
+	ARCH_AARCH64 Arch = iota
+	ARCH_PPC64LE
+	ARCH_S390X
+	ARCH_X86_64
+)
+
+func (a Arch) String() string {
+	switch a {
+	case ARCH_AARCH64:
+		return "aarch64"
+	case ARCH_PPC64LE:
+		return "ppc64le"
+	case ARCH_S390X:
+		return "s390x"
+	case ARCH_X86_64:
+		return "x86_64"
+	default:
+		panic("invalid architecture")
+	}
+}

--- a/pkg/arch/arch_test.go
+++ b/pkg/arch/arch_test.go
@@ -1,0 +1,46 @@
+package arch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCurrentArchAMD64(t *testing.T) {
+	origRuntimeGOARCH := runtimeGOARCH
+	defer func() { runtimeGOARCH = origRuntimeGOARCH }()
+	runtimeGOARCH = "amd64"
+	assert.Equal(t, "x86_64", Current().String())
+	assert.True(t, IsX86_64())
+}
+
+func TestCurrentArchARM64(t *testing.T) {
+	origRuntimeGOARCH := runtimeGOARCH
+	defer func() { runtimeGOARCH = origRuntimeGOARCH }()
+	runtimeGOARCH = "arm64"
+	assert.Equal(t, "aarch64", Current().String())
+	assert.True(t, IsAarch64())
+}
+
+func TestCurrentArchPPC64LE(t *testing.T) {
+	origRuntimeGOARCH := runtimeGOARCH
+	defer func() { runtimeGOARCH = origRuntimeGOARCH }()
+	runtimeGOARCH = "ppc64le"
+	assert.Equal(t, "ppc64le", Current().String())
+	assert.True(t, IsPPC())
+}
+
+func TestCurrentArchS390X(t *testing.T) {
+	origRuntimeGOARCH := runtimeGOARCH
+	defer func() { runtimeGOARCH = origRuntimeGOARCH }()
+	runtimeGOARCH = "s390x"
+	assert.Equal(t, "s390x", Current().String())
+	assert.True(t, IsS390x())
+}
+
+func TestCurrentArchUnsupported(t *testing.T) {
+	origRuntimeGOARCH := runtimeGOARCH
+	defer func() { runtimeGOARCH = origRuntimeGOARCH }()
+	runtimeGOARCH = "UKNOWN"
+	assert.PanicsWithValue(t, "unsupported architecture", func() { Current() })
+}

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osbuild/images/internal/environment"
 	"github.com/osbuild/images/internal/fsnode"
 	"github.com/osbuild/images/internal/oscap"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
@@ -532,23 +533,23 @@ func newDistro(version int) distro.Distro {
 
 	// Architecture definitions
 	x86_64 := architecture{
-		name:   platform.ARCH_X86_64.String(),
+		name:   arch.ARCH_X86_64.String(),
 		distro: &rd,
 	}
 
 	aarch64 := architecture{
-		name:   platform.ARCH_AARCH64.String(),
+		name:   arch.ARCH_AARCH64.String(),
 		distro: &rd,
 	}
 
 	ppc64le := architecture{
 		distro: &rd,
-		name:   platform.ARCH_PPC64LE.String(),
+		name:   arch.ARCH_PPC64LE.String(),
 	}
 
 	s390x := architecture{
 		distro: &rd,
-		name:   platform.ARCH_S390X.String(),
+		name:   arch.ARCH_S390X.String(),
 	}
 
 	ociImgType := qcow2ImgType

--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -364,7 +364,7 @@ func anacondaPackageSet(t *imageType) rpmmd.PackageSet {
 	}
 
 	switch t.Arch().Name() {
-	case platform.ARCH_X86_64.String():
+	case arch.ARCH_X86_64.String():
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"biosdevname",
@@ -374,7 +374,7 @@ func anacondaPackageSet(t *imageType) rpmmd.PackageSet {
 			},
 		})
 
-	case platform.ARCH_AARCH64.String():
+	case arch.ARCH_AARCH64.String():
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"dmidecode",

--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -2,13 +2,13 @@ package fedora
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
-	"github.com/osbuild/images/pkg/platform"
 )
 
 var defaultBasePartitionTables = distro.BasePartitionTableMap{
-	platform.ARCH_X86_64.String(): disk.PartitionTable{
+	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
@@ -60,7 +60,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 			},
 		},
 	},
-	platform.ARCH_AARCH64.String(): disk.PartitionTable{
+	arch.ARCH_AARCH64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
@@ -106,7 +106,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 			},
 		},
 	},
-	platform.ARCH_PPC64LE.String(): disk.PartitionTable{
+	arch.ARCH_PPC64LE.String(): disk.PartitionTable{
 		UUID: "0x14fc63d2",
 		Type: "dos",
 		Partitions: []disk.Partition{
@@ -139,7 +139,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		},
 	},
 
-	platform.ARCH_S390X.String(): disk.PartitionTable{
+	arch.ARCH_S390X.String(): disk.PartitionTable{
 		UUID: "0x14fc63d2",
 		Type: "dos",
 		Partitions: []disk.Partition{
@@ -170,7 +170,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 }
 
 var minimalrawPartitionTables = distro.BasePartitionTableMap{
-	platform.ARCH_X86_64.String(): disk.PartitionTable{
+	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type:        "gpt",
 		StartOffset: 8 * common.MebiByte,
@@ -217,7 +217,7 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 			},
 		},
 	},
-	platform.ARCH_AARCH64.String(): disk.PartitionTable{
+	arch.ARCH_AARCH64.String(): disk.PartitionTable{
 		UUID:        "0xc1748067",
 		Type:        "dos",
 		StartOffset: 8 * common.MebiByte,
@@ -265,7 +265,7 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 }
 
 var iotBasePartitionTables = distro.BasePartitionTableMap{
-	platform.ARCH_X86_64.String(): disk.PartitionTable{
+	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
@@ -311,7 +311,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 			},
 		},
 	},
-	platform.ARCH_AARCH64.String(): disk.PartitionTable{
+	arch.ARCH_AARCH64.String(): disk.PartitionTable{
 		UUID: "0xc1748067",
 		Type: "dos",
 		Partitions: []disk.Partition{
@@ -358,7 +358,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 }
 
 var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
-	platform.ARCH_X86_64.String(): disk.PartitionTable{
+	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
@@ -428,7 +428,7 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 			},
 		},
 	},
-	platform.ARCH_AARCH64.String(): disk.PartitionTable{
+	arch.ARCH_AARCH64.String(): disk.PartitionTable{
 		UUID: "0xc1748067",
 		Type: "dos",
 		Partitions: []disk.Partition{

--- a/pkg/distro/rhel7/azure.go
+++ b/pkg/distro/rhel7/azure.go
@@ -2,10 +2,10 @@ package rhel7
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/subscription"
 )
@@ -273,7 +273,7 @@ func azureRhuiCommonPackageSet(t *imageType) rpmmd.PackageSet {
 }
 
 var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
-	platform.ARCH_X86_64.String(): disk.PartitionTable{
+	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Size: 64 * common.GibiByte,

--- a/pkg/distro/rhel7/distro.go
+++ b/pkg/distro/rhel7/distro.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
@@ -200,7 +201,7 @@ func newDistro(distroName string) distro.Distro {
 
 	// Architecture definitions
 	x86_64 := architecture{
-		name:   platform.ARCH_X86_64.String(),
+		name:   arch.ARCH_X86_64.String(),
 		distro: &rd,
 	}
 

--- a/pkg/distro/rhel7/images.go
+++ b/pkg/distro/rhel7/images.go
@@ -7,13 +7,13 @@ import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/users"
 	"github.com/osbuild/images/internal/workload"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/image"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -40,7 +40,7 @@ func osCustomizations(
 			kernelOptions = append(kernelOptions, bpKernel.Append)
 		}
 		osc.KernelOptionsAppend = kernelOptions
-		if t.platform.GetArch() != platform.ARCH_S390X {
+		if t.platform.GetArch() != arch.ARCH_S390X {
 			osc.KernelOptionsBootloader = true
 		}
 	}

--- a/pkg/distro/rhel7/partition_tables.go
+++ b/pkg/distro/rhel7/partition_tables.go
@@ -2,13 +2,13 @@ package rhel7
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
-	"github.com/osbuild/images/pkg/platform"
 )
 
 var defaultBasePartitionTables = distro.BasePartitionTableMap{
-	platform.ARCH_X86_64.String(): disk.PartitionTable{
+	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{

--- a/pkg/distro/rhel8/azure.go
+++ b/pkg/distro/rhel8/azure.go
@@ -3,10 +3,10 @@ package rhel8
 import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/shell"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/subscription"
 )
@@ -261,7 +261,7 @@ func azureEapPackageSet(t *imageType) rpmmd.PackageSet {
 // PARTITION TABLES
 
 var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
-	platform.ARCH_X86_64.String(): disk.PartitionTable{
+	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Size: 64 * common.GibiByte,
@@ -369,7 +369,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 			},
 		},
 	},
-	platform.ARCH_AARCH64.String(): disk.PartitionTable{
+	arch.ARCH_AARCH64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Size: 64 * common.GibiByte,

--- a/pkg/distro/rhel8/bare_metal.go
+++ b/pkg/distro/rhel8/bare_metal.go
@@ -3,7 +3,7 @@ package rhel8
 import (
 	"fmt"
 
-	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -146,7 +146,7 @@ func installerPackageSet(t *imageType) rpmmd.PackageSet {
 	}
 
 	switch t.arch.Name() {
-	case platform.ARCH_X86_64.String():
+	case arch.ARCH_X86_64.String():
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"biosdevname",
@@ -278,7 +278,7 @@ func anacondaPackageSet(t *imageType) rpmmd.PackageSet {
 	ps = ps.Append(anacondaBootPackageSet(t))
 
 	switch t.arch.Name() {
-	case platform.ARCH_X86_64.String():
+	case arch.ARCH_X86_64.String():
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"biosdevname",
@@ -287,7 +287,7 @@ func anacondaPackageSet(t *imageType) rpmmd.PackageSet {
 			},
 		})
 
-	case platform.ARCH_AARCH64.String():
+	case arch.ARCH_AARCH64.String():
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"dmidecode",

--- a/pkg/distro/rhel8/distro.go
+++ b/pkg/distro/rhel8/distro.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/oscap"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
@@ -198,22 +199,22 @@ func newDistro(name string, minor int) *distribution {
 
 	// Architecture definitions
 	x86_64 := architecture{
-		name:   platform.ARCH_X86_64.String(),
+		name:   arch.ARCH_X86_64.String(),
 		distro: &rd,
 	}
 
 	aarch64 := architecture{
-		name:   platform.ARCH_AARCH64.String(),
+		name:   arch.ARCH_AARCH64.String(),
 		distro: &rd,
 	}
 
 	ppc64le := architecture{
 		distro: &rd,
-		name:   platform.ARCH_PPC64LE.String(),
+		name:   arch.ARCH_PPC64LE.String(),
 	}
 	s390x := architecture{
 		distro: &rd,
-		name:   platform.ARCH_S390X.String(),
+		name:   arch.ARCH_S390X.String(),
 	}
 
 	ociImgType := qcow2ImgType(rd)

--- a/pkg/distro/rhel8/distro_test.go
+++ b/pkg/distro/rhel8/distro_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/distro_test_common"
 	"github.com/osbuild/images/pkg/distro/rhel8"
-	"github.com/osbuild/images/pkg/platform"
 )
 
 type rhelFamilyDistro struct {
@@ -369,7 +369,7 @@ func TestImageType_Name(t *testing.T) {
 	for _, dist := range rhelFamilyDistros {
 		t.Run(dist.name, func(t *testing.T) {
 			for _, mapping := range imgMap {
-				if mapping.arch == platform.ARCH_S390X.String() && dist.name == "centos" {
+				if mapping.arch == arch.ARCH_S390X.String() && dist.name == "centos" {
 					continue
 				}
 				arch, err := dist.distro.GetArch(mapping.arch)

--- a/pkg/distro/rhel8/edge.go
+++ b/pkg/distro/rhel8/edge.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/fsnode"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/distro"
-	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -249,10 +249,10 @@ func edgeCommitPackageSet(t *imageType) rpmmd.PackageSet {
 	}
 
 	switch t.arch.Name() {
-	case platform.ARCH_X86_64.String():
+	case arch.ARCH_X86_64.String():
 		ps = ps.Append(x8664EdgeCommitPackageSet(t))
 
-	case platform.ARCH_AARCH64.String():
+	case arch.ARCH_AARCH64.String():
 		ps = ps.Append(aarch64EdgeCommitPackageSet(t))
 	}
 
@@ -370,9 +370,9 @@ func edgeSimplifiedInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 
 	switch t.arch.Name() {
 
-	case platform.ARCH_X86_64.String():
+	case arch.ARCH_X86_64.String():
 		ps = ps.Append(x8664EdgeCommitPackageSet(t))
-	case platform.ARCH_AARCH64.String():
+	case arch.ARCH_AARCH64.String():
 		ps = ps.Append(aarch64EdgeCommitPackageSet(t))
 
 	default:

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osbuild/images/internal/oscap"
 	"github.com/osbuild/images/internal/users"
 	"github.com/osbuild/images/internal/workload"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/distro"
@@ -17,7 +18,6 @@ import (
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
-	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -44,7 +44,7 @@ func osCustomizations(
 			kernelOptions = append(kernelOptions, bpKernel.Append)
 		}
 		osc.KernelOptionsAppend = kernelOptions
-		if t.platform.GetArch() != platform.ARCH_S390X {
+		if t.platform.GetArch() != arch.ARCH_S390X {
 			osc.KernelOptionsBootloader = true
 		}
 	}

--- a/pkg/distro/rhel8/package_sets.go
+++ b/pkg/distro/rhel8/package_sets.go
@@ -5,7 +5,7 @@ package rhel8
 import (
 	"fmt"
 
-	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -30,7 +30,7 @@ func anacondaBootPackageSet(t *imageType) rpmmd.PackageSet {
 	}
 
 	switch t.arch.Name() {
-	case platform.ARCH_X86_64.String():
+	case arch.ARCH_X86_64.String():
 		ps = ps.Append(grubCommon)
 		ps = ps.Append(efiCommon)
 		ps = ps.Append(rpmmd.PackageSet{
@@ -46,7 +46,7 @@ func anacondaBootPackageSet(t *imageType) rpmmd.PackageSet {
 				"syslinux-nonlinux",
 			},
 		})
-	case platform.ARCH_AARCH64.String():
+	case arch.ARCH_AARCH64.String():
 		ps = ps.Append(grubCommon)
 		ps = ps.Append(efiCommon)
 		ps = ps.Append(rpmmd.PackageSet{

--- a/pkg/distro/rhel8/partition_tables.go
+++ b/pkg/distro/rhel8/partition_tables.go
@@ -2,13 +2,13 @@ package rhel8
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
-	"github.com/osbuild/images/pkg/platform"
 )
 
 var defaultBasePartitionTables = distro.BasePartitionTableMap{
-	platform.ARCH_X86_64.String(): disk.PartitionTable{
+	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
@@ -46,7 +46,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 			},
 		},
 	},
-	platform.ARCH_AARCH64.String(): disk.PartitionTable{
+	arch.ARCH_AARCH64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
@@ -78,7 +78,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 			},
 		},
 	},
-	platform.ARCH_PPC64LE.String(): disk.PartitionTable{
+	arch.ARCH_PPC64LE.String(): disk.PartitionTable{
 		UUID: "0x14fc63d2",
 		Type: "dos",
 		Partitions: []disk.Partition{
@@ -99,7 +99,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 			},
 		},
 	},
-	platform.ARCH_S390X.String(): disk.PartitionTable{
+	arch.ARCH_S390X.String(): disk.PartitionTable{
 		UUID: "0x14fc63d2",
 		Type: "dos",
 		Partitions: []disk.Partition{
@@ -119,7 +119,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 }
 
 var ec2BasePartitionTables = distro.BasePartitionTableMap{
-	platform.ARCH_X86_64.String(): disk.PartitionTable{
+	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
@@ -171,7 +171,7 @@ var ec2BasePartitionTables = distro.BasePartitionTableMap{
 			},
 		},
 	},
-	platform.ARCH_AARCH64.String(): disk.PartitionTable{
+	arch.ARCH_AARCH64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
@@ -222,7 +222,7 @@ var ec2BasePartitionTables = distro.BasePartitionTableMap{
 // ec2LegacyBasePartitionTables is the partition table layout for RHEL EC2
 // images prior to 8.9. It is used for backwards compatibility.
 var ec2LegacyBasePartitionTables = distro.BasePartitionTableMap{
-	platform.ARCH_X86_64.String(): disk.PartitionTable{
+	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
@@ -247,7 +247,7 @@ var ec2LegacyBasePartitionTables = distro.BasePartitionTableMap{
 			},
 		},
 	},
-	platform.ARCH_AARCH64.String(): disk.PartitionTable{
+	arch.ARCH_AARCH64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
@@ -294,7 +294,7 @@ var ec2LegacyBasePartitionTables = distro.BasePartitionTableMap{
 }
 
 var edgeBasePartitionTables = distro.BasePartitionTableMap{
-	platform.ARCH_X86_64.String(): disk.PartitionTable{
+	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
@@ -361,7 +361,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 			},
 		},
 	},
-	platform.ARCH_AARCH64.String(): disk.PartitionTable{
+	arch.ARCH_AARCH64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{

--- a/pkg/distro/rhel9/azure.go
+++ b/pkg/distro/rhel9/azure.go
@@ -2,10 +2,10 @@ package rhel9
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/subscription"
 )
@@ -184,7 +184,7 @@ func azureRhuiBasePartitionTables(t *imageType) (disk.PartitionTable, bool) {
 	}
 
 	switch t.platform.GetArch() {
-	case platform.ARCH_X86_64:
+	case arch.ARCH_X86_64:
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
@@ -293,7 +293,7 @@ func azureRhuiBasePartitionTables(t *imageType) (disk.PartitionTable, bool) {
 				},
 			},
 		}, true
-	case platform.ARCH_AARCH64:
+	case arch.ARCH_AARCH64:
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",

--- a/pkg/distro/rhel9/bare_metal.go
+++ b/pkg/distro/rhel9/bare_metal.go
@@ -3,7 +3,7 @@ package rhel9
 import (
 	"fmt"
 
-	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -148,7 +148,7 @@ func installerPackageSet(t *imageType) rpmmd.PackageSet {
 	})
 
 	switch t.arch.Name() {
-	case platform.ARCH_X86_64.String():
+	case arch.ARCH_X86_64.String():
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"biosdevname",
@@ -306,7 +306,7 @@ func anacondaPackageSet(t *imageType) rpmmd.PackageSet {
 	ps = ps.Append(anacondaBootPackageSet(t))
 
 	switch t.arch.Name() {
-	case platform.ARCH_X86_64.String():
+	case arch.ARCH_X86_64.String():
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"biosdevname",
@@ -316,7 +316,7 @@ func anacondaPackageSet(t *imageType) rpmmd.PackageSet {
 			},
 		})
 
-	case platform.ARCH_AARCH64.String():
+	case arch.ARCH_AARCH64.String():
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"dmidecode",

--- a/pkg/distro/rhel9/distro.go
+++ b/pkg/distro/rhel9/distro.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/oscap"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
@@ -190,23 +191,23 @@ func newDistro(name string, minor int) *distribution {
 
 	// Architecture definitions
 	x86_64 := architecture{
-		name:   platform.ARCH_X86_64.String(),
+		name:   arch.ARCH_X86_64.String(),
 		distro: &rd,
 	}
 
 	aarch64 := architecture{
-		name:   platform.ARCH_AARCH64.String(),
+		name:   arch.ARCH_AARCH64.String(),
 		distro: &rd,
 	}
 
 	ppc64le := architecture{
 		distro: &rd,
-		name:   platform.ARCH_PPC64LE.String(),
+		name:   arch.ARCH_PPC64LE.String(),
 	}
 
 	s390x := architecture{
 		distro: &rd,
-		name:   platform.ARCH_S390X.String(),
+		name:   arch.ARCH_S390X.String(),
 	}
 
 	qcow2ImgType := mkQcow2ImgType(rd)

--- a/pkg/distro/rhel9/distro_test.go
+++ b/pkg/distro/rhel9/distro_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/distro_test_common"
 	"github.com/osbuild/images/pkg/distro/rhel9"
-	"github.com/osbuild/images/pkg/platform"
 )
 
 type rhelFamilyDistro struct {
@@ -368,7 +368,7 @@ func TestImageType_Name(t *testing.T) {
 	for _, dist := range rhelFamilyDistros {
 		t.Run(dist.name, func(t *testing.T) {
 			for _, mapping := range imgMap {
-				if mapping.arch == platform.ARCH_S390X.String() && dist.name == "centos" {
+				if mapping.arch == arch.ARCH_S390X.String() && dist.name == "centos" {
 					continue
 				}
 				arch, err := dist.distro.GetArch(mapping.arch)

--- a/pkg/distro/rhel9/edge.go
+++ b/pkg/distro/rhel9/edge.go
@@ -6,10 +6,10 @@ import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/environment"
 	"github.com/osbuild/images/internal/fsnode"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -237,7 +237,7 @@ func minimalrawPartitionTables(t *imageType) (disk.PartitionTable, bool) {
 	}
 
 	switch t.platform.GetArch() {
-	case platform.ARCH_X86_64:
+	case arch.ARCH_X86_64:
 		return disk.PartitionTable{
 			UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type:        "gpt",
@@ -285,7 +285,7 @@ func minimalrawPartitionTables(t *imageType) (disk.PartitionTable, bool) {
 				},
 			},
 		}, true
-	case platform.ARCH_AARCH64:
+	case arch.ARCH_AARCH64:
 		return disk.PartitionTable{
 			UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type:        "gpt",
@@ -340,7 +340,7 @@ func minimalrawPartitionTables(t *imageType) (disk.PartitionTable, bool) {
 
 func edgeBasePartitionTables(t *imageType) (disk.PartitionTable, bool) {
 	switch t.platform.GetArch() {
-	case platform.ARCH_X86_64:
+	case arch.ARCH_X86_64:
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
@@ -417,7 +417,7 @@ func edgeBasePartitionTables(t *imageType) (disk.PartitionTable, bool) {
 				},
 			},
 		}, true
-	case platform.ARCH_AARCH64:
+	case arch.ARCH_AARCH64:
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
@@ -582,10 +582,10 @@ func edgeCommitPackageSet(t *imageType) rpmmd.PackageSet {
 	}
 
 	switch t.arch.Name() {
-	case platform.ARCH_X86_64.String():
+	case arch.ARCH_X86_64.String():
 		ps = ps.Append(x8664EdgeCommitPackageSet(t))
 
-	case platform.ARCH_AARCH64.String():
+	case arch.ARCH_AARCH64.String():
 		ps = ps.Append(aarch64EdgeCommitPackageSet(t))
 	}
 
@@ -682,9 +682,9 @@ func edgeSimplifiedInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 
 	switch t.arch.Name() {
 
-	case platform.ARCH_X86_64.String():
+	case arch.ARCH_X86_64.String():
 		ps = ps.Append(x8664EdgeCommitPackageSet(t))
-	case platform.ARCH_AARCH64.String():
+	case arch.ARCH_AARCH64.String():
 		ps = ps.Append(aarch64EdgeCommitPackageSet(t))
 
 	default:

--- a/pkg/distro/rhel9/package_sets.go
+++ b/pkg/distro/rhel9/package_sets.go
@@ -5,7 +5,7 @@ package rhel9
 import (
 	"fmt"
 
-	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -35,10 +35,10 @@ func distroBuildPackageSet(t *imageType) rpmmd.PackageSet {
 
 	switch t.arch.Name() {
 
-	case platform.ARCH_X86_64.String():
+	case arch.ARCH_X86_64.String():
 		ps = ps.Append(x8664BuildPackageSet(t))
 
-	case platform.ARCH_PPC64LE.String():
+	case arch.ARCH_PPC64LE.String():
 		ps = ps.Append(ppc64leBuildPackageSet(t))
 	}
 
@@ -84,7 +84,7 @@ func anacondaBootPackageSet(t *imageType) rpmmd.PackageSet {
 	}
 
 	switch t.arch.Name() {
-	case platform.ARCH_X86_64.String():
+	case arch.ARCH_X86_64.String():
 		ps = ps.Append(grubCommon)
 		ps = ps.Append(efiCommon)
 		ps = ps.Append(rpmmd.PackageSet{
@@ -98,7 +98,7 @@ func anacondaBootPackageSet(t *imageType) rpmmd.PackageSet {
 				"syslinux-nonlinux",
 			},
 		})
-	case platform.ARCH_AARCH64.String():
+	case arch.ARCH_AARCH64.String():
 		ps = ps.Append(grubCommon)
 		ps = ps.Append(efiCommon)
 		ps = ps.Append(rpmmd.PackageSet{
@@ -197,7 +197,7 @@ func coreOsCommonPackageSet(t *imageType) rpmmd.PackageSet {
 	}
 
 	switch t.arch.Name() {
-	case platform.ARCH_X86_64.String():
+	case arch.ARCH_X86_64.String():
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"irqbalance",
@@ -205,14 +205,14 @@ func coreOsCommonPackageSet(t *imageType) rpmmd.PackageSet {
 			},
 		})
 
-	case platform.ARCH_AARCH64.String():
+	case arch.ARCH_AARCH64.String():
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"irqbalance",
 			},
 		})
 
-	case platform.ARCH_PPC64LE.String():
+	case arch.ARCH_PPC64LE.String():
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"irqbalance",
@@ -223,7 +223,7 @@ func coreOsCommonPackageSet(t *imageType) rpmmd.PackageSet {
 			},
 		})
 
-	case platform.ARCH_S390X.String():
+	case arch.ARCH_S390X.String():
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"s390utils-core",

--- a/pkg/distro/rhel9/partition_tables.go
+++ b/pkg/distro/rhel9/partition_tables.go
@@ -2,8 +2,8 @@ package rhel9
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/disk"
-	"github.com/osbuild/images/pkg/platform"
 )
 
 func defaultBasePartitionTables(t *imageType) (disk.PartitionTable, bool) {
@@ -14,7 +14,7 @@ func defaultBasePartitionTables(t *imageType) (disk.PartitionTable, bool) {
 	}
 
 	switch t.platform.GetArch() {
-	case platform.ARCH_X86_64:
+	case arch.ARCH_X86_64:
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
@@ -67,7 +67,7 @@ func defaultBasePartitionTables(t *imageType) (disk.PartitionTable, bool) {
 				},
 			},
 		}, true
-	case platform.ARCH_AARCH64:
+	case arch.ARCH_AARCH64:
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
@@ -114,7 +114,7 @@ func defaultBasePartitionTables(t *imageType) (disk.PartitionTable, bool) {
 				},
 			},
 		}, true
-	case platform.ARCH_PPC64LE:
+	case arch.ARCH_PPC64LE:
 		return disk.PartitionTable{
 			UUID: "0x14fc63d2",
 			Type: "dos",
@@ -148,7 +148,7 @@ func defaultBasePartitionTables(t *imageType) (disk.PartitionTable, bool) {
 			},
 		}, true
 
-	case platform.ARCH_S390X:
+	case arch.ARCH_S390X:
 		return disk.PartitionTable{
 			UUID: "0x14fc63d2",
 			Type: "dos",

--- a/pkg/distro/rhel9/qcow2.go
+++ b/pkg/distro/rhel9/qcow2.go
@@ -2,9 +2,9 @@ package rhel9
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/subscription"
 )
@@ -104,7 +104,7 @@ func openstackCommonPackageSet(t *imageType) rpmmd.PackageSet {
 		},
 	}.Append(coreOsCommonPackageSet(t))
 
-	if t.arch.Name() == platform.ARCH_X86_64.String() {
+	if t.arch.Name() == arch.ARCH_X86_64.String() {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				// packages below used to come from @core group and were not excluded

--- a/pkg/distro/rhel9/vmdk.go
+++ b/pkg/distro/rhel9/vmdk.go
@@ -2,8 +2,8 @@ package rhel9
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/distro"
-	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -63,7 +63,7 @@ func vmdkCommonPackageSet(t *imageType) rpmmd.PackageSet {
 		},
 	}.Append(coreOsCommonPackageSet(t))
 
-	if t.arch.Name() == platform.ARCH_X86_64.String() {
+	if t.arch.Name() == arch.ARCH_X86_64.String() {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				// packages below used to come from @core group and were not excluded

--- a/pkg/distroregistry/distroregistry.go
+++ b/pkg/distroregistry/distroregistry.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/fedora"
 	"github.com/osbuild/images/pkg/distro/rhel7"
@@ -52,7 +53,7 @@ func New(hostDistro distro.Distro, distros ...distro.Distro) (*Registry, error) 
 	reg := &Registry{
 		distros:      make(map[string]distro.Distro),
 		hostDistro:   hostDistro,
-		hostArchName: common.CurrentArch(),
+		hostArchName: arch.Current().String(),
 	}
 	for _, d := range distros {
 		name := d.Name()

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/environment"
 	"github.com/osbuild/images/internal/workload"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/artifact"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/manifest"
@@ -61,7 +62,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	livePipeline.ExcludePackages = img.ExtraBasePackages.Exclude
 
 	livePipeline.Variant = img.Variant
-	livePipeline.Biosdevname = (img.Platform.GetArch() == platform.ARCH_X86_64)
+	livePipeline.Biosdevname = (img.Platform.GetArch() == arch.ARCH_X86_64)
 
 	livePipeline.Checkpoint()
 
@@ -103,7 +104,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	bootTreePipeline.KernelOpts = kernelOpts
 
 	// enable ISOLinux on x86_64 only
-	isoLinuxEnabled := img.Platform.GetArch() == platform.ARCH_X86_64
+	isoLinuxEnabled := img.Platform.GetArch() == arch.ARCH_X86_64
 
 	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(buildPipeline, livePipeline, rootfsImagePipeline, bootTreePipeline)
 	isoTreePipeline.PartitionTable = rootfsPartitionTable

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/users"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/artifact"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/manifest"
@@ -69,7 +70,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline.Users = img.Users
 	anacondaPipeline.Groups = img.Groups
 	anacondaPipeline.Variant = img.Variant
-	anacondaPipeline.Biosdevname = (img.Platform.GetArch() == platform.ARCH_X86_64)
+	anacondaPipeline.Biosdevname = (img.Platform.GetArch() == arch.ARCH_X86_64)
 	anacondaPipeline.Checkpoint()
 	anacondaPipeline.AdditionalDracutModules = img.AdditionalDracutModules
 	anacondaPipeline.AdditionalAnacondaModules = img.AdditionalAnacondaModules
@@ -112,7 +113,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	}
 
 	// enable ISOLinux on x86_64 only
-	isoLinuxEnabled := img.Platform.GetArch() == platform.ARCH_X86_64
+	isoLinuxEnabled := img.Platform.GetArch() == arch.ARCH_X86_64
 
 	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(buildPipeline, anacondaPipeline, rootfsImagePipeline, bootTreePipeline)
 	isoTreePipeline.PartitionTable = rootfsPartitionTable

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osbuild/images/internal/environment"
 	"github.com/osbuild/images/internal/users"
 	"github.com/osbuild/images/internal/workload"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/artifact"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/manifest"
@@ -80,7 +81,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline.Users = img.Users
 	anacondaPipeline.Groups = img.Groups
 	anacondaPipeline.Variant = img.Variant
-	anacondaPipeline.Biosdevname = (img.Platform.GetArch() == platform.ARCH_X86_64)
+	anacondaPipeline.Biosdevname = (img.Platform.GetArch() == arch.ARCH_X86_64)
 	anacondaPipeline.AdditionalAnacondaModules = img.AdditionalAnacondaModules
 	anacondaPipeline.AdditionalDracutModules = img.AdditionalDracutModules
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers
@@ -133,7 +134,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.Workload = img.Workload
 
 	// enable ISOLinux on x86_64 only
-	isoLinuxEnabled := img.Platform.GetArch() == platform.ARCH_X86_64
+	isoLinuxEnabled := img.Platform.GetArch() == arch.ARCH_X86_64
 
 	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(buildPipeline, anacondaPipeline, rootfsImagePipeline, bootTreePipeline)
 	isoTreePipeline.PartitionTable = rootfsPartitionTable

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osbuild/images/internal/fdo"
 	"github.com/osbuild/images/internal/ignition"
 	"github.com/osbuild/images/internal/workload"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/artifact"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/manifest"
@@ -93,7 +94,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	coiPipeline.ExtraRepos = img.ExtraBasePackages.Repositories
 	coiPipeline.FDO = img.FDO
 	coiPipeline.Ignition = img.IgnitionEmbedded
-	coiPipeline.Biosdevname = (img.Platform.GetArch() == platform.ARCH_X86_64)
+	coiPipeline.Biosdevname = (img.Platform.GetArch() == arch.ARCH_X86_64)
 	coiPipeline.Variant = img.Variant
 	coiPipeline.AdditionalDracutModules = img.AdditionalDracutModules
 
@@ -146,7 +147,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	}
 
 	// enable ISOLinux on x86_64 only
-	isoLinuxEnabled := img.Platform.GetArch() == platform.ARCH_X86_64
+	isoLinuxEnabled := img.Platform.GetArch() == arch.ARCH_X86_64
 
 	isoTreePipeline := manifest.NewCoreOSISOTree(buildPipeline, compressedImage, coiPipeline, bootTreePipeline)
 	isoTreePipeline.KernelOpts = kernelOpts

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/osbuild/images/internal/fsnode"
 	"github.com/osbuild/images/internal/users"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
@@ -107,7 +108,7 @@ func (p *AnacondaInstaller) anacondaBootPackageSet() []string {
 	}
 
 	switch p.platform.GetArch() {
-	case platform.ARCH_X86_64:
+	case arch.ARCH_X86_64:
 		packages = append(packages,
 			"grub2-efi-x64",
 			"grub2-efi-x64-cdboot",
@@ -117,7 +118,7 @@ func (p *AnacondaInstaller) anacondaBootPackageSet() []string {
 			"syslinux",
 			"syslinux-nonlinux",
 		)
-	case platform.ARCH_AARCH64:
+	case arch.ARCH_AARCH64:
 		packages = append(packages,
 			"grub2-efi-aa64-cdboot",
 			"grub2-efi-aa64",

--- a/pkg/manifest/coreos_installer.go
+++ b/pkg/manifest/coreos_installer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/osbuild/images/internal/fdo"
 	"github.com/osbuild/images/internal/ignition"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
@@ -85,7 +86,7 @@ func (p *CoreOSInstaller) getBootPackages() []string {
 	// For Fedora, this will add a lot of duplicates, but we also add them here
 	// for RHEL and CentOS.
 	switch p.platform.GetArch() {
-	case platform.ARCH_X86_64:
+	case arch.ARCH_X86_64:
 		packages = append(packages,
 			"grub2-efi-x64",
 			"grub2-efi-x64-cdboot",
@@ -95,7 +96,7 @@ func (p *CoreOSInstaller) getBootPackages() []string {
 			"syslinux",
 			"syslinux-nonlinux",
 		)
-	case platform.ARCH_AARCH64:
+	case arch.ARCH_AARCH64:
 		packages = append(packages,
 			"grub2-efi-aa64-cdboot",
 			"grub2-efi-aa64",

--- a/pkg/manifest/efi_boot_tree.go
+++ b/pkg/manifest/efi_boot_tree.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
 )
@@ -33,11 +34,11 @@ func NewEFIBootTree(m *Manifest, buildPipeline *Build, product, version string) 
 func (p *EFIBootTree) serialize() osbuild.Pipeline {
 	pipeline := p.Base.serialize()
 
-	arch := p.Platform.GetArch().String()
+	a := p.Platform.GetArch().String()
 	var architectures []string
-	if arch == platform.ARCH_X86_64.String() {
+	if a == arch.ARCH_X86_64.String() {
 		architectures = []string{"X64"}
-	} else if arch == platform.ARCH_AARCH64.String() {
+	} else if a == arch.ARCH_AARCH64.String() {
 		architectures = []string{"AA64"}
 	} else {
 		panic("unsupported architecture")

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -11,6 +11,7 @@ import (
 	"github.com/osbuild/images/internal/shell"
 	"github.com/osbuild/images/internal/users"
 	"github.com/osbuild/images/internal/workload"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -610,7 +611,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 
 		var bootloader *osbuild.Stage
 		switch p.platform.GetArch() {
-		case platform.ARCH_S390X:
+		case arch.ARCH_S390X:
 			bootloader = osbuild.NewZiplStage(new(osbuild.ZiplStageOptions))
 		default:
 			if p.NoBLS {

--- a/pkg/manifest/raw.go
+++ b/pkg/manifest/raw.go
@@ -1,9 +1,9 @@
 package manifest
 
 import (
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/artifact"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/platform"
 )
 
 // A RawImage represents a raw image file which can be booted in a
@@ -65,7 +65,7 @@ func (p *RawImage) serialize() osbuild.Pipeline {
 	}
 
 	switch p.treePipeline.platform.GetArch() {
-	case platform.ARCH_S390X:
+	case arch.ARCH_S390X:
 		loopback := osbuild.NewLoopbackDevice(&osbuild.LoopbackDeviceOptions{Filename: p.Filename()})
 		pipeline.AddStage(osbuild.NewZiplInstStage(osbuild.NewZiplInstStageOptions(p.treePipeline.kernelVer, pt), loopback, copyDevices, copyMounts))
 	default:

--- a/pkg/platform/aarch64.go
+++ b/pkg/platform/aarch64.go
@@ -1,12 +1,16 @@
 package platform
 
+import (
+	"github.com/osbuild/images/pkg/arch"
+)
+
 type Aarch64 struct {
 	BasePlatform
 	UEFIVendor string
 }
 
-func (p *Aarch64) GetArch() Arch {
-	return ARCH_AARCH64
+func (p *Aarch64) GetArch() arch.Arch {
+	return arch.ARCH_AARCH64
 }
 
 func (p *Aarch64) GetUEFIVendor() string {
@@ -34,8 +38,8 @@ type Aarch64_Fedora struct {
 	BootFiles  [][2]string
 }
 
-func (p *Aarch64_Fedora) GetArch() Arch {
-	return ARCH_AARCH64
+func (p *Aarch64_Fedora) GetArch() arch.Arch {
+	return arch.ARCH_AARCH64
 }
 
 func (p *Aarch64_Fedora) GetUEFIVendor() string {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1,14 +1,10 @@
 package platform
 
-type Arch uint64
-type ImageFormat uint64
-
-const ( // architecture enum
-	ARCH_AARCH64 Arch = iota
-	ARCH_PPC64LE
-	ARCH_S390X
-	ARCH_X86_64
+import (
+	"github.com/osbuild/images/pkg/arch"
 )
+
+type ImageFormat uint64
 
 const ( // image format enum
 	FORMAT_UNSET ImageFormat = iota
@@ -20,21 +16,6 @@ const ( // image format enum
 	FORMAT_GCE
 	FORMAT_OVA
 )
-
-func (a Arch) String() string {
-	switch a {
-	case ARCH_AARCH64:
-		return "aarch64"
-	case ARCH_PPC64LE:
-		return "ppc64le"
-	case ARCH_S390X:
-		return "s390x"
-	case ARCH_X86_64:
-		return "x86_64"
-	default:
-		panic("invalid architecture")
-	}
-}
 
 func (f ImageFormat) String() string {
 	switch f {
@@ -58,7 +39,7 @@ func (f ImageFormat) String() string {
 }
 
 type Platform interface {
-	GetArch() Arch
+	GetArch() arch.Arch
 	GetImageFormat() ImageFormat
 	GetQCOW2Compat() string
 	GetBIOSPlatform() string

--- a/pkg/platform/ppc64le.go
+++ b/pkg/platform/ppc64le.go
@@ -1,12 +1,16 @@
 package platform
 
+import (
+	"github.com/osbuild/images/pkg/arch"
+)
+
 type PPC64LE struct {
 	BasePlatform
 	BIOS bool
 }
 
-func (p *PPC64LE) GetArch() Arch {
-	return ARCH_PPC64LE
+func (p *PPC64LE) GetArch() arch.Arch {
+	return arch.ARCH_PPC64LE
 }
 
 func (p *PPC64LE) GetBIOSPlatform() string {

--- a/pkg/platform/s390x.go
+++ b/pkg/platform/s390x.go
@@ -1,12 +1,16 @@
 package platform
 
+import (
+	"github.com/osbuild/images/pkg/arch"
+)
+
 type S390X struct {
 	BasePlatform
 	Zipl bool
 }
 
-func (p *S390X) GetArch() Arch {
-	return ARCH_S390X
+func (p *S390X) GetArch() arch.Arch {
+	return arch.ARCH_S390X
 }
 
 func (p *S390X) GetZiplSupport() bool {

--- a/pkg/platform/x86_64.go
+++ b/pkg/platform/x86_64.go
@@ -1,5 +1,9 @@
 package platform
 
+import (
+	"github.com/osbuild/images/pkg/arch"
+)
+
 type X86BootLoader uint64
 
 type X86 struct {
@@ -8,8 +12,8 @@ type X86 struct {
 	UEFIVendor string
 }
 
-func (p *X86) GetArch() Arch {
-	return ARCH_X86_64
+func (p *X86) GetArch() arch.Arch {
+	return arch.ARCH_X86_64
 }
 
 func (p *X86) GetBIOSPlatform() string {


### PR DESCRIPTION
This allows importing the architecture separately, and will help getting rid of inline string literals in composer.

---

Alternatively we import platform everywhere.