### PR TITLE
osbuild: use New{Group,Users}StageOptions() in  Gen{Group,Users}Stage()

### DIFF
--- a/pkg/osbuild/groups_stage.go
+++ b/pkg/osbuild/groups_stage.go
@@ -36,13 +36,5 @@ func NewGroupsStageOptions(groups []users.Group) *GroupsStageOptions {
 }
 
 func GenGroupsStage(groups []users.Group) *Stage {
-	options := &GroupsStageOptions{
-		Groups: make(map[string]GroupsStageOptionsGroup, len(groups)),
-	}
-	for _, group := range groups {
-		options.Groups[group.Name] = GroupsStageOptionsGroup{
-			GID: group.GID,
-		}
-	}
-	return NewGroupsStage(options)
+	return NewGroupsStage(NewGroupsStageOptions(groups))
 }

--- a/pkg/osbuild/users_stage.go
+++ b/pkg/osbuild/users_stage.go
@@ -71,41 +71,9 @@ func NewUsersStageOptions(userCustomizations []users.User, omitKey bool) (*Users
 }
 
 func GenUsersStage(users []users.User, omitKey bool) (*Stage, error) {
-	options := &UsersStageOptions{
-		Users: make(map[string]UsersStageOptionsUser, len(users)),
+	options, err := NewUsersStageOptions(users, omitKey)
+	if err != nil {
+		return nil, err
 	}
-
-	for _, user := range users {
-		// Don't hash empty passwords, set to nil to lock account
-		if user.Password != nil && len(*user.Password) == 0 {
-			user.Password = nil
-		}
-
-		// Hash non-empty un-hashed passwords
-		if user.Password != nil && !crypt.PasswordIsCrypted(*user.Password) {
-			cryptedPassword, err := crypt.CryptSHA512(*user.Password)
-			if err != nil {
-				return nil, err
-			}
-
-			user.Password = &cryptedPassword
-		}
-
-		userOptions := UsersStageOptionsUser{
-			UID:         user.UID,
-			GID:         user.GID,
-			Groups:      user.Groups,
-			Description: user.Description,
-			Home:        user.Home,
-			Shell:       user.Shell,
-			Password:    user.Password,
-			Key:         nil,
-		}
-		if !omitKey {
-			userOptions.Key = user.Key
-		}
-		options.Users[user.Name] = userOptions
-	}
-
 	return NewUsersStage(options), nil
 }


### PR DESCRIPTION
We currently duplicate the code that generates the stage options
for users and groups. AFAICT there is no need for this so this
commit just call the existing functions instead of duplicating them.
If we want to remove New{Group,Users}StageOptions() later (which
a previous commit message indicates) we can still do this by just
unexporting or moving the helper.
