### PR TITLE
Rename CI jobs testing the integration with osbuild-composer

### DIFF
--- a/.github/workflows/test-osbuild-composer-intergation.yml
+++ b/.github/workflows/test-osbuild-composer-intergation.yml
@@ -1,4 +1,4 @@
-name: "[osbuild-composer integration]"
+name: "[integration]"
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   unit-tests:
-    name: "🛃 Unit tests"
+    name: "🛃 osbuild-composer unit tests"
     runs-on: ubuntu-20.04
     container:
       image: registry.fedoraproject.org/fedora:latest
@@ -46,7 +46,7 @@ jobs:
         run: go test -race ./...
 
   lint:
-    name: "⌨ Golang Lint"
+    name: "⌨ osbuild-composer Golang Lint"
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.19


### PR DESCRIPTION
It turns out that the required jobs to pass to auto-merge a PR are based only on job names. Therefore the fact that the actions testing the integration with osbuild-composer had the same job names as those that are used to test the images code (specifically the "Unit tests") made them required. There is no other way to distinguish jobs other than to rename them. So let's do it.