### PR TITLE
osbuild: remove unused `ContainersInputs` (note the *s*)

### DIFF
--- a/pkg/osbuild/containers_input.go
+++ b/pkg/osbuild/containers_input.go
@@ -46,6 +46,4 @@ func NewContainersInputForSources(containers []container.Spec) ContainersInput {
 	}
 }
 
-type ContainersInputs map[string]ContainersInput
-
-func (c ContainersInputs) isStageInputs() {}
+func (c ContainersInput) isStageInputs() {}


### PR DESCRIPTION
I noticed this while working on adding support for build roots from container inputs. It looks like an oversight but I wanted to open it as it's own PR so that it does not get lost in the noise of the followup :)

Draft for now as I want to see the testsuite finish first (locally everything seems fine and AFACIT nothing imports this type but maybe I'm missing something?).

---

This commit removes the unused ContainersInputs and moves the `isStageInputs()` function to `ContainersInput` (not the missing *s* at the end).

The type/function looks like an oversight/leftover, I did a `git grep` and `grep -r` accross our repos and AFAICT the type is not used.

