### PR TITLE
test: add bigiso test config (HMS-3710)

### DIFF
--- a/test/config-map.json
+++ b/test/config-map.json
@@ -214,6 +214,17 @@
       "iot-installer"
     ]
   },
+  "./configs/bigiso.json": {
+    "distros": [
+      "rhel-9.4"
+    ],
+    "arches": [
+      "x86_64"
+    ],
+    "image-types": [
+      "image-installer"
+    ]
+  },
   "./configs/unattended-iso.json": {
     "distros": [
       "rhel-*",

--- a/test/configs/bigiso.json
+++ b/test/configs/bigiso.json
@@ -1,0 +1,37 @@
+{
+  "name": "bigiso",
+  "blueprint": {
+    "packages": [
+      {
+        "name": "httpd",
+        "version": "*"
+      },
+      {
+        "name": "gnome-session",
+        "version": "*"
+      }
+    ],
+    "groups": [
+      {
+        "name": "Workstation"
+      }
+    ],
+    "customizations": {
+      "hostname": "custombase",
+      "user": [
+        {
+          "name": "admin",
+          "description": "admin",
+          "password": "$6$ismFu3TUg0KR8.kJ$rddx3JVWXVaPF06XHeS1QNV6D6U3vo8WN4mi/V2mKLZ9ZKsMUlIwLhU.WvxfT.5F1PqUrx8Y8DUr/a5iTJQlw.",
+          "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+          "home": "/home/admin",
+          "shell": "/usr/bin/bash",
+          "groups": [
+            "wheel",
+            "users"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Move the bigiso regression test from osbuild-composer to this repository [1].  The test makes sure that ISOs larger than 4 GiB are buildable (see [2] for original bug report).

[1] https://github.com/osbuild/osbuild-composer/pull/3988
[2] https://bugzilla.redhat.com/show_bug.cgi?id=2056451