### PR TITLE
dnfjson: skip TestDepsolver() if no osbuild-depsolve-dnf is installed

### DIFF
--- a/pkg/dnfjson/dnfjson.go
+++ b/pkg/dnfjson/dnfjson.go
@@ -66,7 +66,6 @@ func findDepsolveDnf() string {
 func NewBaseSolver(cacheDir string) *BaseSolver {
 	return &BaseSolver{
 		cache:       newRPMCache(cacheDir, 1024*1024*1024), // 1 GiB
-		dnfJsonCmd:  []string{findDepsolveDnf()},
 		resultCache: NewDNFCache(60 * time.Second),
 	}
 }
@@ -636,6 +635,9 @@ func ParseError(data []byte) Error {
 }
 
 func run(dnfJsonCmd []string, req *Request) ([]byte, error) {
+	if len(dnfJsonCmd) == 0 {
+		dnfJsonCmd = []string{findDepsolveDnf()}
+	}
 	if len(dnfJsonCmd) == 0 {
 		return nil, fmt.Errorf("osbuild-depsolve-dnf command undefined")
 	}

--- a/pkg/dnfjson/dnfjson.go
+++ b/pkg/dnfjson/dnfjson.go
@@ -57,7 +57,7 @@ func findDepsolveDnf() string {
 
 	// if it's not found, return empty string; the run() function will fail if
 	// it's used before setting.
-	return locations[0]
+	return ""
 }
 
 // Create a new unconfigured BaseSolver (without platform information). It can

--- a/pkg/dnfjson/dnfjson_test.go
+++ b/pkg/dnfjson/dnfjson_test.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"os"
-	"os/exec"
 	"strings"
 	"testing"
 
@@ -17,23 +15,9 @@ import (
 
 var forceDNF = flag.Bool("force-dnf", false, "force dnf testing, making them fail instead of skip if dnf isn't installed")
 
-func dnfInstalled() bool {
-	cmd := exec.Command("python3", "-c", "import dnf")
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to import dnf: %s\n", err.Error())
-		return false
-	}
-	return true
-}
-
 func TestDepsolver(t *testing.T) {
 	if !*forceDNF {
 		// dnf tests aren't forced: skip them if the dnf sniff check fails
-		if !dnfInstalled() {
-			t.Skip()
-		}
-
 		if findDepsolveDnf() == "" {
 			t.Skip("Test needs an installed osbuild-depsolve-dnf")
 		}
@@ -559,10 +543,6 @@ func expectedResult(repo rpmmd.RepoConfig) []rpmmd.PackageSpec {
 func TestErrorRepoInfo(t *testing.T) {
 	if !*forceDNF {
 		// dnf tests aren't forced: skip them if the dnf sniff check fails
-		if !dnfInstalled() {
-			t.Skip()
-		}
-
 		if findDepsolveDnf() == "" {
 			t.Skip("Test needs an installed osbuild-depsolve-dnf")
 		}

--- a/pkg/dnfjson/dnfjson_test.go
+++ b/pkg/dnfjson/dnfjson_test.go
@@ -33,6 +33,10 @@ func TestDepsolver(t *testing.T) {
 		if !dnfInstalled() {
 			t.Skip()
 		}
+
+		if findDepsolveDnf() == "" {
+			t.Skip("Test needs an installed osbuild-depsolve-dnf")
+		}
 	}
 
 	s := rpmrepo.NewTestServer()
@@ -557,6 +561,10 @@ func TestErrorRepoInfo(t *testing.T) {
 		// dnf tests aren't forced: skip them if the dnf sniff check fails
 		if !dnfInstalled() {
 			t.Skip()
+		}
+
+		if findDepsolveDnf() == "" {
+			t.Skip("Test needs an installed osbuild-depsolve-dnf")
 		}
 	}
 


### PR DESCRIPTION
Do not fail if `osbuild-depsolve-dnf` is missing.

It also fixes `dnfjson.go` so that the comment (and I think intention) matches the code :)

