### PR TITLE
osbuild: simplify containers_input.go

### DIFF
--- a/pkg/osbuild/container_deploy_stage.go
+++ b/pkg/osbuild/container_deploy_stage.go
@@ -12,7 +12,7 @@ func (inputs ContainerDeployInputs) validate() error {
 	if inputs.Images.References == nil {
 		return fmt.Errorf("stage requires exactly 1 input container (got nil References)")
 	}
-	if ncontainers := inputs.Images.References.Len(); ncontainers != 1 {
+	if ncontainers := len(inputs.Images.References); ncontainers != 1 {
 		return fmt.Errorf("stage requires exactly 1 input container (got %d)", ncontainers)
 	}
 	return nil

--- a/pkg/osbuild/containers_input.go
+++ b/pkg/osbuild/containers_input.go
@@ -4,32 +4,17 @@ import (
 	"github.com/osbuild/images/pkg/container"
 )
 
-type ContainersInputReferences interface {
-	isContainersInputReferences()
-	Len() int
-}
-
 type ContainersInputSourceRef struct {
 	Name string `json:"name"`
 }
 
-type ContainersInputSourceMap map[string]ContainersInputSourceRef
-
-func (ContainersInputSourceMap) isContainersInputReferences() {}
-
-func (cism ContainersInputSourceMap) Len() int {
-	return len(cism)
-}
-
 type ContainersInput struct {
 	inputCommon
-	References ContainersInputReferences `json:"references"`
+	References map[string]ContainersInputSourceRef `json:"references"`
 }
 
-const InputTypeContainers string = "org.osbuild.containers"
-
 func NewContainersInputForSources(containers []container.Spec) ContainersInput {
-	refs := make(ContainersInputSourceMap, len(containers))
+	refs := make(map[string]ContainersInputSourceRef, len(containers))
 	for _, c := range containers {
 		ref := ContainersInputSourceRef{
 			Name: c.LocalName,
@@ -40,7 +25,7 @@ func NewContainersInputForSources(containers []container.Spec) ContainersInput {
 	return ContainersInput{
 		References: refs,
 		inputCommon: inputCommon{
-			Type:   InputTypeContainers,
+			Type:   "org.osbuild.containers",
 			Origin: InputOriginSource,
 		},
 	}

--- a/pkg/osbuild/ostree_deploy_container_stage.go
+++ b/pkg/osbuild/ostree_deploy_container_stage.go
@@ -51,7 +51,7 @@ func (inputs OSTreeDeployContainerInputs) validate() error {
 	if inputs.Images.References == nil {
 		return fmt.Errorf("stage requires exactly 1 input container (got nil References)")
 	}
-	if ncontainers := inputs.Images.References.Len(); ncontainers != 1 {
+	if ncontainers := len(inputs.Images.References); ncontainers != 1 {
 		return fmt.Errorf("stage requires exactly 1 input container (got %d)", ncontainers)
 	}
 	return nil


### PR DESCRIPTION
[only the second commit is new in this PR]

While writing tests to ensure the that the `ContainerDeployInputs`
generates the correct json I noticed that this was more involved
than I had hoped and it seems there are some indirections in the
code that may not be necessary. I removed them and IMHHO the code
is now a bit more direct and easier to read.

Feedback very welcome!

Build on top of https://github.com/osbuild/images/pull/348 (as I wanted the unit tests from it).