### PR TITLE
Simplify GitHub > GitLab trigger workflow

### DIFF
--- a/.github/workflows/gitlab-helper.yml
+++ b/.github/workflows/gitlab-helper.yml
@@ -1,7 +1,9 @@
+# This workflow runs on PRs and the merge queue and is only responsible for
+# starting the "Start GitLab CI" workflow in a way that makes it possible to
+# use secrets.
+---
 name: GitLab
 
-# NOTE(mhayden): Restricting branches prevents jobs from being doubled since
-# a push to a pull request triggers two events.
 on:
   pull_request:
     branches:

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -55,31 +55,7 @@ jobs:
             git checkout ${{ github.event.workflow_run.head_branch }}
           fi
 
-      - name: Download artifacts
-        uses: actions/github-script@v7
-        with:
-          script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "PR_STATUS"
-            })[0];
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            let fs = require('fs');
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/PR_STATUS.zip`, Buffer.from(download.data));
-
-      - name: Unzip artifact
-        run: unzip PR_STATUS.zip
-
-      - name: Push to gitlab
+      - name: Push to GitLab
         run: |
           mkdir -p ~/.ssh
           echo "${IMAGEBUILDER_BOT_GITLAB_SSH_KEY}" > ~/.ssh/id_rsa
@@ -87,9 +63,4 @@ jobs:
           touch ~/.ssh/known_hosts
           ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
           git remote add ci git@gitlab.com:redhat/services/products/image-builder/ci/images.git
-          SKIP_CI=$(cat SKIP_CI.txt)
-          if [[ "${SKIP_CI}" == true ]];then
-            git push -f -o ci.variable="SKIP_CI=true" ci
-          else
-            git push -f ci
-          fi
+          git push -f ci

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -46,13 +46,7 @@ jobs:
       - name: Checkout branch
         id: pr_data
         run: |
-          PR_DATA=$(mktemp)
-          # use uuid as a file terminator to avoid conflicts with data content
-          cat > "$PR_DATA" <<'a21b3e7f-d5eb-44a3-8be0-c2412851d2e6'
-          ${{ steps.fetch_pulls.outputs.data }}
-          a21b3e7f-d5eb-44a3-8be0-c2412851d2e6
-
-          PR=$(jq -rc '.[] | select(.head.sha | contains("${{ github.event.workflow_run.head_sha }}")) | select(.state | contains("open"))' "$PR_DATA" | jq -r .number)
+          PR=$(jq -rc '.[] | select(.head.sha | contains("${{ github.event.workflow_run.head_sha }}")) | select(.state | contains("open"))' <<< ${{ steps.fetch_pulls.outputs.data }} | jq -r .number)
           if [ ! -z "$PR" ]; then
             # Create branch named PR-<number> to push to GitLab
             echo "pr_branch=PR-$PR" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -1,5 +1,6 @@
-# inspired by rhinstaller/anaconda
-
+# This workflow runs on success of the GitLab workflow.
+# If we run it on PR or merge_group, then we can't use secrets.
+---
 name: Start GitLab CI
 
 on:
@@ -9,6 +10,7 @@ on:
 
 jobs:
   trigger-gitlab:
+    # this should never fail, but check it anyway in case we ever change it
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     env:
@@ -30,7 +32,10 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
-      - uses: octokit/request-action@v2.x
+      - name: Get open PRs
+        # Since this workflow doesn't run on a PR trigger, we need to find the
+        # PR number by querying the GH API and selecting on the commit ID
+        uses: octokit/request-action@v2.x
         id: fetch_pulls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -49,6 +54,7 @@ jobs:
 
           PR=$(jq -rc '.[] | select(.head.sha | contains("${{ github.event.workflow_run.head_sha }}")) | select(.state | contains("open"))' "$PR_DATA" | jq -r .number)
           if [ ! -z "$PR" ]; then
+            # Create branch named PR-<number> to push to GitLab
             echo "pr_branch=PR-$PR" >> "$GITHUB_OUTPUT"
             git checkout -b PR-$PR
           else
@@ -91,5 +97,5 @@ jobs:
           if [[ "${SKIP_CI}" == true ]];then
             git push -f -o ci.variable="SKIP_CI=true" ci
           else
-            git push -f ci 
+            git push -f ci
           fi


### PR DESCRIPTION
We never used the SKIP_CI logic in this repository.  We intend to ake the GitLab workflow a pretty much empty one that's just there to trigger the chain, but we first need to merge this change so it's in main while the PR that changes the trigger workflow runs.

A follow-up PR will drop the SKIP_CI upload artifact bits once this is merged.

Recreated after #493 from a branch on the main repository to get the new workflows running.

EDIT: That didn't work either: https://github.com/osbuild/images/actions/runs/8146383205/job/22264762905