### PR TITLE
Support user-defined entries for sudo NOPASSWD

### DIFF
--- a/pkg/blueprint/installer_customizations.go
+++ b/pkg/blueprint/installer_customizations.go
@@ -1,6 +1,6 @@
 package blueprint
 
 type InstallerCustomization struct {
-	Unattended        bool `json:"unattended,omitempty" toml:"unattended,omitempty"`
-	WheelSudoNopasswd bool `json:"wheel-sudo-nopasswd,omitempty" toml:"wheel-sudo-nopasswd,omitempty"`
+	Unattended   bool     `json:"unattended,omitempty" toml:"unattended,omitempty"`
+	SudoNopasswd []string `json:"sudo-nopasswd,omitempty" toml:"sudo-nopasswd,omitempty"`
 }

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -353,7 +353,7 @@ func imageInstallerImage(workload workload.Workload,
 	img := image.NewAnacondaTarInstaller()
 
 	if instCust := customizations.GetInstaller(); instCust != nil {
-		img.WheelNoPasswd = instCust.WheelSudoNopasswd
+		img.NoPasswd = instCust.SudoNopasswd
 		img.UnattendedKickstart = instCust.Unattended
 	}
 
@@ -541,7 +541,7 @@ func iotInstallerImage(workload workload.Workload,
 	}
 
 	if instCust := customizations.GetInstaller(); instCust != nil {
-		img.WheelNoPasswd = instCust.WheelSudoNopasswd
+		img.NoPasswd = instCust.SudoNopasswd
 		img.UnattendedKickstart = instCust.Unattended
 	}
 

--- a/pkg/distro/rhel8/images.go
+++ b/pkg/distro/rhel8/images.go
@@ -333,7 +333,7 @@ func imageInstallerImage(workload workload.Workload,
 	img.AdditionalAnacondaModules = []string{"org.fedoraproject.Anaconda.Modules.Users"}
 
 	if instCust := customizations.GetInstaller(); instCust != nil {
-		img.WheelNoPasswd = instCust.WheelSudoNopasswd
+		img.NoPasswd = instCust.SudoNopasswd
 		img.UnattendedKickstart = instCust.Unattended
 	}
 
@@ -449,7 +449,7 @@ func edgeInstallerImage(workload workload.Workload,
 	img.Timezone, _ = customizations.GetTimezoneSettings()
 
 	if instCust := customizations.GetInstaller(); instCust != nil {
-		img.WheelNoPasswd = instCust.WheelSudoNopasswd
+		img.NoPasswd = instCust.SudoNopasswd
 		img.UnattendedKickstart = instCust.Unattended
 	}
 

--- a/pkg/distro/rhel9/images.go
+++ b/pkg/distro/rhel9/images.go
@@ -397,7 +397,7 @@ func edgeInstallerImage(workload workload.Workload,
 	img.Timezone, _ = customizations.GetTimezoneSettings()
 
 	if instCust := customizations.GetInstaller(); instCust != nil {
-		img.WheelNoPasswd = instCust.WheelSudoNopasswd
+		img.NoPasswd = instCust.SudoNopasswd
 		img.UnattendedKickstart = instCust.Unattended
 	}
 
@@ -607,7 +607,7 @@ func imageInstallerImage(workload workload.Workload,
 	img.AdditionalAnacondaModules = []string{"org.fedoraproject.Anaconda.Modules.Users"}
 
 	if instCust := customizations.GetInstaller(); instCust != nil {
-		img.WheelNoPasswd = instCust.WheelSudoNopasswd
+		img.NoPasswd = instCust.SudoNopasswd
 		img.UnattendedKickstart = instCust.Unattended
 	}
 

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -27,8 +27,9 @@ type AnacondaOSTreeInstaller struct {
 	Keyboard *string
 	Timezone *string
 
-	// Create a sudoers drop-in file for wheel group with NOPASSWD option
-	WheelNoPasswd bool
+	// Create a sudoers drop-in file for each user or group to enable the
+	// NOPASSWD option
+	NoPasswd []string
 
 	// Add kickstart options to make the installation fully unattended
 	UnattendedKickstart bool
@@ -128,7 +129,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.Remote = img.Remote
 	isoTreePipeline.Users = img.Users
 	isoTreePipeline.Groups = img.Groups
-	isoTreePipeline.WheelNoPasswd = img.WheelNoPasswd
+	isoTreePipeline.NoPasswd = img.NoPasswd
 	isoTreePipeline.UnattendedKickstart = img.UnattendedKickstart
 	isoTreePipeline.SquashfsCompression = img.SquashfsCompression
 	isoTreePipeline.Language = img.Language

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -56,8 +56,9 @@ type AnacondaTarInstaller struct {
 	// defaults.
 	ISORootKickstart bool
 
-	// Create a sudoers drop-in file for wheel group with NOPASSWD option
-	WheelNoPasswd bool
+	// Create a sudoers drop-in file for each user or group to enable the
+	// NOPASSWD option
+	NoPasswd []string
 
 	// Add kickstart options to make the installation fully unattended.
 	// Enabling this option also automatically enables the ISORootKickstart
@@ -193,7 +194,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 		isoTreePipeline.KSPath = kspath
 	}
 
-	isoTreePipeline.WheelNoPasswd = img.WheelNoPasswd
+	isoTreePipeline.NoPasswd = img.NoPasswd
 	isoTreePipeline.UnattendedKickstart = img.UnattendedKickstart
 	isoTreePipeline.SquashfsCompression = img.SquashfsCompression
 

--- a/pkg/manifest/anaconda_installer_iso_tree_test.go
+++ b/pkg/manifest/anaconda_installer_iso_tree_test.go
@@ -110,6 +110,9 @@ func checkRawKickstartFileStage(stages []*osbuild.Stage) bool {
 				panic("copy stage options conversion failed")
 			}
 			if options.Paths[0].To == "tree://"+testKsPath {
+				if options.Paths[0].From != "input://file-479a4230cf9f5e3c4b6f2e1c626d27096c00baf2d94eab96961660405d75877f/sha256:479a4230cf9f5e3c4b6f2e1c626d27096c00baf2d94eab96961660405d75877f" {
+					panic("content mismatch: " + options.Paths[0].From)
+				}
 				return true
 			}
 		}
@@ -258,7 +261,7 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 		pipeline.KSPath = testKsPath
 		pipeline.ISOLinux = true
 		pipeline.UnattendedKickstart = true
-		pipeline.WheelNoPasswd = true
+		pipeline.NoPasswd = []string{`%wheel`, `%sudo`}
 		pipeline.serializeStart(nil, nil, nil)
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
@@ -326,7 +329,7 @@ func TestAnacondaISOTreeSerializeWithOSTree(t *testing.T) {
 		pipeline.KSPath = testKsPath
 		pipeline.ISOLinux = true
 		pipeline.UnattendedKickstart = true
-		pipeline.WheelNoPasswd = true
+		pipeline.NoPasswd = []string{`%wheel`}
 		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()

--- a/pkg/manifest/anaconda_installer_iso_tree_test.go
+++ b/pkg/manifest/anaconda_installer_iso_tree_test.go
@@ -379,3 +379,23 @@ func TestAnacondaISOTreeSerializeWithContainer(t *testing.T) {
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux"), variantStages))
 	})
 }
+
+func TestMakeKickstartSudoersPostEmpty(t *testing.T) {
+	assert.Equal(t, "", makeKickstartSudoersPost(nil))
+}
+
+func TestMakeKickstartSudoersPost(t *testing.T) {
+	exp := `
+%post
+echo -e "%group31\tALL=(ALL)\tNOPASSWD: ALL" > "/etc/sudoers.d/%group31"
+chmod 0440 /etc/sudoers.d/%group31
+echo -e "user42\tALL=(ALL)\tNOPASSWD: ALL" > "/etc/sudoers.d/user42"
+chmod 0440 /etc/sudoers.d/user42
+restorecon -rvF /etc/sudoers.d
+%end
+`
+	assert.Equal(t, exp, makeKickstartSudoersPost([]string{"user42", "%group31"}))
+	assert.Equal(t, exp, makeKickstartSudoersPost([]string{"%group31", "user42"}))
+	assert.Equal(t, exp, makeKickstartSudoersPost([]string{"%group31", "user42", "%group31"}))
+	assert.Equal(t, exp, makeKickstartSudoersPost([]string{"%group31", "user42", "%group31", "%group31", "user42", "%group31", "%group31", "user42", "%group31"}))
+}

--- a/test/configs/unattended-iso-edge.json
+++ b/test/configs/unattended-iso-edge.json
@@ -13,7 +13,9 @@
       ],
       "installer": {
         "unattended": true,
-        "wheel-sudo-nopasswd": true
+        "sudo-nopasswd": [
+          "%wheel"
+        ]
       }
     }
   },

--- a/test/configs/unattended-iso-iot.json
+++ b/test/configs/unattended-iso-iot.json
@@ -13,7 +13,9 @@
       ],
       "installer": {
         "unattended": true,
-        "wheel-sudo-nopasswd": true
+        "sudo-nopasswd": [
+          "%wheel"
+        ]
       }
     }
   },

--- a/test/configs/unattended-iso.json
+++ b/test/configs/unattended-iso.json
@@ -23,7 +23,8 @@
       "installer": {
         "unattended": true,
         "sudo-nopasswd": [
-          "%wheel"
+          "%wheel",
+          "%sudo"
         ]
       }
     }

--- a/test/configs/unattended-iso.json
+++ b/test/configs/unattended-iso.json
@@ -22,7 +22,9 @@
       },
       "installer": {
         "unattended": true,
-        "wheel-sudo-nopasswd": true
+        "sudo-nopasswd": [
+          "%wheel"
+        ]
       }
     }
   }


### PR DESCRIPTION
Replace the wheel-sudo-nopasswd (bool) installer customization with sudo-nopasswd ([]string).  Users can now specify a list of users or groups (groups must be prefixed with %).  For each element in the array, the kickstart file will create a file that enables sudo with NOPASSWD for that entry.  Each entry is added as a separate file in the sudoers.d drop-in directory.