### PR TITLE
Run sudo with -E when building images in CI

### DIFF
--- a/test/scripts/build-image
+++ b/test/scripts/build-image
@@ -28,7 +28,7 @@ def main():
 
     testlib.runcmd(["go", "build", "-o", "./bin/build", "./cmd/build"])
 
-    cmd = ["sudo", "./bin/build", "--output", "./build",
+    cmd = ["sudo", "-E", "./bin/build", "--output", "./build",
            "--distro", distro, "--image", image_type, "--config", config_path]
     testlib.runcmd_nc(cmd, extra_env=testlib.rng_seed_env())
 


### PR DESCRIPTION
When building in CI, we need to preserve the environment so that the command 'sudo ./bin/build' inherits the rng seed.  Without it, we always end up building images with a random seed which means that our cache is updated with metadata that will never match a subsequent manifest check.