### PR TITLE
Add customizations for building unattended Anaconda installers

### DIFF
--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -26,6 +26,7 @@ type Customizations struct {
 	Repositories       []RepositoryCustomization      `json:"repositories,omitempty" toml:"repositories,omitempty"`
 	FIPS               *bool                          `json:"fips,omitempty" toml:"fips,omitempty"`
 	ContainersStorage  *ContainerStorageCustomization `json:"containers-storage,omitempty" toml:"containers-storage,omitempty"`
+	Installer          *InstallerCustomization        `json:"installer,omitempty" toml:"installer,omitempty"`
 }
 
 type IgnitionCustomization struct {
@@ -382,4 +383,11 @@ func (c *Customizations) GetContainerStorage() *ContainerStorageCustomization {
 		return nil
 	}
 	return c.ContainersStorage
+}
+
+func (c *Customizations) GetInstaller() *InstallerCustomization {
+	if c == nil || c.Installer == nil {
+		return nil
+	}
+	return c.Installer
 }

--- a/pkg/blueprint/installer_customizations.go
+++ b/pkg/blueprint/installer_customizations.go
@@ -1,0 +1,6 @@
+package blueprint
+
+type InstallerCustomization struct {
+	Unattended        bool `json:"unattended,omitempty" toml:"unattended,omitempty"`
+	WheelSudoNopasswd bool `json:"wheel-sudo-nopasswd,omitempty" toml:"wheel-sudo-nopasswd,omitempty"`
+}

--- a/pkg/distro/fedora/distro_test.go
+++ b/pkg/distro/fedora/distro_test.go
@@ -521,7 +521,7 @@ func TestDistro_ManifestError(t *testing.T) {
 					} else if imgTypeName == "iot-installer" || imgTypeName == "iot-simplified-installer" {
 						assert.EqualError(t, err, fmt.Sprintf("boot ISO image type \"%s\" requires specifying a URL from which to retrieve the OSTree commit", imgTypeName))
 					} else if imgTypeName == "image-installer" {
-						assert.EqualError(t, err, fmt.Sprintf(distro.UnsupportedCustomizationError, imgTypeName, "User, Group, FIPS"))
+						assert.EqualError(t, err, fmt.Sprintf(distro.UnsupportedCustomizationError, imgTypeName, "User, Group, FIPS, Installer"))
 					} else if imgTypeName == "live-installer" {
 						assert.EqualError(t, err, fmt.Sprintf(distro.NoCustomizationsAllowedError, imgTypeName))
 					} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-qcow2-image" {

--- a/pkg/distro/fedora/distro_test.go
+++ b/pkg/distro/fedora/distro_test.go
@@ -521,7 +521,7 @@ func TestDistro_ManifestError(t *testing.T) {
 					} else if imgTypeName == "iot-installer" || imgTypeName == "iot-simplified-installer" {
 						assert.EqualError(t, err, fmt.Sprintf("boot ISO image type \"%s\" requires specifying a URL from which to retrieve the OSTree commit", imgTypeName))
 					} else if imgTypeName == "image-installer" {
-						assert.EqualError(t, err, fmt.Sprintf(distro.UnsupportedCustomizationError, imgTypeName, "User, Group, FIPS, Installer"))
+						assert.EqualError(t, err, fmt.Sprintf(distro.UnsupportedCustomizationError, imgTypeName, "User, Group, FIPS, Installer, Timezone, Locale"))
 					} else if imgTypeName == "live-installer" {
 						assert.EqualError(t, err, fmt.Sprintf(distro.NoCustomizationsAllowedError, imgTypeName))
 					} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-qcow2-image" {

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -531,6 +531,8 @@ func iotInstallerImage(workload workload.Workload,
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 
 	img.Language, img.Keyboard = customizations.GetPrimaryLocale()
+	// ignore ntp servers - we don't currently support setting these in the
+	// kickstart though kickstart does support setting them
 	img.Timezone, _ = customizations.GetTimezoneSettings()
 
 	img.AdditionalAnacondaModules = []string{

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -366,6 +366,11 @@ func imageInstallerImage(workload workload.Workload,
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 
+	if instCust := customizations.GetInstaller(); instCust != nil {
+		img.WheelNoPasswd = instCust.WheelSudoNopasswd
+		img.UnattendedKickstart = instCust.Unattended
+	}
+
 	img.SquashfsCompression = "lz4"
 
 	d := t.arch.distro
@@ -517,6 +522,11 @@ func iotInstallerImage(workload workload.Workload,
 		"org.fedoraproject.Anaconda.Modules.Timezone",
 		"org.fedoraproject.Anaconda.Modules.Localization",
 		"org.fedoraproject.Anaconda.Modules.Users",
+	}
+
+	if instCust := customizations.GetInstaller(); instCust != nil {
+		img.WheelNoPasswd = instCust.WheelSudoNopasswd
+		img.UnattendedKickstart = instCust.Unattended
 	}
 
 	img.SquashfsCompression = "lz4"

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -344,7 +344,14 @@ func imageInstallerImage(workload workload.Workload,
 	containers []container.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
+	customizations := bp.Customizations
+
 	img := image.NewAnacondaTarInstaller()
+
+	if instCust := customizations.GetInstaller(); instCust != nil {
+		img.WheelNoPasswd = instCust.WheelSudoNopasswd
+		img.UnattendedKickstart = instCust.Unattended
+	}
 
 	// Enable anaconda-webui for Fedora > 38
 	distro := t.Arch().Distro()
@@ -354,22 +361,26 @@ func imageInstallerImage(workload workload.Workload,
 			"org.fedoraproject.Anaconda.Modules.Timezone",
 			"org.fedoraproject.Anaconda.Modules.Localization",
 		}
-		img.AdditionalKernelOpts = []string{"inst.webui", "inst.webui.remote"}
+		if img.UnattendedKickstart {
+			// NOTE: this is not supported right now because the
+			// image-installer on Fedora isn't working when unattended.
+			// These options are probably necessary but could change.
+			// Unattended/non-interactive installations are better set to text
+			// time since they might be running headless and a UI is
+			// unnecessary.
+			img.AdditionalKernelOpts = []string{"inst.text", "inst.noninteractive"}
+		} else {
+			img.AdditionalKernelOpts = []string{"inst.webui", "inst.webui.remote"}
+		}
 	}
 	img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, "org.fedoraproject.Anaconda.Modules.Users")
 
-	customizations := bp.Customizations
 	img.Platform = t.platform
 	img.Workload = workload
 	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, customizations)
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
-
-	if instCust := customizations.GetInstaller(); instCust != nil {
-		img.WheelNoPasswd = instCust.WheelSudoNopasswd
-		img.UnattendedKickstart = instCust.Unattended
-	}
 
 	img.SquashfsCompression = "lz4"
 

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -529,6 +529,10 @@ func iotInstallerImage(workload workload.Workload,
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
+
+	img.Language, img.Keyboard = customizations.GetPrimaryLocale()
+	img.Timezone, _ = customizations.GetTimezoneSettings()
+
 	img.AdditionalAnacondaModules = []string{
 		"org.fedoraproject.Anaconda.Modules.Timezone",
 		"org.fedoraproject.Anaconda.Modules.Localization",

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -334,7 +334,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 			}
 		} else if t.name == "iot-installer" || t.name == "image-installer" {
 			// "Installer" is actually not allowed for image-installer right now, but this is checked at the end
-			allowed := []string{"User", "Group", "FIPS", "Installer"}
+			allowed := []string{"User", "Group", "FIPS", "Installer", "Timezone", "Locale"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return nil, fmt.Errorf(distro.UnsupportedCustomizationError, t.name, strings.Join(allowed, ", "))
 			}

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -333,12 +333,13 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 				}
 			}
 		} else if t.name == "iot-installer" || t.name == "image-installer" {
-			allowed := []string{"User", "Group", "FIPS"}
+			// "Installer" is actually not allowed for image-installer right now, but this is checked at the end
+			allowed := []string{"User", "Group", "FIPS", "Installer"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return nil, fmt.Errorf(distro.UnsupportedCustomizationError, t.name, strings.Join(allowed, ", "))
 			}
 		} else if t.name == "live-installer" {
-			allowed := []string{}
+			allowed := []string{"Installer"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return nil, fmt.Errorf(distro.NoCustomizationsAllowedError, t.name)
 			}
@@ -401,6 +402,13 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 	if customizations.GetFIPS() && !common.IsBuildHostFIPSEnabled() {
 		w := fmt.Sprintln(common.FIPSEnabledImageWarning)
 		return []string{w}, nil
+	}
+
+	if customizations.GetInstaller() != nil {
+		// only supported by the Anaconda installer
+		if slices.Index([]string{"iot-installer"}, t.name) == -1 {
+			return nil, fmt.Errorf("installer customizations are not supported for %q", t.name)
+		}
 	}
 
 	return nil, nil

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -20,10 +20,6 @@ type ImageConfig struct {
 	DisabledServices    []string
 	DefaultTarget       *string
 	Sysconfig           []*osbuild.SysconfigStageOptions
-	// whether to create sudoer file for wheel group with NOPASSWD option
-	WheelNoPasswd *bool
-	// Whether an unattended kickstart was requested
-	UnattendedKickstart *bool
 
 	// List of files from which to import GPG keys into the RPM database
 	GPGKeyFiles []string

--- a/pkg/distro/image_config_test.go
+++ b/pkg/distro/image_config_test.go
@@ -70,8 +70,6 @@ func TestImageConfigInheritFrom(t *testing.T) {
 					},
 					LeapsecTz: common.ToPtr(""),
 				},
-				WheelNoPasswd:       common.ToPtr(true),
-				UnattendedKickstart: common.ToPtr(true),
 			},
 			expectedConfig: &ImageConfig{
 				Timezone: common.ToPtr("UTC"),
@@ -91,11 +89,9 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				Keyboard: &osbuild.KeymapStageOptions{
 					Keymap: "us",
 				},
-				EnabledServices:     []string{"sshd"},
-				DisabledServices:    []string{"named"},
-				DefaultTarget:       common.ToPtr("multi-user.target"),
-				WheelNoPasswd:       common.ToPtr(true),
-				UnattendedKickstart: common.ToPtr(true),
+				EnabledServices:  []string{"sshd"},
+				DisabledServices: []string{"named"},
+				DefaultTarget:    common.ToPtr("multi-user.target"),
 				Sysconfig: []*osbuild.SysconfigStageOptions{
 					{
 						Kernel: &osbuild.SysconfigKernelOptions{
@@ -134,11 +130,9 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				Keyboard: &osbuild.KeymapStageOptions{
 					Keymap: "us",
 				},
-				EnabledServices:     []string{"sshd"},
-				DisabledServices:    []string{"named"},
-				DefaultTarget:       common.ToPtr("multi-user.target"),
-				WheelNoPasswd:       common.ToPtr(true),
-				UnattendedKickstart: common.ToPtr(true),
+				EnabledServices:  []string{"sshd"},
+				DisabledServices: []string{"named"},
+				DefaultTarget:    common.ToPtr("multi-user.target"),
 			},
 			imageConfig: &ImageConfig{},
 			expectedConfig: &ImageConfig{
@@ -150,11 +144,9 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				Keyboard: &osbuild.KeymapStageOptions{
 					Keymap: "us",
 				},
-				EnabledServices:     []string{"sshd"},
-				DisabledServices:    []string{"named"},
-				DefaultTarget:       common.ToPtr("multi-user.target"),
-				WheelNoPasswd:       common.ToPtr(true),
-				UnattendedKickstart: common.ToPtr(true),
+				EnabledServices:  []string{"sshd"},
+				DisabledServices: []string{"named"},
+				DefaultTarget:    common.ToPtr("multi-user.target"),
 			},
 		},
 		{
@@ -169,11 +161,9 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				Keyboard: &osbuild.KeymapStageOptions{
 					Keymap: "us",
 				},
-				EnabledServices:     []string{"sshd"},
-				DisabledServices:    []string{"named"},
-				DefaultTarget:       common.ToPtr("multi-user.target"),
-				WheelNoPasswd:       common.ToPtr(true),
-				UnattendedKickstart: common.ToPtr(true),
+				EnabledServices:  []string{"sshd"},
+				DisabledServices: []string{"named"},
+				DefaultTarget:    common.ToPtr("multi-user.target"),
 			},
 			expectedConfig: &ImageConfig{
 				Timezone: common.ToPtr("America/New_York"),
@@ -184,11 +174,9 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				Keyboard: &osbuild.KeymapStageOptions{
 					Keymap: "us",
 				},
-				EnabledServices:     []string{"sshd"},
-				DisabledServices:    []string{"named"},
-				DefaultTarget:       common.ToPtr("multi-user.target"),
-				WheelNoPasswd:       common.ToPtr(true),
-				UnattendedKickstart: common.ToPtr(true),
+				EnabledServices:  []string{"sshd"},
+				DisabledServices: []string{"named"},
+				DefaultTarget:    common.ToPtr("multi-user.target"),
 			},
 		},
 		{
@@ -203,11 +191,9 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				Keyboard: &osbuild.KeymapStageOptions{
 					Keymap: "us",
 				},
-				EnabledServices:     []string{"sshd"},
-				DisabledServices:    []string{"named"},
-				DefaultTarget:       common.ToPtr("multi-user.target"),
-				WheelNoPasswd:       common.ToPtr(true),
-				UnattendedKickstart: common.ToPtr(true),
+				EnabledServices:  []string{"sshd"},
+				DisabledServices: []string{"named"},
+				DefaultTarget:    common.ToPtr("multi-user.target"),
 			},
 			expectedConfig: &ImageConfig{
 				Timezone: common.ToPtr("America/New_York"),
@@ -218,11 +204,9 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				Keyboard: &osbuild.KeymapStageOptions{
 					Keymap: "us",
 				},
-				EnabledServices:     []string{"sshd"},
-				DisabledServices:    []string{"named"},
-				DefaultTarget:       common.ToPtr("multi-user.target"),
-				WheelNoPasswd:       common.ToPtr(true),
-				UnattendedKickstart: common.ToPtr(true),
+				EnabledServices:  []string{"sshd"},
+				DisabledServices: []string{"named"},
+				DefaultTarget:    common.ToPtr("multi-user.target"),
 			},
 		},
 	}

--- a/pkg/distro/rhel8/edge.go
+++ b/pkg/distro/rhel8/edge.go
@@ -100,9 +100,7 @@ func edgeInstallerImgType(rd distribution) imageType {
 			installerPkgsKey: edgeInstallerPackageSet,
 		},
 		defaultImageConfig: &distro.ImageConfig{
-			EnabledServices:     edgeServices(rd),
-			WheelNoPasswd:       common.ToPtr(true),
-			UnattendedKickstart: common.ToPtr(true),
+			EnabledServices: edgeServices(rd),
 		},
 		rpmOstree:        true,
 		bootISO:          true,

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -424,7 +424,6 @@ func edgeInstallerImage(workload workload.Workload,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	d := t.arch.distro
-	imageConfig := t.getDefaultImageConfig()
 
 	commit, err := makeOSTreePayloadCommit(options.OSTree, t.OSTreeRef())
 	if err != nil {
@@ -437,11 +436,10 @@ func edgeInstallerImage(workload workload.Workload,
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
-	if imageConfig.WheelNoPasswd != nil {
-		img.WheelNoPasswd = *imageConfig.WheelNoPasswd
-	}
-	if imageConfig.UnattendedKickstart != nil {
-		img.UnattendedKickstart = *imageConfig.UnattendedKickstart
+
+	if instCust := customizations.GetInstaller(); instCust != nil {
+		img.WheelNoPasswd = instCust.WheelSudoNopasswd
+		img.UnattendedKickstart = instCust.Unattended
 	}
 
 	img.SquashfsCompression = "xz"

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -443,6 +443,8 @@ func edgeInstallerImage(workload workload.Workload,
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 
 	img.Language, img.Keyboard = customizations.GetPrimaryLocale()
+	// ignore ntp servers - we don't currently support setting these in the
+	// kickstart though kickstart does support setting them
 	img.Timezone, _ = customizations.GetTimezoneSettings()
 
 	if instCust := customizations.GetInstaller(); instCust != nil {

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -331,6 +331,11 @@ func imageInstallerImage(workload workload.Workload,
 	img.AdditionalDracutModules = []string{"prefixdevname", "prefixdevname-tools"}
 	img.AdditionalAnacondaModules = []string{"org.fedoraproject.Anaconda.Modules.Users"}
 
+	if instCust := customizations.GetInstaller(); instCust != nil {
+		img.WheelNoPasswd = instCust.WheelSudoNopasswd
+		img.UnattendedKickstart = instCust.Unattended
+	}
+
 	img.SquashfsCompression = "xz"
 
 	// put the kickstart file in the root of the iso

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -442,6 +442,9 @@ func edgeInstallerImage(workload workload.Workload,
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 
+	img.Language, img.Keyboard = customizations.GetPrimaryLocale()
+	img.Timezone, _ = customizations.GetTimezoneSettings()
+
 	if instCust := customizations.GetInstaller(); instCust != nil {
 		img.WheelNoPasswd = instCust.WheelSudoNopasswd
 		img.UnattendedKickstart = instCust.Unattended

--- a/pkg/distro/rhel8/imagetype.go
+++ b/pkg/distro/rhel8/imagetype.go
@@ -344,7 +344,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 				}
 			}
 		} else if t.name == "edge-installer" {
-			allowed := []string{"User", "Group", "FIPS"}
+			allowed := []string{"User", "Group", "FIPS", "Installer"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return warnings, fmt.Errorf(distro.UnsupportedCustomizationError, t.name, strings.Join(allowed, ", "))
 			}
@@ -437,6 +437,13 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		w := fmt.Sprintln(common.FIPSEnabledImageWarning)
 		log.Print(w)
 		warnings = append(warnings, w)
+	}
+
+	if customizations.GetInstaller() != nil {
+		// only supported by the Anaconda installer
+		if slices.Index([]string{"image-installer", "edge-installer", "live-installer"}, t.name) == -1 {
+			return warnings, fmt.Errorf("installer customizations are not supported for %q", t.name)
+		}
 	}
 
 	return warnings, nil

--- a/pkg/distro/rhel8/imagetype.go
+++ b/pkg/distro/rhel8/imagetype.go
@@ -344,7 +344,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 				}
 			}
 		} else if t.name == "edge-installer" {
-			allowed := []string{"User", "Group", "FIPS", "Installer"}
+			allowed := []string{"User", "Group", "FIPS", "Installer", "Timezone", "Locale"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return warnings, fmt.Errorf(distro.UnsupportedCustomizationError, t.name, strings.Join(allowed, ", "))
 			}

--- a/pkg/distro/rhel9/edge.go
+++ b/pkg/distro/rhel9/edge.go
@@ -97,10 +97,8 @@ var (
 			installerPkgsKey: edgeInstallerPackageSet,
 		},
 		defaultImageConfig: &distro.ImageConfig{
-			Locale:              common.ToPtr("en_US.UTF-8"),
-			EnabledServices:     edgeServices,
-			WheelNoPasswd:       common.ToPtr(true),
-			UnattendedKickstart: common.ToPtr(true),
+			Locale:          common.ToPtr("en_US.UTF-8"),
+			EnabledServices: edgeServices,
 		},
 		rpmOstree:        true,
 		bootISO:          true,

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -390,6 +390,9 @@ func edgeInstallerImage(workload workload.Workload,
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 
+	img.Language, img.Keyboard = customizations.GetPrimaryLocale()
+	img.Timezone, _ = customizations.GetTimezoneSettings()
+
 	if instCust := customizations.GetInstaller(); instCust != nil {
 		img.WheelNoPasswd = instCust.WheelSudoNopasswd
 		img.UnattendedKickstart = instCust.Unattended

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -391,6 +391,8 @@ func edgeInstallerImage(workload workload.Workload,
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 
 	img.Language, img.Keyboard = customizations.GetPrimaryLocale()
+	// ignore ntp servers - we don't currently support setting these in the
+	// kickstart though kickstart does support setting them
 	img.Timezone, _ = customizations.GetTimezoneSettings()
 
 	if instCust := customizations.GetInstaller(); instCust != nil {

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -377,7 +377,6 @@ func edgeInstallerImage(workload workload.Workload,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	d := t.arch.distro
-	imageConfig := t.getDefaultImageConfig()
 
 	commit, err := makeOSTreePayloadCommit(options.OSTree, t.OSTreeRef())
 	if err != nil {
@@ -390,11 +389,10 @@ func edgeInstallerImage(workload workload.Workload,
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
-	if imageConfig.WheelNoPasswd != nil {
-		img.WheelNoPasswd = *imageConfig.WheelNoPasswd
-	}
-	if imageConfig.UnattendedKickstart != nil {
-		img.UnattendedKickstart = *imageConfig.UnattendedKickstart
+
+	if instCust := customizations.GetInstaller(); instCust != nil {
+		img.WheelNoPasswd = instCust.WheelSudoNopasswd
+		img.UnattendedKickstart = instCust.Unattended
 	}
 
 	img.SquashfsCompression = "xz"

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -600,6 +600,11 @@ func imageInstallerImage(workload workload.Workload,
 	img.AdditionalDrivers = []string{"cuse", "ipmi_devintf", "ipmi_msghandler"}
 	img.AdditionalAnacondaModules = []string{"org.fedoraproject.Anaconda.Modules.Users"}
 
+	if instCust := customizations.GetInstaller(); instCust != nil {
+		img.WheelNoPasswd = instCust.WheelSudoNopasswd
+		img.UnattendedKickstart = instCust.Unattended
+	}
+
 	img.SquashfsCompression = "xz"
 
 	// put the kickstart file in the root of the iso

--- a/pkg/distro/rhel9/imagetype.go
+++ b/pkg/distro/rhel9/imagetype.go
@@ -355,7 +355,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 				}
 			}
 		} else if t.name == "edge-installer" {
-			allowed := []string{"User", "Group", "FIPS"}
+			allowed := []string{"User", "Group", "FIPS", "Installer"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return warnings, fmt.Errorf(distro.UnsupportedCustomizationError, t.name, strings.Join(allowed, ", "))
 			}
@@ -452,6 +452,13 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		w := fmt.Sprintln(common.FIPSEnabledImageWarning)
 		log.Print(w)
 		warnings = append(warnings, w)
+	}
+
+	if customizations.GetInstaller() != nil {
+		// only supported by the Anaconda installer
+		if slices.Index([]string{"image-installer", "edge-installer", "live-installer"}, t.name) == -1 {
+			return warnings, fmt.Errorf("installer customizations are not supported for %q", t.name)
+		}
 	}
 
 	return warnings, nil

--- a/pkg/distro/rhel9/imagetype.go
+++ b/pkg/distro/rhel9/imagetype.go
@@ -355,7 +355,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 				}
 			}
 		} else if t.name == "edge-installer" {
-			allowed := []string{"User", "Group", "FIPS", "Installer"}
+			allowed := []string{"User", "Group", "FIPS", "Installer", "Timezone", "Locale"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return warnings, fmt.Errorf(distro.UnsupportedCustomizationError, t.name, strings.Join(allowed, ", "))
 			}

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/runner"
@@ -98,6 +99,8 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	bootTreePipeline.Platform = img.Platform
 	bootTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
 	bootTreePipeline.ISOLabel = isoLabel
+
+	kspath := osbuild.KickstartPathOSBuild
 	bootTreePipeline.KernelOpts = []string{fmt.Sprintf("inst.stage2=hd:LABEL=%s", isoLabel), fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", isoLabel, kspath)}
 	if img.FIPS {
 		bootTreePipeline.KernelOpts = append(bootTreePipeline.KernelOpts, "fips=1")

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osbuild/images/pkg/artifact"
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -99,6 +100,8 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	bootTreePipeline.Platform = img.Platform
 	bootTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
 	bootTreePipeline.ISOLabel = isoLabel
+
+	kspath := osbuild.KickstartPathOSBuild
 	bootTreePipeline.KernelOpts = []string{fmt.Sprintf("inst.stage2=hd:LABEL=%s", isoLabel), fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", isoLabel, kspath)}
 	if img.FIPS {
 		bootTreePipeline.KernelOpts = append(bootTreePipeline.KernelOpts, "fips=1")

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -23,6 +23,10 @@ type AnacondaOSTreeInstaller struct {
 	Users             []users.User
 	Groups            []users.Group
 
+	Language *string
+	Keyboard *string
+	Timezone *string
+
 	// Create a sudoers drop-in file for wheel group with NOPASSWD option
 	WheelNoPasswd bool
 
@@ -120,6 +124,9 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.WheelNoPasswd = img.WheelNoPasswd
 	isoTreePipeline.UnattendedKickstart = img.UnattendedKickstart
 	isoTreePipeline.SquashfsCompression = img.SquashfsCompression
+	isoTreePipeline.Language = img.Language
+	isoTreePipeline.Keyboard = img.Keyboard
+	isoTreePipeline.Timezone = img.Timezone
 
 	// For ostree installers, always put the kickstart file in the root of the ISO
 	isoTreePipeline.KSPath = kspath

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -21,9 +21,11 @@ type AnacondaOSTreeInstaller struct {
 	ExtraBasePackages rpmmd.PackageSet
 	Users             []users.User
 	Groups            []users.Group
-	// whether to create sudoer file for wheel group with NOPASSWD option
+
+	// Create a sudoers drop-in file for wheel group with NOPASSWD option
 	WheelNoPasswd bool
-	// Whether an unattended kickstart was requested
+
+	// Add kickstart options to make the installation fully unattended
 	UnattendedKickstart bool
 
 	SquashfsCompression string

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -51,13 +51,17 @@ type AnacondaTarInstaller struct {
 	// If set, the kickstart file will be added to the bootiso-tree at the
 	// default path for osbuild, otherwise any kickstart options will be
 	// configured in the default location for interactive defaults in the
-	// rootfs.
+	// rootfs. Enabling UnattendedKickstart automatically enables this option
+	// because automatic installations cannot be configured using interactive
+	// defaults.
 	ISORootKickstart bool
 
 	// Create a sudoers drop-in file for wheel group with NOPASSWD option
 	WheelNoPasswd bool
 
-	// Add kickstart options to make the installation fully unattended
+	// Add kickstart options to make the installation fully unattended.
+	// Enabling this option also automatically enables the ISORootKickstart
+	// option.
 	UnattendedKickstart bool
 
 	SquashfsCompression string
@@ -89,6 +93,12 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	rng *rand.Rand) (*artifact.Artifact, error) {
 	buildPipeline := manifest.NewBuild(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
+
+	if img.UnattendedKickstart {
+		// if we're building an unattended installer, override the
+		// ISORootKickstart option
+		img.ISORootKickstart = true
+	}
 
 	anacondaPipeline := manifest.NewAnacondaInstaller(
 		manifest.AnacondaInstallerTypePayload,

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -167,6 +167,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoLinuxEnabled := img.Platform.GetArch() == arch.ARCH_X86_64
 
 	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(buildPipeline, anacondaPipeline, rootfsImagePipeline, bootTreePipeline)
+	// TODO: the partition table is required - make it a ctor arg or set a default one in the pipeline
 	isoTreePipeline.PartitionTable = efiBootPartitionTable(rng)
 	isoTreePipeline.Release = img.Release
 	isoTreePipeline.OSName = img.OSName

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -13,12 +13,11 @@ import (
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/runner"
 )
-
-const kspath = "/osbuild.ks"
 
 func efiBootPartitionTable(rng *rand.Rand) *disk.PartitionTable {
 	var efibootImageSize uint64 = 20 * common.MebiByte
@@ -49,9 +48,10 @@ type AnacondaTarInstaller struct {
 	Users             []users.User
 	Groups            []users.Group
 
-	// If set, the kickstart file will be added to the bootiso-tree as
-	// /osbuild.ks, otherwise any kickstart options will be configured in the
-	// default /usr/share/anaconda/interactive-defaults.ks in the rootfs.
+	// If set, the kickstart file will be added to the bootiso-tree at the
+	// default path for osbuild, otherwise any kickstart options will be
+	// configured in the default location for interactive defaults in the
+	// rootfs.
 	ISORootKickstart bool
 
 	// Create a sudoers drop-in file for wheel group with NOPASSWD option
@@ -137,6 +137,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	bootTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
 	bootTreePipeline.ISOLabel = isoLabel
 
+	kspath := osbuild.KickstartPathOSBuild
 	kernelOpts := []string{fmt.Sprintf("inst.stage2=hd:LABEL=%s", isoLabel)}
 	if img.ISORootKickstart {
 		kernelOpts = append(kernelOpts, fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", isoLabel, kspath))

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -172,6 +172,14 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.OSName = img.OSName
 	isoTreePipeline.Users = img.Users
 	isoTreePipeline.Groups = img.Groups
+	isoTreePipeline.Keyboard = img.OSCustomizations.Keyboard
+
+	if img.OSCustomizations.Language != "" {
+		isoTreePipeline.Language = &img.OSCustomizations.Language
+	}
+	if img.OSCustomizations.Timezone != "" {
+		isoTreePipeline.Timezone = &img.OSCustomizations.Timezone
+	}
 	isoTreePipeline.PayloadPath = tarPath
 	if img.ISORootKickstart {
 		isoTreePipeline.KSPath = kspath

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -54,6 +54,12 @@ type AnacondaTarInstaller struct {
 	// default /usr/share/anaconda/interactive-defaults.ks in the rootfs.
 	ISORootKickstart bool
 
+	// Create a sudoers drop-in file for wheel group with NOPASSWD option
+	WheelNoPasswd bool
+
+	// Add kickstart options to make the installation fully unattended
+	UnattendedKickstart bool
+
 	SquashfsCompression string
 
 	ISOLabelTempl string
@@ -160,6 +166,8 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 		isoTreePipeline.KSPath = kspath
 	}
 
+	isoTreePipeline.WheelNoPasswd = img.WheelNoPasswd
+	isoTreePipeline.UnattendedKickstart = img.UnattendedKickstart
 	isoTreePipeline.SquashfsCompression = img.SquashfsCompression
 
 	isoTreePipeline.OSPipeline = osPipeline

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
@@ -188,24 +189,15 @@ func (p *AnacondaInstaller) serializeEnd() {
 	p.packageSpecs = nil
 }
 
+func installerRootUser() osbuild.UsersStageOptionsUser {
+	return osbuild.UsersStageOptionsUser{
+		Password: common.ToPtr(""),
+	}
+}
+
 func (p *AnacondaInstaller) serialize() osbuild.Pipeline {
 	if len(p.packageSpecs) == 0 {
 		panic("serialization not started")
-	}
-
-	// Let's do a bunch of sanity checks that are dependent on the installer type
-	// being serialized
-	switch p.Type {
-	case AnacondaInstallerTypeLive:
-		if len(p.Users) != 0 || len(p.Groups) != 0 {
-			panic("anaconda installer type live does not support users and groups customization")
-		}
-		if p.InteractiveDefaults != nil {
-			panic("anaconda installer type live does not support interactive defaults")
-		}
-	case AnacondaInstallerTypePayload:
-	default:
-		panic("invalid anaconda installer type")
 	}
 
 	pipeline := p.Base.serialize()
@@ -220,148 +212,144 @@ func (p *AnacondaInstaller) serialize() osbuild.Pipeline {
 	}))
 	pipeline.AddStage(osbuild.NewLocaleStage(&osbuild.LocaleStageOptions{Language: "en_US.UTF-8"}))
 
-	rootPassword := ""
-	rootUser := osbuild.UsersStageOptionsUser{
-		Password: &rootPassword,
-	}
-
-	var usersStageOptions *osbuild.UsersStageOptions
-
+	// Let's do a bunch of sanity checks that are dependent on the installer type
+	// being serialized
 	switch p.Type {
 	case AnacondaInstallerTypeLive:
-		usersStageOptions = &osbuild.UsersStageOptions{
-			Users: map[string]osbuild.UsersStageOptionsUser{
-				"root": rootUser,
-			},
+		if len(p.Users) != 0 || len(p.Groups) != 0 {
+			panic("anaconda installer type live does not support users and groups customization")
 		}
-	case AnacondaInstallerTypePayload:
-		installUID := 0
-		installGID := 0
-		installHome := "/root"
-		installShell := "/usr/libexec/anaconda/run-anaconda"
-		installPassword := ""
-		installUser := osbuild.UsersStageOptionsUser{
-			UID:      &installUID,
-			GID:      &installGID,
-			Home:     &installHome,
-			Shell:    &installShell,
-			Password: &installPassword,
-		}
-
-		usersStageOptions = &osbuild.UsersStageOptions{
-			Users: map[string]osbuild.UsersStageOptionsUser{
-				"root":    rootUser,
-				"install": installUser,
-			},
-		}
-	default:
-		// Repeat of the check above.
-		// Keep it in case this switch block gets moved around.
-		panic("invalid anaconda installer type")
-	}
-
-	pipeline.AddStage(osbuild.NewUsersStage(usersStageOptions))
-
-	switch p.Type {
-	case AnacondaInstallerTypeLive:
-		systemdStageOptions := &osbuild.SystemdStageOptions{
-			EnabledServices: []string{
-				"livesys.service",
-				"livesys-late.service",
-			},
-		}
-
-		pipeline.AddStage(osbuild.NewSystemdStage(systemdStageOptions))
-
-		livesysMode := os.FileMode(int(0644))
-		livesysFile, err := fsnode.NewFile("/etc/sysconfig/livesys", &livesysMode, "root", "root", []byte("livesys_session=\"gnome\""))
-
-		if err != nil {
-			panic(err)
-		}
-
-		p.Files = []*fsnode.File{livesysFile}
-
-		pipeline.AddStages(osbuild.GenFileNodesStages(p.Files)...)
-	case AnacondaInstallerTypePayload:
-		var LoraxPath string
-
-		if p.UseRHELLoraxTemplates {
-			LoraxPath = "80-rhel/runtime-postinstall.tmpl"
-		} else {
-			LoraxPath = "99-generic/runtime-postinstall.tmpl"
-		}
-
-		pipeline.AddStage(osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptions(p.AdditionalAnacondaModules)))
-		pipeline.AddStage(osbuild.NewLoraxScriptStage(&osbuild.LoraxScriptStageOptions{
-			Path:     LoraxPath,
-			BaseArch: p.platform.GetArch().String(),
-		}))
-	default:
-		// Repeat of the check above.
-		// Keep it in case this switch block gets moved around.
-		panic("invalid anaconda installer type")
-	}
-
-	var dracutModules []string
-
-	switch p.Type {
-	case AnacondaInstallerTypeLive:
-		dracutModules = append(
-			p.AdditionalDracutModules,
-			"anaconda",
-			"rdma",
-			"rngd",
-		)
-	case AnacondaInstallerTypePayload:
-		dracutModules = append(
-			p.AdditionalDracutModules,
-			"anaconda",
-			"rdma",
-			"rngd",
-			"multipath",
-			"fcoe",
-			"fcoe-uefi",
-			"iscsi",
-			"lunmask",
-			"nfs",
-		)
-	default:
-		// Repeat of the check above.
-		// Keep it in case this switch block gets moved around.
-		panic("invalid anaconda installer type")
-	}
-
-	dracutOptions := dracutStageOptions(p.kernelVer, p.Biosdevname, dracutModules)
-	dracutOptions.AddDrivers = p.AdditionalDrivers
-	pipeline.AddStage(osbuild.NewDracutStage(dracutOptions))
-	pipeline.AddStage(osbuild.NewSELinuxConfigStage(&osbuild.SELinuxConfigStageOptions{State: osbuild.SELinuxStatePermissive}))
-
-	switch p.Type {
-	case AnacondaInstallerTypeLive:
-	case AnacondaInstallerTypePayload:
-		// TODO: change kickstart path when making unattended ISO
 		if p.InteractiveDefaults != nil {
-			kickstartOptions, err := osbuild.NewKickstartStageOptionsWithLiveIMG(
-				osbuild.KickstartPathInteractiveDefaults,
-				p.Users,
-				p.Groups,
-				p.InteractiveDefaults.TarPath,
-			)
-
-			if err != nil {
-				panic("failed to create kickstartstage options for interactive defaults")
-			}
-
-			pipeline.AddStage(osbuild.NewKickstartStage(kickstartOptions))
+			panic("anaconda installer type live does not support interactive defaults")
 		}
+		pipeline.AddStages(p.liveStages()...)
+	case AnacondaInstallerTypePayload:
+		pipeline.AddStages(p.payloadStages()...)
 	default:
-		// Repeat of the check above.
-		// Keep it in case this switch block gets moved around.
 		panic("invalid anaconda installer type")
 	}
 
 	return pipeline
+}
+
+func (p *AnacondaInstaller) payloadStages() []*osbuild.Stage {
+	stages := make([]*osbuild.Stage, 0)
+
+	installUID := 0
+	installGID := 0
+	installHome := "/root"
+	installShell := "/usr/libexec/anaconda/run-anaconda"
+	installPassword := ""
+	installUser := osbuild.UsersStageOptionsUser{
+		UID:      &installUID,
+		GID:      &installGID,
+		Home:     &installHome,
+		Shell:    &installShell,
+		Password: &installPassword,
+	}
+
+	usersStageOptions := &osbuild.UsersStageOptions{
+		Users: map[string]osbuild.UsersStageOptionsUser{
+			"root":    installerRootUser(),
+			"install": installUser,
+		},
+	}
+	stages = append(stages, osbuild.NewUsersStage(usersStageOptions))
+
+	var LoraxPath string
+
+	if p.UseRHELLoraxTemplates {
+		LoraxPath = "80-rhel/runtime-postinstall.tmpl"
+	} else {
+		LoraxPath = "99-generic/runtime-postinstall.tmpl"
+	}
+
+	stages = append(stages, osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptions(p.AdditionalAnacondaModules)))
+	stages = append(stages, osbuild.NewLoraxScriptStage(&osbuild.LoraxScriptStageOptions{
+		Path:     LoraxPath,
+		BaseArch: p.platform.GetArch().String(),
+	}))
+
+	dracutModules := append(
+		p.AdditionalDracutModules,
+		"anaconda",
+		"rdma",
+		"rngd",
+		"multipath",
+		"fcoe",
+		"fcoe-uefi",
+		"iscsi",
+		"lunmask",
+		"nfs",
+	)
+	dracutOptions := dracutStageOptions(p.kernelVer, p.Biosdevname, dracutModules)
+	dracutOptions.AddDrivers = p.AdditionalDrivers
+	stages = append(stages, osbuild.NewDracutStage(dracutOptions))
+
+	stages = append(stages, osbuild.NewSELinuxConfigStage(&osbuild.SELinuxConfigStageOptions{State: osbuild.SELinuxStatePermissive}))
+
+	// TODO: change kickstart path when making unattended ISO
+	if p.InteractiveDefaults != nil {
+		kickstartOptions, err := osbuild.NewKickstartStageOptionsWithLiveIMG(
+			osbuild.KickstartPathInteractiveDefaults,
+			p.Users,
+			p.Groups,
+			p.InteractiveDefaults.TarPath,
+		)
+
+		if err != nil {
+			panic("failed to create kickstartstage options for interactive defaults")
+		}
+
+		stages = append(stages, osbuild.NewKickstartStage(kickstartOptions))
+	}
+
+	return stages
+}
+
+func (p *AnacondaInstaller) liveStages() []*osbuild.Stage {
+	stages := make([]*osbuild.Stage, 0)
+
+	usersStageOptions := &osbuild.UsersStageOptions{
+		Users: map[string]osbuild.UsersStageOptionsUser{
+			"root": installerRootUser(),
+		},
+	}
+	stages = append(stages, osbuild.NewUsersStage(usersStageOptions))
+
+	systemdStageOptions := &osbuild.SystemdStageOptions{
+		EnabledServices: []string{
+			"livesys.service",
+			"livesys-late.service",
+		},
+	}
+
+	stages = append(stages, osbuild.NewSystemdStage(systemdStageOptions))
+
+	livesysMode := os.FileMode(int(0644))
+	livesysFile, err := fsnode.NewFile("/etc/sysconfig/livesys", &livesysMode, "root", "root", []byte("livesys_session=\"gnome\""))
+
+	if err != nil {
+		panic(err)
+	}
+
+	p.Files = []*fsnode.File{livesysFile}
+
+	stages = append(stages, osbuild.GenFileNodesStages(p.Files)...)
+
+	dracutModules := append(
+		p.AdditionalDracutModules,
+		"anaconda",
+		"rdma",
+		"rngd",
+	)
+	dracutOptions := dracutStageOptions(p.kernelVer, p.Biosdevname, dracutModules)
+	dracutOptions.AddDrivers = p.AdditionalDrivers
+	stages = append(stages, osbuild.NewDracutStage(dracutOptions))
+
+	stages = append(stages, osbuild.NewSELinuxConfigStage(&osbuild.SELinuxConfigStageOptions{State: osbuild.SELinuxStatePermissive}))
+
+	return stages
 }
 
 func dracutStageOptions(kernelVer string, biosdevname bool, additionalModules []string) *osbuild.DracutStageOptions {

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -329,7 +329,7 @@ func (p *AnacondaInstaller) serialize() osbuild.Pipeline {
 	if p.Type == AnacondaInstallerTypePayload {
 		if p.InteractiveDefaults != nil {
 			kickstartOptions, err := osbuild.NewKickstartStageOptionsWithLiveIMG(
-				"/usr/share/anaconda/interactive-defaults.ks",
+				osbuild.KickstartPathInteractiveDefaults,
 				p.Users,
 				p.Groups,
 				p.InteractiveDefaults.TarPath,

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -288,7 +288,6 @@ func (p *AnacondaInstaller) payloadStages() []*osbuild.Stage {
 
 	stages = append(stages, osbuild.NewSELinuxConfigStage(&osbuild.SELinuxConfigStageOptions{State: osbuild.SELinuxStatePermissive}))
 
-	// TODO: change kickstart path when making unattended ISO
 	if p.InteractiveDefaults != nil {
 		kickstartOptions, err := osbuild.NewKickstartStageOptionsWithLiveIMG(
 			osbuild.KickstartPathInteractiveDefaults,

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -197,11 +197,11 @@ func (p *AnacondaInstaller) serialize() osbuild.Pipeline {
 	// being serialized
 	if p.Type == AnacondaInstallerTypeLive {
 		if len(p.Users) != 0 || len(p.Groups) != 0 {
-			panic("anaconda installer type payload does not support users and groups customization")
+			panic("anaconda installer type live does not support users and groups customization")
 		}
 
 		if p.InteractiveDefaults != nil {
-			panic("anaconda installer type payload does not support interactive defaults")
+			panic("anaconda installer type live does not support interactive defaults")
 		}
 	} else if p.Type == AnacondaInstallerTypePayload {
 	} else {

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -297,7 +297,7 @@ func (p *AnacondaInstaller) payloadStages() []*osbuild.Stage {
 		)
 
 		if err != nil {
-			panic("failed to create kickstartstage options for interactive defaults")
+			panic(fmt.Sprintf("failed to create kickstart stage options for interactive defaults: %v", err))
 		}
 
 		stages = append(stages, osbuild.NewKickstartStage(kickstartOptions))

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -28,6 +28,10 @@ type AnacondaInstallerISOTree struct {
 	Users   []users.User
 	Groups  []users.Group
 
+	Language *string
+	Keyboard *string
+	Timezone *string
+
 	// Create a sudoers drop-in file for wheel group with NOPASSWD option
 	WheelNoPasswd bool
 
@@ -501,9 +505,22 @@ func (p *AnacondaInstallerISOTree) makeKickstartStages(kickstartOptions *osbuild
 	if p.UnattendedKickstart {
 		// set the default options for Unattended kickstart
 		kickstartOptions.DisplayMode = "text"
+
+		// override options that can be configured by the image type or the user
 		kickstartOptions.Lang = "en_US.UTF-8"
+		if p.Language != nil {
+			kickstartOptions.Lang = *p.Language
+		}
+
 		kickstartOptions.Keyboard = "us"
+		if p.Keyboard != nil {
+			kickstartOptions.Keyboard = *p.Keyboard
+		}
+
 		kickstartOptions.TimeZone = "UTC"
+		if p.Timezone != nil {
+			kickstartOptions.TimeZone = *p.Timezone
+		}
 
 		kickstartOptions.Reboot = &osbuild.RebootOptions{Eject: true}
 		kickstartOptions.RootPassword = &osbuild.RootPasswordOptions{Lock: true}

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -27,9 +27,11 @@ type AnacondaInstallerISOTree struct {
 	Remote  string
 	Users   []users.User
 	Groups  []users.Group
-	// whether to create sudoer file for wheel group with NOPASSWD option
+
+	// Create a sudoers drop-in file for wheel group with NOPASSWD option
 	WheelNoPasswd bool
-	// Whether an unattended kickstart was requested
+
+	// Add kickstart options to make the installation fully unattended
 	UnattendedKickstart bool
 
 	PartitionTable *disk.PartitionTable

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -424,6 +424,10 @@ func (p *AnacondaInstallerISOTree) ostreeContainerStages() []*osbuild.Stage {
 	kickstartOptions.RootPassword = &osbuild.RootPasswordOptions{
 		Lock: true,
 	}
+
+	// NOTE: These were decided somewhat arbitrarily for the BIB installer. We
+	// might want to drop them here and move them into the bib code as
+	// project-specific defaults.
 	kickstartOptions.Lang = "en_US.UTF-8"
 	kickstartOptions.Keyboard = "us"
 	kickstartOptions.Timezone = "UTC"

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -423,7 +423,7 @@ func (p *AnacondaInstallerISOTree) ostreeContainerStages() []*osbuild.Stage {
 	}
 	kickstartOptions.Lang = "en_US.UTF-8"
 	kickstartOptions.Keyboard = "us"
-	kickstartOptions.TimeZone = "UTC"
+	kickstartOptions.Timezone = "UTC"
 	kickstartOptions.ClearPart = &osbuild.ClearPartOptions{
 		All: true,
 	}
@@ -517,9 +517,9 @@ func (p *AnacondaInstallerISOTree) makeKickstartStages(kickstartOptions *osbuild
 			kickstartOptions.Keyboard = *p.Keyboard
 		}
 
-		kickstartOptions.TimeZone = "UTC"
+		kickstartOptions.Timezone = "UTC"
 		if p.Timezone != nil {
-			kickstartOptions.TimeZone = *p.Timezone
+			kickstartOptions.Timezone = *p.Timezone
 		}
 
 		kickstartOptions.Reboot = &osbuild.RebootOptions{Eject: true}

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -378,7 +378,7 @@ func (p *AnacondaInstallerISOTree) ostreeCommitStages() []*osbuild.Stage {
 		p.OSName)
 
 	if err != nil {
-		panic("failed to create kickstart stage options")
+		panic(fmt.Sprintf("failed to create kickstart stage options: %v", err))
 	}
 
 	stages = append(stages, p.makeKickstartStages(kickstartOptions)...)
@@ -414,6 +414,9 @@ func (p *AnacondaInstallerISOTree) ostreeContainerStages() []*osbuild.Stage {
 		"oci",
 		"",
 		"")
+	if err != nil {
+		panic(fmt.Sprintf("failed to create kickstart stage options: %v", err))
+	}
 
 	// NOTE: these are similar to the unattended kickstart options in the
 	// other two payload configurations but partitioning is different and
@@ -426,10 +429,6 @@ func (p *AnacondaInstallerISOTree) ostreeContainerStages() []*osbuild.Stage {
 	kickstartOptions.Timezone = "UTC"
 	kickstartOptions.ClearPart = &osbuild.ClearPartOptions{
 		All: true,
-	}
-
-	if err != nil {
-		panic("failed to create kickstartstage options")
 	}
 
 	stages = append(stages, osbuild.NewKickstartStage(kickstartOptions))
@@ -489,7 +488,7 @@ func (p *AnacondaInstallerISOTree) tarPayloadStages() []*osbuild.Stage {
 			makeISORootPath(p.PayloadPath))
 
 		if err != nil {
-			panic("failed to create kickstart stage options")
+			panic(fmt.Sprintf("failed to create kickstart stage options: %v", err))
 		}
 
 		stages = append(stages, p.makeKickstartStages(kickstartOptions)...)

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -428,6 +428,15 @@ restorecon -rvF /etc/sudoers.d
 			"oci",
 			"",
 			"")
+		kickstartOptions.RootPassword = &osbuild.RootPasswordOptions{
+			Lock: true,
+		}
+		kickstartOptions.Lang = "en_US.UTF-8"
+		kickstartOptions.Keyboard = "us"
+		kickstartOptions.TimeZone = "UTC"
+		kickstartOptions.ClearPart = &osbuild.ClearPartOptions{
+			All: true,
+		}
 
 		if err != nil {
 			panic("failed to create kickstartstage options")
@@ -450,14 +459,6 @@ restorecon -rvF /etc/sudoers.d
 		// that should very likely become configurable.
 		hardcodedKickstartBits := `
 %include /run/install/repo/osbuild-base.ks
-
-rootpw --lock
-
-lang en_US.UTF-8
-keyboard us
-timezone UTC
-
-clearpart --all
 
 reqpart --add-boot
 

--- a/pkg/manifest/anaconda_installer_iso_tree_test.go
+++ b/pkg/manifest/anaconda_installer_iso_tree_test.go
@@ -1,0 +1,132 @@
+package manifest
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/osbuild"
+	"github.com/osbuild/images/pkg/ostree"
+	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/runner"
+	"github.com/stretchr/testify/assert"
+)
+
+// newTestAnacondaISOTree returns a base AnacondaInstallerISOTree pipeline.
+func newTestAnacondaISOTree() *AnacondaInstallerISOTree {
+	m := &Manifest{}
+	runner := &runner.Linux{}
+	build := NewBuild(m, runner, nil, nil)
+
+	x86plat := &platform.X86{}
+
+	product := ""
+	osversion := ""
+
+	anacondaPipeline := NewAnacondaInstaller(
+		AnacondaInstallerTypePayload,
+		build,
+		x86plat,
+		nil,
+		"kernel",
+		product,
+		osversion,
+	)
+	rootfsImagePipeline := NewISORootfsImg(build, anacondaPipeline)
+	bootTreePipeline := NewEFIBootTree(build, product, osversion)
+
+	pipeline := NewAnacondaInstallerISOTree(build, anacondaPipeline, rootfsImagePipeline, bootTreePipeline)
+	// copy of the default in pkg/image - will be moved to the pipeline
+	var efibootImageSize uint64 = 20 * common.MebiByte
+	pipeline.PartitionTable = &disk.PartitionTable{
+		Size: efibootImageSize,
+		Partitions: []disk.Partition{
+			{
+				Start: 0,
+				Size:  efibootImageSize,
+				Payload: &disk.Filesystem{
+					Type:       "vfat",
+					Mountpoint: "/",
+					// math/rand is good enough in this case
+					/* #nosec G404 */
+					UUID: disk.NewVolIDFromRand(rand.New(rand.NewSource(0))),
+				},
+			},
+		},
+	}
+	return pipeline
+}
+
+func checkISOTreeStages(t *testing.T, stages []*osbuild.Stage, expected []string) {
+	commonStages := []string{
+		"org.osbuild.mkdir",
+		"org.osbuild.copy",
+		"org.osbuild.squashfs",
+		"org.osbuild.truncate",
+		"org.osbuild.mkfs.fat",
+		"org.osbuild.copy",
+		"org.osbuild.copy",
+		"org.osbuild.discinfo",
+	}
+
+	for _, expStage := range append(commonStages, expected...) {
+		t.Run(expStage, func(t *testing.T) {
+			assert.NotNil(t, findStage(expStage, stages))
+		})
+	}
+}
+
+func TestAnacondaISOTreePayloadsBad(t *testing.T) {
+	assert := assert.New(t)
+	pipeline := newTestAnacondaISOTree()
+
+	assert.PanicsWithValue(
+		"pipeline supports at most one ostree commit",
+		func() { pipeline.serializeStart(nil, nil, make([]ostree.CommitSpec, 2)) },
+	)
+	assert.PanicsWithValue(
+		"pipeline supports at most one container",
+		func() { pipeline.serializeStart(nil, make([]container.Spec, 2), nil) },
+	)
+}
+
+func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
+	osPayload := NewTestOS()
+
+	payloadStages := []string{"org.osbuild.tar"}
+
+	t.Run("plain", func(t *testing.T) {
+		pipeline := newTestAnacondaISOTree()
+		pipeline.OSPipeline = osPayload
+		pipeline.serializeStart(nil, nil, nil)
+		sp := pipeline.serialize()
+		pipeline.serializeEnd()
+		checkISOTreeStages(t, sp.Stages, payloadStages)
+	})
+
+	// the os payload variant of the pipeline only adds the kickstart file if
+	// KSPath is defined
+	t.Run("kspath", func(t *testing.T) {
+		pipeline := newTestAnacondaISOTree()
+		pipeline.OSPipeline = osPayload
+		pipeline.KSPath = "/test.ks"
+		pipeline.serializeStart(nil, nil, nil)
+		sp := pipeline.serialize()
+		pipeline.serializeEnd()
+		checkISOTreeStages(t, sp.Stages, append(payloadStages, "org.osbuild.kickstart"))
+	})
+
+	// enable ISOLinux and check for stage
+	t.Run("kspath+isolinux", func(t *testing.T) {
+		pipeline := newTestAnacondaISOTree()
+		pipeline.OSPipeline = osPayload
+		pipeline.KSPath = "/test.ks"
+		pipeline.ISOLinux = true
+		pipeline.serializeStart(nil, nil, nil)
+		sp := pipeline.serialize()
+		pipeline.serializeEnd()
+		checkISOTreeStages(t, sp.Stages, append(payloadStages, "org.osbuild.isolinux", "org.osbuild.kickstart"))
+	})
+}

--- a/pkg/osbuild/kickstart_stage.go
+++ b/pkg/osbuild/kickstart_stage.go
@@ -9,6 +9,11 @@ import (
 	"github.com/osbuild/images/pkg/customizations/users"
 )
 
+const (
+	KickstartPathInteractiveDefaults = "/usr/share/anaconda/interactive-defaults.ks"
+	KickstartPathOSBuild             = "/osbuild.ks"
+)
+
 type KickstartStageOptions struct {
 	// Where to place the kickstart file
 	Path string `json:"path"`

--- a/pkg/osbuild/kickstart_stage.go
+++ b/pkg/osbuild/kickstart_stage.go
@@ -29,7 +29,7 @@ type KickstartStageOptions struct {
 
 	Lang         string               `json:"lang,omitempty"`
 	Keyboard     string               `json:"keyboard,omitempty"`
-	TimeZone     string               `json:"timezone,omitempty"`
+	Timezone     string               `json:"timezone,omitempty"`
 	DisplayMode  string               `json:"display_mode,omitempty"`
 	Reboot       *RebootOptions       `json:"reboot,omitempty"`
 	RootPassword *RootPasswordOptions `json:"rootpw,omitempty"`

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -217,5 +217,24 @@
       "edge-container",
       "iot-container"
     ]
+  },
+  "./configs/unattended-iso-edge.json": {
+    "image-types": [
+      "edge-installer"
+    ]
+  },
+  "./configs/unattended-iso-iot.json": {
+    "image-types": [
+      "iot-installer"
+    ]
+  },
+  "./configs/unattended-iso.json": {
+    "distros": [
+      "rhel-*",
+      "centos-*"
+    ],
+    "image-types": [
+      "image-installer"
+    ]
   }
 }

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -10,13 +10,12 @@
       "qcow2"
     ]
   },
-  "./configs/all-with-oscap.json": {
+  "./configs/all-with-fips.json": {
     "distros": [
-      "rhel-9.1",
-      "rhel-9.2",
-      "rhel-8.7",
-      "rhel-8.8",
+      "rhel-9.3",
+      "rhel-9.4",
       "rhel-8.9",
+      "rhel-8.10",
       "centos*",
       "fedora*"
     ],
@@ -24,12 +23,13 @@
       "qcow2"
     ]
   },
-  "./configs/all-with-fips.json": {
+  "./configs/all-with-oscap.json": {
     "distros": [
-      "rhel-9.3",
-      "rhel-9.4",
+      "rhel-9.1",
+      "rhel-9.2",
+      "rhel-8.7",
+      "rhel-8.8",
       "rhel-8.9",
-      "rhel-8.10",
       "centos*",
       "fedora*"
     ],
@@ -45,9 +45,29 @@
       "ec2-sap"
     ]
   },
-  "./configs/edge-ostree-pull-device.json": {
+  "./configs/ec2-sap-empty.json": {
+    "distros": [
+      "centos-8",
+      "centos-9",
+      "fedora-37",
+      "fedora-38",
+      "fedora-39",
+      "fedora-40",
+      "rhel-7.9",
+      "rhel-8.10",
+      "rhel-8.5",
+      "rhel-8.6",
+      "rhel-8.7",
+      "rhel-8.8",
+      "rhel-8.9",
+      "rhel-9.0",
+      "rhel-9.1",
+      "rhel-9.2",
+      "rhel-9.3",
+      "rhel-9.4"
+    ],
     "image-types": [
-      "edge-simplified-installer"
+      "ec2-sap"
     ]
   },
   "./configs/edge-ostree-pull-device-fips.json": {
@@ -55,6 +75,11 @@
       "rhel-9.3",
       "rhel-9.4"
     ],
+    "image-types": [
+      "edge-simplified-installer"
+    ]
+  },
+  "./configs/edge-ostree-pull-device.json": {
     "image-types": [
       "edge-simplified-installer"
     ]
@@ -77,16 +102,16 @@
       "edge-vsphere"
     ]
   },
-  "./configs/edge-ostree-pull-user.json": {
-    "image-types": [
-      "edge-ami"
-    ]
-  },
   "./configs/edge-ostree-pull-user-fips.json": {
     "distros": [
       "rhel-9.3",
       "rhel-9.4"
     ],
+    "image-types": [
+      "edge-ami"
+    ]
+  },
+  "./configs/edge-ostree-pull-user.json": {
     "image-types": [
       "edge-ami"
     ]
@@ -173,49 +198,24 @@
       "qcow2"
     ]
   },
-  "./configs/ostree.json": {
-    "image-types": [
-      "edge-commit",
-      "edge-container",
-      "iot-container"
-    ]
-  },
-  "./configs/ec2-sap-empty.json": {
+  "./configs/ostree-filesystem-customizations.json": {
     "distros": [
-      "centos-8",
-      "centos-9",
-      "fedora-37",
-      "fedora-38",
-      "fedora-39",
-      "fedora-40",
-      "rhel-7.9",
-      "rhel-8.10",
-      "rhel-8.5",
-      "rhel-8.6",
-      "rhel-8.7",
-      "rhel-8.8",
-      "rhel-8.9",
-      "rhel-9.0",
-      "rhel-9.1",
       "rhel-9.2",
       "rhel-9.3",
       "rhel-9.4"
     ],
-    "image-types": [
-      "ec2-sap"
-    ]
-  },
-  "./configs/ostree-filesystem-customizations.json": {
     "image-types": [
       "edge-raw-image",
       "edge-ami",
       "edge-vsphere",
       "simplified-installer"
-    ],
-    "distros": [
-      "rhel-9.2",
-      "rhel-9.3",
-      "rhel-9.4"
+    ]
+  },
+  "./configs/ostree.json": {
+    "image-types": [
+      "edge-commit",
+      "edge-container",
+      "iot-container"
     ]
   }
 }

--- a/test/configs/unattended-iso-edge.json
+++ b/test/configs/unattended-iso-edge.json
@@ -1,0 +1,27 @@
+{
+  "name": "unattended-iso-edge",
+  "blueprint": {
+    "customizations": {
+      "user": [
+        {
+          "groups": [
+            "wheel"
+          ],
+          "key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNebAh6SjpAn8wB53K4695cGnHGuCtl4RdaX3futZgJUultHyzeYHnzMO7d4++qnRL+Rworew62LKP560uvtncc= github.com/osbuild/images",
+          "name": "osbuild"
+        }
+      ],
+      "installer": {
+        "unattended": true,
+        "wheel-sudo-nopasswd": true
+      }
+    }
+  },
+  "depends": {
+    "config": "empty.json",
+    "image-type": "edge-container"
+  },
+  "ostree": {
+    "url": "http://example.com/repo"
+  }
+}

--- a/test/configs/unattended-iso-iot.json
+++ b/test/configs/unattended-iso-iot.json
@@ -1,0 +1,27 @@
+{
+  "name": "unattended-iso-iot",
+  "blueprint": {
+    "customizations": {
+      "user": [
+        {
+          "groups": [
+            "wheel"
+          ],
+          "key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNebAh6SjpAn8wB53K4695cGnHGuCtl4RdaX3futZgJUultHyzeYHnzMO7d4++qnRL+Rworew62LKP560uvtncc= github.com/osbuild/images",
+          "name": "osbuild"
+        }
+      ],
+      "installer": {
+        "unattended": true,
+        "wheel-sudo-nopasswd": true
+      }
+    }
+  },
+  "depends": {
+    "config": "empty.json",
+    "image-type": "iot-container"
+  },
+  "ostree": {
+    "url": "http://example.com/repo"
+  }
+}

--- a/test/configs/unattended-iso.json
+++ b/test/configs/unattended-iso.json
@@ -11,6 +11,15 @@
           "name": "osbuild"
         }
       ],
+      "locale": {
+        "languages": [
+          "en_GB.UTF-8"
+        ],
+        "keyboard": "uk"
+      },
+      "timezone": {
+        "timezone": "Europe/Berlin"
+      },
       "installer": {
         "unattended": true,
         "wheel-sudo-nopasswd": true

--- a/test/configs/unattended-iso.json
+++ b/test/configs/unattended-iso.json
@@ -1,0 +1,20 @@
+{
+  "name": "unattended-iso",
+  "blueprint": {
+    "customizations": {
+      "user": [
+        {
+          "groups": [
+            "wheel"
+          ],
+          "key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNebAh6SjpAn8wB53K4695cGnHGuCtl4RdaX3futZgJUultHyzeYHnzMO7d4++qnRL+Rworew62LKP560uvtncc= github.com/osbuild/images",
+          "name": "osbuild"
+        }
+      ],
+      "installer": {
+        "unattended": true,
+        "wheel-sudo-nopasswd": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
Followup to #417 and #436.

This PR makes the two new installer options configurable in the blueprint. A new section is added called Installer with two options:
- unattended: adds options to the kickstart to make the installation fully unattended.
- wheel-sudo-nopasswd: adds a %post section to the kickstart file that creates a sudoers.d drop-in enabling NOPASSWD for the wheel group.

(I'm open to suggestions on option naming)

These options are required as part of the RHEL Edge service migration.  I enabled the options for all Anaconda-based installers except the Fedora live installer.

Note that in the two previous PRs, the options were enabled by default for Edge installers.  This is a major default image configuration change to be done by default, so we decided it needed to be a user-configurable option.

Initially the idea for this PR was just to make the two changes optional and deduplicate some of the kickstart inclusion handling, but a bit of tidying up of the pipeline code was also needed to make things more readable.  Also making the options interact with the other blueprint settings seemed like a sensible addition.