### PR TITLE
pkg/arch: get architecture from string

### DIFF
--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -28,6 +28,25 @@ func (a Arch) String() string {
 	}
 }
 
+func FromString(a string) Arch {
+	switch a {
+	case "amd64":
+		fallthrough
+	case "x86_64":
+		return ARCH_X86_64
+	case "arm64":
+		fallthrough
+	case "aarch64":
+		return ARCH_AARCH64
+	case "s390x":
+		return ARCH_S390X
+	case "ppc64le":
+		return ARCH_PPC64LE
+	default:
+		panic("unsupported architecture")
+	}
+}
+
 var runtimeGOARCH = runtime.GOARCH
 
 func Current() Arch {

--- a/pkg/arch/arch_test.go
+++ b/pkg/arch/arch_test.go
@@ -44,3 +44,16 @@ func TestCurrentArchUnsupported(t *testing.T) {
 	runtimeGOARCH = "UKNOWN"
 	assert.PanicsWithValue(t, "unsupported architecture", func() { Current() })
 }
+
+func TestFromStringUnsupported(t *testing.T) {
+	assert.PanicsWithValue(t, "unsupported architecture", func() { FromString("UNKNOWN") })
+}
+
+func TestFromString(t *testing.T) {
+	assert.Equal(t, ARCH_AARCH64, FromString("arm64"))
+	assert.Equal(t, ARCH_AARCH64, FromString("aarch64"))
+	assert.Equal(t, ARCH_X86_64, FromString("amd64"))
+	assert.Equal(t, ARCH_X86_64, FromString("x86_64"))
+	assert.Equal(t, ARCH_S390X, FromString("s390x"))
+	assert.Equal(t, ARCH_PPC64LE, FromString("ppc64le"))
+}


### PR DESCRIPTION
This is useful to parse architectures stored in the jobqueue.