### PR TITLE
Add /usr/local/{bin,sbin} to CustomFilesPolicies

### DIFF
--- a/pkg/policies/policies.go
+++ b/pkg/policies/policies.go
@@ -42,13 +42,15 @@ var CustomDirectoriesPolicies = pathpolicy.NewPathPolicies(map[string]pathpolicy
 
 // CustomFilesPolicies is a set of default policies for custom files
 var CustomFilesPolicies = pathpolicy.NewPathPolicies(map[string]pathpolicy.PathPolicy{
-	"/":           {Deny: true},
-	"/etc":        {},
-	"/root":       {},
-	"/etc/fstab":  {Deny: true},
-	"/etc/shadow": {Deny: true},
-	"/etc/passwd": {Deny: true},
-	"/etc/group":  {Deny: true},
+	"/":               {Deny: true},
+	"/etc":            {},
+	"/root":           {},
+	"/usr/local/bin":  {},
+	"/usr/local/sbin": {},
+	"/etc/fstab":      {Deny: true},
+	"/etc/shadow":     {Deny: true},
+	"/etc/passwd":     {Deny: true},
+	"/etc/group":      {Deny: true},
 })
 
 // MountpointPolicies for ostree


### PR DESCRIPTION
This pull request adds the paths /usr/local/bin and /var/local/bin to the CustomFilesPolicies in the policies.go file. This allows the specified directories to be accessed according to the defined policies.