### PR TITLE
test: replace bigiso test password with existing from qcow2

### DIFF
--- a/test/configs/bigiso.json
+++ b/test/configs/bigiso.json
@@ -22,7 +22,7 @@
         {
           "name": "admin",
           "description": "admin",
-          "password": "$6$ismFu3TUg0KR8.kJ$rddx3JVWXVaPF06XHeS1QNV6D6U3vo8WN4mi/V2mKLZ9ZKsMUlIwLhU.WvxfT.5F1PqUrx8Y8DUr/a5iTJQlw.",
+          "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
           "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
           "home": "/home/admin",
           "shell": "/usr/bin/bash",


### PR DESCRIPTION
Reuse the same test password we have for qcow2, which is already in gitleaks and wont get flagged.