### PR TITLE
Test: return and print stdout from aws s3 sync only when filtering

### DIFF
--- a/test/scripts/check-build-coverage
+++ b/test/scripts/check-build-coverage
@@ -60,7 +60,7 @@ def main():
     parser.add_argument("cachedir", type=str, help="path to download the build test cache")
     args = parser.parse_args()
     cachedir = args.cachedir
-    _, ok = testlib.dl_s3_configs(cachedir)
+    _, ok = testlib.dl_build_info(cachedir)
     # fail the job if the sync failed
     if not ok:
         sys.exit(1)

--- a/test/scripts/check-build-coverage
+++ b/test/scripts/check-build-coverage
@@ -60,7 +60,10 @@ def main():
     parser.add_argument("cachedir", type=str, help="path to download the build test cache")
     args = parser.parse_args()
     cachedir = args.cachedir
-    testlib.dl_s3_configs(cachedir)
+    _, ok = testlib.dl_s3_configs(cachedir)
+    # fail the job if the sync failed
+    if not ok:
+        sys.exit(1)
 
     missing, now, pr = check_build_coverage(cachedir)
 

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -105,7 +105,7 @@ def list_images(distros=None, arches=None, images=None):
     return json.loads(out)
 
 
-def dl_s3_configs(destination, distro=None, arch=None):
+def dl_build_info(destination, distro=None, arch=None):
     """
     Downloads all the configs from the s3 bucket.
     """
@@ -128,6 +128,7 @@ def dl_s3_configs(destination, distro=None, arch=None):
     ok = job.returncode == 0
     if not ok:
         print(f"⚠️ Failed to sync contents of {s3url}:")
+        print(job.stdout.decode())
         print(job.stderr.decode())
     return job.stdout.decode(), ok
 
@@ -276,7 +277,7 @@ def filter_builds(manifests, distro=None, arch=None, skip_ostree_pull=True):
     os.makedirs(dl_path, exist_ok=True)
     build_requests = []
 
-    out, dl_ok = dl_s3_configs(dl_path, distro=distro, arch=arch)
+    out, dl_ok = dl_build_info(dl_path, distro=distro, arch=arch)
     # continue even if the dl failed; will build all configs
     if dl_ok:
         # print output which includes list of downloaded files for CI job log


### PR DESCRIPTION
Followup to #382.  This partially reverts 366d846fd3f749f448594f1f50fdb78d749cd84b.

Return the output from the aws s3 sync command and print it only when running the filter_builds() function, which syncs a limited set of build info.

When running from check-build-coverage, don't print the output since that will download all files and generates too much output for the job log (and isn't very useful).  Also, fail the job if the sync failed since it doesn't make sense to run anything after it and a failure in that job could be a sign that something's wrong.

In the filter_builds() function, don't fail if the sync failed, just let it run and generate a build config for all the image configurations.