### PR TITLE
manifest,images: add new manifest.NewBuildFromContainerSpec and use in new `BootcDiskImage` (HMS-3318)

### DIFF
--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -1,0 +1,72 @@
+package image
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/osbuild/images/pkg/artifact"
+	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/runner"
+)
+
+type BootcDiskImage struct {
+	*OSTreeDiskImage
+}
+
+func NewBootcDiskImage(container container.SourceSpec) *BootcDiskImage {
+	// XXX: hardcoded for now
+	ref := "ostree/1/1/0"
+
+	return &BootcDiskImage{
+		&OSTreeDiskImage{
+			Base:            NewBase("bootc-raw-image"),
+			ContainerSource: &container,
+			Ref:             ref,
+			OSName:          "default",
+		},
+	}
+}
+
+func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifest,
+	containers []container.SourceSpec,
+	runner runner.Runner,
+	rng *rand.Rand) (*artifact.Artifact, error) {
+
+	buildPipeline := manifest.NewBuildFromContainer(m, runner, containers, &manifest.BuildOptions{ContainerBuildable: true})
+	buildPipeline.Checkpoint()
+
+	// don't support compressing non-raw images
+	imgFormat := img.Platform.GetImageFormat()
+	if imgFormat == platform.FORMAT_UNSET {
+		// treat unset as raw for this check
+		imgFormat = platform.FORMAT_RAW
+	}
+	if imgFormat != platform.FORMAT_RAW && img.Compression != "" {
+		panic(fmt.Sprintf("no compression is allowed with %q format for %q", imgFormat, img.name))
+	}
+
+	baseImage := baseRawOstreeImage(img.OSTreeDiskImage, buildPipeline)
+	switch imgFormat {
+	case platform.FORMAT_QCOW2:
+		// TODO: create new build pipeline here that uses "bib" itself
+		// as the buildroot to get access to tooling like "qemu-img"
+		qcow2Pipeline := manifest.NewQCOW2(buildPipeline, baseImage)
+		qcow2Pipeline.Compat = img.Platform.GetQCOW2Compat()
+		qcow2Pipeline.SetFilename(img.Filename)
+		return qcow2Pipeline.Export(), nil
+	}
+
+	switch img.Compression {
+	case "xz":
+		compressedImage := manifest.NewXZ(buildPipeline, baseImage)
+		compressedImage.SetFilename(img.Filename)
+		return compressedImage.Export(), nil
+	case "":
+		baseImage.SetFilename(img.Filename)
+		return baseImage.Export(), nil
+	default:
+		panic(fmt.Sprintf("unsupported compression type %q on %q", img.Compression, img.name))
+	}
+}

--- a/pkg/image/bootc_disk_test.go
+++ b/pkg/image/bootc_disk_test.go
@@ -1,0 +1,22 @@
+package image_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/image"
+)
+
+func TestBootcDiskImageNew(t *testing.T) {
+	containerSource := container.SourceSpec{
+		Source: "source-spec",
+		Name:   "name",
+	}
+
+	img := image.NewBootcDiskImage(containerSource)
+	require.NotNil(t, img)
+	assert.Equal(t, img.OSTreeDiskImage.Base.Name(), "bootc-raw-image")
+}

--- a/pkg/image/export_test.go
+++ b/pkg/image/export_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/osbuild/images/pkg/runner"
 )
 
-func MockManifestNewBuild(new func(m *manifest.Manifest, runner runner.Runner, repos []rpmmd.RepoConfig, opts *manifest.BuildOptions) *manifest.Build) (restore func()) {
+func MockManifestNewBuild(new func(m *manifest.Manifest, runner runner.Runner, repos []rpmmd.RepoConfig, opts *manifest.BuildOptions) manifest.Build) (restore func()) {
 	saved := manifestNewBuild
 	manifestNewBuild = new
 	return func() {

--- a/pkg/image/ostree_disk.go
+++ b/pkg/image/ostree_disk.go
@@ -100,9 +100,10 @@ func baseRawOstreeImage(img *OSTreeDiskImage, buildPipeline manifest.Build) *man
 	osPipeline.LockRoot = img.LockRoot
 
 	// other image types (e.g. live) pass the workload to the pipeline.
-	osPipeline.EnabledServices = img.Workload.GetServices()
-	osPipeline.DisabledServices = img.Workload.GetDisabledServices()
-
+	if img.Workload != nil {
+		osPipeline.EnabledServices = img.Workload.GetServices()
+		osPipeline.DisabledServices = img.Workload.GetDisabledServices()
+	}
 	return manifest.NewRawOStreeImage(buildPipeline, osPipeline, img.Platform)
 }
 

--- a/pkg/image/ostree_disk.go
+++ b/pkg/image/ostree_disk.go
@@ -74,7 +74,7 @@ func NewOSTreeDiskImageFromContainer(container container.SourceSpec, ref string)
 	}
 }
 
-func baseRawOstreeImage(img *OSTreeDiskImage, buildPipeline *manifest.Build) *manifest.RawOSTreeImage {
+func baseRawOstreeImage(img *OSTreeDiskImage, buildPipeline manifest.Build) *manifest.RawOSTreeImage {
 	var osPipeline *manifest.OSTreeDeployment
 	switch {
 	case img.CommitSource != nil:

--- a/pkg/image/ostree_disk_test.go
+++ b/pkg/image/ostree_disk_test.go
@@ -28,7 +28,7 @@ func TestOSTreeDiskImageManifestSetsContainerBuildable(t *testing.T) {
 	}
 
 	var buildOpts []*manifest.BuildOptions
-	restore := image.MockManifestNewBuild(func(m *manifest.Manifest, r runner.Runner, repos []rpmmd.RepoConfig, opts *manifest.BuildOptions) *manifest.Build {
+	restore := image.MockManifestNewBuild(func(m *manifest.Manifest, r runner.Runner, repos []rpmmd.RepoConfig, opts *manifest.BuildOptions) manifest.Build {
 		buildOpts = append(buildOpts, opts)
 		return manifest.NewBuild(m, r, repos, opts)
 	})

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -78,7 +78,7 @@ type AnacondaInstaller struct {
 }
 
 func NewAnacondaInstaller(installerType AnacondaInstallerType,
-	buildPipeline *Build,
+	buildPipeline Build,
 	platform platform.Platform,
 	repos []rpmmd.RepoConfig,
 	kernelName,

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -60,7 +60,7 @@ type AnacondaInstallerISOTree struct {
 	Files []*fsnode.File
 }
 
-func NewAnacondaInstallerISOTree(buildPipeline *Build, anacondaPipeline *AnacondaInstaller, rootfsPipeline *ISORootfsImg, bootTreePipeline *EFIBootTree) *AnacondaInstallerISOTree {
+func NewAnacondaInstallerISOTree(buildPipeline Build, anacondaPipeline *AnacondaInstaller, rootfsPipeline *ISORootfsImg, bootTreePipeline *EFIBootTree) *AnacondaInstallerISOTree {
 
 	// the three pipelines should all belong to the same manifest
 	if anacondaPipeline.Manifest() != rootfsPipeline.Manifest() ||

--- a/pkg/manifest/build_test.go
+++ b/pkg/manifest/build_test.go
@@ -14,7 +14,8 @@ func TestBuildContainerBuildableNo(t *testing.T) {
 	mf := New()
 	runner := &runner.Fedora{Version: 39}
 
-	build := NewBuild(&mf, runner, repos, nil)
+	buildIf := NewBuild(&mf, runner, repos, nil)
+	build := buildIf.(*BuildrootFromPackages)
 	require.NotNil(t, build)
 
 	for _, tc := range []struct {

--- a/pkg/manifest/coi_iso_tree.go
+++ b/pkg/manifest/coi_iso_tree.go
@@ -36,7 +36,7 @@ type CoreOSISOTree struct {
 }
 
 func NewCoreOSISOTree(
-	buildPipeline *Build,
+	buildPipeline Build,
 	payloadPipeline *XZ,
 	coiPipeline *CoreOSInstaller,
 	bootTreePipeline *EFIBootTree) *CoreOSISOTree {

--- a/pkg/manifest/commit.go
+++ b/pkg/manifest/commit.go
@@ -16,7 +16,7 @@ type OSTreeCommit struct {
 // NewOSTreeCommit creates a new OSTree commit pipeline. The
 // treePipeline is the tree representing the content of the commit.
 // ref is the ref to create the commit under.
-func NewOSTreeCommit(buildPipeline *Build, treePipeline *OS, ref string) *OSTreeCommit {
+func NewOSTreeCommit(buildPipeline Build, treePipeline *OS, ref string) *OSTreeCommit {
 	p := &OSTreeCommit{
 		Base:         NewBase("ostree-commit", buildPipeline),
 		treePipeline: treePipeline,

--- a/pkg/manifest/commit_server_tree.go
+++ b/pkg/manifest/commit_server_tree.go
@@ -36,7 +36,7 @@ type OSTreeCommitServer struct {
 // is a pipeline producing an ostree commit to be served. nginxConfigPath
 // is the path to the main nginx config file and listenPort is the port
 // nginx will be listening on.
-func NewOSTreeCommitServer(buildPipeline *Build,
+func NewOSTreeCommitServer(buildPipeline Build,
 	platform platform.Platform,
 	repos []rpmmd.RepoConfig,
 	commitPipeline *OSTreeCommit,

--- a/pkg/manifest/coreos_installer.go
+++ b/pkg/manifest/coreos_installer.go
@@ -47,7 +47,7 @@ type CoreOSInstaller struct {
 }
 
 // NewCoreOSInstaller creates an CoreOS installer pipeline object.
-func NewCoreOSInstaller(buildPipeline *Build,
+func NewCoreOSInstaller(buildPipeline Build,
 	platform platform.Platform,
 	repos []rpmmd.RepoConfig,
 	kernelName,

--- a/pkg/manifest/efi_boot_tree.go
+++ b/pkg/manifest/efi_boot_tree.go
@@ -20,7 +20,7 @@ type EFIBootTree struct {
 	KernelOpts []string
 }
 
-func NewEFIBootTree(buildPipeline *Build, product, version string) *EFIBootTree {
+func NewEFIBootTree(buildPipeline Build, product, version string) *EFIBootTree {
 	p := &EFIBootTree{
 		Base:    NewBase("efiboot-tree", buildPipeline),
 		product: product,

--- a/pkg/manifest/iso.go
+++ b/pkg/manifest/iso.go
@@ -24,7 +24,7 @@ func (p *ISO) SetFilename(filename string) {
 	p.filename = filename
 }
 
-func NewISO(buildPipeline *Build, treePipeline Pipeline, isoLabel string) *ISO {
+func NewISO(buildPipeline Build, treePipeline Pipeline, isoLabel string) *ISO {
 	p := &ISO{
 		Base:         NewBase("bootiso", buildPipeline),
 		treePipeline: treePipeline,

--- a/pkg/manifest/iso_rootfs.go
+++ b/pkg/manifest/iso_rootfs.go
@@ -14,7 +14,7 @@ type ISORootfsImg struct {
 	installerPipeline Pipeline
 }
 
-func NewISORootfsImg(buildPipeline *Build, installerPipeline Pipeline) *ISORootfsImg {
+func NewISORootfsImg(buildPipeline Build, installerPipeline Pipeline) *ISORootfsImg {
 	p := &ISORootfsImg{
 		Base:              NewBase("rootfs-image", buildPipeline),
 		installerPipeline: installerPipeline,

--- a/pkg/manifest/oci_container.go
+++ b/pkg/manifest/oci_container.go
@@ -24,7 +24,7 @@ func (p *OCIContainer) SetFilename(filename string) {
 	p.filename = filename
 }
 
-func NewOCIContainer(buildPipeline *Build, treePipeline TreePipeline) *OCIContainer {
+func NewOCIContainer(buildPipeline Build, treePipeline TreePipeline) *OCIContainer {
 	p := &OCIContainer{
 		Base:         NewBase("container", buildPipeline),
 		treePipeline: treePipeline,

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -179,7 +179,7 @@ type OS struct {
 // NewOS creates a new OS pipeline. build is the build pipeline to use for
 // building the OS pipeline. platform is the target platform for the final
 // image. repos are the repositories to install RPMs from.
-func NewOS(buildPipeline *Build, platform platform.Platform, repos []rpmmd.RepoConfig) *OS {
+func NewOS(buildPipeline Build, platform platform.Platform, repos []rpmmd.RepoConfig) *OS {
 	name := "os"
 	p := &OS{
 		Base:            NewBase(name, buildPipeline),

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -75,7 +75,7 @@ type OSTreeDeployment struct {
 
 // NewOSTreeCommitDeployment creates a pipeline for an ostree deployment from a
 // commit.
-func NewOSTreeCommitDeployment(buildPipeline *Build,
+func NewOSTreeCommitDeployment(buildPipeline Build,
 	commit *ostree.SourceSpec,
 	osName string,
 	platform platform.Platform) *OSTreeDeployment {
@@ -92,7 +92,7 @@ func NewOSTreeCommitDeployment(buildPipeline *Build,
 
 // NewOSTreeDeployment creates a pipeline for an ostree deployment from a
 // container
-func NewOSTreeContainerDeployment(buildPipeline *Build,
+func NewOSTreeContainerDeployment(buildPipeline Build,
 	container *container.SourceSpec,
 	ref string,
 	osName string,

--- a/pkg/manifest/ostree_encapsulate.go
+++ b/pkg/manifest/ostree_encapsulate.go
@@ -12,7 +12,7 @@ type OSTreeEncapsulate struct {
 	inputPipeline Pipeline
 }
 
-func NewOSTreeEncapsulate(buildPipeline *Build, inputPipeline Pipeline, pipelinename string) *OSTreeEncapsulate {
+func NewOSTreeEncapsulate(buildPipeline Build, inputPipeline Pipeline, pipelinename string) *OSTreeEncapsulate {
 	p := &OSTreeEncapsulate{
 		Base:          NewBase(pipelinename, buildPipeline),
 		inputPipeline: inputPipeline,

--- a/pkg/manifest/ovf.go
+++ b/pkg/manifest/ovf.go
@@ -14,7 +14,7 @@ type OVF struct {
 }
 
 // NewOVF creates a new OVF pipeline. imgPipeline is the pipeline producing the vmdk image.
-func NewOVF(buidPipeline *Build, imgPipeline *VMDK) *OVF {
+func NewOVF(buidPipeline Build, imgPipeline *VMDK) *OVF {
 	p := &OVF{
 		Base:        NewBase("ovf", buidPipeline),
 		imgPipeline: imgPipeline,

--- a/pkg/manifest/pipeline.go
+++ b/pkg/manifest/pipeline.go
@@ -25,7 +25,7 @@ type Pipeline interface {
 
 	// BuildPipeline returns a reference to the pipeline that creates the build
 	// root for this pipeline. For build pipelines, it should return nil.
-	BuildPipeline() *Build
+	BuildPipeline() Build
 
 	// Manifest returns a reference to the Manifest which this Pipeline belongs to.
 	Manifest() *Manifest
@@ -76,7 +76,7 @@ type Pipeline interface {
 type Base struct {
 	manifest   *Manifest
 	name       string
-	build      *Build
+	build      Build
 	checkpoint bool
 	export     bool
 }
@@ -104,7 +104,7 @@ func (p Base) getExport() bool {
 	return p.export
 }
 
-func (p Base) BuildPipeline() *Build {
+func (p Base) BuildPipeline() Build {
 	return p.build
 }
 
@@ -156,7 +156,7 @@ func (p Base) getInline() []string {
 // the build host's filesystem is used as the build root. The runner specifies how to use this
 // pipeline as a build pipeline, by naming the distro it contains. When the host system is used
 // as a build root, then the necessary runner is autodetected.
-func NewBase(name string, build *Build) Base {
+func NewBase(name string, build Build) Base {
 	p := Base{
 		name:  name,
 		build: build,
@@ -191,7 +191,7 @@ func (p Base) serialize() osbuild.Pipeline {
 type TreePipeline interface {
 	Name() string
 	Manifest() *Manifest
-	BuildPipeline() *Build
+	BuildPipeline() Build
 	Platform() platform.Platform
 }
 

--- a/pkg/manifest/qcow2.go
+++ b/pkg/manifest/qcow2.go
@@ -25,7 +25,7 @@ func (p *QCOW2) SetFilename(filename string) {
 // NewQCOW2 createsa new QCOW2 pipeline. imgPipeline is the pipeline producing the
 // raw image. The pipeline name is the name of the new pipeline. Filename is the name
 // of the produced qcow2 image.
-func NewQCOW2(buildPipeline *Build, imgPipeline FilePipeline) *QCOW2 {
+func NewQCOW2(buildPipeline Build, imgPipeline FilePipeline) *QCOW2 {
 	p := &QCOW2{
 		Base:        NewBase("qcow2", buildPipeline),
 		imgPipeline: imgPipeline,

--- a/pkg/manifest/raw.go
+++ b/pkg/manifest/raw.go
@@ -23,7 +23,7 @@ func (p *RawImage) SetFilename(filename string) {
 	p.filename = filename
 }
 
-func NewRawImage(buildPipeline *Build, treePipeline *OS) *RawImage {
+func NewRawImage(buildPipeline Build, treePipeline *OS) *RawImage {
 	p := &RawImage{
 		Base:         NewBase("image", buildPipeline),
 		treePipeline: treePipeline,

--- a/pkg/manifest/raw_ostree.go
+++ b/pkg/manifest/raw_ostree.go
@@ -25,7 +25,7 @@ func (p *RawOSTreeImage) SetFilename(filename string) {
 	p.filename = filename
 }
 
-func NewRawOStreeImage(buildPipeline *Build, treePipeline *OSTreeDeployment, platform platform.Platform) *RawOSTreeImage {
+func NewRawOStreeImage(buildPipeline Build, treePipeline *OSTreeDeployment, platform platform.Platform) *RawOSTreeImage {
 	p := &RawOSTreeImage{
 		Base:         NewBase("image", buildPipeline),
 		treePipeline: treePipeline,

--- a/pkg/manifest/tar.go
+++ b/pkg/manifest/tar.go
@@ -30,7 +30,7 @@ func (p *Tar) SetFilename(filename string) {
 // NewTar creates a new TarPipeline. The inputPipeline represents the
 // filesystem tree which will be the contents of the tar file. The pipelinename
 // is the name of the pipeline. The filename is the name of the output tar file.
-func NewTar(buildPipeline *Build, inputPipeline Pipeline, pipelinename string) *Tar {
+func NewTar(buildPipeline Build, inputPipeline Pipeline, pipelinename string) *Tar {
 	p := &Tar{
 		Base:          NewBase(pipelinename, buildPipeline),
 		inputPipeline: inputPipeline,

--- a/pkg/manifest/vmdk.go
+++ b/pkg/manifest/vmdk.go
@@ -25,7 +25,7 @@ func (p *VMDK) SetFilename(filename string) {
 // raw image. imgOstreePipeline is the pipeline producing the raw ostree image.
 // Either imgPipeline or imgOStreePipeline are required, but not both at the same time.
 // Filename is the name of the produced image.
-func NewVMDK(buildPipeline *Build, imgPipeline FilePipeline) *VMDK {
+func NewVMDK(buildPipeline Build, imgPipeline FilePipeline) *VMDK {
 	p := &VMDK{
 		Base:        NewBase("vmdk", buildPipeline),
 		imgPipeline: imgPipeline,

--- a/pkg/manifest/vpc.go
+++ b/pkg/manifest/vpc.go
@@ -26,7 +26,7 @@ func (p *VPC) SetFilename(filename string) {
 // NewVPC createsa new Qemu pipeline. imgPipeline is the pipeline producing the
 // raw image. The pipeline name is the name of the new pipeline. Filename is the name
 // of the produced image.
-func NewVPC(buildPipeline *Build, imgPipeline *RawImage) *VPC {
+func NewVPC(buildPipeline Build, imgPipeline *RawImage) *VPC {
 	p := &VPC{
 		Base:        NewBase("vpc", buildPipeline),
 		imgPipeline: imgPipeline,

--- a/pkg/manifest/xz.go
+++ b/pkg/manifest/xz.go
@@ -23,7 +23,7 @@ func (p *XZ) SetFilename(filename string) {
 
 // NewXZ creates a new XZ pipeline. imgPipeline is the pipeline producing the
 // raw image that will be xz compressed.
-func NewXZ(buildPipeline *Build, imgPipeline FilePipeline) *XZ {
+func NewXZ(buildPipeline Build, imgPipeline FilePipeline) *XZ {
 	p := &XZ{
 		Base:        NewBase("xz", buildPipeline),
 		filename:    "image.xz",


### PR DESCRIPTION
This branch prepares for allowing to have build roots from container sources. This is a bit of a shortcut PR that is mainly tailored to `bootc-image-builder`. 

Alternatively we could change `InstantiateManifest()` to not take `repos []rpmmd.RepoConfig` but instead something like: 
```go
type RepoContainerStuff struct {
    Repos []rpmmd.RepoConfig
    Containers []container.SourceSpec
}

type ImageKind interface {
	Name() string
	InstantiateManifest(m *manifest.Manifest, repoContainer *RepoContainerStuff, runner runner.Runner, rng *rand.Rand) (*artifact.Artifact, error)
}
```
of course with a more sensible name. Happy to do this if that is the preferred way. I will move this out of draft (or close it) once I get feedback on this (or maybe there is a third option).

Once this is available, bib will use:
```go
img := image.NewBootcDiskImage(containerSource)
...
_, err = img.InstantiateManifestFromContainers(&mf, containerSources, runner, rng)
```

Note that this is not sufficient for a full container based buildroot, the following is missing:
1. get EFI binaries from an alternative location (e.g. via https://github.com/osbuild/osbuild/pull/1529 or bootupd)
2. create a second "bib-build" pipeline that uses the "bib" container as the buildroot and run "qemu-img" from there