### PR TITLE
image: add new `ContainerBuildable` flag to OSTreeDiskImage (HMS-3141)

### DIFF
--- a/cmd/osbuild-playground/my-container.go
+++ b/cmd/osbuild-playground/my-container.go
@@ -46,7 +46,7 @@ func (img *MyContainer) InstantiateManifest(m *manifest.Manifest,
 	// Let's create a simple OCI container!
 
 	// configure a build pipeline
-	build := manifest.NewBuild(m, runner, repos)
+	build := manifest.NewBuild(m, runner, repos, nil)
 	build.Checkpoint()
 
 	// create a minimal non-bootable OS tree

--- a/cmd/osbuild-playground/my-image.go
+++ b/cmd/osbuild-playground/my-image.go
@@ -30,7 +30,7 @@ func (img *MyImage) InstantiateManifest(m *manifest.Manifest,
 	// Let's create a simple raw image!
 
 	// configure a build pipeline
-	build := manifest.NewBuild(m, runner, repos)
+	build := manifest.NewBuild(m, runner, repos, nil)
 	build.Checkpoint()
 
 	// create an x86_64 platform with bios boot

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -46,7 +46,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	repos []rpmmd.RepoConfig,
 	runner runner.Runner,
 	rng *rand.Rand) (*artifact.Artifact, error) {
-	buildPipeline := manifest.NewBuild(m, runner, repos)
+	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
 	livePipeline := manifest.NewAnacondaInstaller(m,

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -53,7 +53,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	repos []rpmmd.RepoConfig,
 	runner runner.Runner,
 	rng *rand.Rand) (*artifact.Artifact, error) {
-	buildPipeline := manifest.NewBuild(m, runner, repos)
+	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
 	anacondaPipeline := manifest.NewAnacondaInstaller(m,

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -63,7 +63,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	repos []rpmmd.RepoConfig,
 	runner runner.Runner,
 	rng *rand.Rand) (*artifact.Artifact, error) {
-	buildPipeline := manifest.NewBuild(m, runner, repos)
+	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
 	anacondaPipeline := manifest.NewAnacondaInstaller(m,

--- a/pkg/image/archive.go
+++ b/pkg/image/archive.go
@@ -31,7 +31,7 @@ func (img *Archive) InstantiateManifest(m *manifest.Manifest,
 	repos []rpmmd.RepoConfig,
 	runner runner.Runner,
 	rng *rand.Rand) (*artifact.Artifact, error) {
-	buildPipeline := manifest.NewBuild(m, runner, repos)
+	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
 	osPipeline := manifest.NewOS(m, buildPipeline, img.Platform, repos)

--- a/pkg/image/container.go
+++ b/pkg/image/container.go
@@ -31,7 +31,7 @@ func (img *BaseContainer) InstantiateManifest(m *manifest.Manifest,
 	repos []rpmmd.RepoConfig,
 	runner runner.Runner,
 	rng *rand.Rand) (*artifact.Artifact, error) {
-	buildPipeline := manifest.NewBuild(m, runner, repos)
+	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
 	osPipeline := manifest.NewOS(m, buildPipeline, img.Platform, repos)

--- a/pkg/image/disk.go
+++ b/pkg/image/disk.go
@@ -49,7 +49,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 	repos []rpmmd.RepoConfig,
 	runner runner.Runner,
 	rng *rand.Rand) (*artifact.Artifact, error) {
-	buildPipeline := manifest.NewBuild(m, runner, repos)
+	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
 	osPipeline := manifest.NewOS(m, buildPipeline, img.Platform, repos)

--- a/pkg/image/export_test.go
+++ b/pkg/image/export_test.go
@@ -1,0 +1,15 @@
+package image
+
+import (
+	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/rpmmd"
+	"github.com/osbuild/images/pkg/runner"
+)
+
+func MockManifestNewBuild(new func(m *manifest.Manifest, runner runner.Runner, repos []rpmmd.RepoConfig) *manifest.Build) (restore func()) {
+	saved := manifestNewBuild
+	manifestNewBuild = new
+	return func() {
+		manifestNewBuild = saved
+	}
+}

--- a/pkg/image/export_test.go
+++ b/pkg/image/export_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/osbuild/images/pkg/runner"
 )
 
-func MockManifestNewBuild(new func(m *manifest.Manifest, runner runner.Runner, repos []rpmmd.RepoConfig) *manifest.Build) (restore func()) {
+func MockManifestNewBuild(new func(m *manifest.Manifest, runner runner.Runner, repos []rpmmd.RepoConfig, opts *manifest.BuildOptions) *manifest.Build) (restore func()) {
 	saved := manifestNewBuild
 	manifestNewBuild = new
 	return func() {

--- a/pkg/image/ostree_archive.go
+++ b/pkg/image/ostree_archive.go
@@ -47,7 +47,7 @@ func (img *OSTreeArchive) InstantiateManifest(m *manifest.Manifest,
 	repos []rpmmd.RepoConfig,
 	runner runner.Runner,
 	rng *rand.Rand) (*artifact.Artifact, error) {
-	buildPipeline := manifest.NewBuild(m, runner, repos)
+	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
 	osPipeline := manifest.NewOS(m, buildPipeline, img.Platform, repos)

--- a/pkg/image/ostree_container.go
+++ b/pkg/image/ostree_container.go
@@ -44,7 +44,7 @@ func (img *OSTreeContainer) InstantiateManifest(m *manifest.Manifest,
 	repos []rpmmd.RepoConfig,
 	runner runner.Runner,
 	rng *rand.Rand) (*artifact.Artifact, error) {
-	buildPipeline := manifest.NewBuild(m, runner, repos)
+	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
 	osPipeline := manifest.NewOS(m, buildPipeline, img.Platform, repos)

--- a/pkg/image/ostree_disk.go
+++ b/pkg/image/ostree_disk.go
@@ -113,8 +113,7 @@ func (img *OSTreeDiskImage) InstantiateManifest(m *manifest.Manifest,
 	repos []rpmmd.RepoConfig,
 	runner runner.Runner,
 	rng *rand.Rand) (*artifact.Artifact, error) {
-	buildPipeline := manifestNewBuild(m, runner, repos)
-	buildPipeline.ContainerBuildable = img.ContainerBuildable
+	buildPipeline := manifestNewBuild(m, runner, repos, &manifest.BuildOptions{ContainerBuildable: img.ContainerBuildable})
 	buildPipeline.Checkpoint()
 
 	// don't support compressing non-raw images

--- a/pkg/image/ostree_disk_test.go
+++ b/pkg/image/ostree_disk_test.go
@@ -1,0 +1,59 @@
+package image_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/internal/workload"
+	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/image"
+	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/rpmmd"
+	"github.com/osbuild/images/pkg/runner"
+)
+
+func TestOSTreeDiskImageManifestSetsContainerBuildable(t *testing.T) {
+	rng := rand.New(rand.NewSource(0)) // nolint:gosec
+
+	repos := []rpmmd.RepoConfig{}
+	r := &runner.Fedora{Version: 39}
+
+	ref := "ostree/1/1/0"
+	containerSource := container.SourceSpec{
+		Source: "source-spec",
+		Name:   "name",
+	}
+
+	var buildPipeline *manifest.Build
+	restore := image.MockManifestNewBuild(func(m *manifest.Manifest, r runner.Runner, repos []rpmmd.RepoConfig) *manifest.Build {
+		buildPipeline = manifest.NewBuild(m, r, repos)
+		return buildPipeline
+	})
+	defer restore()
+
+	for _, containerBuildable := range []bool{true, false} {
+		mf := manifest.New()
+		img := image.NewOSTreeDiskImageFromContainer(containerSource, ref)
+		require.NotNil(t, img)
+		img.Platform = &platform.X86{
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_QCOW2,
+			},
+			BIOS:       true,
+			UEFIVendor: "fedora",
+		}
+		img.Workload = &workload.BaseWorkload{}
+		img.OSName = "osname"
+		img.ContainerBuildable = containerBuildable
+
+		_, err := img.InstantiateManifest(&mf, repos, r, rng)
+		require.Nil(t, err)
+		require.NotNil(t, img)
+		require.NotNil(t, buildPipeline)
+
+		require.Equal(t, buildPipeline.ContainerBuildable, containerBuildable)
+	}
+}

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -73,7 +73,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	repos []rpmmd.RepoConfig,
 	runner runner.Runner,
 	rng *rand.Rand) (*artifact.Artifact, error) {
-	buildPipeline := manifest.NewBuild(m, runner, repos)
+	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
 	imageFilename := "image.raw.xz"

--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -23,21 +23,30 @@ type Build struct {
 	repos        []rpmmd.RepoConfig
 	packageSpecs []rpmmd.PackageSpec
 
-	// TODO: make private?
-	// Container buildable tweaks the buildroot to be container friendly,
+	containerBuildable bool
+}
+
+type BuildOptions struct {
+	// ContainerBuildable tweaks the buildroot to be container friendly,
 	// i.e. to not rely on an installed osbuild-selinux
 	ContainerBuildable bool
 }
 
 // NewBuild creates a new build pipeline from the repositories in repos
 // and the specified packages.
-func NewBuild(m *Manifest, runner runner.Runner, repos []rpmmd.RepoConfig) *Build {
+func NewBuild(m *Manifest, runner runner.Runner, repos []rpmmd.RepoConfig, opts *BuildOptions) *Build {
+	if opts == nil {
+		opts = &BuildOptions{}
+	}
+
 	name := "build"
 	pipeline := &Build{
 		Base:       NewBase(m, name, nil),
 		runner:     runner,
 		dependents: make([]Pipeline, 0),
 		repos:      filterRepos(repos, name),
+
+		containerBuildable: opts.ContainerBuildable,
 	}
 	m.addPipeline(pipeline)
 	return pipeline
@@ -114,7 +123,7 @@ func (p *Build) getSELinuxLabels() map[string]string {
 		switch pkg.Name {
 		case "coreutils":
 			labels["/usr/bin/cp"] = "system_u:object_r:install_exec_t:s0"
-			if p.ContainerBuildable {
+			if p.containerBuildable {
 				labels["/usr/bin/mount"] = "system_u:object_r:install_exec_t:s0"
 				labels["/usr/bin/umount"] = "system_u:object_r:install_exec_t:s0"
 			}

--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -22,6 +22,11 @@ type Build struct {
 	dependents   []Pipeline
 	repos        []rpmmd.RepoConfig
 	packageSpecs []rpmmd.PackageSpec
+
+	// TODO: make private?
+	// Container buildable tweaks the buildroot to be container friendly,
+	// i.e. to not rely on an installed osbuild-selinux
+	ContainerBuildable bool
 }
 
 // NewBuild creates a new build pipeline from the repositories in repos
@@ -109,6 +114,10 @@ func (p *Build) getSELinuxLabels() map[string]string {
 		switch pkg.Name {
 		case "coreutils":
 			labels["/usr/bin/cp"] = "system_u:object_r:install_exec_t:s0"
+			if p.ContainerBuildable {
+				labels["/usr/bin/mount"] = "system_u:object_r:install_exec_t:s0"
+				labels["/usr/bin/umount"] = "system_u:object_r:install_exec_t:s0"
+			}
 		case "tar":
 			labels["/usr/bin/tar"] = "system_u:object_r:install_exec_t:s0"
 		}

--- a/pkg/manifest/build_test.go
+++ b/pkg/manifest/build_test.go
@@ -1,0 +1,84 @@
+package manifest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/pkg/rpmmd"
+	"github.com/osbuild/images/pkg/runner"
+)
+
+func TestBuildContainerBuildableNo(t *testing.T) {
+	repos := []rpmmd.RepoConfig{}
+	mf := New()
+	runner := &runner.Fedora{Version: 39}
+
+	build := NewBuild(&mf, runner, repos)
+	require.NotNil(t, build)
+
+	for _, tc := range []struct {
+		packageSpec           []rpmmd.PackageSpec
+		containerBuildable    bool
+		expectedSELinuxLabels map[string]string
+	}{
+		// no pkgs means no selinux labels (container build or not)
+		{
+			[]rpmmd.PackageSpec{},
+			false,
+			map[string]string{},
+		},
+		{
+			[]rpmmd.PackageSpec{},
+			true,
+			map[string]string{},
+		},
+		{
+			[]rpmmd.PackageSpec{{Name: "coreutils"}},
+			false,
+			map[string]string{
+				"/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+			},
+		},
+		{
+			[]rpmmd.PackageSpec{{Name: "tar"}},
+			false,
+			map[string]string{
+				"/usr/bin/tar": "system_u:object_r:install_exec_t:s0",
+			},
+		},
+		{
+			[]rpmmd.PackageSpec{{Name: "coreutils"}, {Name: "tar"}},
+			false,
+			map[string]string{
+				"/usr/bin/cp":  "system_u:object_r:install_exec_t:s0",
+				"/usr/bin/tar": "system_u:object_r:install_exec_t:s0",
+			},
+		},
+		{
+			[]rpmmd.PackageSpec{{Name: "coreutils"}},
+			true,
+			map[string]string{
+				"/usr/bin/cp":     "system_u:object_r:install_exec_t:s0",
+				"/usr/bin/mount":  "system_u:object_r:install_exec_t:s0",
+				"/usr/bin/umount": "system_u:object_r:install_exec_t:s0",
+			},
+		},
+		{
+			[]rpmmd.PackageSpec{{Name: "coreutils"}, {Name: "tar"}},
+			true,
+			map[string]string{
+				"/usr/bin/cp":     "system_u:object_r:install_exec_t:s0",
+				"/usr/bin/mount":  "system_u:object_r:install_exec_t:s0",
+				"/usr/bin/umount": "system_u:object_r:install_exec_t:s0",
+				"/usr/bin/tar":    "system_u:object_r:install_exec_t:s0",
+			},
+		},
+	} {
+		build.packageSpecs = tc.packageSpec
+		build.ContainerBuildable = tc.containerBuildable
+
+		labels := build.getSELinuxLabels()
+		require.Equal(t, labels, tc.expectedSELinuxLabels)
+	}
+}

--- a/pkg/manifest/build_test.go
+++ b/pkg/manifest/build_test.go
@@ -14,7 +14,7 @@ func TestBuildContainerBuildableNo(t *testing.T) {
 	mf := New()
 	runner := &runner.Fedora{Version: 39}
 
-	build := NewBuild(&mf, runner, repos)
+	build := NewBuild(&mf, runner, repos, nil)
 	require.NotNil(t, build)
 
 	for _, tc := range []struct {
@@ -76,7 +76,7 @@ func TestBuildContainerBuildableNo(t *testing.T) {
 		},
 	} {
 		build.packageSpecs = tc.packageSpec
-		build.ContainerBuildable = tc.containerBuildable
+		build.containerBuildable = tc.containerBuildable
 
 		labels := build.getSELinuxLabels()
 		require.Equal(t, labels, tc.expectedSELinuxLabels)

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -18,7 +18,7 @@ func NewTestOS() *OS {
 	repos := []rpmmd.RepoConfig{}
 	manifest := New()
 	runner := &runner.Fedora{Version: 37}
-	build := NewBuild(&manifest, runner, repos)
+	build := NewBuild(&manifest, runner, repos, nil)
 	build.Checkpoint()
 
 	// create an x86_64 platform with bios boot


### PR DESCRIPTION
One objective for bifrost images is that it should be possible to run osbuild inside a container. This can interfere with the selinux policies of the buildroot.

Inside the container everything is labeled
`system_u:object_r:container_files_t`. Labeling /usr/bin/osbuild as `osbuild_exec_t` is not possible in the general case because the host may not have `osbuild-selinux` installed that contains this type. The workaround is that the container labels osbuild itself as `install_exec_t`. This works fine however there is a selinux denial warning when the `{,u}mount` binary is called because the transition from `install_t`->`mount_t` is not allowed. The warning is "harmless" because `install_t` has enough privs to allow the `{,u}mount` binaries to work.

To silence this warning we can label `{,u}mount` in the buildroot as `install_exec_t` directly.

This commit allows to control this now via the `ContainerBuildable` flag that can be set on `manifest.Build` to enable this behavior.

---

Once this has landed https://github.com/osbuild/osbuild-deploy-container/pull/11/files#diff-895717f8731ac528a1e229abd5c4b2d22eb2c471412ea30c1df61b88dd90e4f5R49 will need an update to do `img.ContainerBuildlable = true`