### PR TITLE
osbuild: add new ContainerDeployStage for org.osbuild.container-deploy

### DIFF
--- a/pkg/osbuild/container_deploy_stage.go
+++ b/pkg/osbuild/container_deploy_stage.go
@@ -1,0 +1,32 @@
+package osbuild
+
+import "fmt"
+
+type ContainerDeployInputs struct {
+	Images ContainersInput `json:"images"`
+}
+
+func (ContainerDeployInputs) isStageInputs() {}
+
+func (inputs ContainerDeployInputs) validate() error {
+	if inputs.Images.References == nil {
+		return fmt.Errorf("stage requires exactly 1 input container (got nil References)")
+	}
+	if ncontainers := inputs.Images.References.Len(); ncontainers != 1 {
+		return fmt.Errorf("stage requires exactly 1 input container (got %d)", ncontainers)
+	}
+	return nil
+}
+
+func NewContainerDeployStage(images ContainersInput) (*Stage, error) {
+	inputs := ContainerDeployInputs{
+		Images: images,
+	}
+	if err := inputs.validate(); err != nil {
+		return nil, err
+	}
+	return &Stage{
+		Type:   "org.osbuild.container-deploy",
+		Inputs: inputs,
+	}, nil
+}

--- a/pkg/osbuild/container_deploy_stage_test.go
+++ b/pkg/osbuild/container_deploy_stage_test.go
@@ -1,0 +1,122 @@
+package osbuild_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+func TestContainersDeployStageInputs(t *testing.T) {
+	inputs := osbuild.NewContainersInputForSources([]container.Spec{
+		{
+			ImageID: "id-0",
+			Source:  "registry.example.org/reg/img",
+		},
+	})
+	stage, err := osbuild.NewContainerDeployStage(inputs)
+	require.NotNil(t, stage)
+	require.Nil(t, err)
+
+	assert.Equal(t, stage.Type, "org.osbuild.container-deploy")
+	assert.Equal(t, stage.Inputs.(osbuild.ContainerDeployInputs).Images, inputs)
+}
+
+func TestContainersDeployStageOptionsJson(t *testing.T) {
+	expectedJson := `{
+        "images": {
+                "type": "org.osbuild.containers",
+                "origin": "org.osbuild.source",
+                "references": {
+                        "some-id": {
+                                "name": "some-local-name"
+                        }
+                }
+        }
+}`
+	cdi := osbuild.ContainerDeployInputs{
+		Images: osbuild.NewContainersInputForSources([]container.Spec{
+			{
+				ImageID:   "some-id",
+				LocalName: "some-local-name",
+				// hm, the values below are not actually used?
+				Source:     "some-source",
+				Digest:     "some-digest",
+				ListDigest: "some-list-digest",
+			},
+		}),
+	}
+	json, err := json.MarshalIndent(cdi, "", "        ")
+	require.Nil(t, err)
+	assert.Equal(t, string(json), expectedJson)
+}
+
+func TestContainersDeployStageInputsValidate(t *testing.T) {
+	type testCase struct {
+		inputs osbuild.ContainerDeployInputs
+		err    string
+	}
+
+	testCases := map[string]testCase{
+		"empty": {
+			inputs: osbuild.ContainerDeployInputs{},
+			err:    "stage requires exactly 1 input container (got nil References)",
+		},
+		"nil": {
+			inputs: osbuild.ContainerDeployInputs{
+				Images: osbuild.ContainersInput{
+					References: nil,
+				},
+			},
+			err: "stage requires exactly 1 input container (got nil References)",
+		},
+		"zero": {
+			inputs: osbuild.ContainerDeployInputs{
+				Images: osbuild.NewContainersInputForSources([]container.Spec{}),
+			},
+			err: "stage requires exactly 1 input container (got 0)",
+		},
+		"one": {
+			inputs: osbuild.ContainerDeployInputs{
+				Images: osbuild.NewContainersInputForSources([]container.Spec{
+					{
+						ImageID: "id-0",
+						Source:  "registry.example.org/reg/img",
+					},
+				}),
+			},
+		},
+		"two": {
+			inputs: osbuild.ContainerDeployInputs{
+				Images: osbuild.NewContainersInputForSources([]container.Spec{
+					{
+						ImageID: "id-1",
+						Source:  "registry.example.org/reg/img-one",
+					},
+					{
+						ImageID: "id-2",
+						Source:  "registry.example.org/reg/img-two",
+					},
+				}),
+			},
+			err: "stage requires exactly 1 input container (got 2)",
+		},
+	}
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
+			stage, err := osbuild.NewContainerDeployStage(tc.inputs.Images)
+			if tc.err == "" {
+				require.NotNil(t, stage)
+				require.Nil(t, err)
+			} else {
+				require.Nil(t, stage)
+				assert.ErrorContains(t, err, tc.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit adds support for the new `org.osbuild.container-deploy` stage (see https://github.com/osbuild/osbuild/pull/1509).