### PR TITLE
osbuild: remove unneccessary debug print during the test

### DIFF
--- a/pkg/osbuild/rpm_stage_test.go
+++ b/pkg/osbuild/rpm_stage_test.go
@@ -2,7 +2,6 @@ package osbuild
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -62,8 +61,9 @@ func Test_OSBuildMetadataToRPMs(t *testing.T) {
 	metadata := new(PipelineMetadata)
 	err := json.Unmarshal([]byte(raw), metadata)
 	require.NoError(t, err)
+	require.NotNil(t, metadata)
+	require.Len(t, *metadata, 1)
 
-	fmt.Printf("Result: %#v", metadata)
 	rpms := OSBuildMetadataToRPMs(*metadata)
 
 	require.Len(t, rpms, 3)


### PR DESCRIPTION
Instead of printing the metadata do some basic precondition checks and stop printing. The (no longer) printed data was:
```
Result: &osbuild.PipelineMetadata{"org.osbuild.rpm":(*osbuild.RPMStageMetadata)(0xc0005b71d0)}
```