### PR TITLE
anaconda: Add unattended kickstart options for edge installer

### DIFF
--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -22,6 +22,8 @@ type ImageConfig struct {
 	Sysconfig           []*osbuild.SysconfigStageOptions
 	// whether to create sudoer file for wheel group with NOPASSWD option
 	WheelNoPasswd *bool
+	// Whether an unattended kickstart was requested
+	UnattendedKickstart *bool
 
 	// List of files from which to import GPG keys into the RPM database
 	GPGKeyFiles []string

--- a/pkg/distro/image_config_test.go
+++ b/pkg/distro/image_config_test.go
@@ -70,7 +70,8 @@ func TestImageConfigInheritFrom(t *testing.T) {
 					},
 					LeapsecTz: common.ToPtr(""),
 				},
-				WheelNoPasswd: common.ToPtr(true),
+				WheelNoPasswd:       common.ToPtr(true),
+				UnattendedKickstart: common.ToPtr(true),
 			},
 			expectedConfig: &ImageConfig{
 				Timezone: common.ToPtr("UTC"),
@@ -90,10 +91,11 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				Keyboard: &osbuild.KeymapStageOptions{
 					Keymap: "us",
 				},
-				EnabledServices:  []string{"sshd"},
-				DisabledServices: []string{"named"},
-				DefaultTarget:    common.ToPtr("multi-user.target"),
-				WheelNoPasswd:    common.ToPtr(true),
+				EnabledServices:     []string{"sshd"},
+				DisabledServices:    []string{"named"},
+				DefaultTarget:       common.ToPtr("multi-user.target"),
+				WheelNoPasswd:       common.ToPtr(true),
+				UnattendedKickstart: common.ToPtr(true),
 				Sysconfig: []*osbuild.SysconfigStageOptions{
 					{
 						Kernel: &osbuild.SysconfigKernelOptions{
@@ -132,10 +134,11 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				Keyboard: &osbuild.KeymapStageOptions{
 					Keymap: "us",
 				},
-				EnabledServices:  []string{"sshd"},
-				DisabledServices: []string{"named"},
-				DefaultTarget:    common.ToPtr("multi-user.target"),
-				WheelNoPasswd:    common.ToPtr(true),
+				EnabledServices:     []string{"sshd"},
+				DisabledServices:    []string{"named"},
+				DefaultTarget:       common.ToPtr("multi-user.target"),
+				WheelNoPasswd:       common.ToPtr(true),
+				UnattendedKickstart: common.ToPtr(true),
 			},
 			imageConfig: &ImageConfig{},
 			expectedConfig: &ImageConfig{
@@ -147,10 +150,11 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				Keyboard: &osbuild.KeymapStageOptions{
 					Keymap: "us",
 				},
-				EnabledServices:  []string{"sshd"},
-				DisabledServices: []string{"named"},
-				DefaultTarget:    common.ToPtr("multi-user.target"),
-				WheelNoPasswd:    common.ToPtr(true),
+				EnabledServices:     []string{"sshd"},
+				DisabledServices:    []string{"named"},
+				DefaultTarget:       common.ToPtr("multi-user.target"),
+				WheelNoPasswd:       common.ToPtr(true),
+				UnattendedKickstart: common.ToPtr(true),
 			},
 		},
 		{
@@ -165,10 +169,11 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				Keyboard: &osbuild.KeymapStageOptions{
 					Keymap: "us",
 				},
-				EnabledServices:  []string{"sshd"},
-				DisabledServices: []string{"named"},
-				DefaultTarget:    common.ToPtr("multi-user.target"),
-				WheelNoPasswd:    common.ToPtr(true),
+				EnabledServices:     []string{"sshd"},
+				DisabledServices:    []string{"named"},
+				DefaultTarget:       common.ToPtr("multi-user.target"),
+				WheelNoPasswd:       common.ToPtr(true),
+				UnattendedKickstart: common.ToPtr(true),
 			},
 			expectedConfig: &ImageConfig{
 				Timezone: common.ToPtr("America/New_York"),
@@ -179,10 +184,11 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				Keyboard: &osbuild.KeymapStageOptions{
 					Keymap: "us",
 				},
-				EnabledServices:  []string{"sshd"},
-				DisabledServices: []string{"named"},
-				DefaultTarget:    common.ToPtr("multi-user.target"),
-				WheelNoPasswd:    common.ToPtr(true),
+				EnabledServices:     []string{"sshd"},
+				DisabledServices:    []string{"named"},
+				DefaultTarget:       common.ToPtr("multi-user.target"),
+				WheelNoPasswd:       common.ToPtr(true),
+				UnattendedKickstart: common.ToPtr(true),
 			},
 		},
 		{
@@ -197,10 +203,11 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				Keyboard: &osbuild.KeymapStageOptions{
 					Keymap: "us",
 				},
-				EnabledServices:  []string{"sshd"},
-				DisabledServices: []string{"named"},
-				DefaultTarget:    common.ToPtr("multi-user.target"),
-				WheelNoPasswd:    common.ToPtr(true),
+				EnabledServices:     []string{"sshd"},
+				DisabledServices:    []string{"named"},
+				DefaultTarget:       common.ToPtr("multi-user.target"),
+				WheelNoPasswd:       common.ToPtr(true),
+				UnattendedKickstart: common.ToPtr(true),
 			},
 			expectedConfig: &ImageConfig{
 				Timezone: common.ToPtr("America/New_York"),
@@ -211,10 +218,11 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				Keyboard: &osbuild.KeymapStageOptions{
 					Keymap: "us",
 				},
-				EnabledServices:  []string{"sshd"},
-				DisabledServices: []string{"named"},
-				DefaultTarget:    common.ToPtr("multi-user.target"),
-				WheelNoPasswd:    common.ToPtr(true),
+				EnabledServices:     []string{"sshd"},
+				DisabledServices:    []string{"named"},
+				DefaultTarget:       common.ToPtr("multi-user.target"),
+				WheelNoPasswd:       common.ToPtr(true),
+				UnattendedKickstart: common.ToPtr(true),
 			},
 		},
 	}

--- a/pkg/distro/rhel8/edge.go
+++ b/pkg/distro/rhel8/edge.go
@@ -100,8 +100,9 @@ func edgeInstallerImgType(rd distribution) imageType {
 			installerPkgsKey: edgeInstallerPackageSet,
 		},
 		defaultImageConfig: &distro.ImageConfig{
-			EnabledServices: edgeServices(rd),
-			WheelNoPasswd:   common.ToPtr(true),
+			EnabledServices:     edgeServices(rd),
+			WheelNoPasswd:       common.ToPtr(true),
+			UnattendedKickstart: common.ToPtr(true),
 		},
 		rpmOstree:        true,
 		bootISO:          true,

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -440,6 +440,9 @@ func edgeInstallerImage(workload workload.Workload,
 	if imageConfig.WheelNoPasswd != nil {
 		img.WheelNoPasswd = *imageConfig.WheelNoPasswd
 	}
+	if imageConfig.UnattendedKickstart != nil {
+		img.UnattendedKickstart = *imageConfig.UnattendedKickstart
+	}
 
 	img.SquashfsCompression = "xz"
 	img.AdditionalDracutModules = []string{"prefixdevname", "prefixdevname-tools"}

--- a/pkg/distro/rhel9/edge.go
+++ b/pkg/distro/rhel9/edge.go
@@ -97,9 +97,10 @@ var (
 			installerPkgsKey: edgeInstallerPackageSet,
 		},
 		defaultImageConfig: &distro.ImageConfig{
-			Locale:          common.ToPtr("en_US.UTF-8"),
-			EnabledServices: edgeServices,
-			WheelNoPasswd:   common.ToPtr(true),
+			Locale:              common.ToPtr("en_US.UTF-8"),
+			EnabledServices:     edgeServices,
+			WheelNoPasswd:       common.ToPtr(true),
+			UnattendedKickstart: common.ToPtr(true),
 		},
 		rpmOstree:        true,
 		bootISO:          true,

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -393,6 +393,9 @@ func edgeInstallerImage(workload workload.Workload,
 	if imageConfig.WheelNoPasswd != nil {
 		img.WheelNoPasswd = *imageConfig.WheelNoPasswd
 	}
+	if imageConfig.UnattendedKickstart != nil {
+		img.UnattendedKickstart = *imageConfig.UnattendedKickstart
+	}
 
 	img.SquashfsCompression = "xz"
 	img.AdditionalDracutModules = []string{

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -23,6 +23,8 @@ type AnacondaOSTreeInstaller struct {
 	Groups            []users.Group
 	// whether to create sudoer file for wheel group with NOPASSWD option
 	WheelNoPasswd bool
+	// Whether an unattended kickstart was requested
+	UnattendedKickstart bool
 
 	SquashfsCompression string
 
@@ -111,6 +113,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.Users = img.Users
 	isoTreePipeline.Groups = img.Groups
 	isoTreePipeline.WheelNoPasswd = img.WheelNoPasswd
+	isoTreePipeline.UnattendedKickstart = img.UnattendedKickstart
 	isoTreePipeline.SquashfsCompression = img.SquashfsCompression
 
 	// For ostree installers, always put the kickstart file in the root of the ISO

--- a/pkg/osbuild/kickstart_stage.go
+++ b/pkg/osbuild/kickstart_stage.go
@@ -14,6 +14,17 @@ type KickstartStageOptions struct {
 	Users map[string]UsersStageOptionsUser `json:"users,omitempty"`
 
 	Groups map[string]GroupsStageOptionsGroup `json:"groups,omitempty"`
+
+	Lang         string               `json:"lang,omitempty"`
+	Keyboard     string               `json:"keyboard,omitempty"`
+	TimeZone     string               `json:"timezone,omitempty"`
+	DisplayMode  string               `json:"display_mode,omitempty"`
+	Reboot       *RebootOptions       `json:"reboot,omitempty"`
+	RootPassword *RootPasswordOptions `json:"rootpw,omitempty"`
+	ZeroMBR      bool                 `json:"zerombr,omitempty"`
+	ClearPart    *ClearPartOptions    `json:"clearpart,omitempty"`
+	AutoPart     *AutoPartOptions     `json:"autopart,omitempty"`
+	Network      []NetworkOptions     `json:"network,omitempty"`
 }
 
 type LiveIMGOptions struct {
@@ -34,6 +45,60 @@ type OSTreeContainerOptions struct {
 	Transport             string `json:"transport"`
 	Remote                string `json:"remote"`
 	SignatureVerification bool   `json:"signatureverification"`
+}
+
+type RebootOptions struct {
+	Eject bool `json:"eject,omitempty"`
+	KExec bool `json:"kexec,omitempty"`
+}
+
+type ClearPartOptions struct {
+	All       bool     `json:"all,omitempty"`
+	InitLabel bool     `json:"initlabel,omitempty"`
+	Drives    []string `json:"drives,omitempty"`
+	List      []string `json:"list,omitempty"`
+	Linux     bool     `json:"linux,omitempty"`
+}
+
+type AutoPartOptions struct {
+	Type             string `json:"type,omitempty"`
+	FSType           string `json:"fstype,omitempty"`
+	NoLVM            bool   `json:"nolvm,omitempty"`
+	Encrypted        bool   `json:"encrypted,omitempty"`
+	PassPhrase       string `json:"passphrase,omitempty"`
+	EscrowCert       string `json:"escrowcert,omitempty"`
+	BackupPassPhrase bool   `json:"backuppassphrase,omitempty"`
+	Cipher           string `json:"cipher,omitempty"`
+	LuksVersion      string `json:"luks-version,omitempty"`
+	PBKdf            string `json:"pbkdf,omitempty"`
+	PBKdfMemory      int    `json:"pbkdf-memory,omitempty"`
+	PBKdfTime        int    `json:"pbkdf-time,omitempty"`
+	PBKdfIterations  int    `json:"pbkdf-iterations,omitempty"`
+	NoHome           bool   `json:"nohome,omitempty"`
+}
+
+type NetworkOptions struct {
+	Activate    *bool    `json:"activate,omitempty"`
+	BootProto   string   `json:"bootproto,omitempty"`
+	Device      string   `json:"device,omitempty"`
+	OnBoot      string   `json:"onboot,omitempty"`
+	IP          string   `json:"ip,omitempty"`
+	IPV6        string   `json:"ipv6,omitempty"`
+	Gateway     string   `json:"gateway,omitempty"`
+	IPV6Gateway string   `json:"ipv6gateway,omitempty"`
+	Nameservers []string `json:"nameservers,omitempty"`
+	Netmask     string   `json:"netmask,omitempty"`
+	Hostname    string   `json:"hostname,omitempty"`
+	ESSid       string   `json:"essid,omitempty"`
+	WPAKey      string   `json:"wpakey,omitempty"`
+}
+
+type RootPasswordOptions struct {
+	Lock      bool   `json:"lock,omitempty"`
+	PlainText bool   `json:"plaintext,omitempty"`
+	IsCrypted bool   `json:"iscrypted,omitempty"`
+	AllowSSH  bool   `json:"allow_ssh,omitempty"`
+	Password  string `json:"password,omitempty"`
 }
 
 func (KickstartStageOptions) isStageOptions() {}


### PR DESCRIPTION
In the context of compatibility with edge-management when creating image ISO artifact. 

Add missing kickstart options for edge installer

https://issues.redhat.com/browse/THEEDGE-3836