### PR TITLE
Generate the ALL-MANIFEST for bootc disk images

### DIFF
--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -46,9 +46,6 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 		// treat unset as raw for this check
 		imgFormat = platform.FORMAT_RAW
 	}
-	if imgFormat != platform.FORMAT_RAW && img.Compression != "" {
-		panic(fmt.Sprintf("no compression is allowed with %q format for %q", imgFormat, img.name))
-	}
 
 	// In the bootc flow, we reuse the host container context for tools;
 	// this is signified by passing nil to the below pipelines.
@@ -88,16 +85,6 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 		}
 		return tarPipeline.Export(), nil
 	}
-
-	switch img.Compression {
-	case "xz":
-		compressedImage := manifest.NewXZ(buildPipeline, baseImage)
-		compressedImage.SetFilename(img.Filename)
-		return compressedImage.Export(), nil
-	case "":
-		baseImage.SetFilename(img.Filename)
-		return baseImage.Export(), nil
-	default:
-		panic(fmt.Sprintf("unsupported compression type %q on %q", img.Compression, img.name))
-	}
+	baseImage.SetFilename(img.Filename)
+	return baseImage.Export(), nil
 }


### PR DESCRIPTION
The bootc-disk image manifest now always contains all pipelines needed to generate all image types.  This way we can build any combination of disk images depending on what we need to export without needing to conditionally add or remove pipelines.

The Platform no longer needs to be read, since we're generating all of the formats and the architecture depends on the source container.  However, the Platform is still required for specifying the boot mode (enabling or disabling BIOS boot).

The first return value of the InstantiateManifestFromContainers() function, the artifact, was not used and has been removed now.