### PR TITLE
Include osbuild NEVRA in build info path for test cache

### DIFF
--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -150,6 +150,33 @@ def gen_build_name(distro, arch, image_type, config_name):
     return f"{_u(distro)}-{_u(arch)}-{_u(image_type)}-{_u(config_name)}"
 
 
+def gen_build_info_dir_path(root, osbuild_ver, manifest_id):
+    """
+    Generates the path to the directory that contains the build info.
+    This is a simple os.path.join() of the components, but ensures that paths are consistent.
+    """
+    return os.path.join(root, osbuild_ver, manifest_id, "")
+
+
+def gen_build_info_path(root, osbuild_ver, manifest_id):
+    """
+    Generates the path to the info.json.
+    This is a simple os.path.join() of the components, but ensures that paths are consistent.
+    """
+    return os.path.join(gen_build_info_dir_path(root, osbuild_ver, manifest_id), "info.json")
+
+
+def gen_build_info_s3(distro, arch, manifest_id):
+    """
+    Generates the s3 URL for the location where build info and artifacts will be stored for a specific build
+    configuration.
+    This is a simple concatenation of the components, but ensures that paths are consistent.
+    """
+    osbuild_ver = get_osbuild_nevra()
+    build_info_prefix = f"{S3_BUCKET}/images/builds/{distro}/{arch}"
+    return gen_build_info_dir_path(build_info_prefix, osbuild_ver, manifest_id)
+
+
 def check_config_names():
     """
     Check that all the configs we rely on have names that match the file name, otherwise the test skipping and pipeline

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -372,6 +372,14 @@ def get_osbuild_commit(distro_version):
     return data.get(distro_version, {}).get("dependencies", {}).get("osbuild", {}).get("commit", None)
 
 
+def get_osbuild_nevra():
+    """
+    Returned the installed osbuild version. Exits with an error if osbuild is not installed.
+    """
+    out, _ = runcmd(["rpm", "-q", "--qf", "%{nevra}", "osbuild"])
+    return out.decode().strip()
+
+
 def rng_seed_env():
     """
     Read the rng seed from the Schutzfile and return it as a map to use as an environment variable with the appropriate

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -362,6 +362,10 @@ def read_osrelease():
 
 
 def get_osbuild_commit(distro_version):
+    """
+    Get the osbuild commit defined in the Schutzfile for the host distro.
+    If not set, returns None.
+    """
     with open(SCHUTZFILE, encoding="utf-8") as schutzfile:
         data = json.load(schutzfile)
 

--- a/test/scripts/test_imgtestlib.py
+++ b/test/scripts/test_imgtestlib.py
@@ -1,17 +1,17 @@
 import os
 
-from imgtestlib import rng_seed_env, runcmd
+import imgtestlib as testlib
 
 
 def test_runcmd():
-    stdout, stderr = runcmd(["/bin/echo", "hello"])
+    stdout, stderr = testlib.runcmd(["/bin/echo", "hello"])
     assert stdout == b"hello\n"
     assert stderr == b""
 
 
 def test_runcmd_env():
     os.environ["RUNCMD_GLOBAL_TEST_VAR"] = "global test value"
-    stdout, stderr = runcmd(["env"], extra_env={"RUNCMD_TEST_VAR": "the test value"})
+    stdout, stderr = testlib.runcmd(["env"], extra_env={"RUNCMD_TEST_VAR": "the test value"})
     assert b"RUNCMD_TEST_VAR=the test value\n" in stdout, "extra env var not set"
     assert b"RUNCMD_GLOBAL_TEST_VAR=global test value\n" in stdout, "global env vars not preserved"
     assert stderr == b""
@@ -19,5 +19,16 @@ def test_runcmd_env():
 
 def test_read_seed():
     # check that it's read without error - no need to test the value itself
-    seed_env = rng_seed_env()
+    seed_env = testlib.rng_seed_env()
     assert "OSBUILD_TESTING_RNG_SEED" in seed_env
+
+
+def test_path_generators():
+    testlib.get_osbuild_nevra = lambda: "osbuild-104-1.fc39.noarch"
+
+    assert testlib.gen_build_info_dir_path("inforoot", testlib.get_osbuild_nevra(), "abc123") == \
+        "inforoot/osbuild-104-1.fc39.noarch/abc123/"
+    assert testlib.gen_build_info_path("inforoot", testlib.get_osbuild_nevra(), "abc123") == \
+        "inforoot/osbuild-104-1.fc39.noarch/abc123/info.json"
+    assert testlib.gen_build_info_s3("fedora-39", "aarch64", "abc123") == \
+        testlib.S3_BUCKET + "/images/builds/fedora-39/aarch64/osbuild-104-1.fc39.noarch/abc123/"

--- a/test/scripts/upload-results
+++ b/test/scripts/upload-results
@@ -41,8 +41,7 @@ def main():
         with open(info_path, "w", encoding="utf-8") as info_fp:
             json.dump(build_info, info_fp, indent=2)
 
-    bucket = testlib.S3_BUCKET
-    s3url = f"{bucket}/images/builds/{distro}/{arch}/{manifest_id}/"
+    s3url = testlib.gen_build_info_s3(distro, arch, manifest_id)
 
     print(f"⬆️ Uploading {build_dir} to {s3url}")
     testlib.runcmd(["aws", "s3", "cp", "--acl=private", "--recursive", build_dir+"/", s3url])


### PR DESCRIPTION
Until now, the following scenario would produce unnecessary rebuilds:
- A PR is opened that updates osbuild in `Schutzfile` to `vNew`.
- A manifest is generated with id `abc123`.
- The build info lookup for `abc123` shows that it was built with `vOld` so it's added to the test matrix.
- The new build info is uploaded showing `abc123` was built with `vNew`.
- A different PR runs CI with `vOld` (before the update PR is merged or before this PR is rebased).
- A manifest is generated with id `abc123` again.
- The build info lookup for `abc123` shows that it was built with `vNew` (in the osbuild update PR) but the currently installed version is `vOld` (`!= vNew`) so it's added to the test matrix.
- The new build info is uploaded showing `abc123` was built with `vOld`.

This doesn't just create an unnecessary rebuild, but can create a situation where every image is rebuilt multiple times a day if the two PRs keep getting amended, essentially fighting each other by changing the commit ID back and forth.

This commit changes the build info paths to include the osbuild package version (NEVRA) as a path component:

    s3://images-ci-cache/images/builds/fedora-40/aarch64/osbuild-104-1.fc39.noarch/abc123

The build filter now no longer needs to read the osbuild commit ID from the info.json and compare with the current one.  It can simply check the path with the package version component and if it is not found, the new configuration will be tested.

Note that this PR will of course create a mass rebuild of all the images.  All PRs should be rebased on this when it's merged to avoid pushing images and build info to the old paths.
The old paths should be cleaned up by the bucket retention policy in a few days.