### PR TITLE
osbuild: add support for partscan/partition

### DIFF
--- a/pkg/osbuild/loopback_device.go
+++ b/pkg/osbuild/loopback_device.go
@@ -17,6 +17,9 @@ type LoopbackDeviceOptions struct {
 
 	// Lock (bsd lock) the device after opening it
 	Lock bool `json:"lock,omitempty"`
+
+	// Enable partition scanning as an option
+	Partscan bool `json:"partscan,omitempty"`
 }
 
 func (LoopbackDeviceOptions) isDeviceOptions() {}

--- a/pkg/osbuild/loopback_device_test.go
+++ b/pkg/osbuild/loopback_device_test.go
@@ -1,0 +1,46 @@
+package osbuild_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/osbuild"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoopbackDeviceOptionsSerializesAll(t *testing.T) {
+	dev := osbuild.LoopbackDeviceOptions{
+		Filename:   "foo.disk",
+		Start:      12345,
+		Size:       54321,
+		SectorSize: common.ToPtr(uint64(4096)),
+		Lock:       true,
+		Partscan:   true,
+	}
+	json, err := json.MarshalIndent(dev, "", "  ")
+	require.Nil(t, err)
+	assert.Equal(t, string(json), `
+{
+  "filename": "foo.disk",
+  "start": 12345,
+  "size": 54321,
+  "sector-size": 4096,
+  "lock": true,
+  "partscan": true
+}`[1:])
+}
+
+func TestLoopbackDeviceOptionsSerializesOmitEmptyHonored(t *testing.T) {
+	dev := osbuild.LoopbackDeviceOptions{
+		Filename: "foo.disk",
+	}
+	json, err := json.MarshalIndent(dev, "", "  ")
+	require.Nil(t, err)
+	assert.Equal(t, string(json), `
+{
+  "filename": "foo.disk"
+}`[1:])
+}

--- a/pkg/osbuild/mount.go
+++ b/pkg/osbuild/mount.go
@@ -1,11 +1,12 @@
 package osbuild
 
 type Mount struct {
-	Name    string       `json:"name"`
-	Type    string       `json:"type"`
-	Source  string       `json:"source,omitempty"`
-	Target  string       `json:"target,omitempty"`
-	Options MountOptions `json:"options,omitempty"`
+	Name      string       `json:"name"`
+	Type      string       `json:"type"`
+	Source    string       `json:"source,omitempty"`
+	Target    string       `json:"target,omitempty"`
+	Options   MountOptions `json:"options,omitempty"`
+	Partition *int         `json:"partition,omitempty"`
 }
 
 type MountOptions interface {

--- a/pkg/osbuild/mount_test.go
+++ b/pkg/osbuild/mount_test.go
@@ -1,10 +1,13 @@
 package osbuild_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
@@ -54,4 +57,39 @@ func TestNewMounts(t *testing.T) {
 		}
 		assert.Equal(expected, actual)
 	}
+}
+
+func TestMountJsonAll(t *testing.T) {
+	mnt := &osbuild.Mount{
+		Name:   "xfs",
+		Type:   "org.osbuild.xfs",
+		Source: "/dev/sda4",
+		Target: "/mnt/xfs",
+		//TODO: test "Options:" too
+		Partition: common.ToPtr(1),
+	}
+	json, err := json.MarshalIndent(mnt, "", "  ")
+	require.Nil(t, err)
+	assert.Equal(t, string(json), `
+{
+  "name": "xfs",
+  "type": "org.osbuild.xfs",
+  "source": "/dev/sda4",
+  "target": "/mnt/xfs",
+  "partition": 1
+}`[1:])
+}
+
+func TestMountJsonOmitEmptyHonored(t *testing.T) {
+	mnt := &osbuild.Mount{
+		Name: "xfs",
+		Type: "org.osbuild.xfs",
+	}
+	json, err := json.MarshalIndent(mnt, "", "  ")
+	require.Nil(t, err)
+	assert.Equal(t, string(json), `
+{
+  "name": "xfs",
+  "type": "org.osbuild.xfs"
+}`[1:])
 }

--- a/pkg/osbuild/mount_test.go
+++ b/pkg/osbuild/mount_test.go
@@ -1,17 +1,19 @@
-package osbuild
+package osbuild_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/osbuild"
 )
 
 func TestNewMounts(t *testing.T) {
 	assert := assert.New(t)
 
 	{ // btrfs
-		actual := NewBtrfsMount("btrfs", "/dev/sda1", "/mnt/btrfs")
-		expected := &Mount{
+		actual := osbuild.NewBtrfsMount("btrfs", "/dev/sda1", "/mnt/btrfs")
+		expected := &osbuild.Mount{
 			Name:   "btrfs",
 			Type:   "org.osbuild.btrfs",
 			Source: "/dev/sda1",
@@ -21,8 +23,8 @@ func TestNewMounts(t *testing.T) {
 	}
 
 	{ // ext4
-		actual := NewExt4Mount("ext4", "/dev/sda2", "/mnt/ext4")
-		expected := &Mount{
+		actual := osbuild.NewExt4Mount("ext4", "/dev/sda2", "/mnt/ext4")
+		expected := &osbuild.Mount{
 			Name:   "ext4",
 			Type:   "org.osbuild.ext4",
 			Source: "/dev/sda2",
@@ -32,8 +34,8 @@ func TestNewMounts(t *testing.T) {
 	}
 
 	{ // fat
-		actual := NewFATMount("fat", "/dev/sda3", "/mnt/fat")
-		expected := &Mount{
+		actual := osbuild.NewFATMount("fat", "/dev/sda3", "/mnt/fat")
+		expected := &osbuild.Mount{
 			Name:   "fat",
 			Type:   "org.osbuild.fat",
 			Source: "/dev/sda3",
@@ -43,8 +45,8 @@ func TestNewMounts(t *testing.T) {
 	}
 
 	{ // xfs
-		actual := NewXfsMount("xfs", "/dev/sda4", "/mnt/xfs")
-		expected := &Mount{
+		actual := osbuild.NewXfsMount("xfs", "/dev/sda4", "/mnt/xfs")
+		expected := &osbuild.Mount{
 			Name:   "xfs",
 			Type:   "org.osbuild.xfs",
 			Source: "/dev/sda4",


### PR DESCRIPTION
A tiny PR that will probably be needed to integrate with https://github.com/osbuild/osbuild/pull/1547  

In the work on `bootc install to-filesystem` so far it expects a view of the entire disk (for bootupd). However in https://github.com/osbuild/images/pull/381 with the standalone bootupd integration it was not needed. We can wait with the merge until the osbuild PR is merged and we test this more meaningfully. OTOH it's tiny and does not hurt to have (as there is a coresponding osbuild feature).

The corresponding osbuild PR is https://github.com/osbuild/osbuild/pull/1501

P.S. I can remove [osbuild: move mount_test.go to osbuild_test pattern](https://github.com/osbuild/images/commit/726c3248681505023a5bee64de2d98a289f952f6) is that is undesired (I'm a fan of this pattern but I get that not everyone is :)

