### PR TITLE
pkg/blueprint: remove the container `digest` field

### DIFF
--- a/pkg/blueprint/blueprint.go
+++ b/pkg/blueprint/blueprint.go
@@ -36,9 +36,8 @@ type Group struct {
 }
 
 type Container struct {
-	Source string  `json:"source,omitempty" toml:"source"`
-	Name   string  `json:"name,omitempty" toml:"name,omitempty"`
-	Digest *string `json:"digest,omitempty" toml:"digest,omitempty"`
+	Source string `json:"source,omitempty" toml:"source"`
+	Name   string `json:"name,omitempty" toml:"name,omitempty"`
 
 	TLSVerify           *bool   `json:"tls-verify,omitempty" toml:"tls-verify,omitempty"`
 	ContainersTransport *string `json:"containers-transport,omitempty" toml:"containers-transport,omitempty"`

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -222,8 +222,14 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 	}
 
 	containerSources := make([]container.SourceSpec, len(bp.Containers))
-	for idx := range bp.Containers {
-		containerSources[idx] = container.SourceSpec(bp.Containers[idx])
+	for idx, cont := range bp.Containers {
+		containerSources[idx] = container.SourceSpec{
+			Source:              cont.Source,
+			Name:                cont.Name,
+			TLSVerify:           cont.TLSVerify,
+			ContainersTransport: cont.ContainersTransport,
+			StoragePath:         cont.StoragePath,
+		}
 	}
 
 	source := rand.NewSource(seed)

--- a/pkg/distro/rhel7/imagetype.go
+++ b/pkg/distro/rhel7/imagetype.go
@@ -198,8 +198,14 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 	}
 
 	containerSources := make([]container.SourceSpec, len(bp.Containers))
-	for idx := range bp.Containers {
-		containerSources[idx] = container.SourceSpec(bp.Containers[idx])
+	for idx, cont := range bp.Containers {
+		containerSources[idx] = container.SourceSpec{
+			Source:              cont.Source,
+			Name:                cont.Name,
+			TLSVerify:           cont.TLSVerify,
+			ContainersTransport: cont.ContainersTransport,
+			StoragePath:         cont.StoragePath,
+		}
 	}
 
 	source := rand.NewSource(seed)

--- a/pkg/distro/rhel8/imagetype.go
+++ b/pkg/distro/rhel8/imagetype.go
@@ -243,8 +243,14 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 	}
 
 	containerSources := make([]container.SourceSpec, len(bp.Containers))
-	for idx := range bp.Containers {
-		containerSources[idx] = container.SourceSpec(bp.Containers[idx])
+	for idx, cont := range bp.Containers {
+		containerSources[idx] = container.SourceSpec{
+			Source:              cont.Source,
+			Name:                cont.Name,
+			TLSVerify:           cont.TLSVerify,
+			ContainersTransport: cont.ContainersTransport,
+			StoragePath:         cont.StoragePath,
+		}
 	}
 
 	source := rand.NewSource(seed)

--- a/pkg/distro/rhel9/imagetype.go
+++ b/pkg/distro/rhel9/imagetype.go
@@ -243,8 +243,14 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 	}
 
 	containerSources := make([]container.SourceSpec, len(bp.Containers))
-	for idx := range bp.Containers {
-		containerSources[idx] = container.SourceSpec(bp.Containers[idx])
+	for idx, cont := range bp.Containers {
+		containerSources[idx] = container.SourceSpec{
+			Source:              cont.Source,
+			Name:                cont.Name,
+			TLSVerify:           cont.TLSVerify,
+			ContainersTransport: cont.ContainersTransport,
+			StoragePath:         cont.StoragePath,
+		}
 	}
 
 	source := rand.NewSource(seed)


### PR DESCRIPTION
The `digest` field was incorrectly exposed in the blueprints via 13bf49a. This PR fixes this by removing the field and fixing the conversion from `blueprint.Container` to `container.SourceSpec`.