### PR TITLE
test/configs: update public ssh key

### DIFF
--- a/test/configs/edge-ostree-pull-user.json
+++ b/test/configs/edge-ostree-pull-user.json
@@ -7,7 +7,7 @@
           "groups": [
             "wheel"
           ],
-          "key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPDyeUyVWvuSSOdrikiDWgNoCz0oYP4Ir68jJecn+XYc github.com/osbuild/images",
+          "key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNebAh6SjpAn8wB53K4695cGnHGuCtl4RdaX3futZgJUultHyzeYHnzMO7d4++qnRL+Rworew62LKP560uvtncc= github.com/osbuild/images",
           "name": "osbuild"
         }
       ]

--- a/test/configs/iot-ostree-pull-user.json
+++ b/test/configs/iot-ostree-pull-user.json
@@ -7,7 +7,7 @@
           "groups": [
             "wheel"
           ],
-          "key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPDyeUyVWvuSSOdrikiDWgNoCz0oYP4Ir68jJecn+XYc github.com/osbuild/images",
+          "key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNebAh6SjpAn8wB53K4695cGnHGuCtl4RdaX3futZgJUultHyzeYHnzMO7d4++qnRL+Rworew62LKP560uvtncc= github.com/osbuild/images",
           "name": "osbuild"
         }
       ]

--- a/test/configs/user-customizations.json
+++ b/test/configs/user-customizations.json
@@ -5,7 +5,7 @@
       "user": [
         {
           "name": "osbuild",
-          "key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPDyeUyVWvuSSOdrikiDWgNoCz0oYP4Ir68jJecn+XYc github.com/osbuild/images"
+          "key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNebAh6SjpAn8wB53K4695cGnHGuCtl4RdaX3futZgJUultHyzeYHnzMO7d4++qnRL+Rworew62LKP560uvtncc= github.com/osbuild/images"
         }
       ]
     }


### PR DESCRIPTION
The CI key was replaced with a FIPS compliant SSH key.  We need to set it in all the test configs.