### PR TITLE
fedora: set grub2 timeout to 5 seconds

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -377,6 +377,10 @@ var (
 			// NOTE: temporary workaround for a bug in initial-setup that
 			// requires a kickstart file in the root directory.
 			Files: []*fsnode.File{initialSetupKickstart()},
+			Grub2Config: &osbuild.GRUB2Config{
+				// Overwrite the default Grub2 timeout value.
+				Timeout: 5,
+			},
 		},
 		rpmOstree:           false,
 		kernelOptions:       defaultKernelOptions,


### PR DESCRIPTION
The org.osbuild.grub2 stage has a default timeout of 0 seconds, but Fedora images set this value to 5 instead. Let's do the same for osbuild images.