### PR TITLE
RHEL-8: fix hybrid boot by bringing back /boot/efi

### DIFF
--- a/pkg/distro/rhel8/partition_tables.go
+++ b/pkg/distro/rhel8/partition_tables.go
@@ -271,6 +271,19 @@ func getEc2PartitionTables(osVersion string, isRHEL bool) distro.BasePartitionTa
 					UUID:     disk.BIOSBootPartitionUUID,
 				},
 				{
+					Size: 200 * common.MebiByte,
+					Type: disk.EFISystemPartitionGUID,
+					UUID: disk.EFISystemPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "vfat",
+						UUID:         disk.EFIFilesystemUUID,
+						Mountpoint:   "/boot/efi",
+						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+						FSTabFreq:    0,
+						FSTabPassNo:  2,
+					},
+				},
+				{
 					Size: 2 * common.GibiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.RootPartitionUUID,


### PR DESCRIPTION
PR#450 [1] reverted the separate `/boot` partition for x86_64 images, since it was causing issues. However, it also removed the `/boot/efi` partition. These images are supposed to support UEFI boot and are marked as such. This is causing failures when booting these images with UEFI in osbuild-composer CI.

Fix this regression by bringing back `/boot/efi`.

[1] https://github.com/osbuild/images/pull/450