### PR TITLE
Install minimal depenencies for the check-build-coverage job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ check-build-coverage:
   variables:
     PYTHONUNBUFFERED: 1
   script:
-    - ./test/scripts/install-dependencies
+    - dnf -y install awscli2 python3
     - ./test/scripts/check-build-coverage ./s3configs/
 
 finish:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,10 +42,6 @@ check-build-coverage:
   script:
     - ./test/scripts/install-dependencies
     - ./test/scripts/check-build-coverage ./s3configs/
-  cache:
-    key: testcache
-    paths:
-      - .cache/osbuild-images
 
 finish:
   stage: finish

--- a/test/scripts/configure-generators
+++ b/test/scripts/configure-generators
@@ -37,10 +37,6 @@ generate-build-config-{distro}-{arch}:
   artifacts:
     paths:
       - build-config.yml
-  cache:
-    key: testcache
-    paths:
-      - {cache}
 """
 
 TRIGGER_TEMPLATE = """
@@ -72,10 +68,6 @@ generate-ostree-build-config-{distro}-{arch}:
       - build-configs
   needs:
     - image-build-trigger-{distro}-{arch}
-  cache:
-    key: testcache
-    paths:
-      - {cache}
 """
 
 OSTREE_TRIGGER_TEMPLATE = """


### PR DESCRIPTION
The check-build-coverage script only needs python3 and the aws cli.
Speed up the job by avoiding installing all the dependencies.