### PR TITLE
test: pin bootc-image-builder ref for testing bootable containers

### DIFF
--- a/.github/workflows/update-bootc-image-builder.yml
+++ b/.github/workflows/update-bootc-image-builder.yml
@@ -1,0 +1,41 @@
+# This action updates the bootc-image-builder ref in the Schutzfile
+---
+name: "Update bootc-image-builder ref"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every Sunday at 05:00
+    - cron: "0 5 * * 0"
+
+jobs:
+  update-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apt update
+        run: sudo apt update
+
+      - name: Install Dependencies
+        run: sudo apt install -y skopeo python3
+
+      - name: Update Schutzfile
+        run: ./test/scripts/update-schutzfile-bib
+
+      - name: Open PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.SCHUTZBOT_GH_TOKEN }}
+        run: |
+          git config user.name "schutzbot"
+          git config user.email "schutzbot@gmail.com"
+          branch="schutzfile-bib-$(date -I)"
+          git checkout -b "${branch}"
+          git add Schutzfile
+          git commit -m "schutzfile: Update bootc-image-builder ref"
+          git push https://"$GITHUB_TOKEN"@github.com/schutzbot/images.git
+          echo "Updating bootc-image-builder test container ref to latest"
+          gh pr create \
+            -t "Update bootc-image-builder ref to latest" \
+            -F "body" \
+            --repo "osbuild/images" \
+            --base "main" \
+            --head "schutzbot:${branch}"

--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "common": {
     "rngseed": 1,
     "bootc-image-builder": {
-      "ref": "quay.io/centos-bootc/bootc-image-builder:latest"
+      "ref": "quay.io/centos-bootc/bootc-image-builder@sha256:da4fcda5ae67df2f46859c8dc38c95caabc62cf0320abfbd7f8754caf3d83111"
     }
   },
   "fedora-39": {

--- a/Schutzfile
+++ b/Schutzfile
@@ -1,6 +1,9 @@
 {
   "common": {
-    "rngseed": 1
+    "rngseed": 1,
+    "bootc-image-builder": {
+      "ref": "quay.io/centos-bootc/bootc-image-builder:latest"
+    }
   },
   "fedora-39": {
     "dependencies": {

--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -129,7 +129,7 @@ def boot_container(distro, arch, image_type, image_path, manifest_id):
                    "--security-opt", "label=type:unconfined_t",
                    "-v", f"{tmpdir}:/output",
                    "-v", f"{config_file}:/config.json",
-                   testlib.BIB_REF,
+                   testlib.get_bib_ref(),
                    "--type=ami",
                    "--config=/config.json",
                    container_ref]
@@ -194,10 +194,8 @@ def main():
                 build_info = json.load(info_fp)
             manifest_id = build_info["manifest-checksum"]
             boot_container(distro, arch, image_type, image_path, manifest_id)
-            # get the image ID from the local store so we know it's the one we used in the test
-            # (in case the container in the registry was updated while we were testing)
-            bib_image_id = testlib.skopeo_inspect_id(f"containers-storage:{testlib.BIB_REF}",
-                                                     testlib.host_container_arch())
+            bib_ref = testlib.get_bib_ref()
+            bib_image_id = testlib.skopeo_inspect_id(f"docker://{bib_ref}", testlib.host_container_arch())
         case _:
             # skip
             print(f"{image_type} boot tests are not supported yet")

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -30,7 +30,7 @@ CAN_BOOT_TEST = [
     "ec2-ha",
     "ec2-sap",
     "edge-ami",
-    # "iot-bootable-container",
+    "iot-bootable-container",
 ]
 
 BIB_TYPES = [

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -479,7 +479,10 @@ def skopeo_inspect_id(image_name: str, arch: str) -> str:
         if arch != img_arch or img_ostype != "linux":
             continue
 
-        image_no_tag = ":".join(image_name.split(":")[:-1])
+        if "@" in image_name:
+            image_no_tag = image_name.split("@")[0]
+        else:
+            image_no_tag = ":".join(image_name.split(":")[:-1])
         manifest_digest = manifest["digest"]
         arch_image_name = f"{image_no_tag}@{manifest_digest}"
         # inspect the arch-specific manifest to get the image ID (config digest)

--- a/test/scripts/test_imgtestlib.py
+++ b/test/scripts/test_imgtestlib.py
@@ -50,6 +50,8 @@ def test_path_generators():
 
 test_container = "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
 
+manifest_list_digest = "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+
 # manifest IDs for
 #  registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:latest
 manifest_ids = {
@@ -70,6 +72,7 @@ def test_skopeo_inspect_id_manifest_list(arch):
     transport = "docker://"
     image_id = image_ids[arch]
     assert testlib.skopeo_inspect_id(f"{transport}{test_container}:latest", arch) == image_id
+    assert testlib.skopeo_inspect_id(f"{transport}{test_container}@{manifest_list_digest}", arch) == image_id
 
 
 @pytest.mark.parametrize("arch", TEST_ARCHES)

--- a/test/scripts/update-schutzfile-bib
+++ b/test/scripts/update-schutzfile-bib
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import hashlib
+import json
+
+import imgtestlib as testlib
+
+
+def main():
+    ref = "quay.io/centos-bootc/bootc-image-builder:latest"
+    cmd = ["skopeo", "inspect", "--raw", f"docker://{ref}"]
+    out, _ = testlib.runcmd(cmd)
+    data = json.loads(out)
+    if not testlib.is_manifest_list(data):
+        raise RuntimeError(f"{ref} is not a manifest list")
+
+    checksum = hashlib.sha256(out).hexdigest()
+    digest = "sha256:" + checksum
+    ref_no_tag = ":".join(ref.split(":")[:-1])
+    new_ref = f"{ref_no_tag}@{digest}"
+
+    with open(testlib.SCHUTZFILE, encoding="utf-8") as schutzfile:
+        data = json.load(schutzfile)
+
+    data["common"]["bootc-image-builder"]["ref"] = new_ref
+    with open(testlib.SCHUTZFILE, "w", encoding="utf-8") as schutzfile:
+        json.dump(data, schutzfile, indent=2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
After disabling bootable container boot tests in #526, let's fix them and re-enable.