### PR TITLE
Set RNG seed for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,6 +119,25 @@ jobs:
         # allow seemingly unreachable commands
         SHELLCHECK_OPTS: -e SC1091 -e SC2002 -e SC2317
 
+  python-test:
+    name: "🐍 pytest (imgtestlib)"
+    runs-on: ubuntu-latest
+    container:
+      image: registry.fedoraproject.org/fedora:latest
+    steps:
+
+      - name: Install build and test dependencies
+        run: dnf -y install python3-pytest
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Testing imgtestlib
+        run: |
+          python3 -m pytest -v
+
   python-lint:
     name: "🐍 Lint (test scripts)"
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,3 +118,22 @@ jobs:
         # don't check /etc/os-release sourcing, allow useless cats to live inside our codebase, and
         # allow seemingly unreachable commands
         SHELLCHECK_OPTS: -e SC1091 -e SC2002 -e SC2317
+
+  python-lint:
+    name: "🐍 Lint (test scripts)"
+    runs-on: ubuntu-latest
+    container:
+      image: registry.fedoraproject.org/fedora:latest
+    steps:
+
+      - name: Install build and test dependencies
+        run: dnf -y install python3-pylint git-core grep
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Analysing the code with pylint
+        run: |
+          python3 -m pylint $(grep -l python -r test/scripts) test/scripts/*.py

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,4 +4,7 @@ max-line-length=120
 [MESSAGES CONTROL]
 disable=missing-module-docstring,
     missing-class-docstring,
-    missing-function-docstring
+    missing-function-docstring,
+    too-many-locals,
+    invalid-name,
+    duplicate-code

--- a/Schutzfile
+++ b/Schutzfile
@@ -1,4 +1,5 @@
 {
+  "rngseed": 0,
   "fedora-38": {
     "dependencies": {
       "osbuild": {

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -288,22 +288,17 @@ func main() {
 
 	fmt.Printf("Generating manifest for %s: ", config.Name)
 	mf, err := makeManifest(imgType, config, distribution, repos, archName, rngSeed, rpmCacheRoot)
-	if err != nil {
-		check(err)
-	}
+	check(err)
 	fmt.Print("DONE\n")
 
 	manifestPath := filepath.Join(buildDir, "manifest.json")
-	if err := save(mf, manifestPath); err != nil {
-		check(err)
-	}
+	check(save(mf, manifestPath))
 
 	fmt.Printf("Building manifest: %s\n", manifestPath)
 
 	jobOutput := filepath.Join(outputDir, buildName)
-	if _, err := osbuild.RunOSBuild(mf, osbuildStore, jobOutput, imgType.Exports(), nil, nil, false, os.Stderr); err != nil {
-		check(err)
-	}
+	_, err = osbuild.RunOSBuild(mf, osbuildStore, jobOutput, imgType.Exports(), nil, nil, false, os.Stderr)
+	check(err)
 
 	fmt.Printf("Jobs done. Results saved in\n%s\n", outputDir)
 }

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/osbuild/images/internal/cmdutil"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
@@ -246,7 +247,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	seedArg := int64(0)
+	rngSeed, err := cmdutil.NewRNGSeed()
+	check(err)
 	darm := readRepos()
 	distroReg := distroregistry.NewDefault()
 
@@ -285,7 +287,7 @@ func main() {
 	}
 
 	fmt.Printf("Generating manifest for %s: ", config.Name)
-	mf, err := makeManifest(imgType, config, distribution, repos, archName, seedArg, rpmCacheRoot)
+	mf, err := makeManifest(imgType, config, distribution, repos, archName, rngSeed, rpmCacheRoot)
 	if err != nil {
 		check(err)
 	}

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gobwas/glob"
 
+	"github.com/osbuild/images/internal/cmdutil"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/distro"
@@ -554,7 +555,10 @@ func main() {
 
 	flag.Parse()
 
-	seedArg := int64(0)
+	rngSeed, err := cmdutil.NewRNGSeed()
+	if err != nil {
+		panic(err)
+	}
 	darm := readRepos()
 	distroReg := distroregistry.NewDefault()
 	jobs := make([]manifestJob, 0)
@@ -628,7 +632,7 @@ func main() {
 				}
 
 				for _, itConfig := range imgTypeConfigs {
-					job := makeManifestJob(itConfig.Name, imgType, itConfig, distribution, repos, archName, seedArg, outputDir, cacheRoot, contentResolve, metadata)
+					job := makeManifestJob(itConfig.Name, imgType, itConfig, distribution, repos, archName, rngSeed, outputDir, cacheRoot, contentResolve, metadata)
 					jobs = append(jobs, job)
 				}
 			}

--- a/internal/cmdutil/rand.go
+++ b/internal/cmdutil/rand.go
@@ -1,0 +1,30 @@
+package cmdutil
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math"
+	"math/big"
+	"os"
+	"strconv"
+)
+
+const RNG_SEED_ENV_KEY = "OSBUILD_TESTING_RNG_SEED"
+
+// NewRNGSeed generates a random seed value unless the env var
+// OSBUILD_TESTING_RNG_SEED is set.
+func NewRNGSeed() (int64, error) {
+	if envSeedStr := os.Getenv(RNG_SEED_ENV_KEY); envSeedStr != "" {
+		envSeedInt, err := strconv.ParseInt(envSeedStr, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse %s: %s", RNG_SEED_ENV_KEY, err)
+		}
+		fmt.Printf("TEST MODE: using rng seed %d\n", envSeedInt)
+		return envSeedInt, nil
+	}
+	randSeed, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		return 0, fmt.Errorf("failed to generate random seed: %s", err)
+	}
+	return randSeed.Int64(), nil
+}

--- a/internal/cmdutil/rand_test.go
+++ b/internal/cmdutil/rand_test.go
@@ -1,0 +1,40 @@
+package cmdutil_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/internal/cmdutil"
+)
+
+func TestNewRNGSeed(t *testing.T) {
+	// env is global - run all tests in one function so they don't run in
+	// parallel
+	t.Run("default", func(t *testing.T) {
+		t.Setenv(cmdutil.RNG_SEED_ENV_KEY, "")
+		seed1, err := cmdutil.NewRNGSeed()
+		require.Nil(t, err)
+		require.IsType(t, int64(0), seed1)
+
+		seed2, err := cmdutil.NewRNGSeed()
+		require.Nil(t, err)
+		require.IsType(t, int64(0), seed1)
+		require.NotEqual(t, seed1, seed2) // 1/2^64 chance this will fail randomly
+	})
+
+	t.Run("happy", func(t *testing.T) {
+		t.Setenv(cmdutil.RNG_SEED_ENV_KEY, "1234")
+		seed, err := cmdutil.NewRNGSeed()
+		require.Nil(t, err)
+		assert.Equal(t, seed, int64(1234))
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Setenv(cmdutil.RNG_SEED_ENV_KEY, "NaN")
+		_, err := cmdutil.NewRNGSeed()
+		require.EqualError(t, err, fmt.Sprintf(`failed to parse %s: strconv.ParseInt: parsing "NaN": invalid syntax`, cmdutil.RNG_SEED_ENV_KEY))
+	})
+}

--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -24,7 +24,7 @@ def create_ssh_key():
         keypath = os.path.join(tmpdir, "testkey")
         if ci_priv_key := os.environ.get("CI_PRIV_SSH_KEY_2"):
             # running in CI: use key from env
-            with open(keypath, "w") as keyfile:
+            with open(keypath, "w", encoding="utf-8") as keyfile:
                 keyfile.write(ci_priv_key + "\n")
             os.chmod(keypath, 0o600)
 
@@ -32,7 +32,7 @@ def create_ssh_key():
             cmd = ["ssh-keygen", "-y", "-f", keypath]
             out, _ = testlib.runcmd(cmd)
             pubkey = out.decode()
-            with open(keypath + ".pub", "w") as pubkeyfile:
+            with open(keypath + ".pub", "w", encoding="utf-8") as pubkeyfile:
                 pubkeyfile.write(pubkey)
         else:
             # create an ssh key pair with empty password
@@ -88,13 +88,13 @@ def find_image_file(build_path: str) -> str:
     path.
     """
     manifest_file = os.path.join(build_path, "manifest.json")
-    with open(manifest_file) as manifest:
+    with open(manifest_file, encoding="utf-8") as manifest:
         data = json.load(manifest)
 
     last_pipeline = data["pipelines"][-1]["name"]
     files = os.listdir(os.path.join(build_path, last_pipeline))
     if len(files) > 1:
-        error = ("Multiple files found in build path while searching for image file")
+        error = "Multiple files found in build path while searching for image file"
         error += "\n".join(files)
         raise RuntimeError(error)
 
@@ -133,10 +133,10 @@ def main():
     # amend build info with boot success
     # search_path is the root of the build path (build/build_name)
     info_file_path = os.path.join(search_path, "info.json")
-    with open(info_file_path) as info_fp:
+    with open(info_file_path, encoding="utf-8") as info_fp:
         build_info = json.load(info_fp)
     build_info["boot-success"] = True
-    with open(info_file_path, "w") as info_fp:
+    with open(info_file_path, "w", encoding="utf-8") as info_fp:
         json.dump(build_info, info_fp, indent=2)
 
 

--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -3,19 +3,10 @@ import argparse
 import contextlib
 import json
 import os
-import subprocess as sp
-import sys
 import uuid
 from tempfile import TemporaryDirectory
 
 import imgtestlib as testlib
-
-
-def runcmd(cmd, stdin=None):
-    job = sp.run(cmd)
-    if job.returncode > 0:
-        print(f"❌ Command failed: {cmd}")
-        sys.exit(job.returncode)
 
 
 def get_aws_config():
@@ -46,7 +37,7 @@ def create_ssh_key():
         else:
             # create an ssh key pair with empty password
             cmd = ["ssh-keygen", "-t", "ecdsa", "-b", "256", "-m", "pem", "-N", "", "-f", keypath]
-            runcmd(cmd)
+            testlib.runcmd_nc(cmd)
 
         yield keypath, keypath + ".pub"
 
@@ -60,7 +51,7 @@ def ensure_uncompressed(filepath):
     if ext == ".xz":
         print(f"Uncompressing {filepath}")
         # needs to run as root to set perms and ownership on uncompressed file
-        runcmd(["sudo", "unxz", "--verbose", "--keep", filepath])
+        testlib.runcmd_nc(["sudo", "unxz", "--verbose", "--keep", filepath])
         yield base
         # cleanup when done so the uncompressed file doesn't get uploaded to the build cache
         os.unlink(base)
@@ -87,7 +78,7 @@ def boot_ami(distro, arch, image_type, image_path):
                    "--ssh-privkey", privkey,
                    "--ssh-pubkey", pubkey,
                    raw_image_path, "test/scripts/base-host-check.sh"]
-            runcmd(cmd)
+            testlib.runcmd_nc(cmd)
 
 
 def find_image_file(build_path: str) -> str:

--- a/test/scripts/build-image
+++ b/test/scripts/build-image
@@ -2,8 +2,6 @@
 import argparse
 import json
 import os
-import subprocess as sp
-import sys
 
 import imgtestlib as testlib
 
@@ -29,11 +27,9 @@ def main():
         config_name = config["name"]
 
     testlib.runcmd(["go", "build", "-o", "./bin/build", "./cmd/build"])
+
     cmd = ["sudo", "./bin/build", "-output", "./build", "-distro", distro, "-image", image_type, "-config", config_path]
-    job = sp.run(cmd, capture_output=False)  # print live output
-    if job.returncode > 0:
-        print(f"❌ Build failed: {cmd}")
-        sys.exit(job.returncode)
+    testlib.runcmd_nc(cmd, extra_env=testlib.rng_seed_env())
 
     print("✅ Build finished!!")
 

--- a/test/scripts/build-image
+++ b/test/scripts/build-image
@@ -28,7 +28,8 @@ def main():
 
     testlib.runcmd(["go", "build", "-o", "./bin/build", "./cmd/build"])
 
-    cmd = ["sudo", "./bin/build", "-output", "./build", "-distro", distro, "-image", image_type, "-config", config_path]
+    cmd = ["sudo", "./bin/build", "--output", "./build",
+           "--distro", distro, "--image", image_type, "--config", config_path]
     testlib.runcmd_nc(cmd, extra_env=testlib.rng_seed_env())
 
     print("✅ Build finished!!")

--- a/test/scripts/check-build-coverage
+++ b/test/scripts/check-build-coverage
@@ -18,14 +18,15 @@ def check_build_coverage(cachedir):
     tests = set()
     built_now = set()
     built_pr = set()
-    for root, dirs, files in os.walk(cachedir):
+    for root, _, files in os.walk(cachedir):
         for fname in files:
             _, ext = os.path.splitext(fname)
             if ext != ".json":
                 continue
 
             fpath = os.path.join(root, fname)
-            build_info = json.load(open(fpath))
+            with open(fpath, encoding="utf-8") as info_file:
+                build_info = json.load(info_file)
             distro = build_info["distro"]
             arch = build_info["arch"]
             image = build_info["image-type"]

--- a/test/scripts/generate-build-config
+++ b/test/scripts/generate-build-config
@@ -101,7 +101,7 @@ def main():
         manifests = generate_manifests(manifest_dir, distro, arch)
         build_requests = testlib.filter_builds(manifests)
 
-    with open(config_path, "w") as config_file:
+    with open(config_path, "w", encoding="utf-8") as config_file:
         if len(build_requests) == 0:
             print("⚫ No manifest changes detected. Generating null config.")
             config_file.write(testlib.NULL_CONFIG)

--- a/test/scripts/generate-build-config
+++ b/test/scripts/generate-build-config
@@ -35,20 +35,13 @@ def generate_manifests(outputdir, distro, arch):
     manifest data and its ID.
     """
     target = arch
+    distros = None
     if distro:
         target = distro + "/" + arch
+        distros = [distro]
 
     print(f"🗒️ Generating all manifests using the default config map for {target}")
-    cmd = ["go", "run", "./cmd/gen-manifests",
-           "-cache", os.path.join(testlib.TEST_CACHE_ROOT, "rpmmd"),
-           "-output", outputdir,
-           "-workers", "100",
-           "-arches", arch]
-    if distro:
-        cmd.extend(["-distros", distro])
-
-    print("⌨️" + " ".join(cmd))
-    out, err = testlib.runcmd(cmd)
+    err = testlib.gen_manifests(outputdir, arches=[arch], distros=distros)
 
     # print stderr in case there were errors or warnings about skipped configurations
     # but filter out the annoying ones

--- a/test/scripts/generate-ostree-build-config
+++ b/test/scripts/generate-ostree-build-config
@@ -86,7 +86,7 @@ def gen_dependency_manifests(config_map, distro, arch, outputdir):
 
     # generate a config map for the dependencies
     for config_path in config_map.keys():
-        with open(config_path) as config_file:
+        with open(config_path, encoding="utf-8") as config_file:
             cfg = json.load(config_file)
 
         dep = cfg["depends"]
@@ -194,13 +194,13 @@ def setup_dependencies(manifests, config_map, distro, arch):
 
     container_ports: dict[str, int] = {}
     for config_path, filters in config_map.items():
-        with open(config_path) as config_file:
+        with open(config_path, encoding="utf-8") as config_file:
             config_data = json.load(config_file)
         config_name = config_data["name"]
 
         # dependency config path is relative to config file
         dep_config_path = os.path.join(os.path.dirname(config_path), config_data["depends"]["config"])
-        with open(dep_config_path) as dep_config_file:
+        with open(dep_config_path, encoding="utf-8") as dep_config_file:
             dep_config_data = json.load(dep_config_file)
         dep_config_name = dep_config_data["name"]
         dep_image_type = config_data["depends"]["image-type"]
@@ -270,7 +270,7 @@ def setup_dependencies(manifests, config_map, distro, arch):
             print(out.decode())
 
 
-def generate_configs(build_requests, pull_configs, container_configs, pipeline_file, configs_dir):
+def generate_configs(build_requests, container_configs, pipeline_file, configs_dir):
     print(f"🧪 Generating dynamic pipelines for {len(build_requests)} builds")
     os.makedirs(configs_dir, exist_ok=True)
     for build in build_requests:
@@ -327,14 +327,14 @@ def main():
 
         build_requests = testlib.filter_builds(manifests, skip_ostree_pull=False)
 
-    with open(config_path, "w") as config_file:
+    with open(config_path, "w", encoding="utf-8") as config_file:
         if len(build_requests) == 0:
             print("⚫ No manifest changes detected. Generating null config.")
             config_file.write(testlib.NULL_CONFIG)
             return
 
         config_file.write(testlib.BASE_CONFIG)
-        generate_configs(build_requests, pull_configs, containers, config_file, configs_dir)
+        generate_configs(build_requests, containers, config_file, configs_dir)
 
 
 if __name__ == "__main__":

--- a/test/scripts/generate-ostree-build-config
+++ b/test/scripts/generate-ostree-build-config
@@ -75,8 +75,10 @@ def gen_dependency_manifests(config_map, distro, arch, outputdir):
     Returns a dictionary mapping manifest file name (without path) to the manifest data and its ID.
     """
     target = arch
+    distros = None
     if distro:
         target = distro + "/" + arch
+        distros = [distro]
 
     print(f"🗒️ Generating manifests for dependencies for {target}")
     dep_config_map: dict = {}  # config map for the dependencies
@@ -103,18 +105,8 @@ def gen_dependency_manifests(config_map, distro, arch, outputdir):
     with NamedTemporaryFile(mode="w") as tmpfile:
         json.dump(dep_config_map, tmpfile)
         tmpfile.flush()
-        cmd = ["go", "run", "./cmd/gen-manifests",
-               "-cache", os.path.join(testlib.TEST_CACHE_ROOT, "rpmmd"),
-               "-output", outputdir,
-               "-workers", "100",
-               "-images", ",".join(gen_image_types),
-               "-config-map", tmpfile.name,
-               "-arches", arch]
-        if distro:
-            cmd.extend(["-distros", distro])
-        print("⌨️" + " ".join(cmd))
-        out, err = testlib.runcmd(cmd)
-
+        err = testlib.gen_manifests(outputdir, config_map=tmpfile.name,
+                                    distros=distros, arches=[arch], images=gen_image_types)
     # print stderr in case there were errors or warnings about skipped configurations
     # but filter out the annoying ones
     stderr = err.decode().splitlines()
@@ -138,8 +130,10 @@ def gen_image_manifests(config_map, configs, distro, arch, outputdir):
     Returns a dictionary mapping manifest file name (without path) to the manifest data and its ID.
     """
     target = arch
+    distros = None
     if distro:
         target = distro + "/" + arch
+        distros = [distro]
 
     print(f"🗒️ Generating manifests for ostree-based images for {target}")
     with TemporaryDirectory() as tmpdir:
@@ -153,18 +147,8 @@ def gen_image_manifests(config_map, configs, distro, arch, outputdir):
         with open(config_map_path, "w", encoding="utf-8") as config_map_file:
             json.dump(config_map, config_map_file)
 
-        cmd = ["go", "run", "./cmd/gen-manifests",
-               "-cache", os.path.join(testlib.TEST_CACHE_ROOT, "rpmmd"),
-               "-output", outputdir,
-               "-workers", "100",
-               "-config-map", config_map_path,
-               "-commits=true",  # resolve ostree commit sources
-               "-skip-noconfig",  # skip configs that aren't in the config-map
-               "-arches", arch]
-        if distro:
-            cmd.extend(["-distros", distro])
-        print("⌨️" + " ".join(cmd))
-        out, err = testlib.runcmd(cmd)
+        err = testlib.gen_manifests(outputdir, config_map=config_map_path,
+                                    arches=[arch], distros=distros, commits=True, skip_no_config=True)
 
     # print stderr in case there were errors or warnings about skipped configurations
     # but filter out the annoying ones

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -172,6 +172,30 @@ def check_config_names():
         sys.exit(1)
 
 
+def gen_manifests(outputdir, config_map=None, distros=None, arches=None, images=None,
+                  commits=False, skip_no_config=False):
+    # pylint: disable=too-many-arguments
+    cmd = ["go", "run", "./cmd/gen-manifests",
+           "--cache", os.path.join(TEST_CACHE_ROOT, "rpmmd"),
+           "--output", outputdir,
+           "--workers", "100"]
+    if config_map:
+        cmd.extend(["--config-map", config_map])
+    if distros:
+        cmd.extend(["--distros", ",".join(distros)])
+    if arches:
+        cmd.extend(["--arches", ",".join(arches)])
+    if images:
+        cmd.extend(["--images", ",".join(images)])
+    if commits:
+        cmd.append("--commits")
+    if skip_no_config:
+        cmd.append("--skip-noconfig")
+    print("⌨️" + " ".join(cmd))
+    _, stderr = runcmd(cmd, extra_env=rng_seed_env())
+    return stderr
+
+
 def read_manifests(path):
     """
     Read all manifests in the given path, calculate their IDs, and return a dictionary mapping each filename to the data

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -232,12 +232,8 @@ def check_for_build(manifest_fname, build_info_path, osbuild_ver, osbuild_commit
         ))
 
     # check if osbuild version matches
-    config_osbuild_commit = dl_config.get("osbuild-commit", None)
-    config_osbuild_ver = dl_config.get("osbuild-version", None)
-    if config_osbuild_commit is None:
-        # TODO: remove this check when all the build infos get updated
-        print("osbuild commit ID not found in build info. Scheduling config for rebuild.")
-        return True
+    config_osbuild_commit = dl_config["osbuild-commit"]
+    config_osbuild_ver = dl_config["osbuild-version"]
 
     osbuild_id = f"{osbuild_ver}:{osbuild_commit}"
     config_osbuild_id = f"{config_osbuild_ver}:{config_osbuild_commit}"

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -62,12 +62,12 @@ NullBuild:
 """
 
 
-def runcmd(cmd, stdin=None, extra_env=None):
+def runcmd(cmd, stdin=None, extra_env=None, capture_output=True):
     env = None
     if extra_env:
         env = os.environ
         env.update(extra_env)
-    job = sp.run(cmd, input=stdin, capture_output=True, env=env, check=False)
+    job = sp.run(cmd, input=stdin, capture_output=capture_output, env=env, check=False)
     if job.returncode > 0:
         print(f"❌ Command failed: {cmd}")
         if job.stdout:
@@ -77,6 +77,14 @@ def runcmd(cmd, stdin=None, extra_env=None):
         sys.exit(job.returncode)
 
     return job.stdout, job.stderr
+
+
+def runcmd_nc(cmd, stdin=None, extra_env=None):
+    """
+    Run the cmd using sp.run() and exit with the returncode if it is non-zero.
+    Output it not captured.
+    """
+    runcmd(cmd, stdin=stdin, extra_env=extra_env, capture_output=False)
 
 
 def list_images(distros=None, arches=None, images=None):

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -62,8 +62,12 @@ NullBuild:
 """
 
 
-def runcmd(cmd, stdin=None):
-    job = sp.run(cmd, input=stdin, capture_output=True)
+def runcmd(cmd, stdin=None, extra_env=None):
+    env = None
+    if extra_env:
+        env = os.environ
+        env.update(extra_env)
+    job = sp.run(cmd, input=stdin, capture_output=True, env=env, check=False)
     if job.returncode > 0:
         print(f"❌ Command failed: {cmd}")
         if job.stdout:

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -102,8 +102,8 @@ def list_images(distros=None, arches=None, images=None):
     images_arg = "*"
     if images:
         images_arg = ",".join(images)
-    out, err = runcmd(["go", "run", "./cmd/list-images", "-json",
-                       "-distros", distros_arg, "-arches", arches_arg, "-images", images_arg])
+    out, _ = runcmd(["go", "run", "./cmd/list-images", "--json",
+                     "--distros", distros_arg, "--arches", arches_arg, "--images", images_arg])
     return json.loads(out)
 
 

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -63,6 +63,11 @@ NullBuild:
 
 
 def runcmd(cmd, stdin=None, extra_env=None, capture_output=True):
+    """
+    Run the cmd using sp.run() and exit with the returncode if it is non-zero.
+    Output is captured and both stdout and stderr are returned if the run succeeds.
+    If it fails, the output is printed before exiting.
+    """
     env = None
     if extra_env:
         env = os.environ

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -129,7 +129,8 @@ def dl_s3_configs(destination):
                   "--include=info.json",
                   "--delete-removed",
                   s3url, destination],
-                 capture_output=True)
+                 capture_output=True,
+                 check=False)
     ok = job.returncode == 0
     if not ok:
         print(f"⚠️ Failed to sync contents of {s3url}:")
@@ -205,7 +206,7 @@ def read_manifests(path):
     manifests = {}
     for manifest_fname in os.listdir(path):
         manifest_path = os.path.join(path, manifest_fname)
-        with open(manifest_path) as manifest_file:
+        with open(manifest_path, encoding="utf-8") as manifest_file:
             manifest_data = json.load(manifest_file)
         manifests[manifest_fname] = {
             "data": manifest_data,

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -320,3 +320,19 @@ def get_osbuild_commit(distro_version):
         data = json.load(schutzfile)
 
     return data.get(distro_version, {}).get("dependencies", {}).get("osbuild", {}).get("commit", None)
+
+
+def rng_seed_env():
+    """
+    Read the rng seed from the Schutzfile and return it as a map to use as an environment variable with the appropriate
+    key. Assumes the file exists and that it contains the key 'rngseed', otherwise raises an exception.
+    """
+
+    with open(SCHUTZFILE, encoding="utf-8") as schutzfile:
+        data = json.load(schutzfile)
+
+    seed = data.get("rngseed")
+    if seed is None:
+        raise RuntimeError("'rngseed' not found in Schutzfile")
+
+    return {"OSBUILD_TESTING_RNG_SEED": str(seed)}

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -9,7 +9,7 @@ TEST_CACHE_ROOT = ".cache/osbuild-images"
 CONFIGS_PATH = "./test/configs"
 CONFIG_MAP = "./test/config-map.json"
 
-S3_BUCKET = "s3://{bucket}".format(bucket=os.environ.get("AWS_BUCKET", "images-ci-cache"))
+S3_BUCKET = "s3://" + os.environ.get("AWS_BUCKET", "images-ci-cache")
 S3_PREFIX = "images/builds"
 
 REGISTRY = "registry.gitlab.com/redhat/services/products/image-builder/ci/images"

--- a/test/scripts/test_imgtestlib.py
+++ b/test/scripts/test_imgtestlib.py
@@ -1,0 +1,23 @@
+import os
+
+from imgtestlib import rng_seed_env, runcmd
+
+
+def test_runcmd():
+    stdout, stderr = runcmd(["/bin/echo", "hello"])
+    assert stdout == b"hello\n"
+    assert stderr == b""
+
+
+def test_runcmd_env():
+    os.environ["RUNCMD_GLOBAL_TEST_VAR"] = "global test value"
+    stdout, stderr = runcmd(["env"], extra_env={"RUNCMD_TEST_VAR": "the test value"})
+    assert b"RUNCMD_TEST_VAR=the test value\n" in stdout, "extra env var not set"
+    assert b"RUNCMD_GLOBAL_TEST_VAR=global test value\n" in stdout, "global env vars not preserved"
+    assert stderr == b""
+
+
+def test_read_seed():
+    # check that it's read without error - no need to test the value itself
+    seed_env = rng_seed_env()
+    assert "OSBUILD_TESTING_RNG_SEED" in seed_env

--- a/test/scripts/upload-results
+++ b/test/scripts/upload-results
@@ -19,7 +19,7 @@ def main():
     config_path = args.config
     arch = os.uname().machine
 
-    with open(config_path, "r") as config_file:
+    with open(config_path, "r", encoding="utf-8") as config_file:
         config = json.load(config_file)
         config_name = config["name"]
 
@@ -27,19 +27,19 @@ def main():
 
     # get the manifest ID to use in the destination path
     manifest_path = os.path.join(build_dir, "manifest.json")
-    with open(manifest_path, "r") as manifest_fp:
+    with open(manifest_path, "r", encoding="utf-8") as manifest_fp:
         manifest_data = json.load(manifest_fp)
     manifest_id = testlib.get_manifest_id(manifest_data)
 
     # add the PR number (gitlab branch name) to the info.json if available
     if pr_number := os.environ.get("CI_COMMIT_BRANCH"):
         info_path = os.path.join(build_dir, "info.json")
-        with open(info_path, "r") as info_fp:
+        with open(info_path, "r", encoding="utf-8") as info_fp:
             build_info = json.load(info_fp)
         build_info["pr"] = pr_number
         # strip the PR prefix
         pr_number = pr_number.lstrip("PR-")
-        with open(info_path, "w") as info_fp:
+        with open(info_path, "w", encoding="utf-8") as info_fp:
             json.dump(build_info, info_fp, indent=2)
 
     bucket = testlib.S3_BUCKET


### PR DESCRIPTION
The primary purpose of this PR is to configure a random seed value in the Schutzfile for CI builds and manifest generation.  The seed is used for deterministic builds in CI using the gen-manifests and build tools while also allowing the tools to generate manifests and images with unique values for UUIDS etc.  It also lets us change the value to manually force a complete rebuild of the cached CI images when we need to.  For example, if we want to change some part of the test scripts or infrastructure that wouldn't generate different manifests but want to make sure everything is rebuilt and tested.  We might also add a scheduled action to trigger rebuilds on a regular basis (e.g., every weekend).

Other changes in this PR:
- pylint configuration.
- pylint GitHub action for test scripts.
- Code cleanup to appease pylint.
- Some new helper functions for the imgtestlib.