### PR TITLE
manifest: label `/usr/bin/{,u}mount` correct (HMS-3318)

### DIFF
--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -210,6 +210,17 @@ func (p *BuildrootFromContainer) serializeEnd() {
 	p.containerSpecs = nil
 }
 
+func (p *BuildrootFromContainer) getSELinuxLabels() map[string]string {
+	labels := map[string]string{
+		"/usr/bin/ostree": "system_u:object_r:install_exec_t:s0",
+	}
+	if p.containerBuildable {
+		labels["/usr/bin/mount"] = "system_u:object_r:install_exec_t:s0"
+		labels["/usr/bin/umount"] = "system_u:object_r:install_exec_t:s0"
+	}
+	return labels
+}
+
 func (p *BuildrootFromContainer) serialize() osbuild.Pipeline {
 	if len(p.containerSpecs) == 0 {
 		panic("serialization not started")
@@ -229,9 +240,7 @@ func (p *BuildrootFromContainer) serialize() osbuild.Pipeline {
 	pipeline.AddStage(osbuild.NewSELinuxStage(
 		&osbuild.SELinuxStageOptions{
 			FileContexts: "etc/selinux/targeted/contexts/files/file_contexts",
-			Labels: map[string]string{
-				"/usr/bin/ostree": "system_u:object_r:install_exec_t:s0",
-			},
+			Labels:       p.getSELinuxLabels(),
 		},
 	))
 

--- a/pkg/manifest/build_test.go
+++ b/pkg/manifest/build_test.go
@@ -126,3 +126,23 @@ func TestNewBuildFromContainerSpecs(t *testing.T) {
 	build.serializeEnd()
 	require.Nil(t, build.getContainerSpecs())
 }
+
+func TestBuildFromContainerSpecsGetSelinuxLabelsNotBuildable(t *testing.T) {
+	build := &BuildrootFromContainer{}
+
+	assert.Equal(t, build.getSELinuxLabels(), map[string]string{
+		"/usr/bin/ostree": "system_u:object_r:install_exec_t:s0",
+	})
+}
+
+func TestBuildFromContainerSpecsGetSelinuxLabelsWithContainerBuildable(t *testing.T) {
+	build := &BuildrootFromContainer{
+		containerBuildable: true,
+	}
+
+	assert.Equal(t, build.getSELinuxLabels(), map[string]string{
+		"/usr/bin/ostree": "system_u:object_r:install_exec_t:s0",
+		"/usr/bin/mount":  "system_u:object_r:install_exec_t:s0",
+		"/usr/bin/umount": "system_u:object_r:install_exec_t:s0",
+	})
+}


### PR DESCRIPTION
Similar as https://github.com/osbuild/images/pull/287 we need to label `/usr/bin/{mount,umount}` as `install_exec_t` to prevent an selinux denial warning when osbuild runs mount/unmount.

See dea1af48 for more details.