### PR TITLE
fedora: add bootupd to iot-commit

### DIFF
--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -182,6 +182,12 @@ func iotCommitPackageSet(t *imageType) rpmmd.PackageSet {
 				"podman-plugins", // deprecated in podman 5
 			},
 		})
+	} else {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"bootupd", // added in F40+
+			},
+		})
 	}
 
 	return ps


### PR DESCRIPTION
This PR adds `bootupd` to the `iot-commit` package set in Fedora 40+. 