### PR TITLE
More consistent and readable version checks.

### DIFF
--- a/internal/common/distro.go
+++ b/internal/common/distro.go
@@ -28,14 +28,5 @@ func VersionLessThan(a, b string) bool {
 }
 
 func VersionGreaterThanOrEqual(a, b string) bool {
-	aV, err := version.NewVersion(a)
-	if err != nil {
-		panic(err)
-	}
-	bV, err := version.NewVersion(b)
-	if err != nil {
-		panic(err)
-	}
-
-	return aV.GreaterThanOrEqual(bV)
+	return !VersionLessThan(a, b)
 }

--- a/internal/common/distro.go
+++ b/internal/common/distro.go
@@ -26,3 +26,16 @@ func VersionLessThan(a, b string) bool {
 
 	return aV.LessThan(bV)
 }
+
+func VersionGreaterThanOrEqual(a, b string) bool {
+	aV, err := version.NewVersion(a)
+	if err != nil {
+		panic(err)
+	}
+	bV, err := version.NewVersion(b)
+	if err != nil {
+		panic(err)
+	}
+
+	return aV.GreaterThanOrEqual(bV)
+}

--- a/internal/common/distro_test.go
+++ b/internal/common/distro_test.go
@@ -14,6 +14,12 @@ func TestVersionLessThan(t *testing.T) {
 
 	cases := []testCases{
 		{
+			Name:     "8 < 8",
+			VersionA: "8",
+			VersionB: "8",
+			Expected: false,
+		},
+		{
 			Name:     "8 < 8.1",
 			VersionA: "8",
 			VersionB: "8.1",
@@ -85,6 +91,98 @@ func TestVersionLessThan(t *testing.T) {
 		t.Run(c.Name, func(t *testing.T) {
 			if VersionLessThan(c.VersionA, c.VersionB) != c.Expected {
 				t.Fatalf("VersionLessThan(%s, %s) returned unexpected result", c.VersionA, c.VersionB)
+			}
+		})
+	}
+}
+
+func TestVersionGreaterThanOrEqual(t *testing.T) {
+	type testCases struct {
+		Name     string
+		VersionA string
+		VersionB string
+		Expected bool
+	}
+
+	cases := []testCases{
+		{
+			Name:     "8.1 > 8",
+			VersionA: "8.1",
+			VersionB: "8",
+			Expected: true,
+		},
+		{
+			Name:     "8.2 > 8.1",
+			VersionA: "8.2",
+			VersionB: "8.1",
+			Expected: true,
+		},
+		{
+			Name:     "9 > 8",
+			VersionA: "9",
+			VersionB: "8",
+			Expected: true,
+		},
+		{
+			Name:     "9 > 8.1",
+			VersionA: "9",
+			VersionB: "8.1",
+			Expected: true,
+		},
+		{
+			Name:     "9.1 > 8.1",
+			VersionA: "9.1",
+			VersionB: "8.1",
+			Expected: true,
+		},
+		{
+			Name:     "8.10 > 8",
+			VersionA: "8.10",
+			VersionB: "8",
+			Expected: true,
+		},
+		{
+			Name:     "8.10 > 8.1",
+			VersionA: "8.10",
+			VersionB: "8.1",
+			Expected: true,
+		},
+		{
+			Name:     "8.11 > 8.10",
+			VersionA: "8.11",
+			VersionB: "8.10",
+			Expected: true,
+		},
+		{
+			Name:     "8.6 > 8.10",
+			VersionA: "8.6",
+			VersionB: "8.10",
+			Expected: false,
+		},
+		{
+			Name:     "9-stream > 8-stream",
+			VersionA: "9-stream",
+			VersionB: "8-stream",
+			Expected: true,
+		},
+		{
+			Name:     "9.1 > 9-stream",
+			VersionA: "9.1",
+			VersionB: "9-stream",
+			Expected: true,
+		},
+		{
+			Name:     "9.1 >= 9.1",
+			VersionA: "9.1",
+			VersionB: "9.1",
+			Expected: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			if VersionGreaterThanOrEqual(c.VersionA, c.VersionB) != c.Expected {
+				t.Fatalf("VersionGreaterThanOrEqual(%s, %s) returned unexpected result", c.VersionA, c.VersionB)
 			}
 		})
 	}

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -818,7 +818,7 @@ func newDistro(version int) distro.Distro {
 		minimalrawImgType,
 	)
 
-	if !common.VersionLessThan(rd.Releasever(), "38") {
+	if common.VersionGreaterThanOrEqual(rd.Releasever(), "38") {
 		// iot simplified installer was introduced in F38
 		x86_64.addImageTypes(
 			&platform.X86{
@@ -869,7 +869,7 @@ func newDistro(version int) distro.Distro {
 		)
 	}
 
-	if !common.VersionLessThan(rd.Releasever(), "39") {
+	if common.VersionGreaterThanOrEqual(rd.Releasever(), "39") {
 		// bootc was introduced in F39
 		x86_64.addImageTypes(
 			&platform.X86{

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -353,9 +353,9 @@ func imageInstallerImage(workload workload.Workload,
 		img.UnattendedKickstart = instCust.Unattended
 	}
 
-	// Enable anaconda-webui for Fedora > 38
+	// Enable anaconda-webui for Fedora >= 39
 	distro := t.Arch().Distro()
-	if !common.VersionLessThan(distro.Releasever(), "38") {
+	if !common.VersionLessThan(distro.Releasever(), "39") {
 		img.AdditionalAnacondaModules = []string{
 			"org.fedoraproject.Anaconda.Modules.Security",
 			"org.fedoraproject.Anaconda.Modules.Timezone",

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -355,7 +355,7 @@ func imageInstallerImage(workload workload.Workload,
 
 	// Enable anaconda-webui for Fedora >= 39
 	distro := t.Arch().Distro()
-	if !common.VersionLessThan(distro.Releasever(), "39") {
+	if common.VersionGreaterThanOrEqual(distro.Releasever(), "39") {
 		img.AdditionalAnacondaModules = []string{
 			"org.fedoraproject.Anaconda.Modules.Security",
 			"org.fedoraproject.Anaconda.Modules.Timezone",
@@ -410,7 +410,7 @@ func iotCommitImage(workload workload.Workload,
 
 	img.Platform = t.platform
 	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, bp.Customizations)
-	if !common.VersionLessThan(d.Releasever(), "38") {
+	if common.VersionGreaterThanOrEqual(d.Releasever(), "38") {
 		// see https://github.com/ostreedev/ostree/issues/2840
 		img.OSCustomizations.Presets = []osbuild.Preset{
 			{
@@ -476,7 +476,7 @@ func iotContainerImage(workload workload.Workload,
 	d := t.arch.distro
 	img.Platform = t.platform
 	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, bp.Customizations)
-	if !common.VersionLessThan(d.Releasever(), "38") {
+	if common.VersionGreaterThanOrEqual(d.Releasever(), "38") {
 		// see https://github.com/ostreedev/ostree/issues/2840
 		img.OSCustomizations.Presets = []osbuild.Preset{
 			{
@@ -605,7 +605,7 @@ func iotImage(workload workload.Workload,
 	img.OSName = "fedora-iot"
 	img.LockRoot = true
 
-	if !common.VersionLessThan(distro.Releasever(), "38") {
+	if common.VersionGreaterThanOrEqual(distro.Releasever(), "38") {
 		img.KernelOptionsAppend = append(img.KernelOptionsAppend, "coreos.no_persist_ip")
 		switch img.Platform.GetImageFormat() {
 		case platform.FORMAT_RAW:
@@ -657,7 +657,7 @@ func iotSimplifiedInstallerImage(workload workload.Workload,
 	rawImg.KernelOptionsAppend = []string{"modprobe.blacklist=vc4"}
 	rawImg.Keyboard = "us"
 	rawImg.Locale = "C.UTF-8"
-	if !common.VersionLessThan(t.arch.distro.osVersion, "38") {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "38") {
 		rawImg.SysrootReadOnly = true
 		rawImg.KernelOptionsAppend = append(rawImg.KernelOptionsAppend, "rw")
 	}
@@ -670,7 +670,7 @@ func iotSimplifiedInstallerImage(workload workload.Workload,
 	rawImg.OSName = "fedora"
 	rawImg.LockRoot = true
 
-	if !common.VersionLessThan(t.arch.distro.osVersion, "38") {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "38") {
 		rawImg.IgnitionPlatform = "metal"
 		rawImg.KernelOptionsAppend = append(rawImg.KernelOptionsAppend, "coreos.no_persist_ip")
 		if bpIgnition := customizations.GetIgnition(); bpIgnition != nil && bpIgnition.FirstBoot != nil && bpIgnition.FirstBoot.ProvisioningURL != "" {

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -353,7 +353,6 @@ func imageInstallerImage(workload workload.Workload,
 		img.UnattendedKickstart = instCust.Unattended
 	}
 
-	// Enable anaconda-webui for Fedora >= 39
 	distro := t.Arch().Distro()
 	if common.VersionGreaterThanOrEqual(distro.Releasever(), "39") {
 		img.AdditionalAnacondaModules = []string{

--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -4,7 +4,6 @@ package fedora
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
@@ -498,13 +497,7 @@ func iotInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 	// include anaconda packages
 	ps := anacondaPackageSet(t)
 
-	releasever := t.Arch().Distro().Releasever()
-	version, err := strconv.Atoi(releasever)
-	if err != nil {
-		panic("cannot convert releasever to int: " + err.Error())
-	}
-
-	if version >= 38 {
+	if !common.VersionLessThan(t.arch.distro.osVersion, "39") {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"fedora-release-iot",
@@ -560,14 +553,8 @@ func liveInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 func imageInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 	ps := anacondaPackageSet(t)
 
-	releasever := t.Arch().Distro().Releasever()
-	version, err := strconv.Atoi(releasever)
-	if err != nil {
-		panic("cannot convert releasever to int: " + err.Error())
-	}
-
 	// We want to generate a preview image when rawhide is built
-	if version >= 38 {
+	if !common.VersionLessThan(t.arch.distro.osVersion, "39") {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"anaconda-webui",

--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -538,7 +538,6 @@ func liveInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 		},
 	}
 
-	// We want to generate a preview image when rawhide is built
 	if !common.VersionLessThan(t.arch.distro.osVersion, "39") {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
@@ -553,7 +552,6 @@ func liveInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 func imageInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 	ps := anacondaPackageSet(t)
 
-	// We want to generate a preview image when rawhide is built
 	if !common.VersionLessThan(t.arch.distro.osVersion, "39") {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{

--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -173,7 +173,7 @@ func iotCommitPackageSet(t *imageType) rpmmd.PackageSet {
 		},
 	}
 
-	if !common.VersionLessThan(t.arch.distro.osVersion, "38") {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "38") {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"fdo-client",
@@ -497,7 +497,7 @@ func iotInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 	// include anaconda packages
 	ps := anacondaPackageSet(t)
 
-	if !common.VersionLessThan(t.arch.distro.osVersion, "39") {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "39") {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"fedora-release-iot",
@@ -538,7 +538,7 @@ func liveInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 		},
 	}
 
-	if !common.VersionLessThan(t.arch.distro.osVersion, "39") {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "39") {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"anaconda-webui",
@@ -552,7 +552,7 @@ func liveInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 func imageInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 	ps := anacondaPackageSet(t)
 
-	if !common.VersionLessThan(t.arch.distro.osVersion, "39") {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "39") {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"anaconda-webui",

--- a/pkg/distro/rhel8/ami.go
+++ b/pkg/distro/rhel8/ami.go
@@ -368,7 +368,7 @@ func ec2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 func rhelEc2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 	ps := ec2CommonPackageSet(t)
 	// Include "redhat-cloud-client-configuration" on 8.7+ (COMPOSER-1804)
-	if !common.VersionLessThan(t.arch.distro.osVersion, "8.7") {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "8.7") {
 		ps.Include = append(ps.Include, "redhat-cloud-client-configuration")
 	}
 	return ps

--- a/pkg/distro/rhel8/distro.go
+++ b/pkg/distro/rhel8/distro.go
@@ -397,7 +397,7 @@ func newDistro(name string, minor int) *distribution {
 	)
 
 	if rd.isRHEL() {
-		if !common.VersionLessThan(rd.osVersion, "8.6") {
+		if common.VersionGreaterThanOrEqual(rd.osVersion, "8.6") {
 			// image types only available on 8.6 and later on RHEL
 			// These edge image types require FDO which aren't available on older versions
 			x86_64.addImageTypes(

--- a/pkg/distro/rhel9/ami.go
+++ b/pkg/distro/rhel9/ami.go
@@ -356,7 +356,7 @@ func ec2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 func rhelEc2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 	ps := ec2CommonPackageSet(t)
 	// Include "redhat-cloud-client-configuration" on 9.1+ (COMPOSER-1805)
-	if !common.VersionLessThan(t.arch.distro.osVersion, "9.1") {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "9.1") {
 		ps.Include = append(ps.Include, "redhat-cloud-client-configuration")
 	}
 	return ps

--- a/pkg/distro/rhel9/edge.go
+++ b/pkg/distro/rhel9/edge.go
@@ -589,7 +589,7 @@ func edgeCommitPackageSet(t *imageType) rpmmd.PackageSet {
 		ps = ps.Append(aarch64EdgeCommitPackageSet(t))
 	}
 
-	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || !t.arch.distro.isRHEL() {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "9.2") || !t.arch.distro.isRHEL() {
 		ps.Include = append(ps.Include, "ignition", "ignition-edge", "ssh-key-dir")
 	}
 

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -327,7 +327,7 @@ func edgeCommitImage(workload workload.Workload,
 	img.OSVersion = t.arch.distro.osVersion
 	img.Filename = t.Filename()
 
-	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || !t.arch.distro.isRHEL() {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "9.2") || !t.arch.distro.isRHEL() {
 		img.OSCustomizations.EnabledServices = append(img.OSCustomizations.EnabledServices, "ignition-firstboot-complete.service", "coreos-ignition-write-issues.service")
 	}
 	img.Environment = t.environment
@@ -361,7 +361,7 @@ func edgeContainerImage(workload workload.Workload,
 	img.ExtraContainerPackages = packageSets[containerPkgsKey]
 	img.Filename = t.Filename()
 
-	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || !t.arch.distro.isRHEL() {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "9.2") || !t.arch.distro.isRHEL() {
 		img.OSCustomizations.EnabledServices = append(img.OSCustomizations.EnabledServices, "ignition-firstboot-complete.service", "coreos-ignition-write-issues.service")
 	}
 
@@ -452,12 +452,12 @@ func edgeRawImage(workload workload.Workload,
 	}
 	img.Keyboard = "us"
 	img.Locale = "C.UTF-8"
-	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || !t.arch.distro.isRHEL() {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "9.2") || !t.arch.distro.isRHEL() {
 		img.SysrootReadOnly = true
 		img.KernelOptionsAppend = append(img.KernelOptionsAppend, "rw")
 	}
 
-	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || !t.arch.distro.isRHEL() {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "9.2") || !t.arch.distro.isRHEL() {
 		img.IgnitionPlatform = "metal"
 		img.KernelOptionsAppend = append(img.KernelOptionsAppend, "coreos.no_persist_ip")
 		if bpIgnition := customizations.GetIgnition(); bpIgnition != nil && bpIgnition.FirstBoot != nil && bpIgnition.FirstBoot.ProvisioningURL != "" {
@@ -513,7 +513,7 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 	rawImg.KernelOptionsAppend = []string{"modprobe.blacklist=vc4"}
 	rawImg.Keyboard = "us"
 	rawImg.Locale = "C.UTF-8"
-	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || !t.arch.distro.isRHEL() {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "9.2") || !t.arch.distro.isRHEL() {
 		rawImg.SysrootReadOnly = true
 		rawImg.KernelOptionsAppend = append(rawImg.KernelOptionsAppend, "rw")
 	}
@@ -528,7 +528,7 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 	rawImg.OSName = "redhat"
 	rawImg.LockRoot = true
 
-	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || !t.arch.distro.isRHEL() {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "9.2") || !t.arch.distro.isRHEL() {
 		rawImg.IgnitionPlatform = "metal"
 		rawImg.KernelOptionsAppend = append(rawImg.KernelOptionsAppend, "coreos.no_persist_ip")
 		if bpIgnition := customizations.GetIgnition(); bpIgnition != nil && bpIgnition.FirstBoot != nil && bpIgnition.FirstBoot.ProvisioningURL != "" {


### PR DESCRIPTION
Two idioms were being used in `fedora/package_sets.go` and there was a mismatch between which version of Fedora enables the webui.

To improve readability and since it's such a common idiom in our codebase I've also introduced `VersionGreaterThanOrEqual` in `common`.