### PR TITLE
OpenSCAP tailoring: add key/value rule overrides

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-38": {
     "dependencies": {
       "osbuild": {
-        "commit": "f3d740aaf8531e55b99632f579f2fae13f1511b7"
+        "commit": "0767ebccc120eb4a43e274fec64eb95646a66761"
       }
     },
     "repos": [

--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -109,7 +109,7 @@ type ServicesCustomization struct {
 }
 
 type OpenSCAPCustomization struct {
-	DataStream string                           `json:"datastream,omitempty" toml:"datastream,omitempty"`
+	Datastream string                           `json:"datastream,omitempty" toml:"datastream,omitempty"`
 	ProfileID  string                           `json:"profile_id,omitempty" toml:"profile_id,omitempty"`
 	Tailoring  *OpenSCAPTailoringCustomizations `json:"tailoring,omitempty" toml:"tailoring,omitempty"`
 }

--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -108,17 +108,6 @@ type ServicesCustomization struct {
 	Disabled []string `json:"disabled,omitempty" toml:"disabled,omitempty"`
 }
 
-type OpenSCAPCustomization struct {
-	Datastream string                           `json:"datastream,omitempty" toml:"datastream,omitempty"`
-	ProfileID  string                           `json:"profile_id,omitempty" toml:"profile_id,omitempty"`
-	Tailoring  *OpenSCAPTailoringCustomizations `json:"tailoring,omitempty" toml:"tailoring,omitempty"`
-}
-
-type OpenSCAPTailoringCustomizations struct {
-	Selected   []string `json:"selected,omitempty" toml:"selected,omitempty"`
-	Unselected []string `json:"unselected,omitempty" toml:"unselected,omitempty"`
-}
-
 type CustomizationError struct {
 	Message string
 }
@@ -314,13 +303,6 @@ func (c *Customizations) GetFDO() *FDOCustomization {
 		return nil
 	}
 	return c.FDO
-}
-
-func (c *Customizations) GetOpenSCAP() *OpenSCAPCustomization {
-	if c == nil {
-		return nil
-	}
-	return c.OpenSCAP
 }
 
 func (c *Customizations) GetIgnition() *IgnitionCustomization {

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -371,23 +371,3 @@ func TestGetFilesystemsMinSizeNonSectorSize(t *testing.T) {
 
 	assert.EqualValues(t, uint64(5632), retFilesystemsSize)
 }
-
-func TestGetOpenSCAPConfig(t *testing.T) {
-
-	expectedOscap := OpenSCAPCustomization{
-		Datastream: "test-data-stream.xml",
-		ProfileID:  "test_profile",
-		Tailoring: &OpenSCAPTailoringCustomizations{
-			Selected:   []string{"quick_rule"},
-			Unselected: []string{"very_slow_rule"},
-		},
-	}
-
-	TestCustomizations := Customizations{
-		OpenSCAP: &expectedOscap,
-	}
-
-	retOpenSCAPCustomiztions := TestCustomizations.GetOpenSCAP()
-
-	assert.EqualValues(t, expectedOscap, *retOpenSCAPCustomiztions)
-}

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -375,7 +375,7 @@ func TestGetFilesystemsMinSizeNonSectorSize(t *testing.T) {
 func TestGetOpenSCAPConfig(t *testing.T) {
 
 	expectedOscap := OpenSCAPCustomization{
-		DataStream: "test-data-stream.xml",
+		Datastream: "test-data-stream.xml",
 		ProfileID:  "test_profile",
 		Tailoring: &OpenSCAPTailoringCustomizations{
 			Selected:   []string{"quick_rule"},

--- a/pkg/blueprint/openscap_customizations.go
+++ b/pkg/blueprint/openscap_customizations.go
@@ -1,0 +1,78 @@
+package blueprint
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type OpenSCAPCustomization struct {
+	Datastream string                           `json:"datastream,omitempty" toml:"datastream,omitempty"`
+	ProfileID  string                           `json:"profile_id,omitempty" toml:"profile_id,omitempty"`
+	Tailoring  *OpenSCAPTailoringCustomizations `json:"tailoring,omitempty" toml:"tailoring,omitempty"`
+}
+
+type OpenSCAPTailoringCustomizations struct {
+	Selected   []string                    `json:"selected,omitempty" toml:"selected,omitempty"`
+	Unselected []string                    `json:"unselected,omitempty" toml:"unselected,omitempty"`
+	Overrides  []OpenSCAPTailoringOverride `json:"overrides,omitempty" toml:"overrides,omitempty"`
+}
+
+type OpenSCAPTailoringOverride struct {
+	Var   string      `json:"var,omitempty" toml:"var,omitempty"`
+	Value interface{} `json:"value,omitempty" toml:"value,omitempty"`
+}
+
+func (c *Customizations) GetOpenSCAP() *OpenSCAPCustomization {
+	if c == nil {
+		return nil
+	}
+	return c.OpenSCAP
+}
+
+func (ot *OpenSCAPTailoringOverride) UnmarshalTOML(data interface{}) error {
+	d, _ := data.(map[string]interface{})
+
+	switch d["var"].(type) {
+	case string:
+		ot.Var = d["var"].(string)
+	default:
+		return fmt.Errorf("TOML unmarshal: override var must be string, got %v of type %T", d["var"], d["var"])
+	}
+
+	switch d["value"].(type) {
+	case int64:
+		ot.Value = uint64(d["value"].(int64))
+	case string:
+		ot.Value = d["value"].(string)
+	default:
+		return fmt.Errorf("TOML unmarshal: override value must be integer or string, got %v of type %T", d["value"], d["value"])
+	}
+
+	return nil
+}
+
+func (ot *OpenSCAPTailoringOverride) UnmarshalJSON(data []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	d, _ := v.(map[string]interface{})
+
+	switch d["var"].(type) {
+	case string:
+		ot.Var = d["var"].(string)
+	default:
+		return fmt.Errorf("JSON unmarshal: override var must be string, got %v of type %T", d["var"], d["var"])
+	}
+
+	switch d["value"].(type) {
+	case float64:
+		ot.Value = uint64(d["value"].(float64))
+	case string:
+		ot.Value = d["value"].(string)
+	default:
+		return fmt.Errorf("JSON unmarshal: override var must be float64 number or string, got %v of type %T", d["value"], d["value"])
+	}
+
+	return nil
+}

--- a/pkg/blueprint/openscap_customizations_test.go
+++ b/pkg/blueprint/openscap_customizations_test.go
@@ -1,0 +1,143 @@
+package blueprint
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOpenSCAPConfig(t *testing.T) {
+
+	expectedOscap := OpenSCAPCustomization{
+		Datastream: "test-data-stream.xml",
+		ProfileID:  "test_profile",
+		Tailoring: &OpenSCAPTailoringCustomizations{
+			Selected:   []string{"quick_rule"},
+			Unselected: []string{"very_slow_rule"},
+			Overrides: []OpenSCAPTailoringOverride{
+				OpenSCAPTailoringOverride{
+					Var:   "rule_id",
+					Value: 50,
+				},
+			},
+		},
+	}
+
+	TestCustomizations := Customizations{
+		OpenSCAP: &expectedOscap,
+	}
+
+	retOpenSCAPCustomiztions := TestCustomizations.GetOpenSCAP()
+
+	assert.EqualValues(t, expectedOscap, *retOpenSCAPCustomiztions)
+}
+
+func TestOpenSCAPOverrideTOMLUnmarshaler(t *testing.T) {
+	tests := []struct {
+		name    string
+		TOML    string
+		want    *OpenSCAPTailoringOverride
+		wantErr bool
+	}{
+		{
+			name: "string based rule",
+			TOML: `
+var = "sshd_idle_timeout_value"
+value = "600"
+			`,
+			want: &OpenSCAPTailoringOverride{
+				Var:   "sshd_idle_timeout_value",
+				Value: "600",
+			},
+			wantErr: false,
+		},
+		{
+			name: "integer based rule",
+			TOML: `
+var = "sshd_idle_timeout_value"
+value = 600
+			`,
+			want: &OpenSCAPTailoringOverride{
+				Var:   "sshd_idle_timeout_value",
+				Value: uint64(600),
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid rule",
+			TOML: `
+var = "sshd_idle_timeout_value"
+			`,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		var override OpenSCAPTailoringOverride
+		err := toml.Unmarshal([]byte(tt.TOML), &override)
+		if tt.wantErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.NotNil(t, override)
+			assert.Equal(t, tt.want, &override)
+		}
+	}
+}
+
+func TestOpenSCAPOverrideJSONUnmarshaler(t *testing.T) {
+	tests := []struct {
+		name    string
+		JSON    string
+		want    *OpenSCAPTailoringOverride
+		wantErr bool
+	}{
+		{
+			name: "string based rule",
+			JSON: `{
+				"var": "sshd_idle_timeout_value",
+				"value":  "600"
+			}`,
+			want: &OpenSCAPTailoringOverride{
+				Var:   "sshd_idle_timeout_value",
+				Value: "600",
+			},
+			wantErr: false,
+		},
+		{
+			name: "integer based rule",
+			JSON: `{
+				"var": "sshd_idle_timeout_value",
+				"value":  600
+			}`,
+			want: &OpenSCAPTailoringOverride{
+				Var:   "sshd_idle_timeout_value",
+				Value: uint64(600),
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid rule",
+			JSON: `{
+				"var": "sshd_idle_timeout_value"
+			}`,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		var override OpenSCAPTailoringOverride
+		err := json.Unmarshal([]byte(tt.JSON), &override)
+		if tt.wantErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.NotNil(t, override)
+			assert.Equal(t, tt.want, &override)
+		}
+	}
+}

--- a/pkg/customizations/oscap/oscap.go
+++ b/pkg/customizations/oscap/oscap.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/distro"
 )
 
@@ -41,7 +40,8 @@ const (
 	defaultRHEL8Datastream   string = "/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml"
 	defaultRHEL9Datastream   string = "/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml"
 
-	// tailoring directory path
+	// directory paths
+	dataDirPath      string = "/oscap_data"
 	tailoringDirPath string = "/usr/share/xml/osbuild-openscap-data"
 )
 
@@ -92,14 +92,8 @@ func IsProfileAllowed(profile string, allowlist []Profile) bool {
 	return false
 }
 
-func GetTailoringFile(profile string) (string, string, *fsnode.Directory, error) {
+func GetTailoringFile(profile string) (string, string) {
 	newProfile := fmt.Sprintf("%s_osbuild_tailoring", profile)
 	path := filepath.Join(tailoringDirPath, "tailoring.xml")
-
-	tailoringDir, err := fsnode.NewDirectory(tailoringDirPath, nil, nil, nil, true)
-	if err != nil {
-		return "", "", nil, err
-	}
-
-	return newProfile, path, tailoringDir, nil
+	return newProfile, path
 }

--- a/pkg/customizations/oscap/oscap.go
+++ b/pkg/customizations/oscap/oscap.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/osbuild/images/pkg/customizations/fsnode"
+	"github.com/osbuild/images/pkg/distro"
 )
 
 type Profile string
@@ -44,22 +45,35 @@ const (
 	tailoringDirPath string = "/usr/share/xml/osbuild-openscap-data"
 )
 
-func DefaultFedoraDatastream() string {
-	return defaultFedoraDatastream
-}
-
-func DefaultRHEL8Datastream(isRHEL bool) string {
-	if isRHEL {
-		return defaultRHEL8Datastream
+func GetDatastream(datastream string, d distro.Distro) string {
+	if datastream != "" {
+		return datastream
 	}
-	return defaultCentos8Datastream
+
+	s := strings.ToLower(d.Name())
+	if strings.HasPrefix(s, "fedora") {
+		return defaultFedoraDatastream
+	}
+
+	if strings.HasPrefix(s, "centos") {
+		return defaultCentosDatastream(d.Releasever())
+	}
+
+	return defaultRHELDatastream(d.Releasever())
 }
 
-func DefaultRHEL9Datastream(isRHEL bool) string {
-	if isRHEL {
-		return defaultRHEL9Datastream
+func defaultCentosDatastream(releaseVer string) string {
+	if releaseVer == "8" {
+		return defaultCentos8Datastream
 	}
 	return defaultCentos9Datastream
+}
+
+func defaultRHELDatastream(releaseVer string) string {
+	if releaseVer == "8" {
+		return defaultRHEL8Datastream
+	}
+	return defaultRHEL9Datastream
 }
 
 func IsProfileAllowed(profile string, allowlist []Profile) bool {

--- a/pkg/customizations/oscap/oscap.go
+++ b/pkg/customizations/oscap/oscap.go
@@ -1,8 +1,6 @@
 package oscap
 
 import (
-	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/osbuild/images/pkg/distro"
@@ -90,10 +88,4 @@ func IsProfileAllowed(profile string, allowlist []Profile) bool {
 	}
 
 	return false
-}
-
-func GetTailoringFile(profile string) (string, string) {
-	newProfile := fmt.Sprintf("%s_osbuild_tailoring", profile)
-	path := filepath.Join(tailoringDirPath, "tailoring.xml")
-	return newProfile, path
 }

--- a/pkg/customizations/oscap/oscap.go
+++ b/pkg/customizations/oscap/oscap.go
@@ -43,7 +43,7 @@ const (
 	tailoringDirPath string = "/usr/share/xml/osbuild-openscap-data"
 )
 
-func GetDatastream(datastream string, d distro.Distro) string {
+func getDatastream(datastream string, d distro.Distro) string {
 	if datastream != "" {
 		return datastream
 	}

--- a/pkg/customizations/oscap/stage_options.go
+++ b/pkg/customizations/oscap/stage_options.go
@@ -1,0 +1,31 @@
+package oscap
+
+import (
+	"fmt"
+
+	"github.com/osbuild/images/pkg/customizations/fsnode"
+)
+
+func CreateRequiredDirectories(createTailoring bool) ([]*fsnode.Directory, error) {
+	var directories []*fsnode.Directory
+
+	// although the osbuild stage will create this directory,
+	// it's probably better to ensure that it is created here
+	dataDirNode, err := fsnode.NewDirectory(dataDirPath, nil, nil, nil, true)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error creating OpenSCAP data directory: %s", err)
+	}
+
+	directories = append(directories, dataDirNode)
+
+	if createTailoring {
+		tailoringDirNode, err := fsnode.NewDirectory(tailoringDirPath, nil, nil, nil, true)
+		if err != nil {
+			return nil, fmt.Errorf("unexpected error creating OpenSCAP tailoring directory: %s", err)
+		}
+
+		directories = append(directories, tailoringDirNode)
+	}
+
+	return directories, nil
+}

--- a/pkg/customizations/oscap/stage_options.go
+++ b/pkg/customizations/oscap/stage_options.go
@@ -53,6 +53,14 @@ func CreateTailoringStageOptions(oscapConfig *blueprint.OpenSCAPCustomization, d
 	newProfile := getTailoringProfileID(oscapConfig.ProfileID)
 	path := filepath.Join(tailoringDirPath, "tailoring.xml")
 
+	var overrides []osbuild.OscapAutotailorOverride
+	for _, override := range tailoringConfig.Overrides {
+		overrides = append(overrides, osbuild.OscapAutotailorOverride{
+			Var:   override.Var,
+			Value: override.Value,
+		})
+	}
+
 	return osbuild.NewOscapAutotailorStageOptions(
 		path,
 		osbuild.OscapAutotailorConfig{
@@ -60,6 +68,7 @@ func CreateTailoringStageOptions(oscapConfig *blueprint.OpenSCAPCustomization, d
 			Datastream: datastream,
 			Selected:   tailoringConfig.Selected,
 			Unselected: tailoringConfig.Unselected,
+			Overrides:  overrides,
 			NewProfile: newProfile,
 		},
 	)

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -38,9 +38,6 @@ const (
 
 	// Added kernel command line options for ami, qcow2, openstack, vhd and vmdk types
 	cloudKernelOptions = "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
-
-	// location for saving openscap remediation data
-	oscapDataDir = "/oscap_data"
 )
 
 var (

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -175,10 +175,7 @@ func osCustomizations(
 
 		osc.Directories = append(osc.Directories, dataDirNode)
 
-		var datastream = oscapConfig.DataStream
-		if datastream == "" {
-			datastream = oscap.DefaultFedoraDatastream()
-		}
+		datastream := oscap.GetDatastream(oscapConfig.Datastream, t.arch.distro)
 
 		oscapStageOptions := osbuild.OscapConfig{
 			Datastream:  datastream,

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -166,15 +166,6 @@ func osCustomizations(
 			panic("unexpected oscap options for ostree image type")
 		}
 
-		// although the osbuild stage will create this directory,
-		// it's probably better to ensure that it is created here
-		dataDirNode, err := fsnode.NewDirectory(oscapDataDir, nil, nil, nil, true)
-		if err != nil {
-			panic("unexpected error creating OpenSCAP data directory")
-		}
-
-		osc.Directories = append(osc.Directories, dataDirNode)
-
 		datastream := oscap.GetDatastream(oscapConfig.Datastream, t.arch.distro)
 
 		oscapStageOptions := osbuild.OscapConfig{
@@ -184,10 +175,7 @@ func osCustomizations(
 		}
 
 		if oscapConfig.Tailoring != nil {
-			newProfile, tailoringFilepath, tailoringDir, err := oscap.GetTailoringFile(oscapConfig.ProfileID)
-			if err != nil {
-				panic(fmt.Sprintf("unexpected error creating tailoring file options: %v", err))
-			}
+			newProfile, tailoringFilepath := oscap.GetTailoringFile(oscapConfig.ProfileID)
 
 			tailoringOptions := osbuild.OscapAutotailorConfig{
 				NewProfile: newProfile,
@@ -205,9 +193,15 @@ func osCustomizations(
 			// overwrite the profile id with the new tailoring id
 			oscapStageOptions.ProfileID = newProfile
 			oscapStageOptions.Tailoring = tailoringFilepath
+		}
 
-			// add the parent directory for the tailoring file
-			osc.Directories = append(osc.Directories, tailoringDir)
+		directories, err := oscap.CreateRequiredDirectories(oscapConfig.Tailoring != nil)
+		if err != nil {
+			panic(err)
+		}
+
+		if len(directories) > 0 {
+			osc.Directories = append(osc.Directories, directories...)
 		}
 
 		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscapDataDir, oscapStageOptions)

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -174,25 +174,14 @@ func osCustomizations(
 			Compression: true,
 		}
 
-		if oscapConfig.Tailoring != nil {
-			newProfile, tailoringFilepath := oscap.GetTailoringFile(oscapConfig.ProfileID)
+		osc.OpenSCAPTailorConfig = oscap.CreateTailoringStageOptions(
+			oscapConfig,
+			t.arch.distro,
+		)
 
-			tailoringOptions := osbuild.OscapAutotailorConfig{
-				NewProfile: newProfile,
-				Datastream: datastream,
-				ProfileID:  oscapConfig.ProfileID,
-				Selected:   oscapConfig.Tailoring.Selected,
-				Unselected: oscapConfig.Tailoring.Unselected,
-			}
-
-			osc.OpenSCAPTailorConfig = osbuild.NewOscapAutotailorStageOptions(
-				tailoringFilepath,
-				tailoringOptions,
-			)
-
-			// overwrite the profile id with the new tailoring id
-			oscapStageOptions.ProfileID = newProfile
-			oscapStageOptions.Tailoring = tailoringFilepath
+		if tailorConfig := osc.OpenSCAPTailorConfig; tailorConfig != nil {
+			oscapStageOptions.ProfileID = tailorConfig.Config.NewProfile
+			oscapStageOptions.Tailoring = tailorConfig.Filepath
 		}
 
 		directories, err := oscap.CreateRequiredDirectories(oscapConfig.Tailoring != nil)

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -161,39 +161,22 @@ func osCustomizations(
 		osc.YUMRepos = append(osc.YUMRepos, osbuild.NewYumReposStageOptions(filename, repos))
 	}
 
-	if oscapConfig := c.GetOpenSCAP(); oscapConfig != nil {
-		if t.rpmOstree {
-			panic("unexpected oscap options for ostree image type")
-		}
+	var directories []*fsnode.Directory
+	osc.OpenSCAPTailorConfig = oscap.CreateTailoringStageOptions(
+		c.GetOpenSCAP(),
+		t.arch.distro,
+	)
+	osc.OpenSCAPConfig, directories, err = oscap.CreateRemediationStageOptions(
+		c.GetOpenSCAP(),
+		t.rpmOstree,
+		t.arch.distro,
+	)
+	if err != nil {
+		panic(err)
+	}
 
-		datastream := oscap.GetDatastream(oscapConfig.Datastream, t.arch.distro)
-
-		oscapStageOptions := osbuild.OscapConfig{
-			Datastream:  datastream,
-			ProfileID:   oscapConfig.ProfileID,
-			Compression: true,
-		}
-
-		osc.OpenSCAPTailorConfig = oscap.CreateTailoringStageOptions(
-			oscapConfig,
-			t.arch.distro,
-		)
-
-		if tailorConfig := osc.OpenSCAPTailorConfig; tailorConfig != nil {
-			oscapStageOptions.ProfileID = tailorConfig.Config.NewProfile
-			oscapStageOptions.Tailoring = tailorConfig.Filepath
-		}
-
-		directories, err := oscap.CreateRequiredDirectories(oscapConfig.Tailoring != nil)
-		if err != nil {
-			panic(err)
-		}
-
-		if len(directories) > 0 {
-			osc.Directories = append(osc.Directories, directories...)
-		}
-
-		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscapDataDir, oscapStageOptions)
+	if len(directories) > 0 {
+		osc.Directories = append(osc.Directories, directories...)
 	}
 
 	osc.ShellInit = imageConfig.ShellInit

--- a/pkg/distro/rhel7/images.go
+++ b/pkg/distro/rhel7/images.go
@@ -133,7 +133,7 @@ func osCustomizations(
 		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(
 			oscapDataDir,
 			osbuild.OscapConfig{
-				Datastream:  oscapConfig.DataStream,
+				Datastream:  oscapConfig.Datastream,
 				ProfileID:   oscapConfig.ProfileID,
 				Compression: true,
 			},

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -196,10 +196,7 @@ func osCustomizations(
 
 		osc.Directories = append(osc.Directories, dataDirNode)
 
-		var datastream = oscapConfig.DataStream
-		if datastream == "" {
-			datastream = oscap.DefaultRHEL8Datastream(t.arch.distro.isRHEL())
-		}
+		datastream := oscap.GetDatastream(oscapConfig.Datastream, t.arch.distro)
 
 		oscapStageOptions := osbuild.OscapConfig{
 			Datastream:  datastream,

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -187,15 +187,6 @@ func osCustomizations(
 			panic("unexpected oscap options for ostree image type")
 		}
 
-		// although the osbuild stage will create this directory,
-		// it's probably better to ensure that it is created here
-		dataDirNode, err := fsnode.NewDirectory(oscapDataDir, nil, nil, nil, true)
-		if err != nil {
-			panic("unexpected error creating OpenSCAP data directory")
-		}
-
-		osc.Directories = append(osc.Directories, dataDirNode)
-
 		datastream := oscap.GetDatastream(oscapConfig.Datastream, t.arch.distro)
 
 		oscapStageOptions := osbuild.OscapConfig{
@@ -205,10 +196,7 @@ func osCustomizations(
 		}
 
 		if oscapConfig.Tailoring != nil {
-			newProfile, tailoringFilepath, tailoringDir, err := oscap.GetTailoringFile(oscapConfig.ProfileID)
-			if err != nil {
-				panic(fmt.Sprintf("unexpected error creating tailoring file options: %v", err))
-			}
+			newProfile, tailoringFilepath := oscap.GetTailoringFile(oscapConfig.ProfileID)
 
 			tailoringOptions := osbuild.OscapAutotailorConfig{
 				NewProfile: newProfile,
@@ -226,11 +214,16 @@ func osCustomizations(
 			// overwrite the profile id with the new tailoring id
 			oscapStageOptions.ProfileID = newProfile
 			oscapStageOptions.Tailoring = tailoringFilepath
-
-			// add the parent directory for the tailoring file
-			osc.Directories = append(osc.Directories, tailoringDir)
 		}
 
+		directories, err := oscap.CreateRequiredDirectories(oscapConfig.Tailoring != nil)
+		if err != nil {
+			panic(err)
+		}
+
+		if len(directories) > 0 {
+			osc.Directories = append(osc.Directories, directories...)
+		}
 		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscapDataDir, oscapStageOptions)
 	}
 

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -195,25 +195,14 @@ func osCustomizations(
 			Compression: true,
 		}
 
-		if oscapConfig.Tailoring != nil {
-			newProfile, tailoringFilepath := oscap.GetTailoringFile(oscapConfig.ProfileID)
+		osc.OpenSCAPTailorConfig = oscap.CreateTailoringStageOptions(
+			oscapConfig,
+			t.arch.distro,
+		)
 
-			tailoringOptions := osbuild.OscapAutotailorConfig{
-				NewProfile: newProfile,
-				Datastream: datastream,
-				ProfileID:  oscapConfig.ProfileID,
-				Selected:   oscapConfig.Tailoring.Selected,
-				Unselected: oscapConfig.Tailoring.Unselected,
-			}
-
-			osc.OpenSCAPTailorConfig = osbuild.NewOscapAutotailorStageOptions(
-				tailoringFilepath,
-				tailoringOptions,
-			)
-
-			// overwrite the profile id with the new tailoring id
-			oscapStageOptions.ProfileID = newProfile
-			oscapStageOptions.Tailoring = tailoringFilepath
+		if tailorConfig := osc.OpenSCAPTailorConfig; tailorConfig != nil {
+			oscapStageOptions.ProfileID = tailorConfig.Config.NewProfile
+			oscapStageOptions.Tailoring = tailorConfig.Filepath
 		}
 
 		directories, err := oscap.CreateRequiredDirectories(oscapConfig.Tailoring != nil)

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -182,38 +182,22 @@ func osCustomizations(
 		osc.YUMRepos = append(osc.YUMRepos, osbuild.NewYumReposStageOptions(filename, repos))
 	}
 
-	if oscapConfig := c.GetOpenSCAP(); oscapConfig != nil {
-		if t.rpmOstree {
-			panic("unexpected oscap options for ostree image type")
-		}
+	var directories []*fsnode.Directory
+	osc.OpenSCAPTailorConfig = oscap.CreateTailoringStageOptions(
+		c.GetOpenSCAP(),
+		t.arch.distro,
+	)
+	osc.OpenSCAPConfig, directories, err = oscap.CreateRemediationStageOptions(
+		c.GetOpenSCAP(),
+		t.rpmOstree,
+		t.arch.distro,
+	)
+	if err != nil {
+		panic(err)
+	}
 
-		datastream := oscap.GetDatastream(oscapConfig.Datastream, t.arch.distro)
-
-		oscapStageOptions := osbuild.OscapConfig{
-			Datastream:  datastream,
-			ProfileID:   oscapConfig.ProfileID,
-			Compression: true,
-		}
-
-		osc.OpenSCAPTailorConfig = oscap.CreateTailoringStageOptions(
-			oscapConfig,
-			t.arch.distro,
-		)
-
-		if tailorConfig := osc.OpenSCAPTailorConfig; tailorConfig != nil {
-			oscapStageOptions.ProfileID = tailorConfig.Config.NewProfile
-			oscapStageOptions.Tailoring = tailorConfig.Filepath
-		}
-
-		directories, err := oscap.CreateRequiredDirectories(oscapConfig.Tailoring != nil)
-		if err != nil {
-			panic(err)
-		}
-
-		if len(directories) > 0 {
-			osc.Directories = append(osc.Directories, directories...)
-		}
-		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscapDataDir, oscapStageOptions)
+	if len(directories) > 0 {
+		osc.Directories = append(osc.Directories, directories...)
 	}
 
 	osc.ShellInit = imageConfig.ShellInit

--- a/pkg/distro/rhel8/imagetype.go
+++ b/pkg/distro/rhel8/imagetype.go
@@ -37,9 +37,6 @@ const (
 
 	// blueprint package set name
 	blueprintPkgsKey = "blueprint"
-
-	// location for saving openscap remediation data
-	oscapDataDir = "/oscap_data"
 )
 
 type imageFunc func(workload workload.Workload, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, packageSets map[string]rpmmd.PackageSet, containers []container.SourceSpec, rng *rand.Rand) (image.ImageKind, error)

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -192,25 +192,14 @@ func osCustomizations(
 			Compression: true,
 		}
 
-		if oscapConfig.Tailoring != nil {
-			newProfile, tailoringFilepath := oscap.GetTailoringFile(oscapConfig.ProfileID)
+		osc.OpenSCAPTailorConfig = oscap.CreateTailoringStageOptions(
+			oscapConfig,
+			t.arch.distro,
+		)
 
-			tailoringOptions := osbuild.OscapAutotailorConfig{
-				NewProfile: newProfile,
-				Datastream: datastream,
-				ProfileID:  oscapConfig.ProfileID,
-				Selected:   oscapConfig.Tailoring.Selected,
-				Unselected: oscapConfig.Tailoring.Unselected,
-			}
-
-			osc.OpenSCAPTailorConfig = osbuild.NewOscapAutotailorStageOptions(
-				tailoringFilepath,
-				tailoringOptions,
-			)
-
-			// overwrite the profile id with the new tailoring id
-			oscapStageOptions.ProfileID = newProfile
-			oscapStageOptions.Tailoring = tailoringFilepath
+		if tailorConfig := osc.OpenSCAPTailorConfig; tailorConfig != nil {
+			oscapStageOptions.ProfileID = tailorConfig.Config.NewProfile
+			oscapStageOptions.Tailoring = tailorConfig.Filepath
 		}
 
 		directories, err := oscap.CreateRequiredDirectories(oscapConfig.Tailoring == nil)

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -193,10 +193,7 @@ func osCustomizations(
 
 		osc.Directories = append(osc.Directories, dataDirNode)
 
-		var datastream = oscapConfig.DataStream
-		if datastream == "" {
-			datastream = oscap.DefaultRHEL9Datastream(t.arch.distro.isRHEL())
-		}
+		var datastream = oscap.GetDatastream(oscapConfig.Datastream, t.arch.distro)
 
 		oscapStageOptions := osbuild.OscapConfig{
 			Datastream:  datastream,

--- a/pkg/distro/rhel9/imagetype.go
+++ b/pkg/distro/rhel9/imagetype.go
@@ -40,9 +40,6 @@ const (
 
 	// blueprint package set name
 	blueprintPkgsKey = "blueprint"
-
-	// location for saving openscap remediation data
-	oscapDataDir = "/oscap_data"
 )
 
 type imageFunc func(workload workload.Workload, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, packageSets map[string]rpmmd.PackageSet, containers []container.SourceSpec, rng *rand.Rand) (image.ImageKind, error)

--- a/pkg/osbuild/oscap_autotailor_stage.go
+++ b/pkg/osbuild/oscap_autotailor_stage.go
@@ -8,11 +8,17 @@ type OscapAutotailorStageOptions struct {
 }
 
 type OscapAutotailorConfig struct {
-	NewProfile string   `json:"new_profile"`
-	Datastream string   `json:"datastream" toml:"datastream"`
-	ProfileID  string   `json:"profile_id" toml:"profile_id"`
-	Selected   []string `json:"selected,omitempty"`
-	Unselected []string `json:"unselected,omitempty"`
+	NewProfile string                    `json:"new_profile"`
+	Datastream string                    `json:"datastream" toml:"datastream"`
+	ProfileID  string                    `json:"profile_id" toml:"profile_id"`
+	Selected   []string                  `json:"selected,omitempty"`
+	Unselected []string                  `json:"unselected,omitempty"`
+	Overrides  []OscapAutotailorOverride `json:"overrides,omitempty"`
+}
+
+type OscapAutotailorOverride struct {
+	Var   string      `json:"var"`
+	Value interface{} `json:"value"`
 }
 
 func (OscapAutotailorStageOptions) isStageOptions() {}
@@ -26,6 +32,17 @@ func (c OscapAutotailorConfig) validate() error {
 	}
 	if c.NewProfile == "" {
 		return fmt.Errorf("'new_profile' must be specified")
+	}
+	for _, override := range c.Overrides {
+		if _, ok := override.Value.(uint64); ok {
+			continue
+		}
+
+		if _, ok := override.Value.(string); ok {
+			continue
+		}
+
+		return fmt.Errorf("override 'value' must be an integere or a string")
 	}
 	return nil
 }
@@ -50,6 +67,7 @@ func NewOscapAutotailorStageOptions(filepath string, autotailorOptions OscapAuto
 			ProfileID:  autotailorOptions.ProfileID,
 			Selected:   autotailorOptions.Selected,
 			Unselected: autotailorOptions.Unselected,
+			Overrides:  autotailorOptions.Overrides,
 		},
 	}
 }

--- a/pkg/osbuild/oscap_autotailor_stage_test.go
+++ b/pkg/osbuild/oscap_autotailor_stage_test.go
@@ -15,6 +15,12 @@ func TestNewOscapAutotailorStage(t *testing.T) {
 			NewProfile: "test_profile_osbuild_profile",
 			Selected:   []string{"fast_rule"},
 			Unselected: []string{"slow_rule"},
+			Overrides: []OscapAutotailorOverride{
+				{
+					Var:   "rule1",
+					Value: "value1",
+				},
+			},
 		},
 	}
 
@@ -64,6 +70,56 @@ func TestOscapAutotailorStageOptionsValidate(t *testing.T) {
 				},
 			},
 			err: true,
+		},
+		{
+			name: "invalid-override-value",
+			options: OscapAutotailorStageOptions{
+				Config: OscapAutotailorConfig{
+					ProfileID:  "test-profile",
+					Datastream: "test-datastream",
+					NewProfile: "test-profile-osbuild-profile",
+					Overrides: []OscapAutotailorOverride{
+						{
+							Var: "test-var",
+						},
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "invalid-override-value-string",
+			options: OscapAutotailorStageOptions{
+				Config: OscapAutotailorConfig{
+					ProfileID:  "test-profile",
+					Datastream: "test-datastream",
+					NewProfile: "test-profile-osbuild-profile",
+					Overrides: []OscapAutotailorOverride{
+						{
+							Var:   "test-var",
+							Value: "30",
+						},
+					},
+				},
+			},
+			err: false,
+		},
+		{
+			name: "valid-override-value-int",
+			options: OscapAutotailorStageOptions{
+				Config: OscapAutotailorConfig{
+					ProfileID:  "test-profile",
+					Datastream: "test-datastream",
+					NewProfile: "test-profile-osbuild-profile",
+					Overrides: []OscapAutotailorOverride{
+						{
+							Var:   "test-var",
+							Value: uint64(30),
+						},
+					},
+				},
+			},
+			err: false,
 		},
 		{
 			name: "valid-data",

--- a/test/configs/all-with-oscap.json
+++ b/test/configs/all-with-oscap.json
@@ -9,6 +9,10 @@
       {
         "name": "bluez",
         "version": "*"
+      },
+      {
+        "name": "openscap-utils",
+        "version": "*"
       }
     ],
     "modules": [],
@@ -146,6 +150,12 @@
           "unselected": [
             "rpm_verify_hashes",
             "enable_fips_mode"
+          ],
+          "overrides": [
+            {
+              "var": "sshd_idle_timeout_value",
+              "value": 600
+            }
           ]
         }
       }


### PR DESCRIPTION
Expose a field in the blueprints to be able to override rule values
using the OpenSCAP autotailor feature. The customization exposes an
array with two values, the name of the var to overwrite and the value
to write to the var.

This depends on https://github.com/osbuild/osbuild/pull/1407
Jira: https://issues.redhat.com/browse/COMPOSER-1994