### PR TITLE
Add a btrfs partitioning mode

### DIFF
--- a/internal/testdisk/partition.go
+++ b/internal/testdisk/partition.go
@@ -43,7 +43,7 @@ func MakeFakeBtrfsPartitionTable(mntPoints ...string) *disk.PartitionTable {
 		if name == "/" {
 			name = "root"
 		}
-		subvolumes = append(subvolumes, disk.BtrfsSubvolume{Mountpoint: mntPoint, Name: name})
+		subvolumes = append(subvolumes, disk.BtrfsSubvolume{Mountpoint: mntPoint, Name: name, Compress: "zstd:1"})
 	}
 
 	return &disk.PartitionTable{

--- a/internal/testdisk/partition.go
+++ b/internal/testdisk/partition.go
@@ -43,7 +43,7 @@ func MakeFakeBtrfsPartitionTable(mntPoints ...string) *disk.PartitionTable {
 		if name == "/" {
 			name = "root"
 		}
-		subvolumes = append(subvolumes, disk.BtrfsSubvolume{Mountpoint: mntPoint, Name: name, Compress: "zstd:1"})
+		subvolumes = append(subvolumes, disk.BtrfsSubvolume{Mountpoint: mntPoint, Name: name, Compress: disk.DefaultBtrfsCompression})
 	}
 
 	return &disk.PartitionTable{

--- a/pkg/disk/btrfs.go
+++ b/pkg/disk/btrfs.go
@@ -75,6 +75,10 @@ func (b *Btrfs) GenUUID(rng *rand.Rand) {
 	if b.UUID == "" {
 		b.UUID = uuid.Must(newRandomUUIDFromReader(rng)).String()
 	}
+
+	for i := range b.Subvolumes {
+		b.Subvolumes[i].UUID = b.UUID
+	}
 }
 
 type BtrfsSubvolume struct {

--- a/pkg/disk/btrfs.go
+++ b/pkg/disk/btrfs.go
@@ -7,6 +7,8 @@ import (
 	"github.com/google/uuid"
 )
 
+const DefaultBtrfsCompression = "zstd:1"
+
 type Btrfs struct {
 	UUID       string
 	Label      string
@@ -60,6 +62,7 @@ func (b *Btrfs) CreateMountpoint(mountpoint string, size uint64) (Entity, error)
 		GroupID:    0,
 		UUID:       b.UUID, // subvolumes inherit UUID of main volume
 		Name:       name,
+		Compress:   DefaultBtrfsCompression,
 	}
 
 	b.Subvolumes = append(b.Subvolumes, subvolume)

--- a/pkg/disk/btrfs.go
+++ b/pkg/disk/btrfs.go
@@ -3,7 +3,6 @@ package disk
 import (
 	"fmt"
 	"math/rand"
-	"strings"
 
 	"github.com/google/uuid"
 )
@@ -86,8 +85,7 @@ type BtrfsSubvolume struct {
 	Size       uint64
 	Mountpoint string
 	GroupID    uint64
-
-	MntOps string
+	Compress   string
 
 	// UUID of the parent volume
 	UUID string
@@ -107,7 +105,7 @@ func (bs *BtrfsSubvolume) Clone() Entity {
 		Size:       bs.Size,
 		Mountpoint: bs.Mountpoint,
 		GroupID:    bs.GroupID,
-		MntOps:     bs.MntOps,
+		Compress:   bs.Compress,
 		UUID:       bs.UUID,
 	}
 }
@@ -153,7 +151,10 @@ func (bs *BtrfsSubvolume) GetFSTabOptions() FSTabOptions {
 		return FSTabOptions{}
 	}
 
-	ops := strings.Join([]string{bs.MntOps, fmt.Sprintf("subvol=%s", bs.Name)}, ",")
+	ops := fmt.Sprintf("subvol=%s", bs.Name)
+	if bs.Compress != "" {
+		ops += fmt.Sprintf(",compress=%s", bs.Compress)
+	}
 	return FSTabOptions{
 		MntOps: ops,
 		Freq:   0,

--- a/pkg/disk/btrfs_test.go
+++ b/pkg/disk/btrfs_test.go
@@ -1,0 +1,19 @@
+package disk
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBtrfsSubvolume_GetFSTabOptions(t *testing.T) {
+	subvol := BtrfsSubvolume{
+		Name:       "root",
+		Mountpoint: "/",
+		Compress:   "zstd:1",
+	}
+	actual := subvol.GetFSTabOptions()
+
+	assert.Equal(t, FSTabOptions{
+		MntOps: "subvol=root,compress=zstd:1",
+	}, actual)
+}

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -36,6 +36,9 @@ const (
 	// RawPartitioningMode always creates a raw layout.
 	RawPartitioningMode PartitioningMode = "raw"
 
+	// BtrfsPartitioningMode creates a btrfs layout.
+	BtfrsPartitioningMode PartitioningMode = "btrfs"
+
 	// DefaultPartitioningMode is AutoLVMPartitioningMode and is the empty state
 	DefaultPartitioningMode PartitioningMode = ""
 )
@@ -43,14 +46,15 @@ const (
 func NewPartitionTable(basePT *PartitionTable, mountpoints []blueprint.FilesystemCustomization, imageSize uint64, mode PartitioningMode, requiredSizes map[string]uint64, rng *rand.Rand) (*PartitionTable, error) {
 	newPT := basePT.Clone().(*PartitionTable)
 
-	if basePT.features().LVM && mode == RawPartitioningMode {
-		return nil, fmt.Errorf("raw partitioning mode set for a base partition table with LVM, this is unsupported")
+	if basePT.features().LVM && (mode == RawPartitioningMode || mode == BtfrsPartitioningMode) {
+		return nil, fmt.Errorf("%s partitioning mode set for a base partition table with LVM, this is unsupported", mode)
 	}
 
 	// first pass: enlarge existing mountpoints and collect new ones
 	newMountpoints, _ := newPT.applyCustomization(mountpoints, false)
 
 	var ensureLVM bool
+	ensureBtrfs := false
 	switch mode {
 	case LVMPartitioningMode:
 		ensureLVM = true
@@ -58,11 +62,18 @@ func NewPartitionTable(basePT *PartitionTable, mountpoints []blueprint.Filesyste
 		ensureLVM = false
 	case DefaultPartitioningMode, AutoLVMPartitioningMode:
 		ensureLVM = len(newMountpoints) > 0
+	case BtfrsPartitioningMode:
+		ensureBtrfs = true
 	default:
 		return nil, fmt.Errorf("unsupported partitioning mode %q", mode)
 	}
 	if ensureLVM {
 		err := newPT.ensureLVM()
+		if err != nil {
+			return nil, err
+		}
+	} else if ensureBtrfs {
+		err := newPT.ensureBtrfs()
 		if err != nil {
 			return nil, err
 		}
@@ -673,6 +684,62 @@ func (pt *PartitionTable) ensureLVM() error {
 
 	} else {
 		return fmt.Errorf("Unsupported parent for LVM")
+	}
+
+	return nil
+}
+
+// ensureBtrfs will ensure that the root partition is on a btrfs subvolume, i.e. if
+// it currently is not, it will wrap it in one
+func (pt *PartitionTable) ensureBtrfs() error {
+
+	rootPath := entityPath(pt, "/")
+	if rootPath == nil {
+		panic("no root mountpoint for PartitionTable")
+	}
+
+	// we need a /boot partition to boot btrfs, ensure one exists
+	bootPath := entityPath(pt, "/boot")
+	if bootPath == nil {
+		_, err := pt.CreateMountpoint("/boot", 512*common.MiB)
+
+		if err != nil {
+			return err
+		}
+
+		rootPath = entityPath(pt, "/")
+	}
+
+	parent := rootPath[1] // NB: entityPath has reversed order
+
+	if _, ok := parent.(*Btrfs); ok {
+		return nil
+	} else if part, ok := parent.(*Partition); ok {
+		btrfs := &Btrfs{
+			Label: "root",
+			Subvolumes: []BtrfsSubvolume{
+				{
+					Name:       "root",
+					Mountpoint: "/",
+					Compress:   "zstd:1",
+				},
+			},
+		}
+
+		// replace the top-level partition payload with a new btrfs filesystem
+		part.Payload = btrfs
+
+		// reset the btrfs partition size - it will be grown later
+		part.Size = 0
+
+		if pt.Type == "gpt" {
+			part.Type = FilesystemDataGUID
+		} else {
+			part.Type = "83"
+		}
+
+	} else {
+		return fmt.Errorf("Unsupported parent for btrfs")
 	}
 
 	return nil

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -721,7 +721,7 @@ func (pt *PartitionTable) ensureBtrfs() error {
 				{
 					Name:       "root",
 					Mountpoint: "/",
-					Compress:   "zstd:1",
+					Compress:   DefaultBtrfsCompression,
 				},
 			},
 		}

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -1,6 +1,8 @@
 package disk
 
 import (
+	"github.com/osbuild/images/internal/common"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,4 +25,57 @@ func TestPartitionTableFeatures(t *testing.T) {
 		assert.Equal(t, tc.expectedFeatures, pt.features())
 
 	}
+}
+
+func TestPartitionTable_GenerateUUIDs(t *testing.T) {
+	pt := PartitionTable{
+		Type: "gpt",
+		Partitions: []Partition{
+			{
+				Size:     1 * common.MebiByte,
+				Bootable: true,
+				Type:     BIOSBootPartitionGUID,
+				UUID:     BIOSBootPartitionUUID,
+			},
+			{
+				Size: 2 * common.GibiByte,
+				Type: FilesystemDataGUID,
+				Payload: &Filesystem{
+					Type:         "xfs",
+					Label:        "root",
+					Mountpoint:   "/",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+			{
+				Size: 10 * common.GibiByte,
+				Payload: &Btrfs{
+					Subvolumes: []BtrfsSubvolume{
+						{
+							Mountpoint: "/var",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Static seed for testing
+	/* #nosec G404 */
+	rnd := rand.New(rand.NewSource(0))
+
+	pt.GenerateUUIDs(rnd)
+
+	// Check that GenUUID doesn't change already defined UUIDs
+	assert.Equal(t, BIOSBootPartitionUUID, pt.Partitions[0].UUID)
+
+	// Check that GenUUID generates fresh UUIDs if not defined prior the call
+	assert.Equal(t, "a178892e-e285-4ce1-9114-55780875d64e", pt.Partitions[1].UUID)
+	assert.Equal(t, "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75", pt.Partitions[1].Payload.(*Filesystem).UUID)
+
+	// Check that GenUUID generates the same UUID for BTRFS and its subvolumes
+	assert.Equal(t, "fb180daf-48a7-4ee0-b10d-394651850fd4", pt.Partitions[2].Payload.(*Btrfs).UUID)
+	assert.Equal(t, "fb180daf-48a7-4ee0-b10d-394651850fd4", pt.Partitions[2].Payload.(*Btrfs).Subvolumes[0].UUID)
 }

--- a/pkg/osbuild/btrfs_mount.go
+++ b/pkg/osbuild/btrfs_mount.go
@@ -1,10 +1,21 @@
 package osbuild
 
-func NewBtrfsMount(name, source, target string) *Mount {
+type btrfsMountOptions struct {
+	Subvol   string `json:"subvol,omitempty"`
+	Compress string `json:"compress,omitempty"`
+}
+
+func (b btrfsMountOptions) isMountOptions() {}
+
+func NewBtrfsMount(name, source, target, subvol, compress string) *Mount {
 	return &Mount{
 		Type:   "org.osbuild.btrfs",
 		Name:   name,
 		Source: source,
 		Target: target,
+		Options: btrfsMountOptions{
+			Subvol:   subvol,
+			Compress: compress,
+		},
 	}
 }

--- a/pkg/osbuild/btrfs_subvol_stage.go
+++ b/pkg/osbuild/btrfs_subvol_stage.go
@@ -1,0 +1,73 @@
+package osbuild
+
+import (
+	"github.com/osbuild/images/pkg/disk"
+)
+
+type BtrfsSubVolOptions struct {
+	Subvolumes []BtrfsSubVol `json:"subvolumes"`
+}
+
+type BtrfsSubVol struct {
+	Name string `json:"name"`
+}
+
+func (BtrfsSubVolOptions) isStageOptions() {}
+
+func NewBtrfsSubVol(options *BtrfsSubVolOptions, devices *map[string]Device, mounts *[]Mount) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.btrfs.subvol",
+		Options: options,
+		Devices: *devices,
+		Mounts:  *mounts,
+	}
+}
+
+func GenBtrfsSubVolStage(filename string, pt *disk.PartitionTable) *Stage {
+	var subvolumes []BtrfsSubVol
+
+	genStage := func(mnt disk.Mountable, path []disk.Entity) error {
+		if mnt.GetFSType() != "btrfs" {
+			return nil
+		}
+
+		btrfs := mnt.(*disk.BtrfsSubvolume)
+		subvolumes = append(subvolumes, BtrfsSubVol{Name: "/" + btrfs.Name})
+
+		return nil
+	}
+
+	_ = pt.ForEachMountable(genStage)
+
+	if len(subvolumes) == 0 {
+		return nil
+	}
+
+	devices, mounts := genBtrfsMountDevices(filename, pt)
+
+	return NewBtrfsSubVol(&BtrfsSubVolOptions{subvolumes}, devices, mounts)
+}
+
+func genBtrfsMountDevices(filename string, pt *disk.PartitionTable) (*map[string]Device, *[]Mount) {
+	devices := make(map[string]Device, len(pt.Partitions))
+	mounts := make([]Mount, 0, len(pt.Partitions))
+	genMounts := func(ent disk.Entity, path []disk.Entity) error {
+		if _, isBtrfs := ent.(*disk.Btrfs); !isBtrfs {
+			return nil
+		}
+
+		stageDevices, name := getDevices(path, filename, false)
+
+		mounts = append(mounts, *NewBtrfsMount(name, name, "/", "", ""))
+
+		// update devices map with new elements from stageDevices
+		for devName := range stageDevices {
+			devices[devName] = stageDevices[devName]
+		}
+		return nil
+	}
+
+	_ = pt.ForEachEntity(genMounts)
+
+	return &devices, &mounts
+}

--- a/pkg/osbuild/copy_stage_test.go
+++ b/pkg/osbuild/copy_stage_test.go
@@ -27,7 +27,7 @@ func TestNewCopyStage(t *testing.T) {
 	}
 
 	mounts := []Mount{
-		*NewBtrfsMount("root", "root", "/"),
+		*NewBtrfsMount("root", "root", "/", "", ""),
 	}
 
 	treeInput := NewTreeInput("name:input-pipeline")

--- a/pkg/osbuild/device.go
+++ b/pkg/osbuild/device.go
@@ -250,7 +250,7 @@ func genMountsDevicesFromPt(filename string, pt *disk.PartitionTable) (string, [
 			mount = NewExt4Mount(name, name, mountpoint)
 		case "btrfs":
 			if subvol, isSubvol := mnt.(*disk.BtrfsSubvolume); isSubvol {
-				mount = NewBtrfsMount(subvol.Name, name, mountpoint, subvol.Name, "")
+				mount = NewBtrfsMount(subvol.Name, name, mountpoint, subvol.Name, subvol.Compress)
 				fsRootMntName = subvol.Name
 			} else {
 				panic("mounting bare btrfs partition unsupported!")

--- a/pkg/osbuild/device.go
+++ b/pkg/osbuild/device.go
@@ -160,6 +160,8 @@ func deviceName(p disk.Entity) string {
 		return payload.Name
 	case *disk.LVMLogicalVolume:
 		return payload.Name
+	case *disk.Btrfs:
+		return "btrfs-" + payload.UUID[:4]
 	}
 	panic(fmt.Sprintf("unsupported device type in deviceName: '%T'", p))
 }

--- a/pkg/osbuild/device.go
+++ b/pkg/osbuild/device.go
@@ -249,7 +249,12 @@ func genMountsDevicesFromPt(filename string, pt *disk.PartitionTable) (string, [
 		case "ext4":
 			mount = NewExt4Mount(name, name, mountpoint)
 		case "btrfs":
-			mount = NewBtrfsMount(name, name, mountpoint)
+			if subvol, isSubvol := mnt.(*disk.BtrfsSubvolume); isSubvol {
+				mount = NewBtrfsMount(subvol.Name, name, mountpoint, subvol.Name, "")
+				fsRootMntName = subvol.Name
+			} else {
+				panic("mounting bare btrfs partition unsupported!")
+			}
 		default:
 			return fmt.Errorf("unknown fs type " + t)
 		}

--- a/pkg/osbuild/device_test.go
+++ b/pkg/osbuild/device_test.go
@@ -204,3 +204,22 @@ func TestMountsDeviceFromPtHappy(t *testing.T) {
 		},
 	})
 }
+
+func Test_deviceName(t *testing.T) {
+	tests := []struct {
+		e    disk.Entity
+		name string
+	}{
+		{e: &disk.Filesystem{Mountpoint: "/toucan"}, name: "toucan"},
+		{e: &disk.BtrfsSubvolume{Mountpoint: "/ostrich"}, name: "ostrich"},
+		{e: &disk.LUKSContainer{UUID: "fb180daf-48a7-4ee0-b10d-394651850fd4"}, name: "luks-fb18"},
+		{e: &disk.LVMVolumeGroup{Name: "vg-main"}, name: "vg-main"},
+		{e: &disk.LVMLogicalVolume{Name: "lv-main"}, name: "lv-main"},
+		{e: &disk.Btrfs{UUID: "fb180daf-48a7-4ee0-b10d-394651850fd4"}, name: "btrfs-fb18"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.name, deviceName(tt.e))
+		})
+	}
+}

--- a/pkg/osbuild/device_test.go
+++ b/pkg/osbuild/device_test.go
@@ -213,7 +213,7 @@ func TestMountsDeviceFromBrfs(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, fsRootMntName, "root")
 	assert.Equal(t, mounts, []Mount{
-		{Name: "root", Type: "org.osbuild.btrfs", Source: "btrfs-6264", Target: "/", Options: btrfsMountOptions{Subvol: "root"}},
+		{Name: "root", Type: "org.osbuild.btrfs", Source: "btrfs-6264", Target: "/", Options: btrfsMountOptions{Subvol: "root", Compress: "zstd:1"}},
 		{Name: "boot", Type: "org.osbuild.ext4", Source: "boot", Target: "/boot"},
 	})
 	assert.Equal(t, devices, map[string]Device{

--- a/pkg/osbuild/disk.go
+++ b/pkg/osbuild/disk.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+
 	"github.com/osbuild/images/pkg/disk"
 )
 
@@ -122,6 +123,11 @@ func GenImageKernelOptions(pt *disk.PartitionTable) []string {
 		case *disk.LUKSContainer:
 			karg := "luks.uuid=" + ent.UUID
 			cmdline = append(cmdline, karg)
+		case *disk.BtrfsSubvolume:
+			if ent.Mountpoint == "/" {
+				karg := "rootflags=subvol=" + ent.Name
+				cmdline = append(cmdline, karg)
+			}
 		}
 		return nil
 	}

--- a/pkg/osbuild/disk.go
+++ b/pkg/osbuild/disk.go
@@ -102,6 +102,11 @@ func GenImagePrepareStages(pt *disk.PartitionTable, filename string, partTool Pa
 	s = GenMkfsStages(pt, loopback)
 	stages = append(stages, s...)
 
+	subvolStage := GenBtrfsSubVolStage(filename, pt)
+	if subvolStage != nil {
+		stages = append(stages, subvolStage)
+	}
+
 	return stages
 }
 

--- a/pkg/osbuild/disk_test.go
+++ b/pkg/osbuild/disk_test.go
@@ -42,6 +42,12 @@ func TestGenImageKernelOptions(t *testing.T) {
 	assert.Subset(cmdline, []string{"luks.uuid=" + uuid})
 }
 
+func TestGenImageKernelOptionsBtrfs(t *testing.T) {
+	pt := testdisk.MakeFakeBtrfsPartitionTable("/")
+	actual := GenImageKernelOptions(pt)
+	assert.Equal(t, []string{"rootflags=subvol=root"}, actual)
+}
+
 func TestGenImagePrepareStages(t *testing.T) {
 	pt := testdisk.MakeFakeBtrfsPartitionTable("/")
 	filename := "image.raw"

--- a/pkg/osbuild/disk_test.go
+++ b/pkg/osbuild/disk_test.go
@@ -1,6 +1,9 @@
 package osbuild
 
 import (
+	"fmt"
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/testdisk"
 	"math/rand"
 	"testing"
 
@@ -37,4 +40,107 @@ func TestGenImageKernelOptions(t *testing.T) {
 	cmdline := GenImageKernelOptions(pt)
 
 	assert.Subset(cmdline, []string{"luks.uuid=" + uuid})
+}
+
+func TestGenImagePrepareStages(t *testing.T) {
+	pt := testdisk.MakeFakeBtrfsPartitionTable("/")
+	filename := "image.raw"
+	actualStages := GenImagePrepareStages(pt, filename, PTSfdisk)
+
+	assert.Equal(t, []*Stage{
+		{
+			Type: "org.osbuild.truncate",
+			Options: &TruncateStageOptions{
+				Filename: filename,
+				Size:     fmt.Sprintf("%d", 10*common.GiB),
+			},
+		},
+		{
+			Type: "org.osbuild.sfdisk",
+			Options: &SfdiskStageOptions{
+				Label: "gpt",
+				Partitions: []SfdiskPartition{
+					{
+						Size: 1 * common.GiB / 512,
+					},
+					{
+						Start: 1 * common.GiB / 512,
+						Size:  9 * common.GiB / 512,
+					},
+				},
+			},
+			Devices: map[string]Device{
+				"device": {
+					Type: "org.osbuild.loopback",
+					Options: &LoopbackDeviceOptions{
+						Filename: filename,
+						Lock:     true,
+					},
+				},
+			},
+		},
+		{
+			Type: "org.osbuild.mkfs.ext4",
+			Devices: map[string]Device{
+				"device": {
+					Type: "org.osbuild.loopback",
+					Options: &LoopbackDeviceOptions{
+						Filename: filename,
+						Start:    0,
+						Size:     1 * common.GiB / 512,
+						Lock:     true,
+					},
+				},
+			},
+			Options: &MkfsExt4StageOptions{},
+		},
+		{
+			Type: "org.osbuild.mkfs.btrfs",
+			Devices: map[string]Device{
+				"device": {
+					Type: "org.osbuild.loopback",
+					Options: &LoopbackDeviceOptions{
+						Filename: filename,
+						Start:    1 * common.GiB / 512,
+						Size:     9 * common.GiB / 512,
+						Lock:     true,
+					},
+				},
+			},
+			Options: &MkfsBtrfsStageOptions{
+				UUID: "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
+			},
+		},
+		{
+			Type: "org.osbuild.btrfs.subvol",
+			Devices: map[string]Device{
+				"btrfs-6264": {
+					Type: "org.osbuild.loopback",
+					Options: &LoopbackDeviceOptions{
+						Filename: filename,
+						Start:    1 * common.GiB / 512,
+						Size:     9 * common.GiB / 512,
+						Lock:     false,
+					},
+				},
+			},
+			Mounts: []Mount{
+				{
+					Name:    "btrfs-6264",
+					Type:    "org.osbuild.btrfs",
+					Source:  "btrfs-6264",
+					Target:  "/",
+					Options: btrfsMountOptions{},
+				},
+			},
+			Options: &BtrfsSubVolOptions{
+				Subvolumes: []BtrfsSubVol{
+					{
+						Name: "/root",
+					},
+				},
+			},
+		},
+	}, actualStages)
+
 }

--- a/pkg/osbuild/mount_test.go
+++ b/pkg/osbuild/mount_test.go
@@ -10,12 +10,13 @@ func TestNewMounts(t *testing.T) {
 	assert := assert.New(t)
 
 	{ // btrfs
-		actual := NewBtrfsMount("btrfs", "/dev/sda1", "/mnt/btrfs")
+		actual := NewBtrfsMount("btrfs", "/dev/sda1", "/mnt/btrfs", "", "")
 		expected := &Mount{
-			Name:   "btrfs",
-			Type:   "org.osbuild.btrfs",
-			Source: "/dev/sda1",
-			Target: "/mnt/btrfs",
+			Name:    "btrfs",
+			Type:    "org.osbuild.btrfs",
+			Source:  "/dev/sda1",
+			Target:  "/mnt/btrfs",
+			Options: btrfsMountOptions{},
 		}
 		assert.Equal(expected, actual)
 	}


### PR DESCRIPTION
This PR has basically three parts:

1) The first commits fix already existing btrfs code in the library (it was never used before). Just tiny fixes. I tried to add tests where they had been missing before.
2) The "middle section" adds missing parts for btrfs subvolume. The scaffolding was there, but the translation from an abstract partition table to osbuild stages was missing.
3) The final section is the actual addition of a btrfs partitioning mode. When this mode is used, a root partition from the base partition table is converted to a btrfs one with a subvolume. The code for adding more btrfs subvolumes based on blueprint mountpoints was already there.

Weird parts:
- When a btrfs partitioning mode is used, the compression is hard-coded to zstd:1. It would be great if this could be configured per an image type/distro/arch, but the partitioning code currently cannot do such specific things. In the end, this should be probably also user-configurable. However, I think that this default value is alright for the starters, we can always iterate on this.
- Setting `min-size` for extra mountpoints is a weird thing, because the extra mountpoints are translated to subvolumes... Maybe we should just error out if the min size is set with btrfs and depend just on the total size customization... Happy to discuss this!

Note that I specifically didn't disable the new mode in EL distributions... My thinking is that users are running these distros on a custom btrfs-enabled kernel, we shouldn't block them.

**This doesn't have tests for the actual partitioning mode. There are currently just new tests for the lower level code in the disk package.**