### PR TITLE
osbuild: simplify code by removing `osbuild.Mounts type`

### DIFF
--- a/pkg/manifest/iso_rootfs.go
+++ b/pkg/manifest/iso_rootfs.go
@@ -63,7 +63,7 @@ func (p *ISORootfsImg) serialize() osbuild.Pipeline {
 		},
 	}
 	copyStageInputs := osbuild.NewPipelineTreeInputs(inputName, p.installerPipeline.Name())
-	copyStageMounts := &osbuild.Mounts{*osbuild.NewExt4Mount(devName, devName, "/")}
+	copyStageMounts := []osbuild.Mount{*osbuild.NewExt4Mount(devName, devName, "/")}
 	copyStage := osbuild.NewCopyStage(copyStageOptions, copyStageInputs, &devices, copyStageMounts)
 	pipeline.AddStage(copyStage)
 	return pipeline

--- a/pkg/manifest/raw_ostree.go
+++ b/pkg/manifest/raw_ostree.go
@@ -85,7 +85,7 @@ func (p *RawOSTreeImage) serialize() osbuild.Pipeline {
 		// Find the FS root mount name to use as the destination root
 		// for the target when copying the boot files.
 		var fsRootMntName string
-		for _, mnt := range *bootCopyMounts {
+		for _, mnt := range bootCopyMounts {
 			if mnt.Target == "/" {
 				fsRootMntName = mnt.Name
 				break

--- a/pkg/osbuild/bootupd_stage.go
+++ b/pkg/osbuild/bootupd_stage.go
@@ -58,8 +58,8 @@ func validateBootupdMounts(mounts []Mount) error {
 // NewBootupdStage creates a new stage for the org.osbuild.bootupd stage. It
 // requires a mount setup of "/", "/boot" and "/boot/efi" right now so that
 // bootupd can find and install all required bootloader bits.
-func NewBootupdStage(opts *BootupdStageOptions, devices *Devices, mounts *Mounts) (*Stage, error) {
-	if err := validateBootupdMounts(*mounts); err != nil {
+func NewBootupdStage(opts *BootupdStageOptions, devices *Devices, mounts []Mount) (*Stage, error) {
+	if err := validateBootupdMounts(mounts); err != nil {
 		return nil, err
 	}
 	if err := opts.validate(*devices); err != nil {
@@ -70,6 +70,6 @@ func NewBootupdStage(opts *BootupdStageOptions, devices *Devices, mounts *Mounts
 		Type:    "org.osbuild.bootupd",
 		Options: opts,
 		Devices: *devices,
-		Mounts:  *mounts,
+		Mounts:  mounts,
 	}, nil
 }

--- a/pkg/osbuild/bootupd_stage_test.go
+++ b/pkg/osbuild/bootupd_stage_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
-func makeOsbuildMounts(targets ...string) osbuild.Mounts {
+func makeOsbuildMounts(targets ...string) []osbuild.Mount {
 	var mnts []osbuild.Mount
 	for _, target := range targets {
 		mnts = append(mnts, osbuild.Mount{
@@ -46,7 +46,7 @@ func TestBootupdStageNewHappy(t *testing.T) {
 		Devices: devices,
 		Mounts:  mounts,
 	}
-	stage, err := osbuild.NewBootupdStage(opts, &devices, &mounts)
+	stage, err := osbuild.NewBootupdStage(opts, &devices, mounts)
 	require.Nil(t, err)
 	assert.Equal(t, stage, expectedStage)
 }
@@ -58,7 +58,7 @@ func TestBootupdStageMissingMounts(t *testing.T) {
 	devices := makeOsbuildDevices("dev-/")
 	mounts := makeOsbuildMounts("/")
 
-	stage, err := osbuild.NewBootupdStage(opts, &devices, &mounts)
+	stage, err := osbuild.NewBootupdStage(opts, &devices, mounts)
 	assert.ErrorContains(t, err, "required mounts for bootupd stage [/boot /boot/efi] missing")
 	require.Nil(t, stage)
 }
@@ -72,7 +72,7 @@ func TestBootupdStageMissingDevice(t *testing.T) {
 	devices := makeOsbuildDevices("dev-/", "dev-/boot", "dev-/boot/efi")
 	mounts := makeOsbuildMounts("/", "/boot", "/boot/efi")
 
-	stage, err := osbuild.NewBootupdStage(opts, &devices, &mounts)
+	stage, err := osbuild.NewBootupdStage(opts, &devices, mounts)
 	assert.ErrorContains(t, err, `cannot find expected device "disk" for bootupd bios option in [dev-/ dev-/boot dev-/boot/efi]`)
 	require.Nil(t, stage)
 }
@@ -91,7 +91,7 @@ func TestBootupdStageJsonHappy(t *testing.T) {
 	devices := makeOsbuildDevices("disk", "dev-/", "dev-/boot", "dev-/boot/efi")
 	mounts := makeOsbuildMounts("/", "/boot", "/boot/efi")
 
-	stage, err := osbuild.NewBootupdStage(opts, &devices, &mounts)
+	stage, err := osbuild.NewBootupdStage(opts, &devices, mounts)
 	require.Nil(t, err)
 	stageJson, err := json.MarshalIndent(stage, "", "  ")
 	require.Nil(t, err)

--- a/pkg/osbuild/copy_stage.go
+++ b/pkg/osbuild/copy_stage.go
@@ -26,13 +26,13 @@ type CopyStagePath struct {
 
 func (CopyStageOptions) isStageOptions() {}
 
-func NewCopyStage(options *CopyStageOptions, inputs Inputs, devices *Devices, mounts *Mounts) *Stage {
+func NewCopyStage(options *CopyStageOptions, inputs Inputs, devices *Devices, mounts []Mount) *Stage {
 	return &Stage{
 		Type:    "org.osbuild.copy",
 		Options: options,
 		Inputs:  inputs,
 		Devices: *devices,
-		Mounts:  *mounts,
+		Mounts:  mounts,
 	}
 }
 
@@ -60,7 +60,7 @@ func (*CopyStageFilesInputs) isStageInputs() {}
 func GenCopyFSTreeOptions(inputName, inputPipeline, filename string, pt *disk.PartitionTable) (
 	*CopyStageOptions,
 	*Devices,
-	*Mounts,
+	[]Mount,
 ) {
 
 	devices := make(map[string]Device, len(pt.Partitions))
@@ -118,7 +118,6 @@ func GenCopyFSTreeOptions(inputName, inputPipeline, filename string, pt *disk.Pa
 		panic("no mount found for the filesystem root")
 	}
 
-	stageMounts := Mounts(mounts)
 	stageDevices := Devices(devices)
 
 	options := CopyStageOptions{
@@ -130,5 +129,5 @@ func GenCopyFSTreeOptions(inputName, inputPipeline, filename string, pt *disk.Pa
 		},
 	}
 
-	return &options, &stageDevices, &stageMounts
+	return &options, &stageDevices, mounts
 }

--- a/pkg/osbuild/copy_stage_test.go
+++ b/pkg/osbuild/copy_stage_test.go
@@ -39,9 +39,8 @@ func TestNewCopyStage(t *testing.T) {
 		Mounts:  mounts,
 	}
 	// convert to alias types
-	stageMounts := Mounts(mounts)
 	stageDevices := Devices(devices)
-	actualStage := NewCopyStage(&CopyStageOptions{paths}, NewPipelineTreeInputs("tree-input", "input-pipeline"), &stageDevices, &stageMounts)
+	actualStage := NewCopyStage(&CopyStageOptions{paths}, NewPipelineTreeInputs("tree-input", "input-pipeline"), &stageDevices, mounts)
 	assert.Equal(t, expectedStage, actualStage)
 }
 

--- a/pkg/osbuild/mount.go
+++ b/pkg/osbuild/mount.go
@@ -1,7 +1,5 @@
 package osbuild
 
-type Mounts []Mount
-
 type Mount struct {
 	Name    string       `json:"name"`
 	Type    string       `json:"type"`

--- a/pkg/osbuild/stage.go
+++ b/pkg/osbuild/stage.go
@@ -10,7 +10,7 @@ type Stage struct {
 	Inputs  Inputs       `json:"inputs,omitempty"`
 	Options StageOptions `json:"options,omitempty"`
 	Devices Devices      `json:"devices,omitempty"`
-	Mounts  Mounts       `json:"mounts,omitempty"`
+	Mounts  []Mount      `json:"mounts,omitempty"`
 }
 
 // StageOptions specify the operations of a given stage-type.

--- a/pkg/osbuild/zipl_inst_stage.go
+++ b/pkg/osbuild/zipl_inst_stage.go
@@ -17,7 +17,7 @@ func (ZiplInstStageOptions) isStageOptions() {}
 
 // Return a new zipl.inst stage. The 'disk' parameter must represent the
 // (entire) device that contains the /boot partition.
-func NewZiplInstStage(options *ZiplInstStageOptions, disk *Device, devices *Devices, mounts *Mounts) *Stage {
+func NewZiplInstStage(options *ZiplInstStageOptions, disk *Device, devices *Devices, mounts []Mount) *Stage {
 	// create a new devices map and add the disk to it
 	devmap := map[string]Device(*devices)
 	devmap["disk"] = *disk
@@ -26,7 +26,7 @@ func NewZiplInstStage(options *ZiplInstStageOptions, disk *Device, devices *Devi
 		Type:    "org.osbuild.zipl.inst",
 		Options: options,
 		Devices: ziplDevices,
-		Mounts:  *mounts,
+		Mounts:  mounts,
 	}
 }
 


### PR DESCRIPTION
A quick drive-by commit for your consideration. I noticed while writing a test for the bootupd stage that the osbuild.Mounts type is not really helping me and hence wonder if we can do away with it. I did a grep and it seems the type is also not used outside images. Feel free to close this is you disagree or are attached to the type but to me the code feels easier to work with without it (and if you agree with this change I would like to see if `osbuild.Device` might also benefit from this).

--- 

The `osbuild.Mounts` type is just an alias to `[]osbuild.Mount` and it feels like it does not add clarity. From the type it's not clear if it's a slice or a map (like `osbuild.Devices`). While it is nice to abstract things away one needs to know it anyway when constructing the type so this commit removes the type and just exposes/uses `[]osbuild.Mount` directly.

Another benefit of this is that the pointers used are now clearer (IMHO) - i.e. `[]Mount` is a slice so no need to indirect it further via `*Mounts` in the function signatures.