### PR TITLE
Fedora: Enable remote in iot-installer kickstart

### DIFF
--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -485,7 +485,8 @@ func iotInstallerImage(workload workload.Workload,
 	img.ISOLabelTempl = d.isolabelTmpl
 	img.Product = d.product
 	img.Variant = "IoT"
-	img.OSName = "fedora"
+	img.OSName = "fedora-iot"
+	img.Remote = "fedora-iot"
 	img.OSVersion = d.osVersion
 	img.Release = fmt.Sprintf("%s %s", d.product, d.osVersion)
 

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -31,6 +31,7 @@ type AnacondaOSTreeInstaller struct {
 	OSName        string
 	OSVersion     string
 	Release       string
+	Remote        string
 
 	Commit ostree.SourceSpec
 
@@ -120,6 +121,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.PartitionTable = rootfsPartitionTable
 	isoTreePipeline.Release = img.Release
 	isoTreePipeline.OSName = img.OSName
+	isoTreePipeline.Remote = img.Remote
 	isoTreePipeline.Users = img.Users
 	isoTreePipeline.Groups = img.Groups
 

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -23,6 +23,7 @@ type AnacondaInstallerISOTree struct {
 	// TODO: review optional and mandatory fields and their meaning
 	OSName  string
 	Release string
+	Remote  string
 	Users   []users.User
 	Groups  []users.Group
 
@@ -336,6 +337,7 @@ func (p *AnacondaInstallerISOTree) serialize() osbuild.Pipeline {
 			p.Groups,
 			makeISORootPath(p.PayloadPath),
 			p.ostreeCommitSpec.Ref,
+			p.Remote,
 			p.OSName)
 
 		if err != nil {

--- a/pkg/osbuild/kickstart_stage.go
+++ b/pkg/osbuild/kickstart_stage.go
@@ -22,6 +22,7 @@ type LiveIMGOptions struct {
 
 type OSTreeCommitOptions struct {
 	OSName string `json:"osname"`
+	Remote string `json:"remote"`
 	URL    string `json:"url"`
 	Ref    string `json:"ref"`
 	GPG    bool   `json:"gpg"`
@@ -77,6 +78,7 @@ func NewKickstartStageOptionsWithOSTreeCommit(
 	groupCustomizations []users.Group,
 	ostreeURL string,
 	ostreeRef string,
+	ostreeRemote string,
 	osName string) (*KickstartStageOptions, error) {
 
 	options, err := NewKickstartStageOptions(path, userCustomizations, groupCustomizations)
@@ -88,6 +90,7 @@ func NewKickstartStageOptionsWithOSTreeCommit(
 	if ostreeURL != "" {
 		ostreeCommitOptions := &OSTreeCommitOptions{
 			OSName: osName,
+			Remote: ostreeRemote,
 			URL:    ostreeURL,
 			Ref:    ostreeRef,
 			GPG:    false,


### PR DESCRIPTION
Currently the Fedora IoT installer ISO's are not configured to use the upstream repository and instead use the OStree commit included on the installation ISO.  To use the intended upstream remote, users are currently required to run a few `ostree` commands to make the change.

This PR enables the `--remote` option in the iot-installer kickstart to use the repository listed in the `fedora-iot-config` package. 

Signed-off-by: Paul Whalen <pwhalen@fedoraproject.org>