### PR TITLE
fedora: anaconda cleanups

### DIFF
--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -356,11 +356,6 @@ func imageInstallerImage(workload workload.Workload,
 
 	distro := t.Arch().Distro()
 	if common.VersionGreaterThanOrEqual(distro.Releasever(), "39") {
-		img.AdditionalAnacondaModules = []string{
-			"org.fedoraproject.Anaconda.Modules.Security",
-			"org.fedoraproject.Anaconda.Modules.Timezone",
-			"org.fedoraproject.Anaconda.Modules.Localization",
-		}
 		if img.UnattendedKickstart {
 			// NOTE: this is not supported right now because the
 			// image-installer on Fedora isn't working when unattended.

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -364,8 +364,6 @@ func imageInstallerImage(workload workload.Workload,
 		img.AdditionalKernelOpts = []string{"inst.text", "inst.noninteractive"}
 	}
 
-	img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, "org.fedoraproject.Anaconda.Modules.Users")
-
 	img.Platform = t.platform
 	img.Workload = workload
 	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, customizations)

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -354,18 +354,16 @@ func imageInstallerImage(workload workload.Workload,
 		img.UnattendedKickstart = instCust.Unattended
 	}
 
-	distro := t.Arch().Distro()
-	if common.VersionGreaterThanOrEqual(distro.Releasever(), "39") {
-		if img.UnattendedKickstart {
-			// NOTE: this is not supported right now because the
-			// image-installer on Fedora isn't working when unattended.
-			// These options are probably necessary but could change.
-			// Unattended/non-interactive installations are better set to text
-			// time since they might be running headless and a UI is
-			// unnecessary.
-			img.AdditionalKernelOpts = []string{"inst.text", "inst.noninteractive"}
-		}
+	if img.UnattendedKickstart {
+		// NOTE: this is not supported right now because the
+		// image-installer on Fedora isn't working when unattended.
+		// These options are probably necessary but could change.
+		// Unattended/non-interactive installations are better set to text
+		// time since they might be running headless and a UI is
+		// unnecessary.
+		img.AdditionalKernelOpts = []string{"inst.text", "inst.noninteractive"}
 	}
+
 	img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, "org.fedoraproject.Anaconda.Modules.Users")
 
 	img.Platform = t.platform


### PR DESCRIPTION
I saw some of this code while removing the Fedora 37 version gates and code paths and revisited it today. Turns out we don't need any of it anymore to produce working `image-installer`s.