### PR TITLE
Fix ostree deployment target

### DIFF
--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -228,12 +228,19 @@ func (p *OSTreeDeployment) doOSTreeContainerSpec(pipeline *osbuild.Pipeline, rep
 	cont := *p.containerSpec
 	ref := p.ref
 
+	var targetImgref string
+	// The ostree-remote case is unusual; it may be used by FCOS/Silverblue for example to handle
+	// embedded GPG signatures
+	if p.Remote.Name != "" {
+		targetImgref = fmt.Sprintf("ostree-remote-registry:%s:%s", p.Remote.Name, p.containerSpec.Source)
+	} else {
+		targetImgref = fmt.Sprintf("ostree-unverified-registry:%s", p.containerSpec.Source)
+	}
+
 	options := &osbuild.OSTreeDeployContainerStageOptions{
-		OsName:     p.osName,
-		KernelOpts: p.KernelOptionsAppend,
-		// NOTE: setting the target imgref to be the container source but
-		// we should make this configurable
-		TargetImgref: fmt.Sprintf("ostree-remote-registry:%s:%s", p.Remote.Name, p.containerSpec.Source),
+		OsName:       p.osName,
+		KernelOpts:   p.KernelOptionsAppend,
+		TargetImgref: targetImgref,
 		Mounts:       []string{"/boot", "/boot/efi"},
 		Rootfs: &osbuild.Rootfs{
 			Label: "root",

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -232,9 +232,9 @@ func (p *OSTreeDeployment) doOSTreeContainerSpec(pipeline *osbuild.Pipeline, rep
 	// The ostree-remote case is unusual; it may be used by FCOS/Silverblue for example to handle
 	// embedded GPG signatures
 	if p.Remote.Name != "" {
-		targetImgref = fmt.Sprintf("ostree-remote-registry:%s:%s", p.Remote.Name, p.containerSpec.Source)
+		targetImgref = fmt.Sprintf("ostree-remote-registry:%s:%s", p.Remote.Name, p.containerSpec.LocalName)
 	} else {
-		targetImgref = fmt.Sprintf("ostree-unverified-registry:%s", p.containerSpec.Source)
+		targetImgref = fmt.Sprintf("ostree-unverified-registry:%s", p.containerSpec.LocalName)
 	}
 
 	options := &osbuild.OSTreeDeployContainerStageOptions{


### PR DESCRIPTION
ostree: Fix target imgref

If we haven't been passed an ostree remote, don't use it for
verification; just use `ostree-unverified-image` which matches
https://github.com/containers/bootc/pull/230/commits/20d2d6cdc1bb2ddf7f8a6884ad83efaa708b4c65

---

ostree: Use local name when creating deployment

This will address https://github.com/osbuild/bootc-image-builder/issues/69

(But not marking closes because we need to update the vendor there)

---

