### PR TITLE
Service to create custom mount-points using fsnode

### DIFF
--- a/pkg/distro/rhel9/imagetype.go
+++ b/pkg/distro/rhel9/imagetype.go
@@ -239,6 +239,10 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 			cw.Services = services.Enabled
 			cw.DisabledServices = services.Disabled
 		}
+		//enable custom-service that creates mountpoints , refer func: createFilesystemMounpointService
+		if filesystemCustomization := bp.Customizations.GetFilesystems(); filesystemCustomization != nil {
+			cw.Services = append(cw.Services, "osbuild-ostree-mountpoints.service")
+		}
 		w = cw
 	}
 

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -206,9 +206,8 @@
     ],
     "image-types": [
       "edge-raw-image",
-      "edge-ami",
       "edge-vsphere",
-      "simplified-installer"
+      "edge-ami"
     ]
   },
   "./configs/ostree.json": {
@@ -235,6 +234,16 @@
     ],
     "image-types": [
       "image-installer"
+    ]
+  },
+  "./configs/ostree-filesystem-customizations-installer.json": {
+    "image-types": [
+      "edge-simplified-installer"
+    ],
+    "distros": [
+      "rhel-9.2",
+      "rhel-9.3",
+      "rhel-9.4"
     ]
   }
 }

--- a/test/configs/all-customizations.json
+++ b/test/configs/all-customizations.json
@@ -83,44 +83,6 @@
           "bluetooth.service"
         ]
       },
-      "filesystem": [
-        {
-          "mountpoint": "/home",
-          "minsize": 2147483648
-        },
-        {
-          "mountpoint": "/home/shadowman",
-          "minsize": "500MiB"
-        },
-        {
-          "mountpoint": "/foo",
-          "minsize": "1GiB"
-        },
-        {
-          "mountpoint": "/usr",
-          "minsize": "4GiB"
-        },
-        {
-          "mountpoint": "/opt",
-          "minsize": "1GiB"
-        },
-        {
-          "mountpoint": "/media",
-          "minsize": "1GiB"
-        },
-        {
-          "mountpoint": "/root",
-          "minsize": "1GiB"
-        },
-        {
-          "mountpoint": "/srv",
-          "minsize": "1GiB"
-        },
-        {
-          "mountpoint": "/mnt",
-          "minsize": "1GiB"
-        }
-      ],
       "directories": [
         {
           "path": "/etc/systemd/system/custom.service.d"

--- a/test/configs/all-with-fips.json
+++ b/test/configs/all-with-fips.json
@@ -84,44 +84,6 @@
           "bluetooth.service"
         ]
       },
-      "filesystem": [
-        {
-          "mountpoint": "/home",
-          "minsize": 2147483648
-        },
-        {
-          "mountpoint": "/home/shadowman",
-          "minsize": "500MiB"
-        },
-        {
-          "mountpoint": "/foo",
-          "minsize": "1GiB"
-        },
-        {
-          "mountpoint": "/usr",
-          "minsize": "4GiB"
-        },
-        {
-          "mountpoint": "/opt",
-          "minsize": "1GiB"
-        },
-        {
-          "mountpoint": "/media",
-          "minsize": "1GiB"
-        },
-        {
-          "mountpoint": "/root",
-          "minsize": "1GiB"
-        },
-        {
-          "mountpoint": "/srv",
-          "minsize": "1GiB"
-        },
-        {
-          "mountpoint": "/mnt",
-          "minsize": "1GiB"
-        }
-      ],
       "directories": [
         {
           "path": "/etc/systemd/system/custom.service.d"

--- a/test/configs/ostree-filesystem-customizations-installer.json
+++ b/test/configs/ostree-filesystem-customizations-installer.json
@@ -1,0 +1,54 @@
+{
+  "name": "ostree-filesystem-customizations-installer",
+  "ostree": {
+    "url": "http://example.com/repo"
+  },
+  "blueprint": {
+    "customizations": {
+      "user": [
+        {
+          "groups": [
+            "wheel"
+          ],
+          "key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNebAh6SjpAn8wB53K4695cGnHGuCtl4RdaX3futZgJUultHyzeYHnzMO7d4++qnRL+Rworew62LKP560uvtncc= github.com/osbuild/images",
+          "name": "osbuild"
+        }
+      ],
+      "installation_device": "/dev/vda",
+      "filesystem": [
+        {
+          "mountpoint": "/foo",
+          "minsize": "2147483648"
+        },
+        {
+          "mountpoint": "/foo/bar",
+          "minsize": "2 GiB"
+        },
+        {
+          "mountpoint": "/root",
+          "minsize": "1 GiB"
+        },
+        {
+          "mountpoint": "/mnt",
+          "minsize": "3 GiB"
+        },
+        {
+          "mountpoint": "/srv",
+          "minsize": "4 GiB"
+        },
+        {
+          "mountpoint": "/opt",
+          "minsize": "1 GiB"
+        },
+        {
+          "mountpoint": "/var/mydata",
+          "minsize": "1 GiB"
+        }
+      ]
+    }
+  },
+  "depends": {
+    "image-type": "edge-container",
+    "config": "empty.json"
+  }
+}


### PR DESCRIPTION
#399  for creating service is not surviving upgrade, even when  [org.osbuild.systemd.unit.create](https://github.com/osbuild/osbuild/blob/main/stages/org.osbuild.systemd.unit.create) is modified to save file in /etc/systemd/system.

Adding service using this methods works as expected, and can be a workaround by the time we investigate the issue and fix it accordingly.

