### PR TITLE
test: change default S3 bucket

### DIFF
--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -9,7 +9,7 @@ TEST_CACHE_ROOT = ".cache/osbuild-images"
 CONFIGS_PATH = "./test/configs"
 CONFIG_MAP = "./test/config-map.json"
 
-S3_BUCKET = "s3://{bucket}".format(bucket=os.environ.get("AWS_BUCKET", "image-builder-ci-artifacts"))
+S3_BUCKET = "s3://{bucket}".format(bucket=os.environ.get("AWS_BUCKET", "images-ci-cache"))
 S3_PREFIX = "images/builds"
 
 REGISTRY = "registry.gitlab.com/redhat/services/products/image-builder/ci/images"

--- a/test/scripts/upload-results
+++ b/test/scripts/upload-results
@@ -42,8 +42,8 @@ def main():
         with open(info_path, "w") as info_fp:
             json.dump(build_info, info_fp, indent=2)
 
-    bucket = os.environ.get("AWS_BUCKET", "image-builder-ci-artifacts")
-    s3url = f"s3://{bucket}/images/builds/{distro}/{arch}/{manifest_id}/"
+    bucket = testlib.S3_BUCKET
+    s3url = f"{bucket}/images/builds/{distro}/{arch}/{manifest_id}/"
 
     print(f"⬆️ Uploading {build_dir} to {s3url}")
     testlib.runcmd(["s3cmd", *testlib.s3_auth_args(), "--acl-private", "put", "--recursive", build_dir+"/", s3url])


### PR DESCRIPTION
Default S3 bucket is now a dedicated one for the repo's CI cache called 'images-ci-cache'.

Use the value from the imgtestlib module in the upload-results scripts too.  Now the default bucket name is only specified in one location.