### PR TITLE
Disk image compress pipelines refactor

### DIFF
--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -58,17 +58,6 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 		Filename:    img.Filename,
 	}
 	imagePipeline := makeImagePipeline(img.Platform.GetImageFormat(), baseImage, hostPipeline, opts)
-
-	// todo: refactor
-	switch img.Compression {
-	case "xz":
-		compressedImage := manifest.NewXZ(buildPipeline, imagePipeline)
-		compressedImage.SetFilename(img.Filename)
-		return compressedImage.Export(), nil
-	case "":
-		imagePipeline.SetFilename(img.Filename)
-		return imagePipeline.Export(), nil
-	default:
-		panic(fmt.Sprintf("unsupported compression type %q on %q", img.Compression, img.name))
-	}
+	compressionPipeline := makeCompressionPipeline(img.Compression, img.Filename, imagePipeline, buildPipeline)
+	return compressionPipeline.Export(), nil
 }

--- a/pkg/image/bootc_disk_test.go
+++ b/pkg/image/bootc_disk_test.go
@@ -3,6 +3,7 @@ package image_test
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"math/rand"
 	"testing"
 
@@ -125,6 +126,22 @@ func TestBootcDiskImageInstantiateVmdk(t *testing.T) {
 
 	pipeline := findPipelineFromOsbuildManifest(t, osbuildManifest, "vmdk")
 	require.NotNil(t, pipeline)
+	// no build pipeline
+	assert.Equal(t, pipeline["build"], nil)
+}
+
+func TestBootcDiskImageInstantiateOva(t *testing.T) {
+	opts := &bootcDiskImageTestOpts{ImageFormat: platform.FORMAT_OVA}
+	osbuildManifest := makeBootcDiskImageOsbuildManifest(t, opts)
+
+	for _, piplName := range []string{"vmdk", "ovf", "archive"} {
+		t.Run(fmt.Sprintf("pipeline %v", piplName), func(t *testing.T) {
+			pipeline := findPipelineFromOsbuildManifest(t, osbuildManifest, piplName)
+			require.NotNil(t, pipeline)
+			// no build pipeline
+			assert.Equal(t, pipeline["build"], nil)
+		})
+	}
 }
 
 func TestBootcDiskImageUsesBootupd(t *testing.T) {

--- a/pkg/image/ostree_disk.go
+++ b/pkg/image/ostree_disk.go
@@ -143,16 +143,6 @@ func (img *OSTreeDiskImage) InstantiateManifest(m *manifest.Manifest,
 		Filename:    img.Filename,
 	}
 	imagePipeline := makeImagePipeline(img.Platform.GetImageFormat(), baseImage, buildPipeline, opts)
-
-	switch img.Compression {
-	case "xz":
-		compressedImage := manifest.NewXZ(buildPipeline, imagePipeline)
-		compressedImage.SetFilename(img.Filename)
-		return compressedImage.Export(), nil
-	case "":
-		imagePipeline.SetFilename(img.Filename)
-		return imagePipeline.Export(), nil
-	default:
-		panic(fmt.Sprintf("unsupported compression type %q on %q", img.Compression, img.name))
-	}
+	compressionPipeline := makeCompressionPipeline(img.Compression, img.Filename, imagePipeline, buildPipeline)
+	return compressionPipeline.Export(), nil
 }

--- a/pkg/manifest/vpc.go
+++ b/pkg/manifest/vpc.go
@@ -12,7 +12,7 @@ type VPC struct {
 
 	ForceSize *bool
 
-	imgPipeline *RawImage
+	imgPipeline FilePipeline
 }
 
 func (p VPC) Filename() string {
@@ -26,7 +26,7 @@ func (p *VPC) SetFilename(filename string) {
 // NewVPC createsa new Qemu pipeline. imgPipeline is the pipeline producing the
 // raw image. The pipeline name is the name of the new pipeline. Filename is the name
 // of the produced image.
-func NewVPC(buildPipeline Build, imgPipeline *RawImage) *VPC {
+func NewVPC(buildPipeline Build, imgPipeline FilePipeline) *VPC {
 	p := &VPC{
 		Base:        NewBase("vpc", buildPipeline),
 		imgPipeline: imgPipeline,

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -19,6 +19,8 @@ const ( // image format enum
 
 func (f ImageFormat) String() string {
 	switch f {
+	case FORMAT_UNSET:
+		return "unset"
 	case FORMAT_RAW:
 		return "raw"
 	case FORMAT_ISO:


### PR DESCRIPTION
Draft as a followup for https://github.com/osbuild/images/pull/504 - as a starting point for a discussion how to avoid duplicating the compression and image stages, they are extremely similar right now but also subtly different (like edge images set no ImageFormat right now). The individual commits also need some splitting and more tests