### PR TITLE
github: update the BIB reference daily

### DIFF
--- a/.github/workflows/update-bootc-image-builder.yml
+++ b/.github/workflows/update-bootc-image-builder.yml
@@ -5,8 +5,8 @@ name: "Update bootc-image-builder ref"
 on:
   workflow_dispatch:
   schedule:
-    # Every Sunday at 05:00
-    - cron: "0 5 * * 0"
+    # Every day at 05:00
+    - cron: "0 5 * * *"
 
 jobs:
   update-and-push:


### PR DESCRIPTION
BIB changes fast and it's important to know when we break things, even though it's from the other side.  If it's a BIB bug, we can keep the PR unmerged until it's fixed, but it will still be good to know when it happens.