### PR TITLE
test: temporarily disable boot testing bootable containers

### DIFF
--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -32,7 +32,7 @@ CAN_BOOT_TEST = [
     "ec2-ha",
     "ec2-sap",
     "edge-ami",
-    "iot-bootable-container",
+    # "iot-bootable-container",
 ]
 
 BIB_TYPES = [


### PR DESCRIPTION
Fixing the test can take a while and we want to unblock other PRs.