### PR TITLE
osbuild: remove the unused NewZiplStageOptions()

### DIFF
--- a/pkg/osbuild/zipl_stage.go
+++ b/pkg/osbuild/zipl_stage.go
@@ -9,13 +9,6 @@ type ZiplStageOptions struct {
 
 func (ZiplStageOptions) isStageOptions() {}
 
-// NewZiplStageOptions creates a new ZiplStageOptions object with no timeout
-func NewZiplStageOptions() *ZiplStageOptions {
-	return &ZiplStageOptions{
-		Timeout: 0,
-	}
-}
-
 // NewZiplStage creates a new zipl Stage object.
 func NewZiplStage(options *ZiplStageOptions) *Stage {
 	return &Stage{

--- a/pkg/osbuild/zipl_stage_test.go
+++ b/pkg/osbuild/zipl_stage_test.go
@@ -6,14 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewZiplStageOptions(t *testing.T) {
-	expectedOptions := &ZiplStageOptions{
-		Timeout: 0,
-	}
-	actualOptions := NewZiplStageOptions()
-	assert.Equal(t, expectedOptions, actualOptions)
-}
-
 func TestNewZiplStage(t *testing.T) {
 	expectedStage := &Stage{
 		Type:    "org.osbuild.zipl",


### PR DESCRIPTION
The function is not used in the code and it is also not needed as it will just be equivalent to `new(ZiplStageOptions)` or `&ZiplStageOption{}`. If we can always reintroduce it if we need it with a more meaningful init of the options.