### PR TITLE
Print more informational branch info for previous builds

### DIFF
--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -247,8 +247,12 @@ def check_for_build(manifest_fname, build_info_path, osbuild_ver, osbuild_commit
     pr = dl_config.get("pr")
     url = f"https://github.com/osbuild/images/commit/{commit}"
     print(f"🖼️ Manifest {manifest_fname} was successfully built in commit {commit}\n  {url}")
-    if pr:
+    if "gh-readonly-queue" in pr:
+        print(f"  This commit was on a merge queue: {pr}")
+    elif pr:
         print(f"  PR-{pr}: https://github.com/osbuild/images/pull/{pr}")
+    else:
+        print("  No PR/branch info available")
 
     image_type = dl_config["image-type"]
     if image_type not in CAN_BOOT_TEST:


### PR DESCRIPTION
When a manifest has already been built, we would assume it was on a PR and print a link to the PR in the info message.  But new manifests can also appear on the merge queue (from the rebase) so let's handle that case too.  We can't link to it directly because the merge queue branch is deleted after it's merged, but the commit ID is enough info to recreate the build conditions if needed and the name of the merge queue branch includes the PR number if more context is needed.

If the PR field is empty, print an appropriate message too.  This shouldn't happen now, the condition was there while old info existed that is all gone now, but let's keep it in case something unexpected happens with the writing of the build info in the future.