### PR TITLE
anaconda: preview

### DIFF
--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -334,6 +334,7 @@ func liveInstallerImage(workload workload.Workload,
 	img.OSVersion = d.osVersion
 	img.Release = fmt.Sprintf("%s %s", d.product, d.osVersion)
 	img.ISOLabel = fmt.Sprintf(ISO_LABEL, img.Product, img.OSVersion, img.Variant, img.Platform.GetArch())
+	img.Preview = common.VersionGreaterThanOrEqual(img.OSVersion, VERSION_BRANCHED)
 
 	img.Filename = t.Filename()
 
@@ -390,6 +391,7 @@ func imageInstallerImage(workload workload.Workload,
 
 	// We don't know the variant of the OS pipeline being installed
 	img.ISOLabel = fmt.Sprintf(ISO_LABEL, img.Product, img.OSVersion, img.Variant, img.Platform.GetArch())
+	img.Preview = common.VersionGreaterThanOrEqual(img.OSVersion, VERSION_BRANCHED)
 
 	img.Filename = t.Filename()
 
@@ -554,6 +556,7 @@ func iotInstallerImage(workload workload.Workload,
 	img.OSVersion = d.osVersion
 	img.Release = fmt.Sprintf("%s %s", d.product, d.osVersion)
 	img.ISOLabel = fmt.Sprintf(ISO_LABEL, img.Product, img.OSVersion, img.Variant, img.Platform.GetArch())
+	img.Preview = common.VersionGreaterThanOrEqual(img.OSVersion, VERSION_BRANCHED)
 
 	img.Filename = t.Filename()
 

--- a/pkg/distro/fedora/version.go
+++ b/pkg/distro/fedora/version.go
@@ -1,3 +1,4 @@
 package fedora
 
+const VERSION_BRANCHED = "40"
 const VERSION_RAWHIDE = "41"

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -33,6 +33,7 @@ type AnacondaContainerInstaller struct {
 	Ref          string
 	OSVersion    string
 	Release      string
+	Preview      bool
 
 	ContainerSource container.SourceSpec
 
@@ -67,6 +68,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 		"kernel",
 		img.Product,
 		img.OSVersion,
+		img.Preview,
 	)
 
 	// This is only built with ELN for now

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -30,6 +30,7 @@ type AnacondaLiveInstaller struct {
 	OSName       string
 	OSVersion    string
 	Release      string
+	Preview      bool
 
 	Filename string
 
@@ -57,6 +58,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 		"kernel",
 		img.Product,
 		img.OSVersion,
+		img.Preview,
 	)
 
 	livePipeline.ExtraPackages = img.ExtraBasePackages.Include

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -43,6 +43,7 @@ type AnacondaOSTreeInstaller struct {
 	OSName       string
 	OSVersion    string
 	Release      string
+	Preview      bool
 	Remote       string
 
 	Commit ostree.SourceSpec
@@ -77,6 +78,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 		"kernel",
 		img.Product,
 		img.OSVersion,
+		img.Preview,
 	)
 	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include
 	anacondaPipeline.ExcludePackages = img.ExtraBasePackages.Exclude

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -74,6 +74,7 @@ type AnacondaTarInstaller struct {
 	OSName       string
 	OSVersion    string
 	Release      string
+	Preview      bool
 
 	Filename string
 
@@ -110,6 +111,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 		"kernel",
 		img.Product,
 		img.OSVersion,
+		img.Preview,
 	)
 
 	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -60,6 +60,7 @@ type AnacondaInstaller struct {
 	kernelVer    string
 	product      string
 	version      string
+	preview      bool
 
 	// Interactive defaults is a kickstart stage that can be provided, it
 	// will be written to /usr/share/anaconda/interactive-defaults
@@ -84,7 +85,8 @@ func NewAnacondaInstaller(installerType AnacondaInstallerType,
 	repos []rpmmd.RepoConfig,
 	kernelName,
 	product,
-	version string) *AnacondaInstaller {
+	version string,
+	preview bool) *AnacondaInstaller {
 	name := "anaconda-tree"
 	p := &AnacondaInstaller{
 		Base:       NewBase(name, buildPipeline),
@@ -94,6 +96,7 @@ func NewAnacondaInstaller(installerType AnacondaInstallerType,
 		kernelName: kernelName,
 		product:    product,
 		version:    version,
+		preview:    preview,
 	}
 	buildPipeline.addDependent(p)
 	return p
@@ -208,7 +211,7 @@ func (p *AnacondaInstaller) serialize() osbuild.Pipeline {
 		Product: p.product,
 		Variant: p.Variant,
 		Version: p.version,
-		Final:   true,
+		Final:   !p.preview,
 	}))
 	pipeline.AddStage(osbuild.NewLocaleStage(&osbuild.LocaleStageOptions{Language: "en_US.UTF-8"}))
 

--- a/pkg/manifest/anaconda_installer_iso_tree_test.go
+++ b/pkg/manifest/anaconda_installer_iso_tree_test.go
@@ -31,6 +31,8 @@ func newTestAnacondaISOTree() *AnacondaInstallerISOTree {
 	product := ""
 	osversion := ""
 
+	preview := false
+
 	anacondaPipeline := NewAnacondaInstaller(
 		AnacondaInstallerTypePayload,
 		build,
@@ -39,6 +41,7 @@ func newTestAnacondaISOTree() *AnacondaInstallerISOTree {
 		"kernel",
 		product,
 		osversion,
+		preview,
 	)
 	rootfsImagePipeline := NewISORootfsImg(build, anacondaPipeline)
 	bootTreePipeline := NewEFIBootTree(build, product, osversion)


### PR DESCRIPTION
Don't hardcode the `Final` value being passed to the buildstamp stage as reported in #515. We mark Anaconda based images as `Preview` which is inverted `Final`.

In other build systems this information comes from pungi which passes it on to koji which then writes it correctly into the image. I'd like for us to support the same but that would involve passing it down the API so let's start here with a small duplication of efforts.

I could be convinced to call the property `Final` instead so we don't deal with the inversion but it felt more natural to mark images as preview images than saying they're the "final" artifact.