### PR TITLE
Simplify GitHub > GitLab trigger workflow (part 2)

### DIFF
--- a/.github/workflows/gitlab-helper.yml
+++ b/.github/workflows/gitlab-helper.yml
@@ -15,13 +15,6 @@ jobs:
   gitlab-ci-helper:
     name: "Gitlab CI trigger helper"
     runs-on: ubuntu-latest
-    env:
-      SKIP_CI: ${{ (github.event.pull_request.draft == true || contains(github.event.pull_request.labels.*.name, 'WIP')) && !contains(github.event.pull_request.labels.*.name, 'WIP+test') }}
     steps:
-      - name: Write PR status
-        run: echo "$SKIP_CI" > SKIP_CI.txt
-      - name: Upload status
-        uses: actions/upload-artifact@v4
-        with:
-          name: PR_STATUS
-          path: SKIP_CI.txt
+      - name: Trigger
+        run: echo "GitLab trigger complete"

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -46,7 +46,13 @@ jobs:
       - name: Checkout branch
         id: pr_data
         run: |
-          PR=$(jq -rc '.[] | select(.head.sha | contains("${{ github.event.workflow_run.head_sha }}")) | select(.state | contains("open"))' <<< ${{ steps.fetch_pulls.outputs.data }} | jq -r .number)
+          PR_DATA=$(mktemp)
+          # use uuid as a file terminator to avoid conflicts with data content
+          cat > "$PR_DATA" <<'a21b3e7f-d5eb-44a3-8be0-c2412851d2e6'
+          ${{ steps.fetch_pulls.outputs.data }}
+          a21b3e7f-d5eb-44a3-8be0-c2412851d2e6
+
+          PR=$(jq -rc '.[] | select(.head.sha | contains("${{ github.event.workflow_run.head_sha }}")) | select(.state | contains("open"))' "$PR_DATA" | jq -r .number)
           if [ ! -z "$PR" ]; then
             # Create branch named PR-<number> to push to GitLab
             echo "pr_branch=PR-$PR" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Part 2 of #494.

**github: do nothing in GitLab workflow**

We never used the SKIP_CI logic in this repository.  Make the GitLab workflow a pretty-much-empty one that's just there to trigger the chain.