### PR TITLE
many: use bootupd for image.BootcDiskImage

### DIFF
--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -47,7 +47,8 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 		panic(fmt.Sprintf("no compression is allowed with %q format for %q", imgFormat, img.name))
 	}
 
-	baseImage := baseRawOstreeImage(img.OSTreeDiskImage, buildPipeline)
+	opts := &baseRawOstreeImageOpts{useBootupd: true}
+	baseImage := baseRawOstreeImage(img.OSTreeDiskImage, buildPipeline, opts)
 	switch imgFormat {
 	case platform.FORMAT_QCOW2:
 		// qcow2 runs without a build pipeline directly from "bib"

--- a/pkg/image/ostree_disk.go
+++ b/pkg/image/ostree_disk.go
@@ -74,7 +74,15 @@ func NewOSTreeDiskImageFromContainer(container container.SourceSpec, ref string)
 	}
 }
 
-func baseRawOstreeImage(img *OSTreeDiskImage, buildPipeline manifest.Build) *manifest.RawOSTreeImage {
+type baseRawOstreeImageOpts struct {
+	useBootupd bool
+}
+
+func baseRawOstreeImage(img *OSTreeDiskImage, buildPipeline manifest.Build, opts *baseRawOstreeImageOpts) *manifest.RawOSTreeImage {
+	if opts == nil {
+		opts = &baseRawOstreeImageOpts{}
+	}
+
 	var osPipeline *manifest.OSTreeDeployment
 	switch {
 	case img.CommitSource != nil:
@@ -98,6 +106,7 @@ func baseRawOstreeImage(img *OSTreeDiskImage, buildPipeline manifest.Build) *man
 	osPipeline.FIPS = img.FIPS
 	osPipeline.IgnitionPlatform = img.IgnitionPlatform
 	osPipeline.LockRoot = img.LockRoot
+	osPipeline.UseBootupd = opts.useBootupd
 
 	// other image types (e.g. live) pass the workload to the pipeline.
 	if img.Workload != nil {
@@ -127,7 +136,7 @@ func (img *OSTreeDiskImage) InstantiateManifest(m *manifest.Manifest,
 		panic(fmt.Sprintf("no compression is allowed with %q format for %q", imgFormat, img.name))
 	}
 
-	baseImage := baseRawOstreeImage(img, buildPipeline)
+	baseImage := baseRawOstreeImage(img, buildPipeline, nil)
 	switch img.Platform.GetImageFormat() {
 	case platform.FORMAT_VMDK:
 		vmdkPipeline := manifest.NewVMDK(buildPipeline, baseImage)

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -79,7 +79,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	imageFilename := "image.raw.xz"
 
 	// image in simplified installer is always compressed
-	compressedImage := manifest.NewXZ(buildPipeline, baseRawOstreeImage(img.rawImage, buildPipeline))
+	compressedImage := manifest.NewXZ(buildPipeline, baseRawOstreeImage(img.rawImage, buildPipeline, nil))
 	compressedImage.SetFilename(imageFilename)
 
 	coiPipeline := manifest.NewCoreOSInstaller(

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -71,6 +71,9 @@ type OSTreeDeployment struct {
 	// Lock the root account in the deployment unless the user defined root
 	// user options in the build configuration.
 	LockRoot bool
+
+	// Use bootupd instead of grub2 as the bootloader
+	UseBootupd bool
 }
 
 // NewOSTreeCommitDeployment creates a pipeline for an ostree deployment from a
@@ -411,22 +414,24 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 		}
 	}
 
-	grubOptions := osbuild.NewGrub2StageOptions(p.PartitionTable,
-		strings.Join(kernelOpts, " "),
-		"",
-		p.platform.GetUEFIVendor() != "",
-		p.platform.GetBIOSPlatform(),
-		p.platform.GetUEFIVendor(), true)
-	grubOptions.Greenboot = true
-	grubOptions.Ignition = p.IgnitionPlatform != ""
-	grubOptions.Config = &osbuild.GRUB2Config{
-		Default:        "saved",
-		Timeout:        1,
-		TerminalOutput: []string{"console"},
+	if !p.UseBootupd {
+		grubOptions := osbuild.NewGrub2StageOptions(p.PartitionTable,
+			strings.Join(kernelOpts, " "),
+			"",
+			p.platform.GetUEFIVendor() != "",
+			p.platform.GetBIOSPlatform(),
+			p.platform.GetUEFIVendor(), true)
+		grubOptions.Greenboot = true
+		grubOptions.Ignition = p.IgnitionPlatform != ""
+		grubOptions.Config = &osbuild.GRUB2Config{
+			Default:        "saved",
+			Timeout:        1,
+			TerminalOutput: []string{"console"},
+		}
+		bootloader := osbuild.NewGRUB2Stage(grubOptions)
+		bootloader.MountOSTree(p.osName, ref, 0)
+		pipeline.AddStage(bootloader)
 	}
-	bootloader := osbuild.NewGRUB2Stage(grubOptions)
-	bootloader.MountOSTree(p.osName, ref, 0)
-	pipeline.AddStage(bootloader)
 
 	// First create custom directories, because some of the files may depend on them
 	if len(p.Directories) > 0 {

--- a/pkg/osbuild/bootupd_stage.go
+++ b/pkg/osbuild/bootupd_stage.go
@@ -3,6 +3,8 @@ package osbuild
 import (
 	"fmt"
 	"sort"
+
+	"github.com/osbuild/images/pkg/disk"
 )
 
 type BootupdStageOptionsBios struct {
@@ -72,4 +74,19 @@ func NewBootupdStage(opts *BootupdStageOptions, devices map[string]Device, mount
 		Devices: devices,
 		Mounts:  mounts,
 	}, nil
+}
+
+func GenBootupdDevicesMounts(filename string, pt *disk.PartitionTable) (map[string]Device, []Mount) {
+	_, mounts, devices, err := genMountsDevicesFromPt(filename, pt)
+	if err != nil {
+		panic(err)
+	}
+	devices["disk"] = Device{
+		Type: "org.osbuild.loopback",
+		Options: &LoopbackDeviceOptions{
+			Filename: filename,
+		},
+	}
+
+	return devices, mounts
 }


### PR DESCRIPTION
This commit enables bootupd for the `image.BootcDiskImage` image type.
