### PR TITLE
osbuild: remove unused `NewGrub2StageOptions()`

### DIFF
--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -641,7 +641,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 					),
 				)
 			} else {
-				options := osbuild.NewGrub2StageOptionsUnified(pt,
+				options := osbuild.NewGrub2StageOptions(pt,
 					strings.Join(kernelOptions, " "),
 					p.kernelVer,
 					p.platform.GetUEFIVendor() != "",

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -404,7 +404,7 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 		}
 	}
 
-	grubOptions := osbuild.NewGrub2StageOptionsUnified(p.PartitionTable,
+	grubOptions := osbuild.NewGrub2StageOptions(p.PartitionTable,
 		strings.Join(kernelOpts, " "),
 		"",
 		p.platform.GetUEFIVendor() != "",

--- a/pkg/osbuild/grub2_stage.go
+++ b/pkg/osbuild/grub2_stage.go
@@ -52,7 +52,7 @@ func NewGRUB2Stage(options *GRUB2StageOptions) *Stage {
 	}
 }
 
-func NewGrub2StageOptionsUnified(pt *disk.PartitionTable,
+func NewGrub2StageOptions(pt *disk.PartitionTable,
 	kernelOptions string,
 	kernelVer string,
 	uefi bool,

--- a/pkg/osbuild/grub2_stage.go
+++ b/pkg/osbuild/grub2_stage.go
@@ -4,7 +4,6 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/disk"
 )
 
@@ -51,53 +50,6 @@ func NewGRUB2Stage(options *GRUB2StageOptions) *Stage {
 		Type:    "org.osbuild.grub2",
 		Options: options,
 	}
-}
-
-func NewGrub2StageOptions(pt *disk.PartitionTable,
-	kernelOptions string,
-	kernel *blueprint.KernelCustomization,
-	kernelVer string,
-	uefi bool,
-	legacy string,
-	vendor string,
-	install bool) *GRUB2StageOptions {
-
-	rootFs := pt.FindMountable("/")
-	if rootFs == nil {
-		panic("root filesystem must be defined for grub2 stage, this is a programming error")
-	}
-
-	stageOptions := GRUB2StageOptions{
-		RootFilesystemUUID: uuid.MustParse(rootFs.GetFSSpec().UUID),
-		KernelOptions:      kernelOptions,
-		Legacy:             legacy,
-	}
-
-	bootFs := pt.FindMountable("/boot")
-	if bootFs != nil {
-		bootFsUUID := uuid.MustParse(bootFs.GetFSSpec().UUID)
-		stageOptions.BootFilesystemUUID = &bootFsUUID
-	}
-
-	if uefi {
-		stageOptions.UEFI = &GRUB2UEFI{
-			Vendor:  vendor,
-			Install: install,
-			Unified: legacy == "", // force unified grub scheme for pure efi systems
-		}
-	}
-
-	if kernel != nil {
-		if kernel.Append != "" {
-			stageOptions.KernelOptions += " " + kernel.Append
-		}
-		stageOptions.SavedEntry = "ffffffffffffffffffffffffffffffff-" + kernelVer
-		stageOptions.Config = &GRUB2Config{
-			Default: "saved",
-		}
-	}
-
-	return &stageOptions
 }
 
 func NewGrub2StageOptionsUnified(pt *disk.PartitionTable,


### PR DESCRIPTION
This function was replaced with NewGrub2StageOptionsUnified() in early 2022 and nothing in this code, osbuild-composer or bootc-image-builder is using it. I would like to delete it therefore.

[draft for now as I am not sure what our policy for API stability is and what else might import the images library]