### PR TITLE
Ensure FIPS files are added to the build

### DIFF
--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -611,7 +611,6 @@ func (p *OS) serialize() osbuild.Pipeline {
 				Kernel:     []string{p.kernelVer},
 				AddModules: []string{"fips"},
 			}))
-			p.Files = append(p.Files, osbuild.GenFIPSFiles()...)
 		}
 
 		if !p.KernelOptionsBootloader {
@@ -733,6 +732,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 	}
 
 	if p.FIPS {
+		p.Files = append(p.Files, osbuild.GenFIPSFiles()...)
 		for _, stage := range osbuild.GenFIPSStages() {
 			pipeline.AddStage(stage)
 		}

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -292,7 +292,6 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 
 	if p.FIPS {
 		kernelOpts = append(kernelOpts, osbuild.GenFIPSKernelOptions(p.PartitionTable)...)
-		p.Files = append(p.Files, osbuild.GenFIPSFiles()...)
 	}
 
 	var ref string
@@ -408,6 +407,7 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 	}
 
 	if p.FIPS {
+		p.Files = append(p.Files, osbuild.GenFIPSFiles()...)
 		for _, stage := range osbuild.GenFIPSStages() {
 			stage.MountOSTree(p.osName, ref, 0)
 			pipeline.AddStage(stage)


### PR DESCRIPTION
Make sure the FIPS files are always added to the build
when needed.

Fixes: #407

Signed-off-by: Miguel Martín <mmartinv@redhat.com>
