### PR TITLE
Fedora: Update package sets for upstream changes

### DIFF
--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -138,10 +138,8 @@ func iotCommitPackageSet(t *imageType) rpmmd.PackageSet {
 			"openssh-server",
 			"openssl",
 			"parsec",
-			"passwd",
 			"pinentry",
 			"podman",
-			"podman-plugins",
 			"policycoreutils",
 			"policycoreutils-python-utils",
 			"polkit",
@@ -175,6 +173,15 @@ func iotCommitPackageSet(t *imageType) rpmmd.PackageSet {
 			"zezere-ignition",
 			"zram-generator",
 		},
+	}
+
+	if common.VersionLessThan(t.arch.distro.osVersion, "40") {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"passwd",         // provided by shadow-utils in F40+
+				"podman-plugins", // deprecated in podman 5
+			},
+		})
 	}
 
 	return ps
@@ -221,7 +228,7 @@ func bootableContainerPackageSet(t *imageType) rpmmd.PackageSet {
 			"openssh-server",
 			"openssl",
 			"ostree",
-			"passwd", "shadow-utils", // User configuration
+			"shadow-utils", // User configuration
 			"podman",
 			"rpm-ostree",
 			"selinux-policy-targeted",
@@ -248,6 +255,14 @@ func bootableContainerPackageSet(t *imageType) rpmmd.PackageSet {
 			"plymouth",         // for (datacenter/cloud oriented) servers, we want to see the details by default.  https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/HSMISZ3ETWQ4ETVLWZQJ55ARZT27AAV3/
 			"systemd-networkd", // we use NetworkManager
 		},
+	}
+
+	if common.VersionLessThan(t.arch.distro.osVersion, "40") {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"passwd", // provided by shadow-utils in F40+
+			},
+		})
 	}
 
 	switch t.Arch().Name() {
@@ -667,7 +682,6 @@ func iotSimplifiedInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 			"lvm2",
 			"mdadm",
 			"nss-softokn",
-			"passwd",
 			"policycoreutils",
 			"policycoreutils-python-utils",
 			"procps-ng",
@@ -678,6 +692,20 @@ func iotSimplifiedInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 			"util-linux",
 		},
 	})
+
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "40") {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"shadow-utils", // includes passwd
+			},
+		})
+	} else if common.VersionLessThan(t.arch.distro.osVersion, "40") {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"passwd",
+			},
+		})
+	}
 
 	return ps
 }


### PR DESCRIPTION
In Fedora 40+ `passwd` is now provided by `shadow-utils`  ( https://bodhi.fedoraproject.org/updates/FEDORA-2024-e07b775e4e )

`podman-plugins` is no longer included in the new release of [Podman 5](https://src.fedoraproject.org/rpms/podman/c/2ab1bb3d2d6b3e9df18449494a081fcbe8044d4c?branch=rawhide) (F40+ as well) .

This PR updates the affected package-sets. 



