### PR TITLE
rpmmd: add module_hotfixes flag to RepoConfig

### DIFF
--- a/dnf-json
+++ b/dnf-json
@@ -119,6 +119,11 @@ class Solver():
         # we set the expiration to a short time period, rather than 0.
         repo.metadata_expire = desc.get("metadata_expire", "20s")
 
+        # This option if True disables modularization filtering. Effectively
+        # disabling modularity for given repository.
+        if "module_hotfixes" in desc:
+            repo.module_hotfixes = desc["module_hotfixes"]
+
         return repo
 
     @staticmethod

--- a/pkg/blueprint/repository_customizations.go
+++ b/pkg/blueprint/repository_customizations.go
@@ -12,18 +12,19 @@ import (
 )
 
 type RepositoryCustomization struct {
-	Id           string   `json:"id" toml:"id"`
-	BaseURLs     []string `json:"baseurls,omitempty" toml:"baseurls,omitempty"`
-	GPGKeys      []string `json:"gpgkeys,omitempty" toml:"gpgkeys,omitempty"`
-	Metalink     string   `json:"metalink,omitempty" toml:"metalink,omitempty"`
-	Mirrorlist   string   `json:"mirrorlist,omitempty" toml:"mirrorlist,omitempty"`
-	Name         string   `json:"name,omitempty" toml:"name,omitempty"`
-	Priority     *int     `json:"priority,omitempty" toml:"priority,omitempty"`
-	Enabled      *bool    `json:"enabled,omitempty" toml:"enabled,omitempty"`
-	GPGCheck     *bool    `json:"gpgcheck,omitempty" toml:"gpgcheck,omitempty"`
-	RepoGPGCheck *bool    `json:"repo_gpgcheck,omitempty" toml:"repo_gpgcheck,omitempty"`
-	SSLVerify    *bool    `json:"sslverify,omitempty" toml:"sslverify,omitempty"`
-	Filename     string   `json:"filename,omitempty" toml:"filename,omitempty"`
+	Id             string   `json:"id" toml:"id"`
+	BaseURLs       []string `json:"baseurls,omitempty" toml:"baseurls,omitempty"`
+	GPGKeys        []string `json:"gpgkeys,omitempty" toml:"gpgkeys,omitempty"`
+	Metalink       string   `json:"metalink,omitempty" toml:"metalink,omitempty"`
+	Mirrorlist     string   `json:"mirrorlist,omitempty" toml:"mirrorlist,omitempty"`
+	Name           string   `json:"name,omitempty" toml:"name,omitempty"`
+	Priority       *int     `json:"priority,omitempty" toml:"priority,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty" toml:"enabled,omitempty"`
+	GPGCheck       *bool    `json:"gpgcheck,omitempty" toml:"gpgcheck,omitempty"`
+	RepoGPGCheck   *bool    `json:"repo_gpgcheck,omitempty" toml:"repo_gpgcheck,omitempty"`
+	SSLVerify      *bool    `json:"sslverify,omitempty" toml:"sslverify,omitempty"`
+	ModuleHotfixes *bool    `json:"module_hotfixes,omitempty" toml:"module_hotfixes,omitempty"`
+	Filename       string   `json:"filename,omitempty" toml:"filename,omitempty"`
 }
 
 const repoFilenameRegex = "^[\\w.-]{1,250}\\.repo$"
@@ -117,16 +118,17 @@ func (repo RepositoryCustomization) customRepoToRepoConfig() rpmmd.RepoConfig {
 	copy(keys, repo.GPGKeys)
 
 	repoConfig := rpmmd.RepoConfig{
-		Id:           repo.Id,
-		BaseURLs:     urls,
-		GPGKeys:      keys,
-		Name:         repo.Name,
-		Metalink:     repo.Metalink,
-		MirrorList:   repo.Mirrorlist,
-		CheckGPG:     repo.GPGCheck,
-		CheckRepoGPG: repo.RepoGPGCheck,
-		Priority:     repo.Priority,
-		Enabled:      repo.Enabled,
+		Id:             repo.Id,
+		BaseURLs:       urls,
+		GPGKeys:        keys,
+		Name:           repo.Name,
+		Metalink:       repo.Metalink,
+		MirrorList:     repo.Mirrorlist,
+		CheckGPG:       repo.GPGCheck,
+		CheckRepoGPG:   repo.RepoGPGCheck,
+		Priority:       repo.Priority,
+		ModuleHotfixes: repo.ModuleHotfixes,
+		Enabled:        repo.Enabled,
 	}
 
 	if repo.SSLVerify != nil {

--- a/pkg/dnfjson/dnfjson.go
+++ b/pkg/dnfjson/dnfjson.go
@@ -267,6 +267,7 @@ func (s *Solver) reposFromRPMMD(rpmRepos []rpmmd.RepoConfig) ([]repoConfig, erro
 			MirrorList:     rr.MirrorList,
 			GPGKeys:        rr.GPGKeys,
 			MetadataExpire: rr.MetadataExpire,
+			ModuleHotfixes: rr.ModuleHotfixes,
 			repoHash:       rr.Hash(),
 		}
 
@@ -294,6 +295,7 @@ func (s *Solver) reposFromRPMMD(rpmRepos []rpmmd.RepoConfig) ([]repoConfig, erro
 			dr.SSLClientKey = secrets.SSLClientKey
 			dr.SSLClientCert = secrets.SSLClientCert
 		}
+
 		dnfRepos[idx] = dr
 	}
 	return dnfRepos, nil
@@ -315,6 +317,7 @@ type repoConfig struct {
 	SSLClientKey   string   `json:"sslclientkey,omitempty"`
 	SSLClientCert  string   `json:"sslclientcert,omitempty"`
 	MetadataExpire string   `json:"metadata_expire,omitempty"`
+	ModuleHotfixes *bool    `json:"module_hotfixes,omitempty"`
 	// set the repo hass from `rpmmd.RepoConfig.Hash()` function
 	// rather than re-calculating it
 	repoHash string

--- a/pkg/osbuild/yum_repos_stage.go
+++ b/pkg/osbuild/yum_repos_stage.go
@@ -99,17 +99,18 @@ func repoConfigToYumRepository(repo rpmmd.RepoConfig) YumRepository {
 	}
 
 	yumRepo := YumRepository{
-		Id:           repo.Id,
-		Name:         repo.Name,
-		Mirrorlist:   repo.MirrorList,
-		Metalink:     repo.Metalink,
-		BaseURLs:     urls,
-		GPGKey:       keys,
-		GPGCheck:     repo.CheckGPG,
-		RepoGPGCheck: repo.CheckRepoGPG,
-		Enabled:      repo.Enabled,
-		Priority:     repo.Priority,
-		SSLVerify:    sslVerify,
+		Id:             repo.Id,
+		Name:           repo.Name,
+		Mirrorlist:     repo.MirrorList,
+		Metalink:       repo.Metalink,
+		BaseURLs:       urls,
+		GPGKey:         keys,
+		GPGCheck:       repo.CheckGPG,
+		RepoGPGCheck:   repo.CheckRepoGPG,
+		Enabled:        repo.Enabled,
+		Priority:       repo.Priority,
+		SSLVerify:      sslVerify,
+		ModuleHotfixes: repo.ModuleHotfixes,
 	}
 
 	return yumRepo

--- a/pkg/rpmmd/repository.go
+++ b/pkg/rpmmd/repository.go
@@ -23,6 +23,7 @@ type repository struct {
 	CheckGPG       bool     `json:"check_gpg,omitempty"`
 	IgnoreSSL      bool     `json:"ignore_ssl,omitempty"`
 	RHSM           bool     `json:"rhsm,omitempty"`
+	ModuleHotfixes *bool    `json:"module_hotfixes,omitempty"`
 	MetadataExpire string   `json:"metadata_expire,omitempty"`
 	ImageTypeTags  []string `json:"image_type_tags,omitempty"`
 }
@@ -42,6 +43,7 @@ type RepoConfig struct {
 	Priority       *int     `json:"priority,omitempty"`
 	IgnoreSSL      *bool    `json:"ignore_ssl,omitempty"`
 	MetadataExpire string   `json:"metadata_expire,omitempty"`
+	ModuleHotfixes *bool    `json:"module_hotfixes,omitempty"`
 	RHSM           bool     `json:"rhsm,omitempty"`
 	Enabled        *bool    `json:"enabled,omitempty"`
 	ImageTypeTags  []string `json:"image_type_tags,omitempty"`
@@ -58,6 +60,12 @@ func (r *RepoConfig) Hash() string {
 	bpts := func(b *bool) string {
 		return fmt.Sprintf("%T", b)
 	}
+	bptsIgnoreNil := func(b *bool) string {
+		if b == nil {
+			return ""
+		}
+		return bts(*b)
+	}
 	ats := func(s []string) string {
 		return strings.Join(s, "")
 	}
@@ -69,7 +77,8 @@ func (r *RepoConfig) Hash() string {
 		bpts(r.CheckRepoGPG)+
 		bpts(r.IgnoreSSL)+
 		r.MetadataExpire+
-		bts(r.RHSM))))
+		bts(r.RHSM)+
+		bptsIgnoreNil(r.ModuleHotfixes))))
 }
 
 type DistrosRepoConfigs map[string]map[string][]RepoConfig
@@ -264,6 +273,7 @@ func loadRepositoriesFromFile(filename string) (map[string][]RepoConfig, error) 
 				CheckGPG:       &repo.CheckGPG,
 				RHSM:           repo.RHSM,
 				MetadataExpire: repo.MetadataExpire,
+				ModuleHotfixes: repo.ModuleHotfixes,
 				ImageTypeTags:  repo.ImageTypeTags,
 			}
 


### PR DESCRIPTION
Adds module_hotfixes flag to all repo types so it can be used during osbuild. This enables users to disable modularity filtering on specific repositories.

relates to: https://github.com/osbuild/osbuild-composer/pull/3821