### PR TITLE
test: run oscap checks on images with oscap customizations (HMS-3710)

### DIFF
--- a/cmd/boot-aws/main.go
+++ b/cmd/boot-aws/main.go
@@ -358,7 +358,7 @@ func teardown(cmd *cobra.Command, args []string) {
 	fnerr = doTeardown(a, res)
 }
 
-func doRunExec(a *awscloud.AWS, filename string, flags *pflag.FlagSet, res *resources) error {
+func doRunExec(a *awscloud.AWS, command []string, flags *pflag.FlagSet, res *resources) error {
 	privKey, err := flags.GetString("ssh-privkey")
 	if err != nil {
 		return err
@@ -389,16 +389,42 @@ func doRunExec(a *awscloud.AWS, filename string, flags *pflag.FlagSet, res *reso
 		return err
 	}
 
-	// copy the executable without its path to the remote host
-	destination := filepath.Base(filename)
+	isFile := func(path string) bool {
+		fileInfo, err := os.Stat(path)
+		if err != nil {
+			// ignore error and assume it's not a path
+			return false
+		}
 
-	// copy the executable
-	if err := scpFile(ip, username, privKey, hostsfile, filename, destination); err != nil {
-		return err
+		// Check if it's a regular file
+		return fileInfo.Mode().IsRegular()
 	}
 
+	// copy every argument that is a file to the remote host (basename only)
+	// and construct remote command
+	// NOTE: this wont work with directories or with multiple args in different
+	// paths that share the same basename - it's very limited
+	remoteCommand := make([]string, len(command))
+	for idx := range command {
+		arg := command[idx]
+		if isFile(arg) {
+			// scp the file and add it to the remote command by its base name
+			remotePath := filepath.Base(arg)
+			remoteCommand[idx] = remotePath
+			if err := scpFile(ip, username, privKey, hostsfile, arg, remotePath); err != nil {
+				return err
+			}
+		} else {
+			// not a file: add the arg as is
+			remoteCommand[idx] = arg
+		}
+	}
+
+	// add ./ to first element for the executable
+	remoteCommand[0] = fmt.Sprintf("./%s", remoteCommand[0])
+
 	// run the executable
-	return sshRun(ip, username, privKey, hostsfile, fmt.Sprintf("./%s", destination))
+	return sshRun(ip, username, privKey, hostsfile, remoteCommand...)
 }
 
 func runExec(cmd *cobra.Command, args []string) {
@@ -406,7 +432,7 @@ func runExec(cmd *cobra.Command, args []string) {
 	defer func() { exitCheck(fnerr) }()
 	image := args[0]
 
-	executable := args[1]
+	command := args[1:]
 	flags := cmd.Flags()
 
 	a, fnerr := newClientFromArgs(flags)
@@ -428,7 +454,7 @@ func runExec(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	fnerr = doRunExec(a, executable, flags, res)
+	fnerr = doRunExec(a, command, flags, res)
 }
 
 func setupCLI() *cobra.Command {
@@ -493,9 +519,10 @@ func setupCLI() *cobra.Command {
 	rootCmd.AddCommand(teardownCmd)
 
 	runCmd := &cobra.Command{
-		Use:   "run <image> <executable>",
+		Use:   "run <image> <executable>...",
 		Short: "upload and boot an image, then upload the specified executable and run it on the remote host",
-		Args:  cobra.ExactArgs(2),
+		Long:  "upload and boot an image on AWS EC2, then upload the executable file specified by the second positional argument and execute it via SSH with the args on the command line",
+		Args:  cobra.MinimumNArgs(2),
 		Run:   runExec,
 	}
 	rootCmd.AddCommand(runCmd)

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -198,6 +198,22 @@
       "qcow2"
     ]
   },
+  "./configs/oscap-rhel8.json": {
+    "distros": [
+      "rhel-8.10"
+    ],
+    "image-types": [
+      "ami"
+    ]
+  },
+  "./configs/oscap-rhel9.json": {
+    "distros": [
+      "rhel-9.4"
+    ],
+    "image-types": [
+      "ami"
+    ]
+  },
   "./configs/ostree.json": {
     "image-types": [
       "edge-commit",

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -198,14 +198,6 @@
       "qcow2"
     ]
   },
-  "./configs/oscap-rhel8.json": {
-    "distros": [
-      "rhel-8.10"
-    ],
-    "image-types": [
-      "ami"
-    ]
-  },
   "./configs/oscap-rhel9.json": {
     "distros": [
       "rhel-9.4"

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -23,21 +23,6 @@
       "qcow2"
     ]
   },
-  "./configs/all-with-oscap.json": {
-    "distros": [
-      "rhel-9.1",
-      "rhel-9.2",
-      "rhel-8.7",
-      "rhel-8.8",
-      "rhel-8.9",
-      "centos-8",
-      "centos-9",
-      "fedora*"
-    ],
-    "image-types": [
-      "qcow2"
-    ]
-  },
   "./configs/disable-lm_sensors.json": {
     "distros": [
       "rhel-8.4"
@@ -192,6 +177,21 @@
   },
   "./configs/minimal.json": {
     "distros": [
+      "fedora*"
+    ],
+    "image-types": [
+      "qcow2"
+    ]
+  },
+  "./configs/oscap-generic.json": {
+    "distros": [
+      "rhel-9.1",
+      "rhel-9.2",
+      "rhel-8.7",
+      "rhel-8.8",
+      "rhel-8.9",
+      "centos-8",
+      "centos-9",
       "fedora*"
     ],
     "image-types": [

--- a/test/configs/oscap-generic.json
+++ b/test/configs/oscap-generic.json
@@ -1,5 +1,5 @@
 {
-  "name": "all-with-oscap",
+  "name": "oscap-generic",
   "blueprint": {
     "packages": [
       {

--- a/test/configs/oscap-rhel8.json
+++ b/test/configs/oscap-rhel8.json
@@ -1,0 +1,16 @@
+{
+  "name": "oscap-rhel8",
+  "blueprint": {
+    "customizations": {
+      "openscap": {
+        "profile_id": "xccdf_org.ssgproject.content_profile_cis",
+        "datastream": "/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml",
+        "tailoring": {
+          "unselected": [
+            "grub2_password"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/test/configs/oscap-rhel8.json
+++ b/test/configs/oscap-rhel8.json
@@ -1,6 +1,17 @@
 {
   "name": "oscap-rhel8",
   "blueprint": {
+    "packages": [
+      {
+        "name": "xmlstarlet"
+      },
+      {
+        "name": "openscap-utils"
+      },
+      {
+        "name": "jq"
+      }
+    ],
     "customizations": {
       "openscap": {
         "profile_id": "xccdf_org.ssgproject.content_profile_cis",

--- a/test/configs/oscap-rhel9.json
+++ b/test/configs/oscap-rhel9.json
@@ -1,0 +1,16 @@
+{
+  "name": "oscap-rhel9",
+  "blueprint": {
+    "customizations": {
+      "openscap": {
+        "profile_id": "xccdf_org.ssgproject.content_profile_cis",
+        "datastream": "/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml",
+        "tailoring": {
+          "unselected": [
+            "grub2_password"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/test/configs/oscap-rhel9.json
+++ b/test/configs/oscap-rhel9.json
@@ -1,6 +1,17 @@
 {
   "name": "oscap-rhel9",
   "blueprint": {
+    "packages": [
+      {
+        "name": "xmlstarlet"
+      },
+      {
+        "name": "openscap-utils"
+      },
+      {
+        "name": "jq"
+      }
+    ],
     "customizations": {
       "openscap": {
         "profile_id": "xccdf_org.ssgproject.content_profile_cis",

--- a/test/scripts/base-host-check.sh
+++ b/test/scripts/base-host-check.sh
@@ -32,6 +32,48 @@ running_wait() {
     done
 }
 
+get_oscap_score() {
+    config_file="$1"
+    baseline_score=0.8
+    echo "🔒 Running oscap scanner"
+    # NOTE: sudo works here without password because we test this only on ami
+    # initialised with cloud-init, which sets sudo NOPASSWD for the user
+    profile=$(jq -r .blueprint.customizations.openscap.profile_id "${config_file}")
+    datastream=$(jq -r .blueprint.customizations.openscap.datastream "${config_file}")
+    sudo oscap xccdf eval \
+        --results results.xml \
+        --profile "${profile}_osbuild_tailoring" \
+        --tailoring-file "/usr/share/xml/osbuild-openscap-data/tailoring.xml" \
+        "${datastream}" || true # oscap returns exit code 2 for any failed rules
+
+    echo "📄 Saving results"
+
+    echo "📗 Checking oscap score"
+    hardened_score=$(xmlstarlet sel -N x="http://checklists.nist.gov/xccdf/1.2" -t -v "//x:score" results.xml)
+    echo "Hardened score: ${hardened_score}%"
+
+    echo "📗 Checking for failed rules"
+    severity=$(xmlstarlet sel -N x="http://checklists.nist.gov/xccdf/1.2" -t -v "//x:rule-result[@severity='high']" results.xml | grep -c "fail" || true)
+    echo "Severity count: ${severity}"
+
+    echo "🎏 Checking for test result"
+    echo "Baseline score: ${baseline_score}%"
+    echo "Hardened score: ${hardened_score}%"
+
+    # compare floating point numbers
+    if (( hardened_score < baseline_score )); then
+        echo "❌ Failed"
+        echo "Hardened image score (${hardened_score}) did not improve baseline score (${baseline_score})"
+        exit 1
+    fi
+
+    if (( severity > 0 )); then
+        echo "❌ Failed"
+        echo "One or more oscap rules with high severity failed"
+        exit 1
+    fi
+}
+
 echo "❓ Checking system status"
 if ! running_wait; then
 
@@ -56,3 +98,11 @@ uname -a
 
 echo "🕰️ uptime"
 uptime
+
+# NOTE: we should do a lot more here
+if (( $# > 0 )); then
+    config="$1"
+    if jq -e .blueprint.customizations.openscap "${config}"; then
+        get_oscap_score "${config}"
+    fi
+fi

--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -8,6 +8,8 @@ from tempfile import TemporaryDirectory
 
 import imgtestlib as testlib
 
+BASE_TEST_SCRIPT = "test/scripts/base-host-check.sh"
+
 
 def get_aws_config():
     return {
@@ -61,7 +63,8 @@ def ensure_uncompressed(filepath):
         yield filepath
 
 
-def cmd_boot_aws(arch, image_name, privkey, pubkey, image_path):
+def cmd_boot_aws(arch, image_name, privkey, pubkey, image_path, script_cmd):
+    # pylint: disable=too-many-arguments
     aws_config = get_aws_config()
     cmd = ["go", "run", "./cmd/boot-aws", "run",
            "--access-key-id", aws_config["key_id"],
@@ -74,16 +77,16 @@ def cmd_boot_aws(arch, image_name, privkey, pubkey, image_path):
            "--username", "osbuild",
            "--ssh-privkey", privkey,
            "--ssh-pubkey", pubkey,
-           image_path, "test/scripts/base-host-check.sh"]
+           image_path, *script_cmd]
     testlib.runcmd_nc(cmd)
 
 
 def boot_ami(distro, arch, image_type, image_path, config):
-    # TODO: use the config file to verify customizations in the image
+    cmd = [BASE_TEST_SCRIPT, config]
     with ensure_uncompressed(image_path) as raw_image_path:
         with create_ssh_key() as (privkey, pubkey):
             image_name = f"image-boot-test-{distro}-{arch}-{image_type}-" + str(uuid.uuid4())
-            cmd_boot_aws(arch, image_name, privkey, pubkey, raw_image_path)
+            cmd_boot_aws(arch, image_name, privkey, pubkey, raw_image_path, cmd)
 
 
 def boot_container(distro, arch, image_type, image_path, manifest_id):
@@ -142,7 +145,7 @@ def boot_container(distro, arch, image_type, image_path, manifest_id):
             # Build artifacts are owned by root. Make them world accessible.
             testlib.runcmd(["sudo", "chmod", "a+rwX", "-R", tmpdir])
             raw_image_path = f"{tmpdir}/image/disk.raw"
-            cmd_boot_aws(arch, image_name, privkey_file, pubkey_file, raw_image_path)
+            cmd_boot_aws(arch, image_name, privkey_file, pubkey_file, raw_image_path, [BASE_TEST_SCRIPT])
 
 
 def find_image_file(build_path: str) -> str:

--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -78,7 +78,8 @@ def cmd_boot_aws(arch, image_name, privkey, pubkey, image_path):
     testlib.runcmd_nc(cmd)
 
 
-def boot_ami(distro, arch, image_type, image_path):
+def boot_ami(distro, arch, image_type, image_path, config):
+    # TODO: use the config file to verify customizations in the image
     with ensure_uncompressed(image_path) as raw_image_path:
         with create_ssh_key() as (privkey, pubkey):
             image_name = f"image-boot-test-{distro}-{arch}-{image_type}-" + str(uuid.uuid4())
@@ -189,12 +190,14 @@ def main():
 
     image_path = find_image_file(search_path)
     build_info = read_build_info(search_path)
+    build_config_name = build_info["config"]
+    build_config_path = f"test/configs/{build_config_name}.json"
 
     print(f"Testing image at {image_path}")
     bib_image_id = ""
     match image_type:
         case "ami" | "ec2" | "ec2-ha" | "ec2-sap" | "edge-ami":
-            boot_ami(distro, arch, image_type, image_path)
+            boot_ami(distro, arch, image_type, image_path, build_config_path)
         case "iot-bootable-container":
             manifest_id = build_info["manifest-checksum"]
             boot_container(distro, arch, image_type, image_path, manifest_id)

--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -167,6 +167,12 @@ def find_image_file(build_path: str) -> str:
     return os.path.join(build_path, last_pipeline, files[0])
 
 
+def read_build_info(path):
+    info_file_path = os.path.join(path, "info.json")
+    with open(info_file_path, encoding="utf-8") as info_fp:
+        return json.load(info_fp)
+
+
 def main():
     desc = "Boot an image in the cloud environment it is built for and validate the configuration"
     parser = argparse.ArgumentParser(description=desc)
@@ -182,6 +188,7 @@ def main():
     search_path = args.image_search_path
 
     image_path = find_image_file(search_path)
+    build_info = read_build_info(search_path)
 
     print(f"Testing image at {image_path}")
     bib_image_id = ""
@@ -189,9 +196,6 @@ def main():
         case "ami" | "ec2" | "ec2-ha" | "ec2-sap" | "edge-ami":
             boot_ami(distro, arch, image_type, image_path)
         case "iot-bootable-container":
-            info_file_path = os.path.join(search_path, "info.json")
-            with open(info_file_path, encoding="utf-8") as info_fp:
-                build_info = json.load(info_fp)
             manifest_id = build_info["manifest-checksum"]
             boot_container(distro, arch, image_type, image_path, manifest_id)
             bib_ref = testlib.get_bib_ref()
@@ -204,12 +208,10 @@ def main():
     print("✅ Marking boot successful")
     # amend build info with boot success
     # search_path is the root of the build path (build/build_name)
-    info_file_path = os.path.join(search_path, "info.json")
-    with open(info_file_path, encoding="utf-8") as info_fp:
-        build_info = json.load(info_fp)
     build_info["boot-success"] = True
     if bib_image_id:
         build_info["bib-id"] = bib_image_id
+    info_file_path = os.path.join(search_path, "info.json")
     with open(info_file_path, "w", encoding="utf-8") as info_fp:
         json.dump(build_info, info_fp, indent=2)
 


### PR DESCRIPTION
Add oscap test configs for RHEL 8 and RHEL 9 with the appropriate datastream option enabled.
These replicate the test configs from the oscap test in osbuild-composer [1].

To fully replace the test in osbuild-composer, this PR also adds support for running the boot test script with the config file as argument.  When an oscap config is detected, it runs some extra checks on the score of the system.

_NOTE: This is a bit quick and dirty but should soon be replaced with a more comprehensive test of all customizations on images during boot_

[1] https://github.com/osbuild/osbuild-composer/blob/073e304978acade8bfa059f00a005402aa037c99/test/cases/oscap.sh