### PR TITLE
Simplify Pipeline constructors

### DIFF
--- a/cmd/osbuild-playground/my-container.go
+++ b/cmd/osbuild-playground/my-container.go
@@ -50,7 +50,7 @@ func (img *MyContainer) InstantiateManifest(m *manifest.Manifest,
 	build.Checkpoint()
 
 	// create a minimal non-bootable OS tree
-	os := manifest.NewOS(m, build, &platform.X86{}, repos)
+	os := manifest.NewOS(build, &platform.X86{}, repos)
 	os.ExtraBasePackages = []string{"@core"}
 	os.OSCustomizations.Language = "en_US.UTF-8"
 	os.OSCustomizations.Hostname = "my-host"

--- a/cmd/osbuild-playground/my-image.go
+++ b/cmd/osbuild-playground/my-image.go
@@ -45,7 +45,7 @@ func (img *MyImage) InstantiateManifest(m *manifest.Manifest,
 	}
 
 	// create a minimal bootable OS tree
-	os := manifest.NewOS(m, build, platform, repos)
+	os := manifest.NewOS(build, platform, repos)
 	os.PartitionTable = pt   // we need a partition table
 	os.KernelName = "kernel" // use the default fedora kernel
 

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -58,14 +58,15 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	buildPipeline := manifest.NewBuild(m, runner, repos, &manifest.BuildOptions{ContainerBuildable: true})
 	buildPipeline.Checkpoint()
 
-	anacondaPipeline := manifest.NewAnacondaInstaller(m,
+	anacondaPipeline := manifest.NewAnacondaInstaller(
 		manifest.AnacondaInstallerTypePayload,
 		buildPipeline,
 		img.Platform,
 		repos,
 		"kernel",
 		img.Product,
-		img.OSVersion)
+		img.OSVersion,
+	)
 
 	// This is only built with ELN for now
 	anacondaPipeline.UseRHELLoraxTemplates = true
@@ -109,7 +110,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)
 	rootfsImagePipeline.Size = 4 * common.GibiByte
 
-	bootTreePipeline := manifest.NewEFIBootTree(m, buildPipeline, img.Product, img.OSVersion)
+	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
 	bootTreePipeline.Platform = img.Platform
 	bootTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
 	bootTreePipeline.ISOLabel = isoLabel

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -49,14 +49,15 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
-	livePipeline := manifest.NewAnacondaInstaller(m,
+	livePipeline := manifest.NewAnacondaInstaller(
 		manifest.AnacondaInstallerTypeLive,
 		buildPipeline,
 		img.Platform,
 		repos,
 		"kernel",
 		img.Product,
-		img.OSVersion)
+		img.OSVersion,
+	)
 
 	livePipeline.ExtraPackages = img.ExtraBasePackages.Include
 	livePipeline.ExcludePackages = img.ExtraBasePackages.Exclude
@@ -87,7 +88,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, livePipeline)
 	rootfsImagePipeline.Size = 8 * common.GibiByte
 
-	bootTreePipeline := manifest.NewEFIBootTree(m, buildPipeline, img.Product, img.OSVersion)
+	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
 	bootTreePipeline.Platform = img.Platform
 	bootTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
 	bootTreePipeline.ISOLabel = isoLabel

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -56,14 +56,15 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
-	anacondaPipeline := manifest.NewAnacondaInstaller(m,
+	anacondaPipeline := manifest.NewAnacondaInstaller(
 		manifest.AnacondaInstallerTypePayload,
 		buildPipeline,
 		img.Platform,
 		repos,
 		"kernel",
 		img.Product,
-		img.OSVersion)
+		img.OSVersion,
+	)
 	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include
 	anacondaPipeline.ExcludePackages = img.ExtraBasePackages.Exclude
 	anacondaPipeline.ExtraRepos = img.ExtraBasePackages.Repositories
@@ -103,7 +104,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)
 	rootfsImagePipeline.Size = 4 * common.GibiByte
 
-	bootTreePipeline := manifest.NewEFIBootTree(m, buildPipeline, img.Product, img.OSVersion)
+	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
 	bootTreePipeline.Platform = img.Platform
 	bootTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
 	bootTreePipeline.ISOLabel = isoLabel

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -66,14 +66,15 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
-	anacondaPipeline := manifest.NewAnacondaInstaller(m,
+	anacondaPipeline := manifest.NewAnacondaInstaller(
 		manifest.AnacondaInstallerTypePayload,
 		buildPipeline,
 		img.Platform,
 		repos,
 		"kernel",
 		img.Product,
-		img.OSVersion)
+		img.OSVersion,
+	)
 
 	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include
 	anacondaPipeline.ExcludePackages = img.ExtraBasePackages.Exclude
@@ -122,7 +123,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)
 	rootfsImagePipeline.Size = 4 * common.GibiByte
 
-	bootTreePipeline := manifest.NewEFIBootTree(m, buildPipeline, img.Product, img.OSVersion)
+	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
 	bootTreePipeline.Platform = img.Platform
 	bootTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
 	bootTreePipeline.ISOLabel = isoLabel
@@ -137,7 +138,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	kernelOpts = append(kernelOpts, img.AdditionalKernelOpts...)
 	bootTreePipeline.KernelOpts = kernelOpts
 
-	osPipeline := manifest.NewOS(m, buildPipeline, img.Platform, repos)
+	osPipeline := manifest.NewOS(buildPipeline, img.Platform, repos)
 	osPipeline.OSCustomizations = img.OSCustomizations
 	osPipeline.Environment = img.Environment
 	osPipeline.Workload = img.Workload

--- a/pkg/image/archive.go
+++ b/pkg/image/archive.go
@@ -34,7 +34,7 @@ func (img *Archive) InstantiateManifest(m *manifest.Manifest,
 	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
-	osPipeline := manifest.NewOS(m, buildPipeline, img.Platform, repos)
+	osPipeline := manifest.NewOS(buildPipeline, img.Platform, repos)
 	osPipeline.OSCustomizations = img.OSCustomizations
 	osPipeline.Environment = img.Environment
 	osPipeline.Workload = img.Workload

--- a/pkg/image/container.go
+++ b/pkg/image/container.go
@@ -34,7 +34,7 @@ func (img *BaseContainer) InstantiateManifest(m *manifest.Manifest,
 	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
-	osPipeline := manifest.NewOS(m, buildPipeline, img.Platform, repos)
+	osPipeline := manifest.NewOS(buildPipeline, img.Platform, repos)
 	osPipeline.OSCustomizations = img.OSCustomizations
 	osPipeline.Environment = img.Environment
 	osPipeline.Workload = img.Workload

--- a/pkg/image/disk.go
+++ b/pkg/image/disk.go
@@ -52,7 +52,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
-	osPipeline := manifest.NewOS(m, buildPipeline, img.Platform, repos)
+	osPipeline := manifest.NewOS(buildPipeline, img.Platform, repos)
 	osPipeline.PartitionTable = img.PartitionTable
 	osPipeline.OSCustomizations = img.OSCustomizations
 	osPipeline.Environment = img.Environment

--- a/pkg/image/ostree_archive.go
+++ b/pkg/image/ostree_archive.go
@@ -50,7 +50,7 @@ func (img *OSTreeArchive) InstantiateManifest(m *manifest.Manifest,
 	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
-	osPipeline := manifest.NewOS(m, buildPipeline, img.Platform, repos)
+	osPipeline := manifest.NewOS(buildPipeline, img.Platform, repos)
 	osPipeline.OSCustomizations = img.OSCustomizations
 	osPipeline.Environment = img.Environment
 	osPipeline.Workload = img.Workload

--- a/pkg/image/ostree_container.go
+++ b/pkg/image/ostree_container.go
@@ -47,7 +47,7 @@ func (img *OSTreeContainer) InstantiateManifest(m *manifest.Manifest,
 	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
-	osPipeline := manifest.NewOS(m, buildPipeline, img.Platform, repos)
+	osPipeline := manifest.NewOS(buildPipeline, img.Platform, repos)
 	osPipeline.OSCustomizations = img.OSCustomizations
 	osPipeline.Environment = img.Environment
 	osPipeline.Workload = img.Workload
@@ -60,13 +60,14 @@ func (img *OSTreeContainer) InstantiateManifest(m *manifest.Manifest,
 	nginxConfigPath := "/etc/nginx.conf"
 	listenPort := "8080"
 
-	serverPipeline := manifest.NewOSTreeCommitServer(m,
+	serverPipeline := manifest.NewOSTreeCommitServer(
 		buildPipeline,
 		img.Platform,
 		repos,
 		commitPipeline,
 		nginxConfigPath,
-		listenPort)
+		listenPort,
+	)
 	serverPipeline.Language = img.ContainerLanguage
 
 	containerPipeline := manifest.NewOCIContainer(buildPipeline, serverPipeline)

--- a/pkg/image/ostree_disk.go
+++ b/pkg/image/ostree_disk.go
@@ -74,13 +74,13 @@ func NewOSTreeDiskImageFromContainer(container container.SourceSpec, ref string)
 	}
 }
 
-func baseRawOstreeImage(img *OSTreeDiskImage, m *manifest.Manifest, buildPipeline *manifest.Build) *manifest.RawOSTreeImage {
+func baseRawOstreeImage(img *OSTreeDiskImage, buildPipeline *manifest.Build) *manifest.RawOSTreeImage {
 	var osPipeline *manifest.OSTreeDeployment
 	switch {
 	case img.CommitSource != nil:
-		osPipeline = manifest.NewOSTreeCommitDeployment(buildPipeline, m, img.CommitSource, img.OSName, img.Platform)
+		osPipeline = manifest.NewOSTreeCommitDeployment(buildPipeline, img.CommitSource, img.OSName, img.Platform)
 	case img.ContainerSource != nil:
-		osPipeline = manifest.NewOSTreeContainerDeployment(buildPipeline, m, img.ContainerSource, img.Ref, img.OSName, img.Platform)
+		osPipeline = manifest.NewOSTreeContainerDeployment(buildPipeline, img.ContainerSource, img.Ref, img.OSName, img.Platform)
 	default:
 		panic("no content source defined for ostree image")
 	}
@@ -126,7 +126,7 @@ func (img *OSTreeDiskImage) InstantiateManifest(m *manifest.Manifest,
 		panic(fmt.Sprintf("no compression is allowed with %q format for %q", imgFormat, img.name))
 	}
 
-	baseImage := baseRawOstreeImage(img, m, buildPipeline)
+	baseImage := baseRawOstreeImage(img, buildPipeline)
 	switch img.Platform.GetImageFormat() {
 	case platform.FORMAT_VMDK:
 		vmdkPipeline := manifest.NewVMDK(buildPipeline, baseImage)

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -79,16 +79,17 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	imageFilename := "image.raw.xz"
 
 	// image in simplified installer is always compressed
-	compressedImage := manifest.NewXZ(buildPipeline, baseRawOstreeImage(img.rawImage, m, buildPipeline))
+	compressedImage := manifest.NewXZ(buildPipeline, baseRawOstreeImage(img.rawImage, buildPipeline))
 	compressedImage.SetFilename(imageFilename)
 
-	coiPipeline := manifest.NewCoreOSInstaller(m,
+	coiPipeline := manifest.NewCoreOSInstaller(
 		buildPipeline,
 		img.Platform,
 		repos,
 		"kernel",
 		img.Product,
-		img.OSVersion)
+		img.OSVersion,
+	)
 	coiPipeline.ExtraPackages = img.ExtraBasePackages.Include
 	coiPipeline.ExcludePackages = img.ExtraBasePackages.Exclude
 	coiPipeline.ExtraRepos = img.ExtraBasePackages.Repositories
@@ -100,7 +101,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	isoLabel := fmt.Sprintf(img.ISOLabelTempl, img.Platform.GetArch())
 
-	bootTreePipeline := manifest.NewEFIBootTree(m, buildPipeline, img.Product, img.OSVersion)
+	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
 	bootTreePipeline.Platform = img.Platform
 	bootTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
 	bootTreePipeline.ISOLabel = isoLabel

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -77,8 +77,7 @@ type AnacondaInstaller struct {
 	UseRHELLoraxTemplates bool
 }
 
-func NewAnacondaInstaller(m *Manifest,
-	installerType AnacondaInstallerType,
+func NewAnacondaInstaller(installerType AnacondaInstallerType,
 	buildPipeline *Build,
 	platform platform.Platform,
 	repos []rpmmd.RepoConfig,
@@ -96,7 +95,6 @@ func NewAnacondaInstaller(m *Manifest,
 		version:    version,
 	}
 	buildPipeline.addDependent(p)
-	m.addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -87,7 +87,7 @@ func NewAnacondaInstaller(m *Manifest,
 	version string) *AnacondaInstaller {
 	name := "anaconda-tree"
 	p := &AnacondaInstaller{
-		Base:       NewBase(m, name, buildPipeline),
+		Base:       NewBase(name, buildPipeline),
 		Type:       installerType,
 		platform:   platform,
 		repos:      filterRepos(repos, name),

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -75,7 +75,6 @@ func NewAnacondaInstallerISOTree(buildPipeline *Build, anacondaPipeline *Anacond
 		isoLabel:         bootTreePipeline.ISOLabel,
 	}
 	buildPipeline.addDependent(p)
-	anacondaPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -68,7 +68,7 @@ func NewAnacondaInstallerISOTree(buildPipeline *Build, anacondaPipeline *Anacond
 		panic("pipelines from different manifests")
 	}
 	p := &AnacondaInstallerISOTree{
-		Base:             NewBase(anacondaPipeline.Manifest(), "bootiso-tree", buildPipeline),
+		Base:             NewBase("bootiso-tree", buildPipeline),
 		anacondaPipeline: anacondaPipeline,
 		rootfsPipeline:   rootfsPipeline,
 		bootTreePipeline: bootTreePipeline,

--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -41,11 +41,10 @@ func NewBuild(m *Manifest, runner runner.Runner, repos []rpmmd.RepoConfig, opts 
 
 	name := "build"
 	pipeline := &Build{
-		Base:       NewBase(m, name, nil),
-		runner:     runner,
-		dependents: make([]Pipeline, 0),
-		repos:      filterRepos(repos, name),
-
+		Base:               NewBase(name, nil),
+		runner:             runner,
+		dependents:         make([]Pipeline, 0),
+		repos:              filterRepos(repos, name),
 		containerBuildable: opts.ContainerBuildable,
 	}
 	m.addPipeline(pipeline)

--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -53,6 +53,11 @@ func NewBuild(m *Manifest, runner runner.Runner, repos []rpmmd.RepoConfig, opts 
 
 func (p *Build) addDependent(dep Pipeline) {
 	p.dependents = append(p.dependents, dep)
+	man := p.Manifest()
+	if man == nil {
+		panic("cannot add build dependent without a manifest")
+	}
+	man.addPipeline(dep)
 }
 
 func (p *Build) getPackageSetChain(distro Distro) []rpmmd.PackageSet {

--- a/pkg/manifest/coi_iso_tree.go
+++ b/pkg/manifest/coi_iso_tree.go
@@ -48,7 +48,7 @@ func NewCoreOSISOTree(
 	}
 
 	p := &CoreOSISOTree{
-		Base:             NewBase(coiPipeline.Manifest(), "bootiso-tree", buildPipeline),
+		Base:             NewBase("bootiso-tree", buildPipeline),
 		payloadPipeline:  payloadPipeline,
 		coiPipeline:      coiPipeline,
 		bootTreePipeline: bootTreePipeline,

--- a/pkg/manifest/coi_iso_tree.go
+++ b/pkg/manifest/coi_iso_tree.go
@@ -55,7 +55,6 @@ func NewCoreOSISOTree(
 		isoLabel:         bootTreePipeline.ISOLabel,
 	}
 	buildPipeline.addDependent(p)
-	coiPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/commit.go
+++ b/pkg/manifest/commit.go
@@ -18,7 +18,7 @@ type OSTreeCommit struct {
 // ref is the ref to create the commit under.
 func NewOSTreeCommit(buildPipeline *Build, treePipeline *OS, ref string) *OSTreeCommit {
 	p := &OSTreeCommit{
-		Base:         NewBase(treePipeline.Manifest(), "ostree-commit", buildPipeline),
+		Base:         NewBase("ostree-commit", buildPipeline),
 		treePipeline: treePipeline,
 		ref:          ref,
 	}

--- a/pkg/manifest/commit.go
+++ b/pkg/manifest/commit.go
@@ -23,7 +23,6 @@ func NewOSTreeCommit(buildPipeline *Build, treePipeline *OS, ref string) *OSTree
 		ref:          ref,
 	}
 	buildPipeline.addDependent(p)
-	treePipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/commit_server_tree.go
+++ b/pkg/manifest/commit_server_tree.go
@@ -36,8 +36,7 @@ type OSTreeCommitServer struct {
 // is a pipeline producing an ostree commit to be served. nginxConfigPath
 // is the path to the main nginx config file and listenPort is the port
 // nginx will be listening on.
-func NewOSTreeCommitServer(m *Manifest,
-	buildPipeline *Build,
+func NewOSTreeCommitServer(buildPipeline *Build,
 	platform platform.Platform,
 	repos []rpmmd.RepoConfig,
 	commitPipeline *OSTreeCommit,
@@ -53,11 +52,7 @@ func NewOSTreeCommitServer(m *Manifest,
 		listenPort:      listenPort,
 		Language:        "en_US",
 	}
-	if commitPipeline.Base.manifest != m {
-		panic("commit pipeline from different manifest")
-	}
 	buildPipeline.addDependent(p)
-	m.addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/commit_server_tree.go
+++ b/pkg/manifest/commit_server_tree.go
@@ -45,7 +45,7 @@ func NewOSTreeCommitServer(m *Manifest,
 	listenPort string) *OSTreeCommitServer {
 	name := "container-tree"
 	p := &OSTreeCommitServer{
-		Base:            NewBase(m, name, buildPipeline),
+		Base:            NewBase(name, buildPipeline),
 		platform:        platform,
 		repos:           filterRepos(repos, name),
 		commitPipeline:  commitPipeline,

--- a/pkg/manifest/coreos_installer.go
+++ b/pkg/manifest/coreos_installer.go
@@ -47,8 +47,7 @@ type CoreOSInstaller struct {
 }
 
 // NewCoreOSInstaller creates an CoreOS installer pipeline object.
-func NewCoreOSInstaller(m *Manifest,
-	buildPipeline *Build,
+func NewCoreOSInstaller(buildPipeline *Build,
 	platform platform.Platform,
 	repos []rpmmd.RepoConfig,
 	kernelName,
@@ -64,7 +63,6 @@ func NewCoreOSInstaller(m *Manifest,
 		version:    version,
 	}
 	buildPipeline.addDependent(p)
-	m.addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/coreos_installer.go
+++ b/pkg/manifest/coreos_installer.go
@@ -56,7 +56,7 @@ func NewCoreOSInstaller(m *Manifest,
 	version string) *CoreOSInstaller {
 	name := "coi-tree"
 	p := &CoreOSInstaller{
-		Base:       NewBase(m, name, buildPipeline),
+		Base:       NewBase(name, buildPipeline),
 		platform:   platform,
 		repos:      filterRepos(repos, name),
 		kernelName: kernelName,

--- a/pkg/manifest/efi_boot_tree.go
+++ b/pkg/manifest/efi_boot_tree.go
@@ -20,14 +20,13 @@ type EFIBootTree struct {
 	KernelOpts []string
 }
 
-func NewEFIBootTree(m *Manifest, buildPipeline *Build, product, version string) *EFIBootTree {
+func NewEFIBootTree(buildPipeline *Build, product, version string) *EFIBootTree {
 	p := &EFIBootTree{
 		Base:    NewBase("efiboot-tree", buildPipeline),
 		product: product,
 		version: version,
 	}
 	buildPipeline.addDependent(p)
-	m.addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/efi_boot_tree.go
+++ b/pkg/manifest/efi_boot_tree.go
@@ -22,7 +22,7 @@ type EFIBootTree struct {
 
 func NewEFIBootTree(m *Manifest, buildPipeline *Build, product, version string) *EFIBootTree {
 	p := &EFIBootTree{
-		Base:    NewBase(m, "efiboot-tree", buildPipeline),
+		Base:    NewBase("efiboot-tree", buildPipeline),
 		product: product,
 		version: version,
 	}

--- a/pkg/manifest/empty.go
+++ b/pkg/manifest/empty.go
@@ -30,7 +30,7 @@ type ContentTest struct {
 // content sources.
 func NewContentTest(m *Manifest, name string, packageSets []rpmmd.PackageSet, containers []container.SourceSpec, commits []ostree.SourceSpec) *ContentTest {
 	pipeline := &ContentTest{
-		Base:        NewBase(m, name, nil),
+		Base:        NewBase(name, nil),
 		packageSets: packageSets,
 		containers:  containers,
 		commits:     commits,

--- a/pkg/manifest/iso.go
+++ b/pkg/manifest/iso.go
@@ -26,7 +26,7 @@ func (p *ISO) SetFilename(filename string) {
 
 func NewISO(buildPipeline *Build, treePipeline Pipeline, isoLabel string) *ISO {
 	p := &ISO{
-		Base:         NewBase(treePipeline.Manifest(), "bootiso", buildPipeline),
+		Base:         NewBase("bootiso", buildPipeline),
 		treePipeline: treePipeline,
 		filename:     "image.iso",
 		isoLabel:     isoLabel,

--- a/pkg/manifest/iso.go
+++ b/pkg/manifest/iso.go
@@ -32,7 +32,6 @@ func NewISO(buildPipeline *Build, treePipeline Pipeline, isoLabel string) *ISO {
 		isoLabel:     isoLabel,
 	}
 	buildPipeline.addDependent(p)
-	treePipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/iso_rootfs.go
+++ b/pkg/manifest/iso_rootfs.go
@@ -20,7 +20,6 @@ func NewISORootfsImg(buildPipeline *Build, installerPipeline Pipeline) *ISORootf
 		installerPipeline: installerPipeline,
 	}
 	buildPipeline.addDependent(p)
-	installerPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/iso_rootfs.go
+++ b/pkg/manifest/iso_rootfs.go
@@ -16,7 +16,7 @@ type ISORootfsImg struct {
 
 func NewISORootfsImg(buildPipeline *Build, installerPipeline Pipeline) *ISORootfsImg {
 	p := &ISORootfsImg{
-		Base:              NewBase(installerPipeline.Manifest(), "rootfs-image", buildPipeline),
+		Base:              NewBase("rootfs-image", buildPipeline),
 		installerPipeline: installerPipeline,
 	}
 	buildPipeline.addDependent(p)

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -86,7 +86,15 @@ func (m *Manifest) addPipeline(p Pipeline) {
 			panic("duplicate pipeline name in manifest")
 		}
 	}
+	if p.Manifest() != nil {
+		panic("pipeline already added to a different manifest")
+	}
 	m.pipelines = append(m.pipelines, p)
+	p.setManifest(m)
+	// check that the pipeline's build pipeline is included in the same manifest
+	if build := p.BuildPipeline(); build != nil && build.Manifest() != m {
+		panic("cannot add pipeline to a different manifest than its build pipeline")
+	}
 }
 
 type PackageSelector func([]rpmmd.PackageSet) []rpmmd.PackageSet

--- a/pkg/manifest/oci_container.go
+++ b/pkg/manifest/oci_container.go
@@ -31,7 +31,6 @@ func NewOCIContainer(buildPipeline *Build, treePipeline TreePipeline) *OCIContai
 		filename:     "oci-archive.tar",
 	}
 	buildPipeline.addDependent(p)
-	treePipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/oci_container.go
+++ b/pkg/manifest/oci_container.go
@@ -26,7 +26,7 @@ func (p *OCIContainer) SetFilename(filename string) {
 
 func NewOCIContainer(buildPipeline *Build, treePipeline TreePipeline) *OCIContainer {
 	p := &OCIContainer{
-		Base:         NewBase(treePipeline.Manifest(), "container", buildPipeline),
+		Base:         NewBase("container", buildPipeline),
 		treePipeline: treePipeline,
 		filename:     "oci-archive.tar",
 	}

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -179,10 +179,7 @@ type OS struct {
 // NewOS creates a new OS pipeline. build is the build pipeline to use for
 // building the OS pipeline. platform is the target platform for the final
 // image. repos are the repositories to install RPMs from.
-func NewOS(m *Manifest,
-	buildPipeline *Build,
-	platform platform.Platform,
-	repos []rpmmd.RepoConfig) *OS {
+func NewOS(buildPipeline *Build, platform platform.Platform, repos []rpmmd.RepoConfig) *OS {
 	name := "os"
 	p := &OS{
 		Base:            NewBase(name, buildPipeline),
@@ -191,7 +188,6 @@ func NewOS(m *Manifest,
 		InstallWeakDeps: true,
 	}
 	buildPipeline.addDependent(p)
-	m.addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -185,7 +185,7 @@ func NewOS(m *Manifest,
 	repos []rpmmd.RepoConfig) *OS {
 	name := "os"
 	p := &OS{
-		Base:            NewBase(m, name, buildPipeline),
+		Base:            NewBase(name, buildPipeline),
 		repos:           filterRepos(repos, name),
 		platform:        platform,
 		InstallWeakDeps: true,

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -26,7 +26,7 @@ func NewTestOS() *OS {
 		BIOS: true,
 	}
 
-	os := NewOS(&manifest, build, platform, repos)
+	os := NewOS(build, platform, repos)
 	packages := []rpmmd.PackageSpec{
 		{Name: "pkg1", Checksum: "sha1:c02524e2bd19490f2a7167958f792262754c5f46"},
 	}

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -76,7 +76,6 @@ type OSTreeDeployment struct {
 // NewOSTreeCommitDeployment creates a pipeline for an ostree deployment from a
 // commit.
 func NewOSTreeCommitDeployment(buildPipeline *Build,
-	m *Manifest,
 	commit *ostree.SourceSpec,
 	osName string,
 	platform platform.Platform) *OSTreeDeployment {
@@ -88,14 +87,12 @@ func NewOSTreeCommitDeployment(buildPipeline *Build,
 		platform:     platform,
 	}
 	buildPipeline.addDependent(p)
-	m.addPipeline(p)
 	return p
 }
 
 // NewOSTreeDeployment creates a pipeline for an ostree deployment from a
 // container
 func NewOSTreeContainerDeployment(buildPipeline *Build,
-	m *Manifest,
 	container *container.SourceSpec,
 	ref string,
 	osName string,
@@ -109,7 +106,6 @@ func NewOSTreeContainerDeployment(buildPipeline *Build,
 		platform:        platform,
 	}
 	buildPipeline.addDependent(p)
-	m.addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -82,7 +82,7 @@ func NewOSTreeCommitDeployment(buildPipeline *Build,
 	platform platform.Platform) *OSTreeDeployment {
 
 	p := &OSTreeDeployment{
-		Base:         NewBase(m, "ostree-deployment", buildPipeline),
+		Base:         NewBase("ostree-deployment", buildPipeline),
 		commitSource: commit,
 		osName:       osName,
 		platform:     platform,
@@ -102,7 +102,7 @@ func NewOSTreeContainerDeployment(buildPipeline *Build,
 	platform platform.Platform) *OSTreeDeployment {
 
 	p := &OSTreeDeployment{
-		Base:            NewBase(m, "ostree-deployment", buildPipeline),
+		Base:            NewBase("ostree-deployment", buildPipeline),
 		containerSource: container,
 		osName:          osName,
 		ref:             ref,

--- a/pkg/manifest/ostree_encapsulate.go
+++ b/pkg/manifest/ostree_encapsulate.go
@@ -19,7 +19,6 @@ func NewOSTreeEncapsulate(buildPipeline *Build, inputPipeline Pipeline, pipeline
 		filename:      "bootable-container.tar",
 	}
 	buildPipeline.addDependent(p)
-	inputPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/ostree_encapsulate.go
+++ b/pkg/manifest/ostree_encapsulate.go
@@ -14,7 +14,7 @@ type OSTreeEncapsulate struct {
 
 func NewOSTreeEncapsulate(buildPipeline *Build, inputPipeline Pipeline, pipelinename string) *OSTreeEncapsulate {
 	p := &OSTreeEncapsulate{
-		Base:          NewBase(inputPipeline.Manifest(), pipelinename, buildPipeline),
+		Base:          NewBase(pipelinename, buildPipeline),
 		inputPipeline: inputPipeline,
 		filename:      "bootable-container.tar",
 	}

--- a/pkg/manifest/ovf.go
+++ b/pkg/manifest/ovf.go
@@ -20,7 +20,6 @@ func NewOVF(buidPipeline *Build, imgPipeline *VMDK) *OVF {
 		imgPipeline: imgPipeline,
 	}
 	buidPipeline.addDependent(p)
-	imgPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/ovf.go
+++ b/pkg/manifest/ovf.go
@@ -16,7 +16,7 @@ type OVF struct {
 // NewOVF creates a new OVF pipeline. imgPipeline is the pipeline producing the vmdk image.
 func NewOVF(buidPipeline *Build, imgPipeline *VMDK) *OVF {
 	p := &OVF{
-		Base:        NewBase(imgPipeline.Manifest(), "ovf", buidPipeline),
+		Base:        NewBase("ovf", buidPipeline),
 		imgPipeline: imgPipeline,
 	}
 	buidPipeline.addDependent(p)

--- a/pkg/manifest/pipeline.go
+++ b/pkg/manifest/pipeline.go
@@ -30,6 +30,8 @@ type Pipeline interface {
 	// Manifest returns a reference to the Manifest which this Pipeline belongs to.
 	Manifest() *Manifest
 
+	setManifest(*Manifest)
+
 	getCheckpoint() bool
 
 	getExport() bool
@@ -110,6 +112,10 @@ func (p Base) Manifest() *Manifest {
 	return p.manifest
 }
 
+func (p *Base) setManifest(m *Manifest) {
+	p.manifest = m
+}
+
 func (p Base) getBuildPackages(Distro) []string {
 	return []string{}
 }
@@ -150,16 +156,10 @@ func (p Base) getInline() []string {
 // the build host's filesystem is used as the build root. The runner specifies how to use this
 // pipeline as a build pipeline, by naming the distro it contains. When the host system is used
 // as a build root, then the necessary runner is autodetected.
-func NewBase(m *Manifest, name string, build *Build) Base {
+func NewBase(name string, build *Build) Base {
 	p := Base{
-		manifest: m,
-		name:     name,
-		build:    build,
-	}
-	if build != nil {
-		if build.Base.manifest != m {
-			panic("build pipeline from a different manifest")
-		}
+		name:  name,
+		build: build,
 	}
 	return p
 }

--- a/pkg/manifest/qcow2.go
+++ b/pkg/manifest/qcow2.go
@@ -32,7 +32,6 @@ func NewQCOW2(buildPipeline *Build, imgPipeline FilePipeline) *QCOW2 {
 		filename:    "image.qcow2",
 	}
 	buildPipeline.addDependent(p)
-	imgPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/qcow2.go
+++ b/pkg/manifest/qcow2.go
@@ -27,7 +27,7 @@ func (p *QCOW2) SetFilename(filename string) {
 // of the produced qcow2 image.
 func NewQCOW2(buildPipeline *Build, imgPipeline FilePipeline) *QCOW2 {
 	p := &QCOW2{
-		Base:        NewBase(imgPipeline.Manifest(), "qcow2", buildPipeline),
+		Base:        NewBase("qcow2", buildPipeline),
 		imgPipeline: imgPipeline,
 		filename:    "image.qcow2",
 	}

--- a/pkg/manifest/raw.go
+++ b/pkg/manifest/raw.go
@@ -31,7 +31,6 @@ func NewRawImage(buildPipeline *Build, treePipeline *OS) *RawImage {
 	}
 	buildPipeline.addDependent(p)
 	p.PartTool = osbuild.PTSfdisk // default; can be changed after initialisation
-	treePipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/raw.go
+++ b/pkg/manifest/raw.go
@@ -25,7 +25,7 @@ func (p *RawImage) SetFilename(filename string) {
 
 func NewRawImage(buildPipeline *Build, treePipeline *OS) *RawImage {
 	p := &RawImage{
-		Base:         NewBase(treePipeline.Manifest(), "image", buildPipeline),
+		Base:         NewBase("image", buildPipeline),
 		treePipeline: treePipeline,
 		filename:     "disk.img",
 	}

--- a/pkg/manifest/raw_ostree.go
+++ b/pkg/manifest/raw_ostree.go
@@ -33,7 +33,6 @@ func NewRawOStreeImage(buildPipeline *Build, treePipeline *OSTreeDeployment, pla
 		platform:     platform,
 	}
 	buildPipeline.addDependent(p)
-	treePipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/raw_ostree.go
+++ b/pkg/manifest/raw_ostree.go
@@ -27,7 +27,7 @@ func (p *RawOSTreeImage) SetFilename(filename string) {
 
 func NewRawOStreeImage(buildPipeline *Build, treePipeline *OSTreeDeployment, platform platform.Platform) *RawOSTreeImage {
 	p := &RawOSTreeImage{
-		Base:         NewBase(treePipeline.Manifest(), "image", buildPipeline),
+		Base:         NewBase("image", buildPipeline),
 		treePipeline: treePipeline,
 		filename:     "disk.img",
 		platform:     platform,

--- a/pkg/manifest/tar.go
+++ b/pkg/manifest/tar.go
@@ -37,7 +37,6 @@ func NewTar(buildPipeline *Build, inputPipeline Pipeline, pipelinename string) *
 		filename:      "image.tar",
 	}
 	buildPipeline.addDependent(p)
-	inputPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/tar.go
+++ b/pkg/manifest/tar.go
@@ -32,7 +32,7 @@ func (p *Tar) SetFilename(filename string) {
 // is the name of the pipeline. The filename is the name of the output tar file.
 func NewTar(buildPipeline *Build, inputPipeline Pipeline, pipelinename string) *Tar {
 	p := &Tar{
-		Base:          NewBase(inputPipeline.Manifest(), pipelinename, buildPipeline),
+		Base:          NewBase(pipelinename, buildPipeline),
 		inputPipeline: inputPipeline,
 		filename:      "image.tar",
 	}

--- a/pkg/manifest/vmdk.go
+++ b/pkg/manifest/vmdk.go
@@ -32,7 +32,6 @@ func NewVMDK(buildPipeline *Build, imgPipeline FilePipeline) *VMDK {
 		filename:    "image.vmdk",
 	}
 	buildPipeline.addDependent(p)
-	imgPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/vmdk.go
+++ b/pkg/manifest/vmdk.go
@@ -27,7 +27,7 @@ func (p *VMDK) SetFilename(filename string) {
 // Filename is the name of the produced image.
 func NewVMDK(buildPipeline *Build, imgPipeline FilePipeline) *VMDK {
 	p := &VMDK{
-		Base:        NewBase(imgPipeline.Manifest(), "vmdk", buildPipeline),
+		Base:        NewBase("vmdk", buildPipeline),
 		imgPipeline: imgPipeline,
 		filename:    "image.vmdk",
 	}

--- a/pkg/manifest/vpc.go
+++ b/pkg/manifest/vpc.go
@@ -28,7 +28,7 @@ func (p *VPC) SetFilename(filename string) {
 // of the produced image.
 func NewVPC(buildPipeline *Build, imgPipeline *RawImage) *VPC {
 	p := &VPC{
-		Base:        NewBase(imgPipeline.Manifest(), "vpc", buildPipeline),
+		Base:        NewBase("vpc", buildPipeline),
 		imgPipeline: imgPipeline,
 		filename:    "image.vhd",
 	}

--- a/pkg/manifest/vpc.go
+++ b/pkg/manifest/vpc.go
@@ -33,7 +33,6 @@ func NewVPC(buildPipeline *Build, imgPipeline *RawImage) *VPC {
 		filename:    "image.vhd",
 	}
 	buildPipeline.addDependent(p)
-	imgPipeline.Manifest().addPipeline(p)
 	return p
 }
 

--- a/pkg/manifest/xz.go
+++ b/pkg/manifest/xz.go
@@ -25,7 +25,7 @@ func (p *XZ) SetFilename(filename string) {
 // raw image that will be xz compressed.
 func NewXZ(buildPipeline *Build, imgPipeline FilePipeline) *XZ {
 	p := &XZ{
-		Base:        NewBase(imgPipeline.Manifest(), "xz", buildPipeline),
+		Base:        NewBase("xz", buildPipeline),
 		filename:    "image.xz",
 		imgPipeline: imgPipeline,
 	}

--- a/pkg/manifest/xz.go
+++ b/pkg/manifest/xz.go
@@ -30,7 +30,6 @@ func NewXZ(buildPipeline *Build, imgPipeline FilePipeline) *XZ {
 		imgPipeline: imgPipeline,
 	}
 	buildPipeline.addDependent(p)
-	imgPipeline.Manifest().addPipeline(p)
 	return p
 }
 


### PR DESCRIPTION
This PR simplifies the Pipeline constructors (all the `manifest.New...` functions such as `NewOS()`, `NewXZ()` etc.) by removing the manifest argument.  Reasoning:

- All Pipeline implementations, excluding Build, require a build pipeline because they run in the build root.  This is not an osbuild restriction, but something we "enforce" or strongly incentivise in our image definitions.
- Any pipeline that uses a specific build pipeline must belong to the same manifest as the build pipeline.

BEFORE:
- Pipeline constructors would take a build pipeline argument and a manifest.  They would check that the build pipeline's manifest reference and the manifest argument were the same.
NOW:
- Pipeline constructors take a build pipeline argument and use the manifest reference from that argument to add themselves to the manifest

Sanity checks for manifest equivalence between the manifest's build pipeline and the manifest it is being added to are done in the `Manifest.addPipeline()` method.

See individual commit messages for more details.

---

This is part of a bigger plan to simplify the pipeline generation and configuration in general.  I still haven't figured everything out, but some of these smaller things are, I think, obvious improvements.  I'd like to get some of them merged as smaller PRs so there might be a few more like this coming.
For larger changes, like things that change the general manifest generation flow, I will discuss in advance before implementing.