### PR TITLE
fedora: minimal-raw: bump /boot to 1Gb

### DIFF
--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -190,7 +190,7 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 500 * common.MebiByte,
+				Size: 1 * common.GibiByte,
 				Type: disk.XBootLDRPartitionGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -237,7 +237,7 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 500 * common.MebiByte,
+				Size: 1 * common.GibiByte,
 				Type: "83",
 				Payload: &disk.Filesystem{
 					Type:         "ext4",


### PR DESCRIPTION
The default package set includes the dracut plugin to create a rescue image which is quite large, with that and more than one kernel we run out of space so lets bump boot so we have more room to move.