### PR TITLE
distro/rhel9: handle two-digit minor version without the dot

### DIFF
--- a/pkg/distro/rhel9/distro.go
+++ b/pkg/distro/rhel9/distro.go
@@ -474,14 +474,17 @@ func ParseID(idStr string) (*distro.ID, error) {
 		return nil, fmt.Errorf("invalid distro name: %s", id.Name)
 	}
 
-	// Backward compatibility layer for "rhel-93" and friends
+	// Backward compatibility layer for "rhel-93" or "rhel-910"
 	if id.Name == "rhel" && id.MinorVersion == -1 {
 		if id.MajorVersion/10 == 9 {
 			// handle single digit minor version
 			id.MinorVersion = id.MajorVersion % 10
 			id.MajorVersion = 9
+		} else if id.MajorVersion/100 == 9 {
+			// handle two digit minor version
+			id.MinorVersion = id.MajorVersion % 100
+			id.MajorVersion = 9
 		}
-		// two digit minor versions in the old format are not supported
 	}
 
 	if id.MajorVersion != 9 {

--- a/pkg/distro/rhel9/distro_internal_test.go
+++ b/pkg/distro/rhel9/distro_internal_test.go
@@ -32,8 +32,8 @@ func TestDistroFactory(t *testing.T) {
 			expected: newDistro("rhel", 3),
 		},
 		{
-			strID:    "rhel-910", // this is intentionally not supported for el9
-			expected: nil,
+			strID:    "rhel-910",
+			expected: newDistro("rhel", 10),
 		},
 		{
 			strID:    "rhel-9.10",

--- a/pkg/distrofactory/distrofactory_test.go
+++ b/pkg/distrofactory/distrofactory_test.go
@@ -42,6 +42,14 @@ func TestGetDistroDefaultList(t *testing.T) {
 			expectedDistroName: "rhel-9.1",
 		},
 		{
+			strID:              "rhel-910",
+			expectedDistroName: "rhel-9.10",
+		},
+		{
+			strID:              "rhel-9.10",
+			expectedDistroName: "rhel-9.10",
+		},
+		{
 			strID:              "fedora-38",
 			expectedDistroName: "fedora-38",
 		},

--- a/pkg/distroidparser/idparser_test.go
+++ b/pkg/distroidparser/idparser_test.go
@@ -99,7 +99,7 @@ func TestDefaltParser(t *testing.T) {
 		},
 		{
 			idStr:    "rhel-910",
-			expected: &distro.ID{Name: "rhel", MajorVersion: 910, MinorVersion: -1},
+			expected: &distro.ID{Name: "rhel", MajorVersion: 9, MinorVersion: 10},
 		},
 		{
 			idStr:    "rhel-9.10",


### PR DESCRIPTION
Let's gracefully handle the "old" naming scheme without a dot to separate the major and minor version also for two-digit minor versions. RHEL-9 parser is now consistent with RHEL-8. The motivation behind this change is to not introduce any breaking changes within the RHEL-9 major version.