### PR TITLE
Generate *all* manifests in CI

### DIFF
--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -251,8 +251,6 @@ func bootableContainerPackageSet(t *imageType) rpmmd.PackageSet {
 			"initscripts",                         // make sure initscripts doesn't get pulled back in https://github.com/coreos/fedora-coreos-tracker/issues/220#issuecomment-611566254
 			"NetworkManager-initscripts-ifcfg-rh", // do not use legacy ifcfg config format in NetworkManager See https://github.com/coreos/fedora-coreos-config/pull/1991
 			"nodejs",
-			"perl",
-			"perl-interpreter",
 			"plymouth",         // for (datacenter/cloud oriented) servers, we want to see the details by default.  https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/HSMISZ3ETWQ4ETVLWZQJ55ARZT27AAV3/
 			"systemd-networkd", // we use NetworkManager
 		},
@@ -264,6 +262,10 @@ func bootableContainerPackageSet(t *imageType) rpmmd.PackageSet {
 			Include: []string{
 				"irqbalance",
 				"ostree-grub2",
+			},
+			Exclude: []string{
+				"perl",
+				"perl-interpreter",
 			},
 		})
 	case arch.ARCH_PPC64LE.String():
@@ -279,6 +281,10 @@ func bootableContainerPackageSet(t *imageType) rpmmd.PackageSet {
 		ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"irqbalance",
+			},
+			Exclude: []string{
+				"perl",
+				"perl-interpreter",
 			},
 		})
 	}

--- a/test/scripts/configure-generators
+++ b/test/scripts/configure-generators
@@ -6,6 +6,7 @@ import sys
 import imgtestlib as testlib
 
 ARCHITECTURES = ["x86_64", "aarch64"]
+MANIFEST_ONLY_ARCHES = ["ppc64le", "s390x"]
 
 
 BASE_CONFIG = """
@@ -90,6 +91,19 @@ image-build-ostree-trigger-{distro}-{arch}:
 """
 
 
+MANIFEST_GEN_TEMPLATE = """
+generate-manifests-{distro}-{arch}:
+  stage: gen
+  extends: .terraform
+  variables:
+    RUNNER: aws/fedora-39-x86_64
+    INTERNAL_NETWORK: "true"
+  script:
+    - sudo ./test/scripts/install-dependencies
+    - go run ./cmd/gen-manifests --arches {arch} --distros {distro} --workers 10
+"""
+
+
 def main():
     config_path = sys.argv[1]
     images = testlib.list_images(arches=ARCHITECTURES)
@@ -112,6 +126,16 @@ def main():
         ostree_gen_stage.append(OSTREE_GEN_TEMPLATE.format(distro=img["distro"], arch=img["arch"], cache=cache))
         ostree_trigger_stage.append(OSTREE_TRIGGER_TEMPLATE.format(distro=img["distro"], arch=img["arch"], cache=cache))
 
+    man_only_images = testlib.list_images(arches=MANIFEST_ONLY_ARCHES)
+    man_gen_stage = []
+    for img in man_only_images:
+        combo = (img["distro"], img["arch"])
+        if combo in combos:
+            continue
+
+        combos.add(combo)
+        man_gen_stage.append(MANIFEST_GEN_TEMPLATE.format(distro=img["distro"], arch=img["arch"]))
+
     with open(config_path, "w", encoding="utf-8") as config_file:
         config_file.write(BASE_CONFIG)
         config_file.write(testlib.BASE_CONFIG)
@@ -119,6 +143,7 @@ def main():
         config_file.write("\n".join(trigger_stage))
         config_file.write("\n".join(ostree_gen_stage))
         config_file.write("\n".join(ostree_trigger_stage))
+        config_file.write("\n".join(man_gen_stage))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Since we were only testing x86_64 and aarch64, the manifests for ppc64le and s390x were never being generated in CI.
Adding new jobs, generated by the same configure-generators script, that just generate these manifests in a new type of child pipeline: generate-manifests-{distro}-{arch}.
These jobs all run on x86_64, but we separate them per distro-arch so they can run in parallel.  The goal is to ensure that at least the manifest generation works for these architectures and the package sets resolve, even if we don't test that they actually build.

----

Removed the `perl` and `perl-interpreter` exclusions from iot-bootable-container for ppc64le and s390x because `/usr/bin/perl` is required by `powerpc-utils` and `s390utils-base`.