### PR TITLE
create ostree user sudoers file

### DIFF
--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -20,6 +20,8 @@ type ImageConfig struct {
 	DisabledServices    []string
 	DefaultTarget       *string
 	Sysconfig           []*osbuild.SysconfigStageOptions
+	// whether to create sudoer file for wheel group with NOPASSWD option
+	WheelNoPasswd *bool
 
 	// List of files from which to import GPG keys into the RPM database
 	GPGKeyFiles []string

--- a/pkg/distro/image_config_test.go
+++ b/pkg/distro/image_config_test.go
@@ -70,6 +70,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 					},
 					LeapsecTz: common.ToPtr(""),
 				},
+				WheelNoPasswd: common.ToPtr(true),
 			},
 			expectedConfig: &ImageConfig{
 				Timezone: common.ToPtr("UTC"),
@@ -92,6 +93,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				EnabledServices:  []string{"sshd"},
 				DisabledServices: []string{"named"},
 				DefaultTarget:    common.ToPtr("multi-user.target"),
+				WheelNoPasswd:    common.ToPtr(true),
 				Sysconfig: []*osbuild.SysconfigStageOptions{
 					{
 						Kernel: &osbuild.SysconfigKernelOptions{
@@ -133,6 +135,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				EnabledServices:  []string{"sshd"},
 				DisabledServices: []string{"named"},
 				DefaultTarget:    common.ToPtr("multi-user.target"),
+				WheelNoPasswd:    common.ToPtr(true),
 			},
 			imageConfig: &ImageConfig{},
 			expectedConfig: &ImageConfig{
@@ -147,6 +150,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				EnabledServices:  []string{"sshd"},
 				DisabledServices: []string{"named"},
 				DefaultTarget:    common.ToPtr("multi-user.target"),
+				WheelNoPasswd:    common.ToPtr(true),
 			},
 		},
 		{
@@ -164,6 +168,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				EnabledServices:  []string{"sshd"},
 				DisabledServices: []string{"named"},
 				DefaultTarget:    common.ToPtr("multi-user.target"),
+				WheelNoPasswd:    common.ToPtr(true),
 			},
 			expectedConfig: &ImageConfig{
 				Timezone: common.ToPtr("America/New_York"),
@@ -177,6 +182,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				EnabledServices:  []string{"sshd"},
 				DisabledServices: []string{"named"},
 				DefaultTarget:    common.ToPtr("multi-user.target"),
+				WheelNoPasswd:    common.ToPtr(true),
 			},
 		},
 		{
@@ -194,6 +200,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				EnabledServices:  []string{"sshd"},
 				DisabledServices: []string{"named"},
 				DefaultTarget:    common.ToPtr("multi-user.target"),
+				WheelNoPasswd:    common.ToPtr(true),
 			},
 			expectedConfig: &ImageConfig{
 				Timezone: common.ToPtr("America/New_York"),
@@ -207,6 +214,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				EnabledServices:  []string{"sshd"},
 				DisabledServices: []string{"named"},
 				DefaultTarget:    common.ToPtr("multi-user.target"),
+				WheelNoPasswd:    common.ToPtr(true),
 			},
 		},
 	}

--- a/pkg/distro/rhel8/edge.go
+++ b/pkg/distro/rhel8/edge.go
@@ -101,6 +101,7 @@ func edgeInstallerImgType(rd distribution) imageType {
 		},
 		defaultImageConfig: &distro.ImageConfig{
 			EnabledServices: edgeServices(rd),
+			WheelNoPasswd:   common.ToPtr(true),
 		},
 		rpmOstree:        true,
 		bootISO:          true,

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -424,6 +424,7 @@ func edgeInstallerImage(workload workload.Workload,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	d := t.arch.distro
+	imageConfig := t.getDefaultImageConfig()
 
 	commit, err := makeOSTreePayloadCommit(options.OSTree, t.OSTreeRef())
 	if err != nil {
@@ -436,6 +437,9 @@ func edgeInstallerImage(workload workload.Workload,
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
+	if imageConfig.WheelNoPasswd != nil {
+		img.WheelNoPasswd = *imageConfig.WheelNoPasswd
+	}
 
 	img.SquashfsCompression = "xz"
 	img.AdditionalDracutModules = []string{"prefixdevname", "prefixdevname-tools"}

--- a/pkg/distro/rhel9/edge.go
+++ b/pkg/distro/rhel9/edge.go
@@ -99,6 +99,7 @@ var (
 		defaultImageConfig: &distro.ImageConfig{
 			Locale:          common.ToPtr("en_US.UTF-8"),
 			EnabledServices: edgeServices,
+			WheelNoPasswd:   common.ToPtr(true),
 		},
 		rpmOstree:        true,
 		bootISO:          true,

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -377,6 +377,7 @@ func edgeInstallerImage(workload workload.Workload,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	d := t.arch.distro
+	imageConfig := t.getDefaultImageConfig()
 
 	commit, err := makeOSTreePayloadCommit(options.OSTree, t.OSTreeRef())
 	if err != nil {
@@ -389,6 +390,9 @@ func edgeInstallerImage(workload workload.Workload,
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
+	if imageConfig.WheelNoPasswd != nil {
+		img.WheelNoPasswd = *imageConfig.WheelNoPasswd
+	}
 
 	img.SquashfsCompression = "xz"
 	img.AdditionalDracutModules = []string{

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -21,6 +21,8 @@ type AnacondaOSTreeInstaller struct {
 	ExtraBasePackages rpmmd.PackageSet
 	Users             []users.User
 	Groups            []users.Group
+	// whether to create sudoer file for wheel group with NOPASSWD option
+	WheelNoPasswd bool
 
 	SquashfsCompression string
 
@@ -108,7 +110,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.Remote = img.Remote
 	isoTreePipeline.Users = img.Users
 	isoTreePipeline.Groups = img.Groups
-
+	isoTreePipeline.WheelNoPasswd = img.WheelNoPasswd
 	isoTreePipeline.SquashfsCompression = img.SquashfsCompression
 
 	// For ostree installers, always put the kickstart file in the root of the ISO


### PR DESCRIPTION
In the context of compatibility with edge-management when creating image ISO artifact. 
When creating an ostree user, the user is created with username and ssh-key without a password, the user has no possibility to manage the system as has no password to enter when using sudo command.
Create a sudoer file at first boot stage.

FIXES: https://issues.redhat.com/browse/THEEDGE-3837