### PR TITLE
container: make `container.NewResolver()` return a pointer

### DIFF
--- a/pkg/container/resolver.go
+++ b/pkg/container/resolver.go
@@ -31,8 +31,8 @@ type SourceSpec struct {
 	StoragePath         *string
 }
 
-func NewResolver(arch string) Resolver {
-	return Resolver{
+func NewResolver(arch string) *Resolver {
+	return &Resolver{
 		ctx:   context.Background(),
 		queue: make(chan resolveResult, 2),
 		Arch:  arch,


### PR DESCRIPTION
Most go packages return pointers to structs when using `NewFoo()`. But `NewResolver()` does not and AFAICT there is no deep reason for this. I would prefer to return a pointer here, I got tripped up by this in
https://github.com/osbuild/bootc-image-builder/pull/139#discussion_r1479679146

This will be the first part to fix https://github.com/osbuild/bootc-image-builder/pull/139#discussion_r1479679146

I checked the various uses of container.NewResolver() and this does not even seem to require any code change in the current consumers.