### PR TITLE
many: exclude /sysroot in bootc container-deploy stage

### DIFF
--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -217,7 +217,11 @@ func (p *BuildrootFromContainer) serialize() osbuild.Pipeline {
 	pipeline := p.Base.serialize()
 	pipeline.Runner = p.runner.String()
 
-	stage, err := osbuild.NewContainerDeployStage(osbuild.NewContainersInputForSources(p.containerSpecs))
+	inputs := osbuild.NewContainersInputForSources(p.containerSpecs)
+	options := &osbuild.ContainerDeployOptions{
+		Exclude: []string{"/sysroot"},
+	}
+	stage, err := osbuild.NewContainerDeployStage(inputs, options)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/osbuild/container_deploy_stage.go
+++ b/pkg/osbuild/container_deploy_stage.go
@@ -8,6 +8,12 @@ type ContainerDeployInputs struct {
 
 func (ContainerDeployInputs) isStageInputs() {}
 
+type ContainerDeployOptions struct {
+	Exclude []string `json:"exclude"`
+}
+
+func (ContainerDeployOptions) isStageOptions() {}
+
 func (inputs ContainerDeployInputs) validate() error {
 	if inputs.Images.References == nil {
 		return fmt.Errorf("stage requires exactly 1 input container (got nil References)")
@@ -18,7 +24,7 @@ func (inputs ContainerDeployInputs) validate() error {
 	return nil
 }
 
-func NewContainerDeployStage(images ContainersInput) (*Stage, error) {
+func NewContainerDeployStage(images ContainersInput, options *ContainerDeployOptions) (*Stage, error) {
 	inputs := ContainerDeployInputs{
 		Images: images,
 	}
@@ -26,7 +32,8 @@ func NewContainerDeployStage(images ContainersInput) (*Stage, error) {
 		return nil, err
 	}
 	return &Stage{
-		Type:   "org.osbuild.container-deploy",
-		Inputs: inputs,
+		Type:    "org.osbuild.container-deploy",
+		Inputs:  inputs,
+		Options: options,
 	}, nil
 }

--- a/pkg/osbuild/container_deploy_stage_test.go
+++ b/pkg/osbuild/container_deploy_stage_test.go
@@ -18,7 +18,7 @@ func TestContainersDeployStageInputs(t *testing.T) {
 			Source:  "registry.example.org/reg/img",
 		},
 	})
-	stage, err := osbuild.NewContainerDeployStage(inputs)
+	stage, err := osbuild.NewContainerDeployStage(inputs, nil)
 	require.NotNil(t, stage)
 	require.Nil(t, err)
 
@@ -26,7 +26,7 @@ func TestContainersDeployStageInputs(t *testing.T) {
 	assert.Equal(t, stage.Inputs.(osbuild.ContainerDeployInputs).Images, inputs)
 }
 
-func TestContainersDeployStageOptionsJson(t *testing.T) {
+func TestContainersDeployStageInputsInputsJson(t *testing.T) {
 	expectedJson := `{
         "images": {
                 "type": "org.osbuild.containers",
@@ -49,6 +49,21 @@ func TestContainersDeployStageOptionsJson(t *testing.T) {
 				ListDigest: "some-list-digest",
 			},
 		}),
+	}
+	json, err := json.MarshalIndent(cdi, "", "        ")
+	require.Nil(t, err)
+	assert.Equal(t, string(json), expectedJson)
+}
+
+func TestContainersDeployStageOptionsJson(t *testing.T) {
+	expectedJson := `{
+        "exclude": [
+                "/sysroot",
+                "/other"
+        ]
+}`
+	cdi := osbuild.ContainerDeployOptions{
+		Exclude: []string{"/sysroot", "/other"},
 	}
 	json, err := json.MarshalIndent(cdi, "", "        ")
 	require.Nil(t, err)
@@ -109,7 +124,7 @@ func TestContainersDeployStageInputsValidate(t *testing.T) {
 	for name := range testCases {
 		tc := testCases[name]
 		t.Run(name, func(t *testing.T) {
-			stage, err := osbuild.NewContainerDeployStage(tc.inputs.Images)
+			stage, err := osbuild.NewContainerDeployStage(tc.inputs.Images, nil)
 			if tc.err == "" {
 				require.NotNil(t, stage)
 				require.Nil(t, err)


### PR DESCRIPTION
When using bootc based images as buildroots we need to exclude the `/sysroot` to prevent selinux errors.

See https://github.com/osbuild/osbuild/pull/1552