### PR TITLE
Report GitLab job failures globally

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,3 +54,11 @@ finish:
     - shell
   script:
     - schutzbot/update_github_status.sh finish
+
+fail:
+  stage: finish
+  tags:
+    - shell
+  script:
+    - schutzbot/update_github_status.sh fail
+  when: on_failure

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,4 +61,5 @@ fail:
     - shell
   script:
     - schutzbot/update_github_status.sh fail
+    - exit 1  # make the pipeline fail so it doesn't look like success
   when: on_failure

--- a/schutzbot/update_github_status.sh
+++ b/schutzbot/update_github_status.sh
@@ -22,6 +22,9 @@ elif [[ $1 == "update" ]]; then
   else
     exit 0
   fi
+elif [[ $1 == "fail" ]]; then
+    GITHUB_NEW_STATE="failure"
+    GITHUB_NEW_DESC="I'm sorry, something is odd about this commit."
 else
   echo "unknown command"
   exit 1

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -40,8 +40,6 @@ BASE_CONFIG = """
   before_script:
     - cat schutzbot/team_ssh_keys.txt |
         tee -a ~/.ssh/authorized_keys > /dev/null
-  after_script:
-    - schutzbot/update_github_status.sh update || true
   interruptible: true
   retry: 1
   tags:


### PR DESCRIPTION
Never update the GitHub status at the end of a job.  Instead, let the
job retry and if another failure occurs, when everything is done, the
`fail` job will run in the `finish` stage and update the status
accordingly.

Fixes #368 