### PR TITLE
github: run unit tests on CentOS Stream 9 and 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,76 @@ jobs:
       - name: Send coverage to codecov.io
         run: bash <(curl -s https://codecov.io/bash)
 
+  unit-tests-c9s:
+    name: "🛃 Unit tests (CentOS Stream 9)"
+    runs-on: ubuntu-20.04
+    container:
+      image: quay.io/centos/centos:stream9
+    env:
+      GOFLAGS: "-tags=exclude_graphdriver_btrfs"
+
+    steps:
+      - name: Install dnf plugins
+        run: dnf -y install dnf-plugins-core
+
+      - name: Enable crb repo
+        run: dnf config-manager --set-enabled crb
+
+      - name: Install build and test dependencies
+        run: dnf -y install krb5-devel gcc git-core go gpgme-devel osbuild-depsolve-dnf device-mapper-devel
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Mark the working directory as safe for git
+        run: git config --global --add safe.directory "$(pwd)"
+
+      - name: Run unit tests
+        run: go test -race -covermode=atomic -coverprofile=coverage.txt -coverpkg=$(go list ./... | grep -v rpmmd/test$ | tr "\n" ",") ./...
+
+      - name: Run depsolver tests with force-dnf to make sure it's not skipped for any reason
+        run: go test -race ./pkg/dnfjson/... -force-dnf
+
+      - name: Send coverage to codecov.io
+        run: bash <(curl -s https://codecov.io/bash)
+
+  unit-tests-c8s:
+    name: "🛃 Unit tests (CentOS Stream 8)"
+    runs-on: ubuntu-20.04
+    container:
+      image: quay.io/centos/centos:stream8
+    env:
+      GOFLAGS: "-tags=exclude_graphdriver_btrfs"
+
+    steps:
+      - name: Install dnf plugins
+        run: dnf -y install dnf-plugins-core
+
+      - name: Enable powertools repo
+        run: dnf config-manager --set-enabled powertools
+
+      - name: Install build and test dependencies
+        run: dnf -y install krb5-devel gcc git-core go gpgme-devel osbuild-depsolve-dnf device-mapper-devel
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Mark the working directory as safe for git
+        run: git config --global --add safe.directory "$(pwd)"
+
+      - name: Run unit tests
+        run: go test -race -covermode=atomic -coverprofile=coverage.txt -coverpkg=$(go list ./... | grep -v rpmmd/test$ | tr "\n" ",") ./...
+
+      - name: Run depsolver tests with force-dnf to make sure it's not skipped for any reason
+        run: go test -race ./pkg/dnfjson/... -force-dnf
+
+      - name: Send coverage to codecov.io
+        run: bash <(curl -s https://codecov.io/bash)
+
   lint:
     name: "⌨ Lint"
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,13 +35,10 @@ jobs:
         run: git config --global --add safe.directory "$(pwd)"
 
       - name: Run unit tests
-        run: go test -race -covermode=atomic -coverprofile=coverage.txt -coverpkg=$(go list ./... | grep -v rpmmd/test$ | tr "\n" ",") ./...
+        run: go test -race  ./...
 
       - name: Run depsolver tests with force-dnf to make sure it's not skipped for any reason
         run: go test -race ./pkg/dnfjson/... -force-dnf
-
-      - name: Send coverage to codecov.io
-        run: bash <(curl -s https://codecov.io/bash)
 
   unit-tests-c9s:
     name: "🛃 Unit tests (CentOS Stream 9)"
@@ -70,13 +67,10 @@ jobs:
         run: git config --global --add safe.directory "$(pwd)"
 
       - name: Run unit tests
-        run: go test -race -covermode=atomic -coverprofile=coverage.txt -coverpkg=$(go list ./... | grep -v rpmmd/test$ | tr "\n" ",") ./...
+        run: go test -race  ./...
 
       - name: Run depsolver tests with force-dnf to make sure it's not skipped for any reason
         run: go test -race ./pkg/dnfjson/... -force-dnf
-
-      - name: Send coverage to codecov.io
-        run: bash <(curl -s https://codecov.io/bash)
 
   unit-tests-c8s:
     name: "🛃 Unit tests (CentOS Stream 8)"
@@ -105,13 +99,10 @@ jobs:
         run: git config --global --add safe.directory "$(pwd)"
 
       - name: Run unit tests
-        run: go test -race -covermode=atomic -coverprofile=coverage.txt -coverpkg=$(go list ./... | grep -v rpmmd/test$ | tr "\n" ",") ./...
+        run: go test -race  ./...
 
       - name: Run depsolver tests with force-dnf to make sure it's not skipped for any reason
         run: go test -race ./pkg/dnfjson/... -force-dnf
-
-      - name: Send coverage to codecov.io
-        run: bash <(curl -s https://codecov.io/bash)
 
   lint:
     name: "⌨ Lint"


### PR DESCRIPTION
Run unit tests on CentOS Stream 9 and 8.  This will catch scenarios where we use Go features or libraries not supported by those distributions.

I intend to mark these as required in the repo config when this PR is merged.