### PR TITLE
Move the actual path policies into a public package 'policies'

### DIFF
--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/environment"
-	"github.com/osbuild/images/internal/pathpolicy"
 	"github.com/osbuild/images/internal/workload"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
@@ -17,6 +16,7 @@ import (
 	"github.com/osbuild/images/pkg/image"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/policies"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"golang.org/x/exp/slices"
 )
@@ -349,7 +349,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		return nil, fmt.Errorf("Custom mountpoints are not supported for ostree types")
 	}
 
-	err := blueprint.CheckMountpointsPolicy(mountpoints, pathpolicy.MountpointPolicies)
+	err := blueprint.CheckMountpointsPolicy(mountpoints, policies.MountpointPolicies)
 	if err != nil {
 		return nil, err
 	}
@@ -376,12 +376,12 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		return nil, err
 	}
 
-	err = blueprint.CheckDirectoryCustomizationsPolicy(dc, pathpolicy.CustomDirectoriesPolicies)
+	err = blueprint.CheckDirectoryCustomizationsPolicy(dc, policies.CustomDirectoriesPolicies)
 	if err != nil {
 		return nil, err
 	}
 
-	err = blueprint.CheckFileCustomizationsPolicy(fc, pathpolicy.CustomFilesPolicies)
+	err = blueprint.CheckFileCustomizationsPolicy(fc, policies.CustomFilesPolicies)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distro/rhel7/imagetype.go
+++ b/pkg/distro/rhel7/imagetype.go
@@ -5,7 +5,6 @@ import (
 	"math/rand"
 
 	"github.com/osbuild/images/internal/environment"
-	"github.com/osbuild/images/internal/pathpolicy"
 	"github.com/osbuild/images/internal/workload"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
@@ -14,6 +13,7 @@ import (
 	"github.com/osbuild/images/pkg/image"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/policies"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"golang.org/x/exp/slices"
 )
@@ -247,7 +247,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 
 	mountpoints := customizations.GetFilesystems()
 
-	err := blueprint.CheckMountpointsPolicy(mountpoints, pathpolicy.MountpointPolicies)
+	err := blueprint.CheckMountpointsPolicy(mountpoints, policies.MountpointPolicies)
 	if err != nil {
 		return warnings, err
 	}
@@ -265,12 +265,12 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		return warnings, err
 	}
 
-	err = blueprint.CheckDirectoryCustomizationsPolicy(dc, pathpolicy.CustomDirectoriesPolicies)
+	err = blueprint.CheckDirectoryCustomizationsPolicy(dc, policies.CustomDirectoriesPolicies)
 	if err != nil {
 		return warnings, err
 	}
 
-	err = blueprint.CheckFileCustomizationsPolicy(fc, pathpolicy.CustomFilesPolicies)
+	err = blueprint.CheckFileCustomizationsPolicy(fc, policies.CustomFilesPolicies)
 	if err != nil {
 		return warnings, err
 	}

--- a/pkg/distro/rhel8/imagetype.go
+++ b/pkg/distro/rhel8/imagetype.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/environment"
-	"github.com/osbuild/images/internal/pathpolicy"
 	"github.com/osbuild/images/internal/workload"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
@@ -20,6 +19,7 @@ import (
 	"github.com/osbuild/images/pkg/image"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/policies"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -383,7 +383,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		return warnings, fmt.Errorf("Custom mountpoints are not supported for ostree types")
 	}
 
-	err := blueprint.CheckMountpointsPolicy(mountpoints, pathpolicy.MountpointPolicies)
+	err := blueprint.CheckMountpointsPolicy(mountpoints, policies.MountpointPolicies)
 	if err != nil {
 		return warnings, err
 	}
@@ -411,12 +411,12 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 	if err != nil {
 		return warnings, err
 	}
-	err = blueprint.CheckDirectoryCustomizationsPolicy(dc, pathpolicy.CustomDirectoriesPolicies)
+	err = blueprint.CheckDirectoryCustomizationsPolicy(dc, policies.CustomDirectoriesPolicies)
 	if err != nil {
 		return warnings, err
 	}
 
-	err = blueprint.CheckFileCustomizationsPolicy(fc, pathpolicy.CustomFilesPolicies)
+	err = blueprint.CheckFileCustomizationsPolicy(fc, policies.CustomFilesPolicies)
 	if err != nil {
 		return warnings, err
 	}

--- a/pkg/distro/rhel9/imagetype.go
+++ b/pkg/distro/rhel9/imagetype.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/environment"
-	"github.com/osbuild/images/internal/pathpolicy"
 	"github.com/osbuild/images/internal/workload"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
@@ -20,6 +19,7 @@ import (
 	"github.com/osbuild/images/pkg/image"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/policies"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -392,13 +392,13 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		return warnings, fmt.Errorf("Custom mountpoints are not supported for edge-container and edge-commit")
 	} else if mountpoints != nil && t.rpmOstree && !(t.name == "edge-container" || t.name == "edge-commit") {
 		//customization allowed for edge-raw-image,edge-ami,edge-vsphere,edge-simplified-installer
-		err := blueprint.CheckMountpointsPolicy(mountpoints, pathpolicy.OstreeMountpointPolicies)
+		err := blueprint.CheckMountpointsPolicy(mountpoints, policies.OstreeMountpointPolicies)
 		if err != nil {
 			return warnings, err
 		}
 	}
 
-	err := blueprint.CheckMountpointsPolicy(mountpoints, pathpolicy.MountpointPolicies)
+	err := blueprint.CheckMountpointsPolicy(mountpoints, policies.MountpointPolicies)
 	if err != nil {
 		return warnings, err
 	}
@@ -426,12 +426,12 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 	if err != nil {
 		return warnings, err
 	}
-	err = blueprint.CheckDirectoryCustomizationsPolicy(dc, pathpolicy.CustomDirectoriesPolicies)
+	err = blueprint.CheckDirectoryCustomizationsPolicy(dc, policies.CustomDirectoriesPolicies)
 	if err != nil {
 		return warnings, err
 	}
 
-	err = blueprint.CheckFileCustomizationsPolicy(fc, pathpolicy.CustomFilesPolicies)
+	err = blueprint.CheckFileCustomizationsPolicy(fc, policies.CustomFilesPolicies)
 	if err != nil {
 		return warnings, err
 	}

--- a/pkg/policies/policies.go
+++ b/pkg/policies/policies.go
@@ -1,7 +1,11 @@
-package pathpolicy
+package policies
+
+import (
+	"github.com/osbuild/images/internal/pathpolicy"
+)
 
 // MountpointPolicies is a set of default mountpoint policies used for filesystem customizations
-var MountpointPolicies = NewPathPolicies(map[string]PathPolicy{
+var MountpointPolicies = pathpolicy.NewPathPolicies(map[string]pathpolicy.PathPolicy{
 	"/": {},
 	// /etc must be on the root filesystem
 	"/etc": {Deny: true},
@@ -31,13 +35,13 @@ var MountpointPolicies = NewPathPolicies(map[string]PathPolicy{
 })
 
 // CustomDirectoriesPolicies is a set of default policies for custom directories
-var CustomDirectoriesPolicies = NewPathPolicies(map[string]PathPolicy{
+var CustomDirectoriesPolicies = pathpolicy.NewPathPolicies(map[string]pathpolicy.PathPolicy{
 	"/":    {Deny: true},
 	"/etc": {},
 })
 
 // CustomFilesPolicies is a set of default policies for custom files
-var CustomFilesPolicies = NewPathPolicies(map[string]PathPolicy{
+var CustomFilesPolicies = pathpolicy.NewPathPolicies(map[string]pathpolicy.PathPolicy{
 	"/":           {Deny: true},
 	"/etc":        {},
 	"/root":       {},
@@ -48,7 +52,7 @@ var CustomFilesPolicies = NewPathPolicies(map[string]PathPolicy{
 })
 
 // MountpointPolicies for ostree
-var OstreeMountpointPolicies = NewPathPolicies(map[string]PathPolicy{
+var OstreeMountpointPolicies = pathpolicy.NewPathPolicies(map[string]pathpolicy.PathPolicy{
 	"/":             {},
 	"/ostree":       {Deny: true},
 	"/home":         {Deny: true},

--- a/pkg/policies/policies_test.go
+++ b/pkg/policies/policies_test.go
@@ -1,4 +1,4 @@
-package pathpolicy
+package policies
 
 import "testing"
 


### PR DESCRIPTION
This will allow them to be used along with the
blueprints.CheckMountpointsPolicy() function outside of images itself.