### PR TITLE
New image type: Fedora iot-bootable-container

### DIFF
--- a/pkg/distro/fedora/distro_test.go
+++ b/pkg/distro/fedora/distro_test.go
@@ -216,6 +216,14 @@ func TestFilenameFromType(t *testing.T) {
 		},
 		"39": {
 			{
+				name: "iot-bootable-container",
+				args: args{"iot-bootable-container"},
+				want: wantResult{
+					filename: "iot-bootable-container.tar",
+					mimeType: "application/x-tar",
+				},
+			},
+			{
 				name: "iot-simplified-installer",
 				args: args{"iot-simplified-installer"},
 				want: wantResult{
@@ -225,6 +233,14 @@ func TestFilenameFromType(t *testing.T) {
 			},
 		},
 		"40": {
+			{
+				name: "iot-bootable-container",
+				args: args{"iot-bootable-container"},
+				want: wantResult{
+					filename: "iot-bootable-container.tar",
+					mimeType: "application/x-tar",
+				},
+			},
 			{
 				name: "iot-simplified-installer",
 				args: args{"iot-simplified-installer"},
@@ -236,7 +252,7 @@ func TestFilenameFromType(t *testing.T) {
 		},
 	}
 	for _, dist := range fedoraFamilyDistros {
-		t.Run(dist.name, func(t *testing.T) {
+		t.Run(dist.distro.Name(), func(t *testing.T) {
 			allTests := append(tests, verTypes[dist.distro.Releasever()]...)
 			for _, tt := range allTests {
 				t.Run(tt.name, func(t *testing.T) {
@@ -292,7 +308,7 @@ func TestImageType_BuildPackages(t *testing.T) {
 		"aarch64": aarch64BuildPackages,
 	}
 	for _, dist := range fedoraFamilyDistros {
-		t.Run(dist.name, func(t *testing.T) {
+		t.Run(dist.distro.Name(), func(t *testing.T) {
 			d := dist.distro
 			for _, archLabel := range d.ListArches() {
 				archStruct, err := d.GetArch(archLabel)
@@ -344,8 +360,14 @@ func TestImageType_Name(t *testing.T) {
 			},
 			verTypes: map[string][]string{
 				"38": {"iot-simplified-installer"},
-				"39": {"iot-simplified-installer"},
-				"40": {"iot-simplified-installer"},
+				"39": {
+					"iot-bootable-container",
+					"iot-simplified-installer",
+				},
+				"40": {
+					"iot-bootable-container",
+					"iot-simplified-installer",
+				},
 			},
 		},
 		{
@@ -365,14 +387,20 @@ func TestImageType_Name(t *testing.T) {
 			},
 			verTypes: map[string][]string{
 				"38": {"iot-simplified-installer"},
-				"39": {"iot-simplified-installer"},
-				"40": {"iot-simplified-installer"},
+				"39": {
+					"iot-bootable-container",
+					"iot-simplified-installer",
+				},
+				"40": {
+					"iot-bootable-container",
+					"iot-simplified-installer",
+				},
 			},
 		},
 	}
 
 	for _, dist := range fedoraFamilyDistros {
-		t.Run(dist.name, func(t *testing.T) {
+		t.Run(dist.distro.Name(), func(t *testing.T) {
 			for _, mapping := range imgMap {
 				arch, err := dist.distro.GetArch(mapping.arch)
 				if assert.NoError(t, err) {
@@ -534,8 +562,14 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 			},
 			verTypes: map[string][]string{
 				"38": {"iot-simplified-installer"},
-				"39": {"iot-simplified-installer"},
-				"40": {"iot-simplified-installer"},
+				"39": {
+					"iot-bootable-container",
+					"iot-simplified-installer",
+				},
+				"40": {
+					"iot-bootable-container",
+					"iot-simplified-installer",
+				},
 			},
 		},
 		{
@@ -557,8 +591,14 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 			},
 			verTypes: map[string][]string{
 				"38": {"iot-simplified-installer"},
-				"39": {"iot-simplified-installer"},
-				"40": {"iot-simplified-installer"},
+				"39": {
+					"iot-bootable-container",
+					"iot-simplified-installer",
+				},
+				"40": {
+					"iot-bootable-container",
+					"iot-simplified-installer",
+				},
 			},
 		},
 		{
@@ -567,6 +607,14 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"container",
 				"qcow2",
 			},
+			verTypes: map[string][]string{
+				"39": {
+					"iot-bootable-container",
+				},
+				"40": {
+					"iot-bootable-container",
+				},
+			},
 		},
 		{
 			arch: "s390x",
@@ -574,11 +622,19 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"container",
 				"qcow2",
 			},
+			verTypes: map[string][]string{
+				"39": {
+					"iot-bootable-container",
+				},
+				"40": {
+					"iot-bootable-container",
+				},
+			},
 		},
 	}
 
 	for _, dist := range fedoraFamilyDistros {
-		t.Run(dist.name, func(t *testing.T) {
+		t.Run(dist.distro.Name(), func(t *testing.T) {
 			for _, mapping := range imgMap {
 				arch, err := dist.distro.GetArch(mapping.arch)
 				require.NoError(t, err)
@@ -624,7 +680,7 @@ func TestFedora37_GetArch(t *testing.T) {
 	}
 
 	for _, dist := range fedoraFamilyDistros {
-		t.Run(dist.name, func(t *testing.T) {
+		t.Run(dist.distro.Name(), func(t *testing.T) {
 			for _, a := range arches {
 				actualArch, err := dist.distro.GetArch(a.name)
 				if a.errorExpected {

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -423,6 +423,32 @@ func iotCommitImage(workload workload.Workload,
 	return img, nil
 }
 
+func bootableContainerImage(workload workload.Workload,
+	t *imageType,
+	bp *blueprint.Blueprint,
+	options distro.ImageOptions,
+	packageSets map[string]rpmmd.PackageSet,
+	containers []container.SourceSpec,
+	rng *rand.Rand) (image.ImageKind, error) {
+
+	parentCommit, commitRef := makeOSTreeParentCommit(options.OSTree, t.OSTreeRef())
+	img := image.NewOSTreeArchive(commitRef)
+
+	d := t.arch.distro
+
+	img.Platform = t.platform
+	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, bp.Customizations)
+	img.Environment = t.environment
+	img.Workload = workload
+	img.OSTreeParent = parentCommit
+	img.OSVersion = d.osVersion
+	img.Filename = t.Filename()
+	img.InstallWeakDeps = false
+	img.BootContainer = true
+
+	return img, nil
+}
+
 func iotContainerImage(workload workload.Workload,
 	t *imageType,
 	bp *blueprint.Blueprint,

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -66,7 +66,7 @@
       "edge-vsphere"
     ]
   },
- "./configs/edge-ostree-pull-fips.json": {
+  "./configs/edge-ostree-pull-fips.json": {
     "distros": [
       "rhel-93",
       "rhel-94"
@@ -91,7 +91,6 @@
       "edge-ami"
     ]
   },
-
   "./configs/embed-containers-2.json": {
     "image-types": [
       "edge-container"
@@ -117,6 +116,7 @@
       "gce",
       "gce-rhui",
       "image-installer",
+      "iot-bootable-container",
       "iot-container",
       "live-installer",
       "minimal-raw",

--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -137,6 +137,9 @@ def boot_container(distro, arch, image_type, image_path, manifest_id):
 
             # boot it
             image_name = f"image-boot-test-{distro}-{arch}-{image_type}-" + str(uuid.uuid4())
+
+            # Build artifacts are owned by root. Make them world accessible.
+            testlib.runcmd(["sudo", "chmod", "a+rwX", "-R", tmpdir])
             raw_image_path = f"{tmpdir}/image/disk.raw"
             cmd_boot_aws(arch, image_name, privkey_file, pubkey_file, raw_image_path)
 

--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -61,24 +61,84 @@ def ensure_uncompressed(filepath):
         yield filepath
 
 
-def boot_ami(distro, arch, image_type, image_path):
+def cmd_boot_aws(arch, image_name, privkey, pubkey, image_path):
     aws_config = get_aws_config()
+    cmd = ["go", "run", "./cmd/boot-aws", "run",
+           "--access-key-id", aws_config["key_id"],
+           "--secret-access-key", aws_config["secret_key"],
+           "--region", aws_config["region"],
+           "--bucket", aws_config["bucket"],
+           "--arch", arch,
+           "--ami-name", image_name,
+           "--s3-key", f"images/boot/{image_name}",
+           "--username", "osbuild",
+           "--ssh-privkey", privkey,
+           "--ssh-pubkey", pubkey,
+           image_path, "test/scripts/base-host-check.sh"]
+    testlib.runcmd_nc(cmd)
+
+
+def boot_ami(distro, arch, image_type, image_path):
     with ensure_uncompressed(image_path) as raw_image_path:
         with create_ssh_key() as (privkey, pubkey):
             image_name = f"image-boot-test-{distro}-{arch}-{image_type}-" + str(uuid.uuid4())
-            cmd = ["go", "run", "./cmd/boot-aws", "run",
-                   "--access-key-id", aws_config["key_id"],
-                   "--secret-access-key", aws_config["secret_key"],
-                   "--region", aws_config["region"],
-                   "--bucket", aws_config["bucket"],
-                   "--arch", arch,
-                   "--ami-name", image_name,
-                   "--s3-key", f"images/boot/{image_name}",
-                   "--username", "osbuild",
-                   "--ssh-privkey", privkey,
-                   "--ssh-pubkey", pubkey,
-                   raw_image_path, "test/scripts/base-host-check.sh"]
+            cmd_boot_aws(arch, image_name, privkey, pubkey, raw_image_path)
+
+
+def boot_container(distro, arch, image_type, image_path, manifest_id):
+    """
+    Use bootc-image-builder to build an AMI and boot it.
+    """
+    # push container to registry so we can build it with BIB
+    # remove when BIB can pull from containers-storage: https://github.com/osbuild/bootc-image-builder/pull/120
+    container_name = f"iot-bootable-container:{distro}-{arch}-{manifest_id}"
+    cmd = ["./tools/ci/push-container.sh", image_path, container_name]
+    testlib.runcmd_nc(cmd)
+    container_ref = f"{testlib.REGISTRY}/{container_name}"
+
+    with TemporaryDirectory() as tmpdir:
+        with create_ssh_key() as (privkey_file, pubkey_file):
+            with open(pubkey_file, encoding="utf-8") as pubkey_fp:
+                pubkey = pubkey_fp.read()
+
+            # write a config to create a user
+            config_file = os.path.join(tmpdir, "config.json")
+            with open(config_file, "w", encoding="utf-8") as cfg_fp:
+                config = {
+                    "blueprint": {
+                        "customizations": {
+                            "user": [
+                                {
+                                    "name": "osbuild",
+                                    "key": pubkey,
+                                    "groups": [
+                                        "wheel"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+                json.dump(config, cfg_fp)
+
+            # build an AMI
+            cmd = ["sudo", "podman", "run",
+                   "--rm", "-it",
+                   "--privileged",
+                   "--pull=newer",
+                   "--security-opt", "label=type:unconfined_t",
+                   "-v", f"{tmpdir}:/output",
+                   "-v", f"{config_file}:/config.json",
+                   "quay.io/centos-bootc/bootc-image-builder:latest",
+                   "--type=ami",
+                   "--config=/config.json",
+                   container_ref]
             testlib.runcmd_nc(cmd)
+
+            # boot it
+            image_name = f"image-boot-test-{distro}-{arch}-{image_type}-" + str(uuid.uuid4())
+            raw_image_path = f"{tmpdir}/image/disk.raw"
+            cmd_boot_aws(arch, image_name, privkey_file, pubkey_file, raw_image_path)
 
 
 def find_image_file(build_path: str) -> str:
@@ -124,6 +184,12 @@ def main():
     match image_type:
         case "ami" | "ec2" | "ec2-ha" | "ec2-sap" | "edge-ami":
             boot_ami(distro, arch, image_type, image_path)
+        case "iot-bootable-container":
+            info_file_path = os.path.join(search_path, "info.json")
+            with open(info_file_path, encoding="utf-8") as info_fp:
+                build_info = json.load(info_fp)
+            manifest_id = build_info["manifest-checksum"]
+            boot_container(distro, arch, image_type, image_path, manifest_id)
         case _:
             # skip
             print(f"{image_type} boot tests are not supported yet")

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -30,6 +30,7 @@ CAN_BOOT_TEST = [
     "ec2-ha",
     "ec2-sap",
     "edge-ami",
+    "iot-bootable-container",
 ]
 
 


### PR DESCRIPTION
Add new image type and its image function called "bootc-container".  The image function is very similar to the iot commit but enables the BootContainer flag so it exports a bootable base container instead of a tarball of the ostree repo.

The package set for the container mostly replicates the package selection from centos-bootc [1].  Comments are also retained from the original source files to assist in future decisions for modifications.

The two differences from the centos-bootc package set are:
- Kernel not specified: it is selected automatically along with user package selection.
- The packages specified in the user-experience [2] file aren't added.  We want to keep the image definition minimal, and the existing set is already bigger than minimal.

[1] https://github.com/CentOS/centos-bootc/tree/4d5e1d86fbe1028f47e08d5533b4825e3b42dc68
[2] https://github.com/CentOS/centos-bootc/blob/4d5e1d86fbe1028f47e08d5533b4825e3b42dc68/tier-1/user-experience.yaml

## DRAFT

Keeping draft until I include a boot test for this.