### PR TITLE
Strip PR prefix from PR number in build cache

### DIFF
--- a/test/scripts/upload-results
+++ b/test/scripts/upload-results
@@ -37,6 +37,8 @@ def main():
         with open(info_path, "r") as info_fp:
             build_info = json.load(info_fp)
         build_info["pr"] = pr_number
+        # strip the PR prefix
+        pr_number = pr_number.lstrip("PR-")
         with open(info_path, "w") as info_fp:
             json.dump(build_info, info_fp, indent=2)
 


### PR DESCRIPTION
We've been saving the PR number to the build cache metadata by reading the branch name in GitLab CI, but the branch name is prefixed with `PR-`.  Save it as a plain number so we can use it for links etc.