### PR TITLE
Allow ISO labels to be predefined instead of templated

### DIFF
--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -326,7 +326,7 @@ func liveInstallerImage(workload workload.Workload,
 
 	d := t.arch.distro
 
-	img.ISOLabelTempl = d.isolabelTmpl
+	img.ISOLabelTmpl = d.isolabelTmpl
 	img.Product = d.product
 	img.OSName = "fedora"
 	img.OSVersion = d.osVersion
@@ -375,7 +375,7 @@ func imageInstallerImage(workload workload.Workload,
 
 	d := t.arch.distro
 
-	img.ISOLabelTempl = d.isolabelTmpl
+	img.ISOLabelTmpl = d.isolabelTmpl
 	img.Product = d.product
 	img.OSName = "fedora"
 	img.OSVersion = d.osVersion
@@ -537,7 +537,7 @@ func iotInstallerImage(workload workload.Workload,
 
 	img.SquashfsCompression = "lz4"
 
-	img.ISOLabelTempl = d.isolabelTmpl
+	img.ISOLabelTmpl = d.isolabelTmpl
 	img.Product = d.product
 	img.Variant = "IoT"
 	img.OSName = "fedora-iot"
@@ -694,7 +694,7 @@ func iotSimplifiedInstallerImage(workload workload.Workload,
 	}
 
 	d := t.arch.distro
-	img.ISOLabelTempl = d.isolabelTmpl
+	img.ISOLabelTmpl = d.isolabelTmpl
 	img.Product = d.product
 	img.Variant = "iot"
 	img.OSName = "fedora"

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -696,7 +696,7 @@ func iotSimplifiedInstallerImage(workload workload.Workload,
 	d := t.arch.distro
 	img.ISOLabelTmpl = d.isolabelTmpl
 	img.Product = d.product
-	img.Variant = "iot"
+	img.Variant = "IoT"
 	img.OSName = "fedora"
 	img.OSVersion = d.osVersion
 

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -344,7 +344,7 @@ func imageInstallerImage(workload workload.Workload,
 
 	d := t.arch.distro
 
-	img.ISOLabelTempl = d.isolabelTmpl
+	img.ISOLabelTmpl = d.isolabelTmpl
 	img.Product = d.product
 	img.OSName = "redhat"
 	img.OSVersion = d.osVersion
@@ -461,7 +461,7 @@ func edgeInstallerImage(workload workload.Workload,
 		img.AdditionalAnacondaModules = []string{"org.fedoraproject.Anaconda.Modules.Users"}
 	}
 
-	img.ISOLabelTempl = d.isolabelTmpl
+	img.ISOLabelTmpl = d.isolabelTmpl
 	img.Product = d.product
 	img.Variant = "edge"
 	img.OSName = "rhel"
@@ -586,7 +586,7 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 	}
 
 	d := t.arch.distro
-	img.ISOLabelTempl = d.isolabelTmpl
+	img.ISOLabelTmpl = d.isolabelTmpl
 	img.Product = d.product
 	img.Variant = "edge"
 	img.OSName = "redhat"

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -414,7 +414,7 @@ func edgeInstallerImage(workload workload.Workload,
 		img.AdditionalAnacondaModules = []string{"org.fedoraproject.Anaconda.Modules.Users"}
 	}
 
-	img.ISOLabelTempl = d.isolabelTmpl
+	img.ISOLabelTmpl = d.isolabelTmpl
 	img.Product = d.product
 	img.Variant = "edge"
 	img.OSName = "rhel"
@@ -571,7 +571,7 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 	}
 
 	d := t.arch.distro
-	img.ISOLabelTempl = d.isolabelTmpl
+	img.ISOLabelTmpl = d.isolabelTmpl
 	img.Product = d.product
 	img.Variant = "edge"
 	img.OSName = "redhat"
@@ -618,7 +618,7 @@ func imageInstallerImage(workload workload.Workload,
 
 	d := t.arch.distro
 
-	img.ISOLabelTempl = d.isolabelTmpl
+	img.ISOLabelTmpl = d.isolabelTmpl
 	img.Product = d.product
 	img.OSName = "redhat"
 	img.OSVersion = d.osVersion

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -25,6 +25,7 @@ type AnacondaContainerInstaller struct {
 
 	SquashfsCompression string
 
+	ISOLabel     string
 	ISOLabelTmpl string
 	Product      string
 	Variant      string
@@ -89,8 +90,14 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	}
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers
 
-	// TODO: replace isoLabelTmpl with more high-level properties
-	isoLabel := fmt.Sprintf(img.ISOLabelTmpl, img.Platform.GetArch())
+	var isoLabel string
+
+	if len(img.ISOLabel) > 0 {
+		isoLabel = img.ISOLabel
+	} else {
+		// TODO: replace isoLabelTmpl with more high-level properties
+		isoLabel = fmt.Sprintf(img.ISOLabelTmpl, img.Platform.GetArch())
+	}
 
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)
 	rootfsImagePipeline.Size = 4 * common.GibiByte

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -25,13 +25,13 @@ type AnacondaContainerInstaller struct {
 
 	SquashfsCompression string
 
-	ISOLabelTempl string
-	Product       string
-	Variant       string
-	OSName        string
-	Ref           string
-	OSVersion     string
-	Release       string
+	ISOLabelTmpl string
+	Product      string
+	Variant      string
+	OSName       string
+	Ref          string
+	OSVersion    string
+	Release      string
 
 	ContainerSource container.SourceSpec
 
@@ -90,7 +90,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers
 
 	// TODO: replace isoLabelTmpl with more high-level properties
-	isoLabel := fmt.Sprintf(img.ISOLabelTempl, img.Platform.GetArch())
+	isoLabel := fmt.Sprintf(img.ISOLabelTmpl, img.Platform.GetArch())
 
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)
 	rootfsImagePipeline.Size = 4 * common.GibiByte

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -23,6 +23,7 @@ type AnacondaLiveInstaller struct {
 
 	ExtraBasePackages rpmmd.PackageSet
 
+	ISOLabel     string
 	ISOLabelTmpl string
 	Product      string
 	Variant      string
@@ -66,8 +67,14 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	livePipeline.Checkpoint()
 
-	// TODO: replace isoLabelTmpl with more high-level properties
-	isoLabel := fmt.Sprintf(img.ISOLabelTmpl, img.Platform.GetArch())
+	var isoLabel string
+
+	if len(img.ISOLabel) > 0 {
+		isoLabel = img.ISOLabel
+	} else {
+		// TODO: replace isoLabelTmpl with more high-level properties
+		isoLabel = fmt.Sprintf(img.ISOLabelTmpl, img.Platform.GetArch())
+	}
 
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, livePipeline)
 	rootfsImagePipeline.Size = 8 * common.GibiByte

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -23,12 +23,12 @@ type AnacondaLiveInstaller struct {
 
 	ExtraBasePackages rpmmd.PackageSet
 
-	ISOLabelTempl string
-	Product       string
-	Variant       string
-	OSName        string
-	OSVersion     string
-	Release       string
+	ISOLabelTmpl string
+	Product      string
+	Variant      string
+	OSName       string
+	OSVersion    string
+	Release      string
 
 	Filename string
 
@@ -67,7 +67,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	livePipeline.Checkpoint()
 
 	// TODO: replace isoLabelTmpl with more high-level properties
-	isoLabel := fmt.Sprintf(img.ISOLabelTempl, img.Platform.GetArch())
+	isoLabel := fmt.Sprintf(img.ISOLabelTmpl, img.Platform.GetArch())
 
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, livePipeline)
 	rootfsImagePipeline.Size = 8 * common.GibiByte

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -35,6 +35,7 @@ type AnacondaOSTreeInstaller struct {
 
 	SquashfsCompression string
 
+	ISOLabel     string
 	ISOLabelTmpl string
 	Product      string
 	Variant      string
@@ -94,8 +95,14 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	}
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers
 
-	// TODO: replace isoLabelTmpl with more high-level properties
-	isoLabel := fmt.Sprintf(img.ISOLabelTmpl, img.Platform.GetArch())
+	var isoLabel string
+
+	if len(img.ISOLabel) > 0 {
+		isoLabel = img.ISOLabel
+	} else {
+		// TODO: replace isoLabelTmpl with more high-level properties
+		isoLabel = fmt.Sprintf(img.ISOLabelTmpl, img.Platform.GetArch())
+	}
 
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)
 	rootfsImagePipeline.Size = 4 * common.GibiByte

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -35,13 +35,13 @@ type AnacondaOSTreeInstaller struct {
 
 	SquashfsCompression string
 
-	ISOLabelTempl string
-	Product       string
-	Variant       string
-	OSName        string
-	OSVersion     string
-	Release       string
-	Remote        string
+	ISOLabelTmpl string
+	Product      string
+	Variant      string
+	OSName       string
+	OSVersion    string
+	Release      string
+	Remote       string
 
 	Commit ostree.SourceSpec
 
@@ -95,7 +95,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers
 
 	// TODO: replace isoLabelTmpl with more high-level properties
-	isoLabel := fmt.Sprintf(img.ISOLabelTempl, img.Platform.GetArch())
+	isoLabel := fmt.Sprintf(img.ISOLabelTmpl, img.Platform.GetArch())
 
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)
 	rootfsImagePipeline.Size = 4 * common.GibiByte

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -66,12 +66,12 @@ type AnacondaTarInstaller struct {
 
 	SquashfsCompression string
 
-	ISOLabelTempl string
-	Product       string
-	Variant       string
-	OSName        string
-	OSVersion     string
-	Release       string
+	ISOLabelTmpl string
+	Product      string
+	Variant      string
+	OSName       string
+	OSVersion    string
+	Release      string
 
 	Filename string
 
@@ -137,7 +137,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline.Checkpoint()
 
 	// TODO: replace isoLabelTmpl with more high-level properties
-	isoLabel := fmt.Sprintf(img.ISOLabelTempl, img.Platform.GetArch())
+	isoLabel := fmt.Sprintf(img.ISOLabelTmpl, img.Platform.GetArch())
 
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)
 	rootfsImagePipeline.Size = 5 * common.GibiByte

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -66,6 +66,7 @@ type AnacondaTarInstaller struct {
 
 	SquashfsCompression string
 
+	ISOLabel     string
 	ISOLabelTmpl string
 	Product      string
 	Variant      string
@@ -136,8 +137,14 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	anacondaPipeline.Checkpoint()
 
-	// TODO: replace isoLabelTmpl with more high-level properties
-	isoLabel := fmt.Sprintf(img.ISOLabelTmpl, img.Platform.GetArch())
+	var isoLabel string
+
+	if len(img.ISOLabel) > 0 {
+		isoLabel = img.ISOLabel
+	} else {
+		// TODO: replace isoLabelTmpl with more high-level properties
+		isoLabel = fmt.Sprintf(img.ISOLabelTmpl, img.Platform.GetArch())
+	}
 
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)
 	rootfsImagePipeline.Size = 5 * common.GibiByte

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -30,7 +30,7 @@ type OSTreeSimplifiedInstaller struct {
 	ExtraBasePackages rpmmd.PackageSet
 
 	// ISO label template (architecture-free)
-	ISOLabelTempl string
+	ISOLabelTmpl string
 
 	// Product string for ISO buildstamp
 	Product string
@@ -97,7 +97,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	coiPipeline.Variant = img.Variant
 	coiPipeline.AdditionalDracutModules = img.AdditionalDracutModules
 
-	isoLabel := fmt.Sprintf(img.ISOLabelTempl, img.Platform.GetArch())
+	isoLabel := fmt.Sprintf(img.ISOLabelTmpl, img.Platform.GetArch())
 
 	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
 	bootTreePipeline.Platform = img.Platform

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -29,6 +29,8 @@ type OSTreeSimplifiedInstaller struct {
 
 	ExtraBasePackages rpmmd.PackageSet
 
+	ISOLabel string
+
 	// ISO label template (architecture-free)
 	ISOLabelTmpl string
 
@@ -97,7 +99,14 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	coiPipeline.Variant = img.Variant
 	coiPipeline.AdditionalDracutModules = img.AdditionalDracutModules
 
-	isoLabel := fmt.Sprintf(img.ISOLabelTmpl, img.Platform.GetArch())
+	var isoLabel string
+
+	if len(img.ISOLabel) > 0 {
+		isoLabel = img.ISOLabel
+	} else {
+		// TODO: replace isoLabelTmpl with more high-level properties
+		isoLabel = fmt.Sprintf(img.ISOLabelTmpl, img.Platform.GetArch())
+	}
 
 	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
 	bootTreePipeline.Platform = img.Platform


### PR DESCRIPTION
Sometimes templating ISO labels is a bit of a chore, they are different between multiple distributions. This PR allows for a new property on installer pipelines to set a non-templated ISO label.

This allows us to move up the generation of the ISO label thus allowing us to override it per image type without being dependent on whatever is already in the format string and the `fmt.Sprintf` call later on.

I also considered using `text/template` here but it was a bit wild. In the future we might want to move all ISO label generation into the specific distro packages and remove the `ISOLabelTmpl` from installer pipelines entirely as it's harder to share.