### PR TITLE
anaconda: reqpart for container-installer

### DIFF
--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -391,9 +391,8 @@ timezone UTC
 
 clearpart --all
 
-part biosboot --size=1 --fstype=biosboot
-part /boot/efi --fstype=efi --size=512 --fsoptions="umask=0077"
-part /boot --fstype=ext2 --size=1024 --label=boot
+reqpart --add-boot
+
 part swap --fstype=swap --size=1024
 part / --fstype=ext4 --grow
 


### PR DESCRIPTION
Using `reqpart` in the kickstart automatically handles the hardware specific partitions that are necessary in UEFI or BIOS environments.

Closes #362.

Note that `reqpart` creates `/boot` as XFS.

@cgwalters we'd need to split off the discussion of the duplicate partition definitions in Anaconda, Go-code, and such; where should we take that?