### PR TITLE
container: simplify resolver

### DIFF
--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -342,21 +342,11 @@ func (m RawManifest) Digest() (digest.Digest, error) {
 }
 
 func getImageRef(target reference.Named, local bool) (types.ImageReference, error) {
-
-	if !local {
-		ref, err := docker.NewReference(target)
-		if err != nil {
-			return nil, err
-		}
-		return ref, nil
-	} else {
-		ref, err := alltransports.ParseImageName(fmt.Sprintf("containers-storage:%s", target))
-		if err != nil {
-			fmt.Printf("FAILED %s\n", err)
-			return nil, err
-		}
-		return ref, nil
+	if local {
+		return alltransports.ParseImageName(fmt.Sprintf("containers-storage:%s", target))
 	}
+
+	return docker.NewReference(target)
 }
 
 // GetManifest fetches the raw manifest data from the server. If digest is not empty

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -35,9 +35,6 @@ import (
 const (
 	DefaultUserAgent  = "osbuild-composer/1.0"
 	DefaultPolicyPath = "/etc/containers/policy.json"
-
-	containersStorageTransport = "containers-storage"
-	dockerTransport            = "docker"
 )
 
 // GetDefaultAuthFile returns the authentication file to use for the
@@ -344,32 +341,27 @@ func (m RawManifest) Digest() (digest.Digest, error) {
 	return manifest.Digest(m.Data)
 }
 
-func getImageRef(target reference.Named, transport string, storagePath string) (types.ImageReference, error) {
-	switch transport {
-	case "", dockerTransport:
+func getImageRef(target reference.Named, local bool) (types.ImageReference, error) {
+
+	if !local {
 		ref, err := docker.NewReference(target)
 		if err != nil {
 			return nil, err
 		}
 		return ref, nil
-	case containersStorageTransport:
-		var storage string
-		if storagePath != "" {
-			storage = fmt.Sprintf("[overlay@%s]", storagePath)
-		}
-		ref, err := alltransports.ParseImageName(fmt.Sprintf("%s:%s%s", transport, storage, target))
+	} else {
+		ref, err := alltransports.ParseImageName(fmt.Sprintf("containers-storage:%s", target))
 		if err != nil {
+			fmt.Printf("FAILED %s\n", err)
 			return nil, err
 		}
 		return ref, nil
-	default:
-		return nil, fmt.Errorf("Unknown containers-transport: %s", transport)
 	}
 }
 
 // GetManifest fetches the raw manifest data from the server. If digest is not empty
 // it will override any given tag for the Client's Target.
-func (cl *Client) GetManifest(ctx context.Context, digest digest.Digest, container *SourceSpec) (r RawManifest, err error) {
+func (cl *Client) GetManifest(ctx context.Context, digest digest.Digest, local bool) (r RawManifest, err error) {
 	target := cl.Target
 
 	if digest != "" {
@@ -382,17 +374,7 @@ func (cl *Client) GetManifest(ctx context.Context, digest digest.Digest, contain
 		target = t
 	}
 
-	var transport string
-	if container != nil && container.ContainersTransport != nil {
-		transport = *container.ContainersTransport
-	}
-
-	var storagePath string
-	if container != nil && container.StoragePath != nil {
-		storagePath = *container.StoragePath
-	}
-
-	ref, err := getImageRef(target, transport, storagePath)
+	ref, err := getImageRef(target, local)
 	if err != nil {
 		return
 	}
@@ -438,7 +420,7 @@ func (cl *Client) resolveManifestList(ctx context.Context, list manifestList) (r
 		return resolvedIds{}, err
 	}
 
-	raw, err := cl.GetManifest(ctx, digest, nil)
+	raw, err := cl.GetManifest(ctx, digest, false)
 	if err != nil {
 		return resolvedIds{}, fmt.Errorf("error getting manifest: %w", err)
 	}
@@ -522,9 +504,9 @@ func (cl *Client) resolveRawManifest(ctx context.Context, rm RawManifest) (resol
 // which is the digest of the configuration object. It uses the architecture and
 // variant specified via SetArchitectureChoice or the corresponding defaults for
 // the host.
-func (cl *Client) Resolve(ctx context.Context, name string, container *SourceSpec) (Spec, error) {
+func (cl *Client) Resolve(ctx context.Context, name string, local bool) (Spec, error) {
 
-	raw, err := cl.GetManifest(ctx, "", container)
+	raw, err := cl.GetManifest(ctx, "", local)
 
 	if err != nil {
 		return Spec{}, fmt.Errorf("error getting manifest: %w", err)
@@ -535,13 +517,6 @@ func (cl *Client) Resolve(ctx context.Context, name string, container *SourceSpe
 		return Spec{}, err
 	}
 
-	var transport *string
-	var location *string
-	if container != nil {
-		transport = container.ContainersTransport
-		location = container.StoragePath
-	}
-
 	spec := NewSpec(
 		cl.Target,
 		ids.Manifest,
@@ -549,8 +524,7 @@ func (cl *Client) Resolve(ctx context.Context, name string, container *SourceSpe
 		cl.GetTLSVerify(),
 		ids.ListManifest.String(),
 		name,
-		transport,
-		location,
+		local,
 	)
 
 	return spec, nil

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -357,7 +357,7 @@ func getImageRef(target reference.Named, transport string, storagePath string) (
 		if storagePath != "" {
 			storage = fmt.Sprintf("[overlay@%s]", storagePath)
 		}
-		ref, err := alltransports.ParseImageName(fmt.Sprintf("%s:%s%s", transport, storage, target.Name()))
+		ref, err := alltransports.ParseImageName(fmt.Sprintf("%s:%s%s", transport, storage, target))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -35,7 +35,7 @@ func TestClientResolve(t *testing.T) {
 	ctx := context.Background()
 
 	client.SetArchitectureChoice("amd64")
-	spec, err := client.Resolve(ctx, "", nil)
+	spec, err := client.Resolve(ctx, "", false)
 
 	assert.NoError(t, err)
 	assert.Equal(t, container.Spec{
@@ -48,7 +48,7 @@ func TestClientResolve(t *testing.T) {
 	}, spec)
 
 	client.SetArchitectureChoice("ppc64le")
-	spec, err = client.Resolve(ctx, "", nil)
+	spec, err = client.Resolve(ctx, "", false)
 
 	assert.NoError(t, err)
 	assert.Equal(t, container.Spec{
@@ -62,7 +62,7 @@ func TestClientResolve(t *testing.T) {
 
 	// don't have that architecture
 	client.SetArchitectureChoice("s390x")
-	_, err = client.Resolve(ctx, "", nil)
+	_, err = client.Resolve(ctx, "", false)
 
 	assert.Error(t, err)
 }

--- a/pkg/container/resolver.go
+++ b/pkg/container/resolver.go
@@ -55,7 +55,7 @@ func (r *Resolver) Add(spec SourceSpec) {
 	}
 
 	go func() {
-		spec, err := client.Resolve(r.ctx, spec.Name, &spec)
+		spec, err := client.Resolve(r.ctx, spec.Name, spec.StoragePath != nil)
 		if err != nil {
 			err = fmt.Errorf("'%s': %w", spec.Source, err)
 		}

--- a/pkg/container/spec.go
+++ b/pkg/container/spec.go
@@ -19,23 +19,23 @@ type Spec struct {
 	ListDigest          string  // digest of the list manifest at the Source (optional)
 	ContainersTransport *string // the type of transport used for the container
 	StoragePath         *string // location of the local containers-storage
+	LocalStorage        bool
 }
 
 // NewSpec creates a new Spec from the essential information.
 // It also converts is the transition point from container
 // specific types (digest.Digest) to generic types (string).
-func NewSpec(source reference.Named, digest, imageID digest.Digest, tlsVerify *bool, listDigest string, localName string, transport *string, storagePath *string) Spec {
+func NewSpec(source reference.Named, digest, imageID digest.Digest, tlsVerify *bool, listDigest string, localName string, localStorage bool) Spec {
 	if localName == "" {
 		localName = source.String()
 	}
 	return Spec{
-		Source:              source.Name(),
-		Digest:              digest.String(),
-		TLSVerify:           tlsVerify,
-		ImageID:             imageID.String(),
-		LocalName:           localName,
-		ListDigest:          listDigest,
-		ContainersTransport: transport,
-		StoragePath:         storagePath,
+		Source:       source.Name(),
+		Digest:       digest.String(),
+		TLSVerify:    tlsVerify,
+		ImageID:      imageID.String(),
+		LocalName:    localName,
+		ListDigest:   listDigest,
+		LocalStorage: localStorage,
 	}
 }


### PR DESCRIPTION
[split out from https://github.com/osbuild/images/pull/448 to make it easier to review]

his commit simplifies how local containers are resolved. We can read the
storage-path from system config, which makes it possible to remove the
storage-path argument from the blueprints in a later commit.

---

Minor fix to the local container resolver, using `target.Name()` removes
the container's tag, which is undesirable if we are trying to resolve a
container that is not tagged with `latest`.
