### PR TITLE
fedora: remove webui kernel arguments

### DIFF
--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -369,8 +369,6 @@ func imageInstallerImage(workload workload.Workload,
 			// time since they might be running headless and a UI is
 			// unnecessary.
 			img.AdditionalKernelOpts = []string{"inst.text", "inst.noninteractive"}
-		} else {
-			img.AdditionalKernelOpts = []string{"inst.webui", "inst.webui.remote"}
 		}
 	}
 	img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, "org.fedoraproject.Anaconda.Modules.Users")


### PR DESCRIPTION
Anaconda auto-detects the webui being available in recent versions instead of using the kernel arguments. See the codepath in pyanaconda here: https://github.com/rhinstaller/anaconda/blob/8b5f5920d62bcebfadc06285e9b681d4d36f45d1/pyanaconda/anaconda.py#L209