### PR TITLE
osbuild: add org.osbuild.bootc.install-to-filesystem support

### DIFF
--- a/pkg/osbuild/bootc_install_to_filesystem_stage.go
+++ b/pkg/osbuild/bootc_install_to_filesystem_stage.go
@@ -1,0 +1,21 @@
+package osbuild
+
+// NewBootcInstallToFilesystem creates a new stage for the
+// org.osbuild.bootc.install-to-filesystem stage.
+//
+// It requires a mount setup so that bootupd can be run by bootc. I.e
+// "/", "/boot" and "/boot/efi" need to be set up so that
+// bootc/bootupd find and install all required bootloader bits.
+//
+// The mounts input should be generated with GenBootupdDevicesMounts.
+func NewBootcInstallToFilesystemStage(devices map[string]Device, mounts []Mount) (*Stage, error) {
+	if err := validateBootupdMounts(mounts); err != nil {
+		return nil, err
+	}
+
+	return &Stage{
+		Type:    "org.osbuild.bootc.install-to-filesystem",
+		Devices: devices,
+		Mounts:  mounts,
+	}, nil
+}

--- a/pkg/osbuild/bootc_install_to_filesystem_stage_test.go
+++ b/pkg/osbuild/bootc_install_to_filesystem_stage_test.go
@@ -1,0 +1,82 @@
+package osbuild_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+func TestBootcInstallToFilesystemStageNewHappy(t *testing.T) {
+	devices := makeOsbuildDevices("dev-for-/", "dev-for-/boot", "dev-for-/boot/efi")
+	mounts := makeOsbuildMounts("/", "/boot", "/boot/efi")
+
+	expectedStage := &osbuild.Stage{
+		Type:    "org.osbuild.bootc.install-to-filesystem",
+		Devices: devices,
+		Mounts:  mounts,
+	}
+	stage, err := osbuild.NewBootcInstallToFilesystemStage(devices, mounts)
+	require.Nil(t, err)
+	assert.Equal(t, stage, expectedStage)
+}
+
+func TestBootcInstallToFilesystemStageMissingMounts(t *testing.T) {
+	devices := makeOsbuildDevices("dev-for-/")
+	mounts := makeOsbuildMounts("/")
+
+	stage, err := osbuild.NewBootcInstallToFilesystemStage(devices, mounts)
+	// XXX: rename error
+	assert.ErrorContains(t, err, "required mounts for bootupd stage [/boot /boot/efi] missing")
+	require.Nil(t, stage)
+}
+
+func TestBootcInstallToFilesystemStageJsonHappy(t *testing.T) {
+	devices := makeOsbuildDevices("disk", "dev-for-/", "dev-for-/boot", "dev-for-/boot/efi")
+	mounts := makeOsbuildMounts("/", "/boot", "/boot/efi")
+
+	stage, err := osbuild.NewBootcInstallToFilesystemStage(devices, mounts)
+	require.Nil(t, err)
+	stageJson, err := json.MarshalIndent(stage, "", "  ")
+	require.Nil(t, err)
+	assert.Equal(t, string(stageJson), `{
+  "type": "org.osbuild.bootc.install-to-filesystem",
+  "devices": {
+    "dev-for-/": {
+      "type": "org.osbuild.loopback"
+    },
+    "dev-for-/boot": {
+      "type": "org.osbuild.loopback"
+    },
+    "dev-for-/boot/efi": {
+      "type": "org.osbuild.loopback"
+    },
+    "disk": {
+      "type": "org.osbuild.loopback"
+    }
+  },
+  "mounts": [
+    {
+      "name": "mnt-for-/",
+      "type": "org.osbuild.ext4",
+      "source": "dev-for-/",
+      "target": "/"
+    },
+    {
+      "name": "mnt-for-/boot",
+      "type": "org.osbuild.ext4",
+      "source": "dev-for-/boot",
+      "target": "/boot"
+    },
+    {
+      "name": "mnt-for-/boot/efi",
+      "type": "org.osbuild.ext4",
+      "source": "dev-for-/boot/efi",
+      "target": "/boot/efi"
+    }
+  ]
+}`)
+}

--- a/pkg/osbuild/bootupd_stage_test.go
+++ b/pkg/osbuild/bootupd_stage_test.go
@@ -15,8 +15,8 @@ func makeOsbuildMounts(targets ...string) []osbuild.Mount {
 	for _, target := range targets {
 		mnts = append(mnts, osbuild.Mount{
 			Type:   "org.osbuild.ext4",
-			Name:   "mnt-" + target,
-			Source: "dev-" + target,
+			Name:   "mnt-for-" + target,
+			Source: "dev-for-" + target,
 			Target: target,
 		})
 	}
@@ -37,7 +37,7 @@ func TestBootupdStageNewHappy(t *testing.T) {
 	opts := &osbuild.BootupdStageOptions{
 		StaticConfigs: true,
 	}
-	devices := makeOsbuildDevices("dev-/", "dev-/boot", "dev-/boot/efi")
+	devices := makeOsbuildDevices("dev-for-/", "dev-for-/boot", "dev-for-/boot/efi")
 	mounts := makeOsbuildMounts("/", "/boot", "/boot/efi")
 
 	expectedStage := &osbuild.Stage{
@@ -55,7 +55,7 @@ func TestBootupdStageMissingMounts(t *testing.T) {
 	opts := &osbuild.BootupdStageOptions{
 		StaticConfigs: true,
 	}
-	devices := makeOsbuildDevices("dev-/")
+	devices := makeOsbuildDevices("dev-for-/")
 	mounts := makeOsbuildMounts("/")
 
 	stage, err := osbuild.NewBootupdStage(opts, devices, mounts)
@@ -69,11 +69,11 @@ func TestBootupdStageMissingDevice(t *testing.T) {
 			Device: "disk",
 		},
 	}
-	devices := makeOsbuildDevices("dev-/", "dev-/boot", "dev-/boot/efi")
+	devices := makeOsbuildDevices("dev-for-/", "dev-for-/boot", "dev-for-/boot/efi")
 	mounts := makeOsbuildMounts("/", "/boot", "/boot/efi")
 
 	stage, err := osbuild.NewBootupdStage(opts, devices, mounts)
-	assert.ErrorContains(t, err, `cannot find expected device "disk" for bootupd bios option in [dev-/ dev-/boot dev-/boot/efi]`)
+	assert.ErrorContains(t, err, `cannot find expected device "disk" for bootupd bios option in [dev-for-/ dev-for-/boot dev-for-/boot/efi]`)
 	require.Nil(t, stage)
 }
 
@@ -88,7 +88,7 @@ func TestBootupdStageJsonHappy(t *testing.T) {
 			Device: "disk",
 		},
 	}
-	devices := makeOsbuildDevices("disk", "dev-/", "dev-/boot", "dev-/boot/efi")
+	devices := makeOsbuildDevices("disk", "dev-for-/", "dev-for-/boot", "dev-for-/boot/efi")
 	mounts := makeOsbuildMounts("/", "/boot", "/boot/efi")
 
 	stage, err := osbuild.NewBootupdStage(opts, devices, mounts)
@@ -108,13 +108,13 @@ func TestBootupdStageJsonHappy(t *testing.T) {
     }
   },
   "devices": {
-    "dev-/": {
+    "dev-for-/": {
       "type": "org.osbuild.loopback"
     },
-    "dev-/boot": {
+    "dev-for-/boot": {
       "type": "org.osbuild.loopback"
     },
-    "dev-/boot/efi": {
+    "dev-for-/boot/efi": {
       "type": "org.osbuild.loopback"
     },
     "disk": {
@@ -123,21 +123,21 @@ func TestBootupdStageJsonHappy(t *testing.T) {
   },
   "mounts": [
     {
-      "name": "mnt-/",
+      "name": "mnt-for-/",
       "type": "org.osbuild.ext4",
-      "source": "dev-/",
+      "source": "dev-for-/",
       "target": "/"
     },
     {
-      "name": "mnt-/boot",
+      "name": "mnt-for-/boot",
       "type": "org.osbuild.ext4",
-      "source": "dev-/boot",
+      "source": "dev-for-/boot",
       "target": "/boot"
     },
     {
-      "name": "mnt-/boot/efi",
+      "name": "mnt-for-/boot/efi",
       "type": "org.osbuild.ext4",
-      "source": "dev-/boot/efi",
+      "source": "dev-for-/boot/efi",
       "target": "/boot/efi"
     }
   ]

--- a/pkg/osbuild/bootupd_stage_test.go
+++ b/pkg/osbuild/bootupd_stage_test.go
@@ -27,7 +27,7 @@ func makeOsbuildDevices(devnames ...string) map[string]osbuild.Device {
 	devices := make(map[string]osbuild.Device)
 	for _, devname := range devnames {
 		devices[devname] = osbuild.Device{
-			Type: "orgosbuild.loopback",
+			Type: "org.osbuild.loopback",
 		}
 	}
 	return devices
@@ -109,16 +109,16 @@ func TestBootupdStageJsonHappy(t *testing.T) {
   },
   "devices": {
     "dev-/": {
-      "type": "orgosbuild.loopback"
+      "type": "org.osbuild.loopback"
     },
     "dev-/boot": {
-      "type": "orgosbuild.loopback"
+      "type": "org.osbuild.loopback"
     },
     "dev-/boot/efi": {
-      "type": "orgosbuild.loopback"
+      "type": "org.osbuild.loopback"
     },
     "disk": {
-      "type": "orgosbuild.loopback"
+      "type": "org.osbuild.loopback"
     }
   },
   "mounts": [


### PR DESCRIPTION
This PR adds support for `org.osbuild.bootc.install-to-filesystem` from https://github.com/osbuild/osbuild/pull/1547.

