### PR TITLE
osbuild: include context in skopeo error messages

### DIFF
--- a/internal/assertx/testify_extensions.go
+++ b/internal/assertx/testify_extensions.go
@@ -1,0 +1,29 @@
+package assertx
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// needed until https://github.com/stretchr/testify/issues/1304 is fixed
+func PanicsWithErrorRegexp(t assert.TestingT, reg *regexp.Regexp, f assert.PanicTestFunc) (assertOk bool) {
+	defer func() {
+		var message interface{} // nolint: gosimple
+
+		message = recover()
+		if message == nil {
+			return
+		}
+		err, ok := message.(error)
+		if !ok || err == nil {
+			assert.Fail(t, fmt.Sprintf("func %#v should return an error but got: %[2]v (type %[2]T)", f, message))
+			return
+		}
+		assertOk = assert.Regexp(t, reg, err.Error())
+	}()
+
+	f()
+	return assert.Fail(t, fmt.Sprintf("func %#v should panic but did not", f))
+}

--- a/internal/assertx/testify_extensions_test.go
+++ b/internal/assertx/testify_extensions_test.go
@@ -1,0 +1,46 @@
+package assertx_test
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/internal/assertx"
+)
+
+type mockTestingT struct {
+	errs []string
+}
+
+func (mt *mockTestingT) Errorf(format string, args ...interface{}) {
+	mt.errs = append(mt.errs, fmt.Sprintf(format, args...))
+}
+
+func TestAssertPanicWithErrorRegexpWrongType(t *testing.T) {
+	mockT := &mockTestingT{}
+
+	assertx.PanicsWithErrorRegexp(mockT, regexp.MustCompile("ignore"), func() {
+		panic("panic-with-string")
+	})
+	assert.Equal(t, len(mockT.errs), 1)
+	assert.Contains(t, mockT.errs[0], "should return an error but got: panic-with-string (type string)")
+}
+
+func TestAssertPanicWithErrorRegexpNoError(t *testing.T) {
+	mockT := &mockTestingT{}
+
+	assertx.PanicsWithErrorRegexp(mockT, regexp.MustCompile("ignore"), func() {
+		// no error
+	})
+	assert.Equal(t, len(mockT.errs), 1)
+	assert.Contains(t, mockT.errs[0], " should panic but did not")
+}
+
+func TestAssertPanicWithErrorRegexpHappy(t *testing.T) {
+	assertx.PanicsWithErrorRegexp(t, regexp.MustCompile(`(some|other) error`), func() {
+		panic(errors.New("some error"))
+	})
+}

--- a/pkg/osbuild/skopeo_source.go
+++ b/pkg/osbuild/skopeo_source.go
@@ -39,13 +39,12 @@ func NewSkopeoSourceItem(name, digest string, tlsVerify *bool) SkopeoSourceItem 
 }
 
 func (item SkopeoSourceItem) validate() error {
-
 	if item.Image.Name == "" {
-		return fmt.Errorf("source item has empty name")
+		return fmt.Errorf("source item %#v has empty name", item)
 	}
 
 	if !skopeoDigestPattern.MatchString(item.Image.Digest) {
-		return fmt.Errorf("source item has invalid digest")
+		return fmt.Errorf("source item %#v has invalid digest", item)
 	}
 
 	return nil
@@ -63,7 +62,7 @@ func NewSkopeoSource() *SkopeoSource {
 func (source *SkopeoSource) AddItem(name, digest, image string, tlsVerify *bool) {
 	item := NewSkopeoSourceItem(name, digest, tlsVerify)
 	if !skopeoDigestPattern.MatchString(image) {
-		panic("item has invalid image id")
+		panic(fmt.Errorf("item %#v has invalid image id", image))
 	}
 	source.Items[image] = item
 }

--- a/pkg/osbuild/skopeo_source_test.go
+++ b/pkg/osbuild/skopeo_source_test.go
@@ -1,10 +1,12 @@
 package osbuild
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/osbuild/images/internal/assertx"
 	"github.com/osbuild/images/internal/common"
 )
 
@@ -33,27 +35,30 @@ func TestNewSkopeoSource(t *testing.T) {
 	assert.Nil(t, item.Image.TLSVerify)
 
 	// empty name
-	assert.Panics(t, func() {
+	expectedErr := regexp.MustCompile(`source item osbuild.SkopeoSourceItem.* has empty name`)
+	assertx.PanicsWithErrorRegexp(t, expectedErr, func() {
 		source.AddItem("", testDigest, imageID, nil)
 	})
 
 	// empty digest
-	assert.Panics(t, func() {
+	expectedErr = regexp.MustCompile(`source item osbuild.SkopeoSourceItem.* has invalid digest`)
+	assertx.PanicsWithErrorRegexp(t, expectedErr, func() {
 		source.AddItem("name", "", imageID, nil)
 	})
 
 	// empty image id
-	assert.Panics(t, func() {
+	assert.PanicsWithError(t, `item "" has invalid image id`, func() {
 		source.AddItem("name", testDigest, "", nil)
 	})
 
 	// invalid digest
-	assert.Panics(t, func() {
+	expectedErr = regexp.MustCompile(`item osbuild.SkopeoSourceItem.* has invalid digest`)
+	assertx.PanicsWithErrorRegexp(t, expectedErr, func() {
 		source.AddItem("name", "foo", imageID, nil)
 	})
 
 	// invalid image id
-	assert.Panics(t, func() {
+	assert.PanicsWithError(t, `item "sha256:foo" has invalid image id`, func() {
 		source.AddItem("name", testDigest, "sha256:foo", nil)
 	})
 }


### PR DESCRIPTION
When trying to create enough data for a full pipeline run for https://github.com/osbuild/images/pull/287 I struggled a bit because it was not clear which items where faulty.

This commit adds more context to the errors. Sadly I had to implement `assertPanicsWithErrorRegexp` because of https://github.com/stretchr/testify/issues/1304

I can contribute it upstream but for that it needs some tests around it first :)