### PR TITLE
pkg: test that "empty" RepoConfig marshal to "empty" json

### DIFF
--- a/pkg/dnfjson/dnfjson_test.go
+++ b/pkg/dnfjson/dnfjson_test.go
@@ -1,6 +1,7 @@
 package dnfjson
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -661,4 +662,11 @@ func TestRequestHash(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 64, len(req.Hash()))
 	assert.NotEqual(t, hash, req.Hash())
+}
+
+func TestRepoConfigMarshalAlsmostEmpty(t *testing.T) {
+	repoCfg := &repoConfig{}
+	js, _ := json.Marshal(repoCfg)
+	// double check here that anything that uses pointers has "omitempty" set
+	assert.Equal(t, string(js), `{"id":"","gpgcheck":false,"check_repogpg":false,"ignoressl":false}`)
 }

--- a/pkg/rpmmd/repository_test.go
+++ b/pkg/rpmmd/repository_test.go
@@ -1,6 +1,7 @@
 package rpmmd
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,7 +27,6 @@ func TestPackageSpecGetEVRA(t *testing.T) {
 
 	assert.Equal(t, "3.3a-3.fc38.x86_64", specs[0].GetEVRA())
 	assert.Equal(t, "1:2.06-94.fc38.noarch", specs[1].GetEVRA())
-
 }
 
 func TestPackageSpecGetNEVRA(t *testing.T) {
@@ -49,5 +49,10 @@ func TestPackageSpecGetNEVRA(t *testing.T) {
 
 	assert.Equal(t, "tmux-3.3a-3.fc38.x86_64", specs[0].GetNEVRA())
 	assert.Equal(t, "grub2-1:2.06-94.fc38.noarch", specs[1].GetNEVRA())
+}
 
+func TestRepoConfigMarshalEmpty(t *testing.T) {
+	repoCfg := &RepoConfig{}
+	js, _ := json.Marshal(repoCfg)
+	assert.Equal(t, string(js), `{}`)
 }


### PR DESCRIPTION
This is a regression test for an issue found during the review of PR#284 [0]. The issue was that
```
	ModuleHotfixes *bool    `json:"module_hotfixes"`
```
lacked the required `omitempty` which may cause issues with dnfjson.

As a quick and easy way to prevent this in the future this commit adds a small test that ensures that we notice any missing `omitempty`.

Note that the `rpmmd` part is not strictly needed but it feels more correct to do the check in both places that use a repoConfig.

[0] https://github.com/osbuild/images/pull/284#discussion_r1414048979