### PR TITLE
Add FIPS enabled image warning

### DIFF
--- a/internal/common/fips.go
+++ b/internal/common/fips.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+const (
+	FIPSEnabledImageWarning = `The host building this image is not ` +
+		`running in FIPS mode. The image will still be FIPS compliant. ` +
+		`If you have custom steps that generate keys or perform ` +
+		`cryptographic operations, those must be considered non-compliant.`
+)
+
+var (
+	FIPSEnabledFilePath = "/proc/sys/crypto/fips_enabled"
+)
+
+func IsBuildHostFIPSEnabled() (enabled bool) {
+	file, err := os.Open(FIPSEnabledFilePath)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	buf := []byte{}
+	_, err = file.Read(buf)
+	if err != nil {
+		return
+	}
+	scanner := bufio.NewScanner(file)
+	scanner.Scan()
+	if err := scanner.Err(); err != nil {
+		return
+	}
+	return strings.TrimSpace(scanner.Text()) == "1"
+}

--- a/internal/common/fips_test.go
+++ b/internal/common/fips_test.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFIPSEnabledHost(t *testing.T) {
+	file, err := os.CreateTemp("/tmp", "fips_enabled")
+	assert.NoError(t, err, "unable to create tmp file")
+	defer file.Close()
+	defer os.Remove(file.Name())
+	FIPSEnabledFilePath = file.Name()
+
+	fileContents := []string{
+		"",
+		"0\n",
+		"1\n",
+		"xxxxxx\n",
+	}
+
+	for _, fileContent := range fileContents {
+		err = file.Truncate(0)
+		assert.NoError(t, err, "truncating file: %s", file.Name())
+		_, err = file.Seek(0, 0)
+		assert.NoError(t, err, "seeking the begining of file: %s", file.Name())
+		_, err = file.Write([]byte(fileContent))
+		assert.NoError(t, err, "unable to write to file: %s", file.Name())
+		if strings.TrimSpace(fileContent) == "1" {
+			assert.Equal(t, IsBuildHostFIPSEnabled(), true)
+		} else {
+			assert.Equal(t, IsBuildHostFIPSEnabled(), false)
+		}
+	}
+}

--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -17,6 +17,8 @@ const (
 	BOOT_LEGACY
 	BOOT_UEFI
 	BOOT_HYBRID
+	UnsupportedCustomizationError = "unsupported blueprint customizations found for image type %q: (allowed: %s)"
+	NoCustomizationsAllowedError  = "image type %q does not support customizations"
 )
 
 func (m BootMode) String() string {

--- a/pkg/distro/fedora/distro_test.go
+++ b/pkg/distro/fedora/distro_test.go
@@ -492,11 +492,11 @@ func TestDistro_ManifestError(t *testing.T) {
 				} else if imgTypeName == "iot-installer" || imgTypeName == "iot-simplified-installer" {
 					assert.EqualError(t, err, fmt.Sprintf("boot ISO image type \"%s\" requires specifying a URL from which to retrieve the OSTree commit", imgTypeName))
 				} else if imgTypeName == "image-installer" {
-					assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for boot ISO image type \"%s\": (allowed: User, Group, FIPS)", imgTypeName))
+					assert.EqualError(t, err, fmt.Sprintf(distro.UnsupportedCustomizationError, imgTypeName, "User, Group, FIPS"))
 				} else if imgTypeName == "live-installer" {
-					assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for boot ISO image type \"%s\": (allowed: None)", imgTypeName))
+					assert.EqualError(t, err, fmt.Sprintf(distro.NoCustomizationsAllowedError, imgTypeName))
 				} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-qcow2-image" {
-					assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services, FIPS)", imgTypeName))
+					assert.EqualError(t, err, fmt.Sprintf(distro.UnsupportedCustomizationError, imgTypeName, "User, Group, Directories, Files, Services, FIPS"))
 				} else {
 					assert.NoError(t, err)
 				}
@@ -672,11 +672,11 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
 			} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-qcow2-image" {
-				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services, FIPS)", imgTypeName))
+				assert.EqualError(t, err, fmt.Sprintf(distro.UnsupportedCustomizationError, imgTypeName, "User, Group, Directories, Files, Services, FIPS"))
 			} else if imgTypeName == "iot-installer" || imgTypeName == "iot-simplified-installer" || imgTypeName == "image-installer" {
 				continue
 			} else if imgTypeName == "live-installer" {
-				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for boot ISO image type \"%s\": (allowed: None)", imgTypeName))
+				assert.EqualError(t, err, fmt.Sprintf(distro.NoCustomizationsAllowedError, imgTypeName))
 			} else {
 				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/etc\"]")
 			}
@@ -704,11 +704,11 @@ func TestDistro_TestRootMountPoint(t *testing.T) {
 			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
 			} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-qcow2-image" {
-				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services, FIPS)", imgTypeName))
+				assert.EqualError(t, err, fmt.Sprintf(distro.UnsupportedCustomizationError, imgTypeName, "User, Group, Directories, Files, Services, FIPS"))
 			} else if imgTypeName == "iot-installer" || imgTypeName == "iot-simplified-installer" || imgTypeName == "image-installer" {
 				continue
 			} else if imgTypeName == "live-installer" {
-				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for boot ISO image type \"%s\": (allowed: None)", imgTypeName))
+				assert.EqualError(t, err, fmt.Sprintf(distro.NoCustomizationsAllowedError, imgTypeName))
 			} else {
 				assert.NoError(t, err)
 			}
@@ -740,7 +740,7 @@ func TestDistro_CustomFileSystemSubDirectories(t *testing.T) {
 			if strings.HasPrefix(imgTypeName, "iot-") || strings.HasPrefix(imgTypeName, "image-") {
 				continue
 			} else if imgTypeName == "live-installer" {
-				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for boot ISO image type \"%s\": (allowed: None)", imgTypeName))
+				assert.EqualError(t, err, fmt.Sprintf(distro.NoCustomizationsAllowedError, imgTypeName))
 			} else {
 				assert.NoError(t, err)
 			}
@@ -780,7 +780,7 @@ func TestDistro_MountpointsWithArbitraryDepthAllowed(t *testing.T) {
 			if strings.HasPrefix(imgTypeName, "iot-") || strings.HasPrefix(imgTypeName, "image-") {
 				continue
 			} else if imgTypeName == "live-installer" {
-				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for boot ISO image type \"%s\": (allowed: None)", imgTypeName))
+				assert.EqualError(t, err, fmt.Sprintf(distro.NoCustomizationsAllowedError, imgTypeName))
 			} else {
 				assert.NoError(t, err)
 			}
@@ -816,7 +816,7 @@ func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 			if strings.HasPrefix(imgTypeName, "iot-") || strings.HasPrefix(imgTypeName, "image-") {
 				continue
 			} else if imgTypeName == "live-installer" {
-				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for boot ISO image type \"%s\": (allowed: None)", imgTypeName))
+				assert.EqualError(t, err, fmt.Sprintf(distro.NoCustomizationsAllowedError, imgTypeName))
 			} else {
 				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"//\" \"/var//\" \"/var//log/audit/\"]")
 			}
@@ -844,11 +844,11 @@ func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
 			} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-qcow2-image" {
-				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services, FIPS)", imgTypeName))
+				assert.EqualError(t, err, fmt.Sprintf(distro.UnsupportedCustomizationError, imgTypeName, "User, Group, Directories, Files, Services, FIPS"))
 			} else if imgTypeName == "iot-installer" || imgTypeName == "iot-simplified-installer" || imgTypeName == "image-installer" {
 				continue
 			} else if imgTypeName == "live-installer" {
-				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for boot ISO image type \"%s\": (allowed: None)", imgTypeName))
+				assert.EqualError(t, err, fmt.Sprintf(distro.NoCustomizationsAllowedError, imgTypeName))
 			} else {
 				assert.NoError(t, err)
 			}

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -392,5 +392,10 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		return nil, err
 	}
 
+	if customizations.GetFIPS() && !common.IsBuildHostFIPSEnabled() {
+		w := fmt.Sprintln(common.FIPSEnabledImageWarning)
+		return []string{w}, nil
+	}
+
 	return nil, nil
 }

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -280,7 +280,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 	if t.name == "iot-raw-image" || t.name == "iot-qcow2-image" {
 		allowed := []string{"User", "Group", "Directories", "Files", "Services", "FIPS"}
 		if err := customizations.CheckAllowed(allowed...); err != nil {
-			return nil, fmt.Errorf("unsupported blueprint customizations found for image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
+			return nil, fmt.Errorf(distro.UnsupportedCustomizationError, t.name, strings.Join(allowed, ", "))
 		}
 		// TODO: consider additional checks, such as those in "edge-simplified-installer" in RHEL distros
 	}
@@ -291,7 +291,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		if t.name == "iot-simplified-installer" {
 			allowed := []string{"InstallationDevice", "FDO", "Ignition", "Kernel", "User", "Group", "FIPS"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
-				return nil, fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
+				return nil, fmt.Errorf(distro.UnsupportedCustomizationError, t.name, strings.Join(allowed, ", "))
 			}
 			if customizations.GetInstallationDevice() == "" {
 				return nil, fmt.Errorf("boot ISO image type %q requires specifying an installation device to install to", t.name)
@@ -329,12 +329,12 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		} else if t.name == "iot-installer" || t.name == "image-installer" {
 			allowed := []string{"User", "Group", "FIPS"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
-				return nil, fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
+				return nil, fmt.Errorf(distro.UnsupportedCustomizationError, t.name, strings.Join(allowed, ", "))
 			}
 		} else if t.name == "live-installer" {
 			allowed := []string{}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
-				return nil, fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: None)", t.name)
+				return nil, fmt.Errorf(distro.NoCustomizationsAllowedError, t.name)
 			}
 		}
 	}

--- a/pkg/distro/rhel7/imagetype.go
+++ b/pkg/distro/rhel7/imagetype.go
@@ -237,7 +237,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		// set of customizations.  The current set of customizations defined in
 		// the blueprint spec corresponds to the Custom workflow.
 		if customizations != nil {
-			return warnings, fmt.Errorf("image type %q does not support customizations", t.name)
+			return warnings, fmt.Errorf(distro.NoCustomizationsAllowedError, t.name)
 		}
 	}
 

--- a/pkg/distro/rhel8/distro_test.go
+++ b/pkg/distro/rhel8/distro_test.go
@@ -493,7 +493,7 @@ func TestDistro_ManifestError(t *testing.T) {
 			} else if imgTypeName == "edge-installer" || imgTypeName == "edge-simplified-installer" {
 				assert.EqualError(t, err, fmt.Sprintf("boot ISO image type %q requires specifying a URL from which to retrieve the OSTree commit", imgTypeName))
 			} else if imgTypeName == "azure-eap7-rhui" {
-				assert.EqualError(t, err, fmt.Sprintf("image type %q does not support customizations", imgTypeName))
+				assert.EqualError(t, err, fmt.Sprintf(distro.NoCustomizationsAllowedError, imgTypeName))
 			} else {
 				assert.NoError(t, err)
 			}

--- a/pkg/distro/rhel8/imagetype.go
+++ b/pkg/distro/rhel8/imagetype.go
@@ -427,5 +427,11 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		return warnings, err
 	}
 
+	if customizations.GetFIPS() && !common.IsBuildHostFIPSEnabled() {
+		w := fmt.Sprintln(common.FIPSEnabledImageWarning)
+		log.Print(w)
+		warnings = append(warnings, w)
+	}
+
 	return warnings, nil
 }

--- a/pkg/distro/rhel8/imagetype.go
+++ b/pkg/distro/rhel8/imagetype.go
@@ -282,7 +282,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		// set of customizations.  The current set of customizations defined in
 		// the blueprint spec corresponds to the Custom workflow.
 		if customizations != nil {
-			return warnings, fmt.Errorf("image type %q does not support customizations", t.name)
+			return warnings, fmt.Errorf(distro.NoCustomizationsAllowedError, t.name)
 		}
 	}
 	// we do not support embedding containers on ostree-derived images, only on commits themselves
@@ -313,7 +313,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		if t.name == "edge-simplified-installer" {
 			allowed := []string{"InstallationDevice", "FDO", "User", "Group", "FIPS"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
-				return warnings, fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
+				return warnings, fmt.Errorf(distro.UnsupportedCustomizationError, t.name, strings.Join(allowed, ", "))
 			}
 			if customizations.GetInstallationDevice() == "" {
 				return warnings, fmt.Errorf("boot ISO image type %q requires specifying an installation device to install to", t.name)
@@ -340,7 +340,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		} else if t.name == "edge-installer" {
 			allowed := []string{"User", "Group", "FIPS"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
-				return warnings, fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
+				return warnings, fmt.Errorf(distro.UnsupportedCustomizationError, t.name, strings.Join(allowed, ", "))
 			}
 		}
 	}
@@ -353,7 +353,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 
 		allowed := []string{"User", "Group", "FIPS"}
 		if err := customizations.CheckAllowed(allowed...); err != nil {
-			return warnings, fmt.Errorf("unsupported blueprint customizations found for image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
+			return warnings, fmt.Errorf(distro.UnsupportedCustomizationError, t.name, strings.Join(allowed, ", "))
 		}
 		// TODO: consider additional checks, such as those in "edge-simplified-installer"
 	}

--- a/pkg/distro/rhel9/imagetype.go
+++ b/pkg/distro/rhel9/imagetype.go
@@ -442,5 +442,11 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		return warnings, err
 	}
 
+	if customizations.GetFIPS() && !common.IsBuildHostFIPSEnabled() {
+		w := fmt.Sprintln(common.FIPSEnabledImageWarning)
+		log.Print(w)
+		warnings = append(warnings, w)
+	}
+
 	return warnings, nil
 }

--- a/pkg/distro/rhel9/imagetype.go
+++ b/pkg/distro/rhel9/imagetype.go
@@ -281,7 +281,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		// set of customizations.  The current set of customizations defined in
 		// the blueprint spec corresponds to the Custom workflow.
 		if customizations != nil {
-			return warnings, fmt.Errorf("image type %q does not support customizations", t.name)
+			return warnings, fmt.Errorf(distro.NoCustomizationsAllowedError, t.name)
 		}
 	}
 
@@ -313,7 +313,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		if t.name == "edge-simplified-installer" {
 			allowed := []string{"InstallationDevice", "FDO", "Ignition", "Kernel", "User", "Group", "FIPS", "Filesystem"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
-				return warnings, fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
+				return warnings, fmt.Errorf(distro.UnsupportedCustomizationError, t.name, strings.Join(allowed, ", "))
 			}
 			if customizations.GetInstallationDevice() == "" {
 				return warnings, fmt.Errorf("boot ISO image type %q requires specifying an installation device to install to", t.name)
@@ -351,7 +351,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		} else if t.name == "edge-installer" {
 			allowed := []string{"User", "Group", "FIPS"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
-				return warnings, fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
+				return warnings, fmt.Errorf(distro.UnsupportedCustomizationError, t.name, strings.Join(allowed, ", "))
 			}
 		}
 	}
@@ -363,7 +363,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		}
 		allowed := []string{"Ignition", "Kernel", "User", "Group", "FIPS", "Filesystem"}
 		if err := customizations.CheckAllowed(allowed...); err != nil {
-			return warnings, fmt.Errorf("unsupported blueprint customizations found for image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
+			return warnings, fmt.Errorf(distro.UnsupportedCustomizationError, t.name, strings.Join(allowed, ", "))
 		}
 		// TODO: consider additional checks, such as those in "edge-simplified-installer"
 	}


### PR DESCRIPTION
Show a warning message when building a FIPS enabled image in a non enabled FIPS host
