### PR TITLE
RHEL: fix Azure images configuration according to documentation

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -3,7 +3,7 @@
   "fedora-39": {
     "dependencies": {
       "osbuild": {
-        "commit": "6e12f08a2965e15cfae479fbe8f80a64ba474e5b"
+        "commit": "b42e1afddc37dae3199e039f2a3d3cb10f01485c"
       }
     },
     "repos": [

--- a/pkg/distro/rhel8/azure.go
+++ b/pkg/distro/rhel8/azure.go
@@ -11,7 +11,8 @@ import (
 	"github.com/osbuild/images/pkg/subscription"
 )
 
-const defaultAzureKernelOptions = "ro crashkernel=auto console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
+// use loglevel=3 as described in the RHEL documentation and used in existing RHEL images built by MSFT
+const defaultAzureKernelOptions = "ro loglevel=3 crashkernel=auto console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
 
 func azureRhuiImgType() imageType {
 	return imageType{
@@ -473,6 +474,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 	},
 }
 
+// based on https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deploying_rhel_8_on_microsoft_azure/assembly_deploying-a-rhel-image-as-a-virtual-machine-on-microsoft-azure_cloud-content-azure#making-configuration-changes_configure-the-image-azure
 var defaultAzureImageConfig = &distro.ImageConfig{
 	Timezone: common.ToPtr("Etc/UTC"),
 	Locale:   common.ToPtr("en_US.UTF-8"),
@@ -584,10 +586,13 @@ var defaultAzureImageConfig = &distro.ImageConfig{
 		},
 	},
 	Grub2Config: &osbuild.GRUB2Config{
-		TerminalInput:  []string{"serial", "console"},
-		TerminalOutput: []string{"serial", "console"},
-		Serial:         "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1",
-		Timeout:        10,
+		DisableRecovery: common.ToPtr(true),
+		DisableSubmenu:  common.ToPtr(true),
+		Distributor:     "$(sed 's, release .*$,,g' /etc/system-release)",
+		Terminal:        []string{"serial", "console"},
+		Serial:          "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1",
+		Timeout:         10,
+		TimeoutStyle:    osbuild.GRUB2ConfigTimeoutStyleCountdown,
 	},
 	UdevRules: &osbuild.UdevRulesStageOptions{
 		Filename: "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules",

--- a/pkg/osbuild/grub2_legacy_stage.go
+++ b/pkg/osbuild/grub2_legacy_stage.go
@@ -83,8 +83,7 @@ type GRUB2BIOS struct {
 
 type GRUB2LegacyConfig struct {
 	GRUB2Config
-	CmdLine     string `json:"cmdline,omitempty"`
-	Distributor string `json:"distributor,omitempty"`
+	CmdLine string `json:"cmdline,omitempty"`
 }
 
 type GRUB2LegacyStageOptions struct {
@@ -145,13 +144,19 @@ func NewGrub2LegacyStageOptions(cfg *GRUB2Config,
 		RootFS:  GRUB2FSDesc{UUID: &rootFsUUID},
 		Entries: entries,
 		Config: &GRUB2LegacyConfig{
-			CmdLine:     kopts,
-			Distributor: "$(sed 's, release .*$,,g' /etc/system-release)",
+			CmdLine: kopts,
 		},
 	}
 
 	if cfg != nil {
 		stageOptions.Config.GRUB2Config = *cfg
+	}
+
+	// NB: previously, the distributor was part of the GRUB2LegacyConfig struct and
+	// was always set. Now it is part of GRUB2Config, which could override it above.
+	// Set it here if it is not set.
+	if stageOptions.Config.Distributor == "" {
+		stageOptions.Config.Distributor = "$(sed 's, release .*$,,g' /etc/system-release)"
 	}
 
 	bootFs := pt.FindMountable("/boot")

--- a/pkg/osbuild/grub2_stage.go
+++ b/pkg/osbuild/grub2_stage.go
@@ -34,12 +34,25 @@ type GRUB2UEFI struct {
 	Unified bool   `json:"unified,omitempty"`
 }
 
+type GRUB2ConfigTimeoutStyle string
+
+const (
+	GRUB2ConfigTimeoutStyleCountdown GRUB2ConfigTimeoutStyle = "countdown"
+	GRUB2ConfigTimeoutStyleHidden    GRUB2ConfigTimeoutStyle = "hidden"
+	GRUB2ConfigTimeoutStyleMenu      GRUB2ConfigTimeoutStyle = "menu"
+)
+
 type GRUB2Config struct {
-	Default        string   `json:"default,omitempty"`
-	TerminalInput  []string `json:"terminal_input,omitempty"`
-	TerminalOutput []string `json:"terminal_output,omitempty"`
-	Timeout        int      `json:"timeout,omitempty"`
-	Serial         string   `json:"serial,omitempty"`
+	Default         string                  `json:"default,omitempty"`
+	DisableRecovery *bool                   `json:"disable_recovery,omitempty"`
+	DisableSubmenu  *bool                   `json:"disable_submenu,omitempty"`
+	Distributor     string                  `json:"distributor,omitempty"`
+	Terminal        []string                `json:"terminal,omitempty"`
+	TerminalInput   []string                `json:"terminal_input,omitempty"`
+	TerminalOutput  []string                `json:"terminal_output,omitempty"`
+	Timeout         int                     `json:"timeout,omitempty"`
+	TimeoutStyle    GRUB2ConfigTimeoutStyle `json:"timeout_style,omitempty"`
+	Serial          string                  `json:"serial,omitempty"`
 }
 
 func (GRUB2StageOptions) isStageOptions() {}


### PR DESCRIPTION
Make sure that the RHEL-8 and RHEL-9 Azure images have the following configuration consistent with the official RHEL documentation:

- kernel commandline 
- modules disabled via modprobe configuration
- grub2 configuration in `/etc/default/grub`

Depends on https://github.com/osbuild/osbuild/pull/1601

Related to https://issues.redhat.com/browse/RHEL-19583