### PR TITLE
Enabled masked services customization (HMS-3661)

### DIFF
--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -108,6 +108,7 @@ type FirewallServicesCustomization struct {
 type ServicesCustomization struct {
 	Enabled  []string `json:"enabled,omitempty" toml:"enabled,omitempty"`
 	Disabled []string `json:"disabled,omitempty" toml:"disabled,omitempty"`
+	Masked   []string `json:"masked,omitempty" toml:"masked,omitempty"`
 }
 
 type OpenSCAPCustomization struct {

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -227,6 +227,7 @@ func TestGetServices(t *testing.T) {
 	expectedServices := ServicesCustomization{
 		Enabled:  []string{"cockpit", "osbuild-composer"},
 		Disabled: []string{"sshd", "ftp"},
+		Masked:   []string{"firewalld"},
 	}
 
 	TestCustomizations := Customizations{
@@ -237,6 +238,7 @@ func TestGetServices(t *testing.T) {
 
 	assert.ElementsMatch(t, expectedServices.Enabled, retServices.Enabled)
 	assert.ElementsMatch(t, expectedServices.Disabled, retServices.Disabled)
+	assert.ElementsMatch(t, expectedServices.Masked, retServices.Masked)
 }
 
 func TestError(t *testing.T) {

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -69,6 +69,7 @@ func osCustomizations(
 
 	osc.EnabledServices = imageConfig.EnabledServices
 	osc.DisabledServices = imageConfig.DisabledServices
+	osc.MaskedServices = imageConfig.MaskedServices
 	if imageConfig.DefaultTarget != nil {
 		osc.DefaultTarget = *imageConfig.DefaultTarget
 	}

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -18,6 +18,7 @@ type ImageConfig struct {
 	Keyboard            *osbuild.KeymapStageOptions
 	EnabledServices     []string
 	DisabledServices    []string
+	MaskedServices      []string
 	DefaultTarget       *string
 	Sysconfig           []*osbuild.SysconfigStageOptions
 

--- a/pkg/distro/rhel7/images.go
+++ b/pkg/distro/rhel7/images.go
@@ -63,6 +63,7 @@ func osCustomizations(
 
 	osc.EnabledServices = imageConfig.EnabledServices
 	osc.DisabledServices = imageConfig.DisabledServices
+	osc.MaskedServices = imageConfig.MaskedServices
 	if imageConfig.DefaultTarget != nil {
 		osc.DefaultTarget = *imageConfig.DefaultTarget
 	}

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -71,6 +71,7 @@ func osCustomizations(
 
 	osc.EnabledServices = imageConfig.EnabledServices
 	osc.DisabledServices = imageConfig.DisabledServices
+	osc.MaskedServices = imageConfig.MaskedServices
 	if imageConfig.DefaultTarget != nil {
 		osc.DefaultTarget = *imageConfig.DefaultTarget
 	}

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -68,6 +68,7 @@ func osCustomizations(
 
 	osc.EnabledServices = imageConfig.EnabledServices
 	osc.DisabledServices = imageConfig.DisabledServices
+	osc.MaskedServices = imageConfig.MaskedServices
 	if imageConfig.DefaultTarget != nil {
 		osc.DefaultTarget = *imageConfig.DefaultTarget
 	}

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -77,6 +77,7 @@ type OSCustomizations struct {
 	Timezone         string
 	EnabledServices  []string
 	DisabledServices []string
+	MaskedServices   []string
 	DefaultTarget    string
 
 	// SELinux policy, when set it enables the labeling of the tree with the
@@ -706,8 +707,10 @@ func (p *OS) serialize() osbuild.Pipeline {
 
 	enabledServices := []string{}
 	disabledServices := []string{}
+	maskedServices := []string{}
 	enabledServices = append(enabledServices, p.EnabledServices...)
 	disabledServices = append(disabledServices, p.DisabledServices...)
+	maskedServices = append(maskedServices, p.MaskedServices...)
 	if p.Environment != nil {
 		enabledServices = append(enabledServices, p.Environment.GetServices()...)
 	}
@@ -716,10 +719,12 @@ func (p *OS) serialize() osbuild.Pipeline {
 		disabledServices = append(disabledServices, p.Workload.GetDisabledServices()...)
 	}
 	if len(enabledServices) != 0 ||
-		len(disabledServices) != 0 || p.DefaultTarget != "" {
+		len(disabledServices) != 0 ||
+		len(maskedServices) != 0 || p.DefaultTarget != "" {
 		pipeline.AddStage(osbuild.NewSystemdStage(&osbuild.SystemdStageOptions{
 			EnabledServices:  enabledServices,
 			DisabledServices: disabledServices,
+			MaskedServices:   maskedServices,
 			DefaultTarget:    p.DefaultTarget,
 		}))
 	}

--- a/test/configs/all-customizations.json
+++ b/test/configs/all-customizations.json
@@ -81,6 +81,11 @@
         ],
         "disabled": [
           "bluetooth.service"
+        ],
+        "masked": [
+          "nfs-server",
+          "rpcbind",
+          "nftables"
         ]
       },
       "filesystem": [


### PR DESCRIPTION
In some cases we might want to ensure a service is disabled without installing the package to the image. We can workaround this by masking the service instead of disabling it.