### PR TITLE
osbuild: generate bootupd mounts to span a single disk via  partscan=True

### DIFF
--- a/pkg/manifest/raw_ostree.go
+++ b/pkg/manifest/raw_ostree.go
@@ -122,7 +122,10 @@ func (p *RawOSTreeImage) serialize() osbuild.Pipeline {
 func (p *RawOSTreeImage) addBootupdStage(pipeline *osbuild.Pipeline) {
 	pt := p.treePipeline.PartitionTable
 
-	treeBootupdDevices, treeBootupdMounts := osbuild.GenBootupdDevicesMounts(p.Filename(), pt)
+	treeBootupdDevices, treeBootupdMounts, err := osbuild.GenBootupdDevicesMounts(p.Filename(), pt)
+	if err != nil {
+		panic(err)
+	}
 	opts := &osbuild.BootupdStageOptions{
 		Deployment: &osbuild.OSTreeDeployment{
 			OSName: p.treePipeline.osName,

--- a/pkg/osbuild/bootupd_stage_test.go
+++ b/pkg/osbuild/bootupd_stage_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
@@ -142,4 +144,103 @@ func TestBootupdStageJsonHappy(t *testing.T) {
     }
   ]
 }`)
+}
+
+func TestGenBootupdDevicesMountsMissingRoot(t *testing.T) {
+	filename := "fake-disk.img"
+	pt := &disk.PartitionTable{}
+	_, _, err := osbuild.GenBootupdDevicesMounts(filename, pt)
+	assert.EqualError(t, err, "required mounts for bootupd stage [/ /boot /boot/efi] missing")
+}
+
+var fakePt = &disk.PartitionTable{
+	UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+	Type: "gpt",
+	Partitions: []disk.Partition{
+		{
+			Size:     1 * common.MebiByte,
+			Bootable: true,
+			Type:     disk.BIOSBootPartitionGUID,
+			UUID:     disk.BIOSBootPartitionUUID,
+		},
+		{
+			Size: 501 * common.MebiByte,
+			Type: disk.EFISystemPartitionGUID,
+			UUID: disk.EFISystemPartitionUUID,
+			Payload: &disk.Filesystem{
+				Type:         "vfat",
+				UUID:         disk.EFIFilesystemUUID,
+				Mountpoint:   "/boot/efi",
+				Label:        "EFI-SYSTEM",
+				FSTabOptions: "umask=0077,shortname=winnt",
+				FSTabFreq:    0,
+				FSTabPassNo:  2,
+			},
+		},
+		{
+			Size: 1 * common.GibiByte,
+			Type: disk.FilesystemDataGUID,
+			UUID: disk.FilesystemDataUUID,
+			Payload: &disk.Filesystem{
+				Type:         "ext4",
+				Mountpoint:   "/boot",
+				Label:        "boot",
+				FSTabOptions: "defaults",
+				FSTabFreq:    1,
+				FSTabPassNo:  2,
+			},
+		},
+		{
+			Size: 2 * common.GibiByte,
+			Type: disk.FilesystemDataGUID,
+			UUID: disk.RootPartitionUUID,
+			Payload: &disk.Filesystem{
+				Type:         "ext4",
+				Label:        "root",
+				Mountpoint:   "/",
+				FSTabOptions: "defaults",
+				FSTabFreq:    1,
+				FSTabPassNo:  1,
+			},
+		},
+	},
+}
+
+func TestGenBootupdDevicesMountsHappy(t *testing.T) {
+	filename := "fake-disk.img"
+
+	devices, mounts, err := osbuild.GenBootupdDevicesMounts(filename, fakePt)
+	require.Nil(t, err)
+	assert.Equal(t, devices, map[string]osbuild.Device{
+		"disk": {
+			Type: "org.osbuild.loopback",
+			Options: &osbuild.LoopbackDeviceOptions{
+				Filename: "fake-disk.img",
+				Partscan: true,
+			},
+		},
+	})
+	assert.Equal(t, mounts, []osbuild.Mount{
+		{
+			Name:      "part4",
+			Type:      "org.osbuild.ext4",
+			Source:    "disk",
+			Target:    "/",
+			Partition: common.ToPtr(4),
+		},
+		{
+			Name:      "part3",
+			Type:      "org.osbuild.ext4",
+			Source:    "disk",
+			Target:    "/boot",
+			Partition: common.ToPtr(3),
+		},
+		{
+			Name:      "part2",
+			Type:      "org.osbuild.fat",
+			Source:    "disk",
+			Target:    "/boot/efi",
+			Partition: common.ToPtr(2),
+		},
+	})
 }

--- a/pkg/osbuild/device.go
+++ b/pkg/osbuild/device.go
@@ -249,7 +249,6 @@ func genMountsDevicesFromPt(filename string, pt *disk.PartitionTable) (string, [
 	genMounts := func(mnt disk.Mountable, path []disk.Entity) error {
 		stageDevices, name := getDevices(path, filename, false)
 		mountpoint := mnt.GetMountpoint()
-
 		if mountpoint == "/" {
 			fsRootMntName = name
 		}

--- a/pkg/osbuild/device.go
+++ b/pkg/osbuild/device.go
@@ -225,6 +225,23 @@ func pathEscape(path string) string {
 	return strings.ReplaceAll(path, "/", "-")
 }
 
+func genOsbuildMount(name, source string, mnt disk.Mountable) (*Mount, error) {
+	mountpoint := mnt.GetMountpoint()
+	t := mnt.GetFSType()
+	switch t {
+	case "xfs":
+		return NewXfsMount(name, source, mountpoint), nil
+	case "vfat":
+		return NewFATMount(name, source, mountpoint), nil
+	case "ext4":
+		return NewExt4Mount(name, source, mountpoint), nil
+	case "btrfs":
+		return NewBtrfsMount(name, source, mountpoint), nil
+	default:
+		return nil, fmt.Errorf("unknown fs type " + t)
+	}
+}
+
 func genMountsDevicesFromPt(filename string, pt *disk.PartitionTable) (string, []Mount, map[string]Device, error) {
 	devices := make(map[string]Device, len(pt.Partitions))
 	mounts := make([]Mount, 0, len(pt.Partitions))
@@ -237,19 +254,9 @@ func genMountsDevicesFromPt(filename string, pt *disk.PartitionTable) (string, [
 			fsRootMntName = name
 		}
 
-		var mount *Mount
-		t := mnt.GetFSType()
-		switch t {
-		case "xfs":
-			mount = NewXfsMount(name, name, mountpoint)
-		case "vfat":
-			mount = NewFATMount(name, name, mountpoint)
-		case "ext4":
-			mount = NewExt4Mount(name, name, mountpoint)
-		case "btrfs":
-			mount = NewBtrfsMount(name, name, mountpoint)
-		default:
-			return fmt.Errorf("unknown fs type " + t)
+		mount, err := genOsbuildMount(name, name, mnt)
+		if err != nil {
+			return err
 		}
 		mounts = append(mounts, *mount)
 


### PR DESCRIPTION
The `bootupd` and `bootc install to-filesystem` stages require a
continous disk so that grub can install the bootloader onto the
disk. This means that the new `partscan` feature from [0] must be
used when generating the disk instead of the current approach that
generates a bunch of loopback devices for each partition.

Note that this version of the code does not implement support
for "container" partition tables like LUKS.

[0] https://github.com/osbuild/osbuild/pull/1501
