### PR TITLE
RHEL-8/9: don't touch rhsm.conf on non-RHUI images.

### DIFF
--- a/pkg/distro/rhel8/ami.go
+++ b/pkg/distro/rhel8/ami.go
@@ -16,7 +16,7 @@ func amiImgTypeX86_64(rd distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: ec2CommonPackageSet,
 		},
-		defaultImageConfig:  defaultAMIImageConfigX86_64(rd),
+		defaultImageConfig:  defaultAMIImageConfigX86_64(),
 		kernelOptions:       "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
 		bootable:            true,
 		defaultSize:         10 * common.GibiByte,
@@ -82,7 +82,7 @@ func amiImgTypeAarch64(rd distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: ec2CommonPackageSet,
 		},
-		defaultImageConfig:  defaultAMIImageConfig(rd),
+		defaultImageConfig:  defaultAMIImageConfig(),
 		kernelOptions:       "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0 crashkernel=auto",
 		bootable:            true,
 		defaultSize:         10 * common.GibiByte,
@@ -203,7 +203,6 @@ func baseEc2ImageConfig() *distro.ImageConfig {
 			{
 				Filename: "00-getty-fixes.conf",
 				Config: osbuild.SystemdLogindConfigDropin{
-
 					Login: osbuild.SystemdLogindConfigLoginSection{
 						NAutoVTs: common.ToPtr(0),
 					},
@@ -283,24 +282,23 @@ func defaultEc2ImageConfig(rd distribution) *distro.ImageConfig {
 	return ic
 }
 
-// default AMI (EC2 BYOS) images config
-func defaultAMIImageConfig(rd distribution) *distro.ImageConfig {
-	ic := defaultEc2ImageConfig(rd)
-	if rd.isRHEL() {
-		// defaultEc2ImageConfig() adds the rhsm options only for RHEL < 8.7
-		// Add it unconditionally for AMI
-		ic = appendRHSM(ic)
-	}
-	return ic
-}
-
 func defaultEc2ImageConfigX86_64(rd distribution) *distro.ImageConfig {
 	ic := defaultEc2ImageConfig(rd)
 	return appendEC2DracutX86_64(ic)
 }
 
-func defaultAMIImageConfigX86_64(rd distribution) *distro.ImageConfig {
-	ic := defaultAMIImageConfig(rd).InheritFrom(defaultEc2ImageConfigX86_64(rd))
+// Default AMI (custom image built by users) images config.
+// The configuration does not touch the RHSM configuration at all.
+// https://issues.redhat.com/browse/COMPOSER-2157
+func defaultAMIImageConfig() *distro.ImageConfig {
+	return baseEc2ImageConfig()
+}
+
+// Default AMI x86_64 (custom image built by users) images config.
+// The configuration does not touch the RHSM configuration at all.
+// https://issues.redhat.com/browse/COMPOSER-2157
+func defaultAMIImageConfigX86_64() *distro.ImageConfig {
+	ic := defaultAMIImageConfig()
 	return appendEC2DracutX86_64(ic)
 }
 

--- a/pkg/distro/rhel8/azure.go
+++ b/pkg/distro/rhel8/azure.go
@@ -629,34 +629,11 @@ var defaultAzureImageConfig = &distro.ImageConfig{
 }
 
 // Diff of the default Image Config compare to the `defaultAzureImageConfig`
+// The configuration for non-RHUI images does not touch the RHSM configuration at all.
+// https://issues.redhat.com/browse/COMPOSER-2157
 var defaultAzureByosImageConfig = &distro.ImageConfig{
 	GPGKeyFiles: []string{
 		"/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
-	},
-	RHSMConfig: map[subscription.RHSMStatus]*osbuild.RHSMStageOptions{
-		subscription.RHSMConfigNoSubscription: {
-			SubMan: &osbuild.RHSMStageOptionsSubMan{
-				Rhsmcertd: &osbuild.SubManConfigRHSMCERTDSection{
-					AutoRegistration: common.ToPtr(true),
-				},
-				// Don't disable RHSM redhat.repo management on the GCE
-				// image, which is BYOS and does not use RHUI for content.
-				// Otherwise subscribing the system manually after booting
-				// it would result in empty redhat.repo. Without RHUI, such
-				// system would have no way to get Red Hat content, but
-				// enable the repo management manually, which would be very
-				// confusing.
-			},
-		},
-		subscription.RHSMConfigWithSubscription: {
-			SubMan: &osbuild.RHSMStageOptionsSubMan{
-				Rhsmcertd: &osbuild.SubManConfigRHSMCERTDSection{
-					AutoRegistration: common.ToPtr(true),
-				},
-				// do not disable the redhat.repo management if the user
-				// explicitly request the system to be subscribed
-			},
-		},
 	},
 }
 

--- a/pkg/distro/rhel8/gce.go
+++ b/pkg/distro/rhel8/gce.go
@@ -52,6 +52,8 @@ func gceRhuiImgType(rd distribution) imageType {
 	}
 }
 
+// The configuration for non-RHUI images does not touch the RHSM configuration at all.
+// https://issues.redhat.com/browse/COMPOSER-2157
 func defaultGceByosImageConfig(rd distribution) *distro.ImageConfig {
 	ic := &distro.ImageConfig{
 		Timezone: common.ToPtr("UTC"),
@@ -156,33 +158,6 @@ func defaultGceByosImageConfig(rd distribution) *distro.ImageConfig {
 		)
 	}
 
-	if rd.isRHEL() {
-		ic.RHSMConfig = map[subscription.RHSMStatus]*osbuild.RHSMStageOptions{
-			subscription.RHSMConfigNoSubscription: {
-				SubMan: &osbuild.RHSMStageOptionsSubMan{
-					Rhsmcertd: &osbuild.SubManConfigRHSMCERTDSection{
-						AutoRegistration: common.ToPtr(true),
-					},
-					// Don't disable RHSM redhat.repo management on the GCE
-					// image, which is BYOS and does not use RHUI for content.
-					// Otherwise subscribing the system manually after booting
-					// it would result in empty redhat.repo. Without RHUI, such
-					// system would have no way to get Red Hat content, but
-					// enable the repo management manually, which would be very
-					// confusing.
-				},
-			},
-			subscription.RHSMConfigWithSubscription: {
-				SubMan: &osbuild.RHSMStageOptionsSubMan{
-					Rhsmcertd: &osbuild.SubManConfigRHSMCERTDSection{
-						AutoRegistration: common.ToPtr(true),
-					},
-					// do not disable the redhat.repo management if the user
-					// explicitly request the system to be subscribed
-				},
-			},
-		}
-	}
 	return ic
 }
 

--- a/pkg/distro/rhel9/ami.go
+++ b/pkg/distro/rhel9/ami.go
@@ -189,7 +189,6 @@ func baseEc2ImageConfig() *distro.ImageConfig {
 			{
 				Filename: "00-getty-fixes.conf",
 				Config: osbuild.SystemdLogindConfigDropin{
-
 					Login: osbuild.SystemdLogindConfigLoginSection{
 						NAutoVTs: common.ToPtr(0),
 					},
@@ -266,24 +265,23 @@ func defaultEc2ImageConfig(osVersion string, rhsm bool) *distro.ImageConfig {
 	return ic
 }
 
-// default AMI (EC2 BYOS) images config
-func defaultAMIImageConfig(osVersion string, rhsm bool) *distro.ImageConfig {
-	ic := defaultEc2ImageConfig(osVersion, rhsm)
-	if rhsm {
-		// defaultEc2ImageConfig() adds the rhsm options only for RHEL < 9.1
-		// Add it unconditionally for AMI
-		ic = appendRHSM(ic)
-	}
-	return ic
-}
-
 func defaultEc2ImageConfigX86_64(osVersion string, rhsm bool) *distro.ImageConfig {
 	ic := defaultEc2ImageConfig(osVersion, rhsm)
 	return appendEC2DracutX86_64(ic)
 }
 
-func defaultAMIImageConfigX86_64(osVersion string, rhsm bool) *distro.ImageConfig {
-	ic := defaultAMIImageConfig(osVersion, rhsm).InheritFrom(defaultEc2ImageConfigX86_64(osVersion, rhsm))
+// Default AMI (custom image built by users) images config.
+// The configuration does not touch the RHSM configuration at all.
+// https://issues.redhat.com/browse/COMPOSER-2157
+func defaultAMIImageConfig() *distro.ImageConfig {
+	return baseEc2ImageConfig()
+}
+
+// Default AMI x86_64 (custom image built by users) images config.
+// The configuration does not touch the RHSM configuration at all.
+// https://issues.redhat.com/browse/COMPOSER-2157
+func defaultAMIImageConfigX86_64() *distro.ImageConfig {
+	ic := defaultAMIImageConfig()
 	return appendEC2DracutX86_64(ic)
 }
 
@@ -418,9 +416,9 @@ func mkEc2ImgTypeX86_64(osVersion string, rhsm bool) imageType {
 	return it
 }
 
-func mkAMIImgTypeX86_64(osVersion string, rhsm bool) imageType {
+func mkAMIImgTypeX86_64() imageType {
 	it := amiImgTypeX86_64
-	ic := defaultAMIImageConfigX86_64(osVersion, rhsm)
+	ic := defaultAMIImageConfigX86_64()
 	it.defaultImageConfig = ic
 	return it
 }
@@ -438,9 +436,9 @@ func mkEc2HaImgTypeX86_64(osVersion string, rhsm bool) imageType {
 	return it
 }
 
-func mkAMIImgTypeAarch64(osVersion string, rhsm bool) imageType {
+func mkAMIImgTypeAarch64() imageType {
 	it := amiImgTypeAarch64
-	ic := defaultAMIImageConfig(osVersion, rhsm)
+	ic := defaultAMIImageConfig()
 	it.defaultImageConfig = ic
 	return it
 }

--- a/pkg/distro/rhel9/azure.go
+++ b/pkg/distro/rhel9/azure.go
@@ -572,34 +572,11 @@ var defaultAzureImageConfig = &distro.ImageConfig{
 }
 
 // Diff of the default Image Config compare to the `defaultAzureImageConfig`
+// The configuration for non-RHUI images does not touch the RHSM configuration at all.
+// https://issues.redhat.com/browse/COMPOSER-2157
 var defaultAzureByosImageConfig = &distro.ImageConfig{
 	GPGKeyFiles: []string{
 		"/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
-	},
-	RHSMConfig: map[subscription.RHSMStatus]*osbuild.RHSMStageOptions{
-		subscription.RHSMConfigNoSubscription: {
-			SubMan: &osbuild.RHSMStageOptionsSubMan{
-				Rhsmcertd: &osbuild.SubManConfigRHSMCERTDSection{
-					AutoRegistration: common.ToPtr(true),
-				},
-				// Don't disable RHSM redhat.repo management on the GCE
-				// image, which is BYOS and does not use RHUI for content.
-				// Otherwise subscribing the system manually after booting
-				// it would result in empty redhat.repo. Without RHUI, such
-				// system would have no way to get Red Hat content, but
-				// enable the repo management manually, which would be very
-				// confusing.
-			},
-		},
-		subscription.RHSMConfigWithSubscription: {
-			SubMan: &osbuild.RHSMStageOptionsSubMan{
-				Rhsmcertd: &osbuild.SubManConfigRHSMCERTDSection{
-					AutoRegistration: common.ToPtr(true),
-				},
-				// do not disable the redhat.repo management if the user
-				// explicitly request the system to be subscribed
-			},
-		},
 	},
 }
 

--- a/pkg/distro/rhel9/distro.go
+++ b/pkg/distro/rhel9/distro.go
@@ -253,7 +253,7 @@ func newDistro(name string, minor int) *distribution {
 	}
 	x86_64.addImageTypes(
 		ec2X86Platform,
-		mkAMIImgTypeX86_64(rd.osVersion, rd.isRHEL()),
+		mkAMIImgTypeX86_64(),
 	)
 
 	gceX86Platform := &platform.X86{
@@ -264,7 +264,7 @@ func newDistro(name string, minor int) *distribution {
 	}
 	x86_64.addImageTypes(
 		gceX86Platform,
-		mkGCEImageType(rd.isRHEL()),
+		mkGCEImageType(),
 	)
 
 	x86_64.addImageTypes(
@@ -391,7 +391,7 @@ func newDistro(name string, minor int) *distribution {
 				ImageFormat: platform.FORMAT_RAW,
 			},
 		},
-		mkAMIImgTypeAarch64(rd.osVersion, rd.isRHEL()),
+		mkAMIImgTypeAarch64(),
 	)
 
 	ppc64le.addImageTypes(
@@ -455,7 +455,7 @@ func newDistro(name string, minor int) *distribution {
 		)
 
 		// add GCE RHUI image to RHEL only
-		x86_64.addImageTypes(gceX86Platform, mkGCERHUIImageType(rd.isRHEL()))
+		x86_64.addImageTypes(gceX86Platform, mkGCERHUIImageType())
 	} else {
 		x86_64.addImageTypes(azureX64Platform, azureImgType)
 		aarch64.addImageTypes(azureAarch64Platform, azureImgType)


### PR DESCRIPTION
Previously, the auto-registration was explicitly enabled in `rhsm.conf` even for non-RHUI cloud images. These are the images that users can build on-prem or in the hosted service (as vanilla or as customized). However, the feature never really worked for these images.

Stop enabling the auto-registration in rhsm.conf (basically stop touching the configuration at all).

Related to https://issues.redhat.com/browse/COMPOSER-2157