### PR TITLE
platform: fix panic() when trying to print an unset ImageFormat

### DIFF
--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1,6 +1,8 @@
 package platform
 
 import (
+	"fmt"
+
 	"github.com/osbuild/images/pkg/arch"
 )
 
@@ -19,6 +21,8 @@ const ( // image format enum
 
 func (f ImageFormat) String() string {
 	switch f {
+	case FORMAT_UNSET:
+		return "unset"
 	case FORMAT_RAW:
 		return "raw"
 	case FORMAT_ISO:
@@ -34,7 +38,7 @@ func (f ImageFormat) String() string {
 	case FORMAT_OVA:
 		return "ova"
 	default:
-		panic("invalid image format")
+		panic(fmt.Errorf("unknown image format %d", f))
 	}
 }
 

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -1,0 +1,20 @@
+package platform_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/platform"
+)
+
+func TestImageFormatString(t *testing.T) {
+	assert.Equal(t, "unset", platform.FORMAT_UNSET.String())
+	assert.Equal(t, "ova", platform.FORMAT_OVA.String())
+}
+
+func TestImageFormatStringUnknown(t *testing.T) {
+	assert.PanicsWithError(t, "unknown image format 999", func() {
+		_ = platform.ImageFormat(999).String()
+	})
+}


### PR DESCRIPTION
During the development of the image pipeline refactor I noticed that the platform code will panic for unset image types. This is a bug and I added a small test to ensure it won't happen again.

[0] https://github.com/osbuild/images/pull/506