### PR TITLE
fedora: webui only on rawhide

### DIFF
--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -546,7 +546,7 @@ func liveInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 		},
 	}
 
-	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "41") {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, RAWHIDE) {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"anaconda-webui",
@@ -560,7 +560,7 @@ func liveInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 func imageInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 	ps := anacondaPackageSet(t)
 
-	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "41") {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, RAWHIDE) {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"anaconda-webui",

--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -546,7 +546,7 @@ func liveInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 		},
 	}
 
-	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "39") {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "41") {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"anaconda-webui",
@@ -560,7 +560,7 @@ func liveInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 func imageInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 	ps := anacondaPackageSet(t)
 
-	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "39") {
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "41") {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"anaconda-webui",

--- a/pkg/distro/fedora/version.go
+++ b/pkg/distro/fedora/version.go
@@ -1,0 +1,3 @@
+package fedora
+
+const RAWHIDE = "41"


### PR DESCRIPTION
The webui for Fedora has been delayed until Fedora 41, current rawhide. Let our version gates reflect that.