### PR TITLE
dnfjson: support new osbuild-depsolve-dnf options for loading repositories from a root dir

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,16 +20,19 @@ jobs:
       image: registry.fedoraproject.org/fedora:latest
 
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up repository for pinned osbuild commit
+        run: ./test/scripts/setup-osbuild-repo
+
         # krb5-devel is needed to test internal/upload/koji package
         # gcc is needed to build the mock depsolver binary for the unit tests
         # gpgme-devel is needed for container upload dependencies
       - name: Install build and test dependencies
         run: dnf -y install krb5-devel gcc git-core go gpgme-devel osbuild-depsolve-dnf btrfs-progs-devel device-mapper-devel
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Mark the working directory as safe for git
         run: git config --global --add safe.directory "$(pwd)"
@@ -55,13 +58,16 @@ jobs:
       - name: Enable crb repo
         run: dnf config-manager --set-enabled crb
 
-      - name: Install build and test dependencies
-        run: dnf -y install krb5-devel gcc git-core go gpgme-devel osbuild-depsolve-dnf device-mapper-devel
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up repository for pinned osbuild commit
+        run: ./test/scripts/setup-osbuild-repo
+
+      - name: Install build and test dependencies
+        run: dnf -y install krb5-devel gcc git-core go gpgme-devel osbuild-depsolve-dnf device-mapper-devel
 
       - name: Mark the working directory as safe for git
         run: git config --global --add safe.directory "$(pwd)"
@@ -87,13 +93,18 @@ jobs:
       - name: Enable powertools repo
         run: dnf config-manager --set-enabled powertools
 
-      - name: Install build and test dependencies
-        run: dnf -y install krb5-devel gcc git-core go gpgme-devel osbuild-depsolve-dnf device-mapper-devel
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up repository for pinned osbuild commit
+        run: |
+          dnf -y install python3
+          ./test/scripts/setup-osbuild-repo
+
+      - name: Install build and test dependencies
+        run: dnf -y install krb5-devel gcc git-core go gpgme-devel osbuild-depsolve-dnf device-mapper-devel
 
       - name: Mark the working directory as safe for git
         run: git config --global --add safe.directory "$(pwd)"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2401,6 +2401,7 @@ generate-manifests-centos-10-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros centos-10 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2419,6 +2420,7 @@ generate-manifests-centos-10-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros centos-10 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2437,6 +2439,7 @@ generate-manifests-centos-8-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros centos-8 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2455,6 +2458,7 @@ generate-manifests-centos-9-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros centos-9 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2473,6 +2477,7 @@ generate-manifests-centos-9-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros centos-9 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2491,6 +2496,7 @@ generate-manifests-fedora-38-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros fedora-38 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2509,6 +2515,7 @@ generate-manifests-fedora-38-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros fedora-38 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2527,6 +2534,7 @@ generate-manifests-fedora-39-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros fedora-39 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2545,6 +2553,7 @@ generate-manifests-fedora-39-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros fedora-39 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2563,6 +2572,7 @@ generate-manifests-rhel-10.0-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros rhel-10.0 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2581,6 +2591,7 @@ generate-manifests-rhel-10.0-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros rhel-10.0 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2599,6 +2610,7 @@ generate-manifests-rhel-8.10-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros rhel-8.10 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2617,6 +2629,7 @@ generate-manifests-rhel-8.10-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros rhel-8.10 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2635,6 +2648,7 @@ generate-manifests-rhel-8.4-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros rhel-8.4 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2653,6 +2667,7 @@ generate-manifests-rhel-8.4-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros rhel-8.4 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2671,6 +2686,7 @@ generate-manifests-rhel-8.5-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros rhel-8.5 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2689,6 +2705,7 @@ generate-manifests-rhel-8.5-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros rhel-8.5 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2707,6 +2724,7 @@ generate-manifests-rhel-8.6-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros rhel-8.6 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2725,6 +2743,7 @@ generate-manifests-rhel-8.6-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros rhel-8.6 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2743,6 +2762,7 @@ generate-manifests-rhel-8.7-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros rhel-8.7 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2761,6 +2781,7 @@ generate-manifests-rhel-8.7-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros rhel-8.7 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2779,6 +2800,7 @@ generate-manifests-rhel-8.8-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros rhel-8.8 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2797,6 +2819,7 @@ generate-manifests-rhel-8.8-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros rhel-8.8 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2815,6 +2838,7 @@ generate-manifests-rhel-8.9-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros rhel-8.9 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2833,6 +2857,7 @@ generate-manifests-rhel-8.9-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros rhel-8.9 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2851,6 +2876,7 @@ generate-manifests-rhel-9.0-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros rhel-9.0 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2869,6 +2895,7 @@ generate-manifests-rhel-9.0-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros rhel-9.0 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2887,6 +2914,7 @@ generate-manifests-rhel-9.1-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros rhel-9.1 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2905,6 +2933,7 @@ generate-manifests-rhel-9.1-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros rhel-9.1 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2923,6 +2952,7 @@ generate-manifests-rhel-9.2-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros rhel-9.2 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2941,6 +2971,7 @@ generate-manifests-rhel-9.2-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros rhel-9.2 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2959,6 +2990,7 @@ generate-manifests-rhel-9.3-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros rhel-9.3 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2977,6 +3009,7 @@ generate-manifests-rhel-9.3-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros rhel-9.3 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -2995,6 +3028,7 @@ generate-manifests-rhel-9.4-ppc64le:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches ppc64le --distros rhel-9.4 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
@@ -3013,6 +3047,7 @@ generate-manifests-rhel-9.4-s390x:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros rhel-9.4 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do

--- a/Schutzfile
+++ b/Schutzfile
@@ -8,7 +8,7 @@
   "fedora-39": {
     "dependencies": {
       "osbuild": {
-        "commit": "6549bf1992b9731d52df5416584fab3f014a421f"
+        "commit": "f26e62b23f547fc5ad665cb08cc52e6431657779"
       }
     },
     "repos": [

--- a/Schutzfile
+++ b/Schutzfile
@@ -5,6 +5,20 @@
       "ref": "quay.io/centos-bootc/bootc-image-builder@sha256:3a75eeb703b4f8a711f43f37bafb2c3e84f5dd12b499c8146603f05be8cccabd"
     }
   },
+  "centos-8": {
+    "dependencies": {
+      "osbuild": {
+        "commit": "f26e62b23f547fc5ad665cb08cc52e6431657779"
+      }
+    }
+  },
+  "centos-9": {
+    "dependencies": {
+      "osbuild": {
+        "commit": "f26e62b23f547fc5ad665cb08cc52e6431657779"
+      }
+    }
+  },
   "fedora-39": {
     "dependencies": {
       "osbuild": {

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -154,11 +154,11 @@ func depsolve(cacheDir string, packageSets map[string][]rpmmd.PackageSet, d dist
 	solver := dnfjson.NewSolver(d.ModulePlatformID(), d.Releasever(), arch, d.Name(), cacheDir)
 	depsolvedSets := make(map[string][]rpmmd.PackageSpec)
 	for name, pkgSet := range packageSets {
-		res, err := solver.Depsolve(pkgSet)
+		pkgs, _, err := solver.Depsolve(pkgSet)
 		if err != nil {
 			return nil, err
 		}
-		depsolvedSets[name] = res
+		depsolvedSets[name] = pkgs
 	}
 	return depsolvedSets, nil
 }

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -105,7 +105,7 @@ func makeManifest(imgType distro.ImageType, config BuildConfig, distribution dis
 		return nil, fmt.Errorf("[ERROR] ostree commit resolution failed: %s\n", err.Error())
 	}
 
-	mf, err := manifest.Serialize(packageSpecs, containerSpecs, commitSpecs)
+	mf, err := manifest.Serialize(packageSpecs, containerSpecs, commitSpecs, nil)
 	if err != nil {
 		return nil, fmt.Errorf("[ERROR] manifest serialization failed: %s", err.Error())
 	}

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -382,11 +382,11 @@ func depsolve(cacheDir string, packageSets map[string][]rpmmd.PackageSet, d dist
 	solver := dnfjson.NewSolver(d.ModulePlatformID(), d.Releasever(), arch, d.Name(), cacheDir)
 	depsolvedSets := make(map[string][]rpmmd.PackageSpec)
 	for name, pkgSet := range packageSets {
-		res, err := solver.Depsolve(pkgSet)
+		packages, _, err := solver.Depsolve(pkgSet)
 		if err != nil {
 			return nil, err
 		}
-		depsolvedSets[name] = res
+		depsolvedSets[name] = packages
 	}
 	return depsolvedSets, nil
 }

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -276,7 +276,7 @@ func makeManifestJob(
 			commitSpecs = mockResolveCommits(manifest.GetOSTreeSourceSpecs())
 		}
 
-		mf, err := manifest.Serialize(packageSpecs, containerSpecs, commitSpecs)
+		mf, err := manifest.Serialize(packageSpecs, containerSpecs, commitSpecs, repoConfigs)
 		if err != nil {
 			return fmt.Errorf("[%s] manifest serialization failed: %s", filename, err.Error())
 		}

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -48,7 +48,7 @@ func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos
 		fmt.Fprintf(os.Stderr, "could not clean dnf cache: %s", err.Error())
 	}
 
-	bytes, err := manifest.Serialize(packageSpecs, nil, nil)
+	bytes, err := manifest.Serialize(packageSpecs, nil, nil, nil)
 	if err != nil {
 		panic("failed to serialize manifest: " + err.Error())
 	}

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -36,7 +36,7 @@ func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos
 
 	packageSpecs := make(map[string][]rpmmd.PackageSpec)
 	for name, chain := range manifest.GetPackageSetChains() {
-		packages, err := solver.Depsolve(chain)
+		packages, _, err := solver.Depsolve(chain)
 		if err != nil {
 			panic(fmt.Sprintf("failed to depsolve for pipeline %s: %s\n", name, err.Error()))
 		}

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -150,8 +150,10 @@ func TestImageTypePipelineNames(t *testing.T) {
 					}
 
 					packageSets := make(map[string][]rpmmd.PackageSpec, len(allPipelines))
+					repoSets := make(map[string][]rpmmd.RepoConfig, len(allPipelines))
 					for _, plName := range allPipelines {
 						packageSets[plName] = minimalPackageSet
+						repoSets[plName] = repos
 					}
 
 					m, _, err := imageType.Manifest(&bp, options, repos, seed)
@@ -172,7 +174,7 @@ func TestImageTypePipelineNames(t *testing.T) {
 						}
 						commits[name] = commitSpecs
 					}
-					mf, err := m.Serialize(packageSets, containers, commits)
+					mf, err := m.Serialize(packageSets, containers, commits, repoSets)
 					assert.NoError(err)
 					pm := new(manifest)
 					err = json.Unmarshal(mf, pm)

--- a/pkg/dnfjson/dnfjson.go
+++ b/pkg/dnfjson/dnfjson.go
@@ -187,12 +187,14 @@ func (s *Solver) Depsolve(pkgSets []rpmmd.PackageSet) ([]rpmmd.PackageSpec, erro
 	}
 	s.cache.updateInfo()
 
-	var result packageSpecs
-	if err := json.Unmarshal(output, &result); err != nil {
+	var result depsolveResult
+	dec := json.NewDecoder(bytes.NewReader(output))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&result); err != nil {
 		return nil, err
 	}
 
-	return result.toRPMMD(repoMap), nil
+	return result.Packages.toRPMMD(repoMap), nil
 }
 
 // FetchMetadata returns the list of all the available packages in repos and
@@ -591,6 +593,11 @@ type transactionArgs struct {
 }
 
 type packageSpecs []PackageSpec
+
+type depsolveResult struct {
+	Packages packageSpecs          `json:"packages"`
+	Repos    map[string]repoConfig `json:"repos"`
+}
 
 // Package specification
 type PackageSpec struct {

--- a/pkg/dnfjson/dnfjson.go
+++ b/pkg/dnfjson/dnfjson.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/rhsm"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -309,15 +310,15 @@ func (s *Solver) reposFromRPMMD(rpmRepos []rpmmd.RepoConfig) ([]repoConfig, erro
 		}
 
 		if rr.CheckGPG != nil {
-			dr.CheckGPG = *rr.CheckGPG
+			dr.GPGCheck = *rr.CheckGPG
 		}
 
 		if rr.CheckRepoGPG != nil {
-			dr.CheckRepoGPG = *rr.CheckRepoGPG
+			dr.RepoGPGCheck = *rr.CheckRepoGPG
 		}
 
 		if rr.IgnoreSSL != nil {
-			dr.IgnoreSSL = *rr.IgnoreSSL
+			dr.SSLVerify = common.ToPtr(!*rr.IgnoreSSL)
 		}
 
 		if rr.RHSM {
@@ -347,9 +348,9 @@ type repoConfig struct {
 	Metalink       string   `json:"metalink,omitempty"`
 	MirrorList     string   `json:"mirrorlist,omitempty"`
 	GPGKeys        []string `json:"gpgkeys,omitempty"`
-	CheckGPG       bool     `json:"gpgcheck"`
-	CheckRepoGPG   bool     `json:"check_repogpg"`
-	IgnoreSSL      bool     `json:"ignoressl"`
+	GPGCheck       bool     `json:"gpgcheck"`
+	RepoGPGCheck   bool     `json:"repo_gpgcheck"`
+	SSLVerify      *bool    `json:"sslverify,omitempty"`
 	SSLCACert      string   `json:"sslcacert,omitempty"`
 	SSLClientKey   string   `json:"sslclientkey,omitempty"`
 	SSLClientCert  string   `json:"sslclientcert,omitempty"`

--- a/pkg/dnfjson/dnfjson.go
+++ b/pkg/dnfjson/dnfjson.go
@@ -378,13 +378,11 @@ func (r *repoConfig) Hash() string {
 	return r.repoHash
 }
 
-// Helper function for creating a depsolve request payload.
-// The request defines a sequence of transactions, each depsolving one of the
-// elements of `pkgSets` in the order they appear.  The `repoConfigs` are used
-// as the base repositories for all transactions.  The extra repository configs
-// in `pkgsetsRepos` are used for each of the `pkgSets` with matching index.
-// The length of `pkgsetsRepos` must match the length of `pkgSets` or be empty
-// (nil or empty slice).
+// Helper function for creating a depsolve request payload. The request defines
+// a sequence of transactions, each depsolving one of the elements of `pkgSets`
+// in the order they appear. The repositories are collected in the request
+// arguments indexed by their ID, and each transaction lists the repositories
+// it will use for depsolving.
 //
 // NOTE: Due to implementation limitations of DNF and dnf-json, each package set
 // in the chain must use all of the repositories used by its predecessor.

--- a/pkg/dnfjson/dnfjson.go
+++ b/pkg/dnfjson/dnfjson.go
@@ -203,7 +203,7 @@ func (s *Solver) Depsolve(pkgSets []rpmmd.PackageSet) ([]rpmmd.PackageSpec, erro
 		return nil, err
 	}
 
-	return result.Packages.toRPMMD(repoMap), nil
+	return result.toRPMMD(repoMap), nil
 }
 
 // FetchMetadata returns the list of all the available packages in repos and
@@ -498,7 +498,8 @@ func (s *Solver) makeSearchRequest(repos []rpmmd.RepoConfig, packages []string) 
 
 // convert internal a list of PackageSpecs to the rpmmd equivalent and attach
 // key and subscription information based on the repository configs.
-func (pkgs packageSpecs) toRPMMD(repos map[string]rpmmd.RepoConfig) []rpmmd.PackageSpec {
+func (result depsolveResult) toRPMMD(repos map[string]rpmmd.RepoConfig) []rpmmd.PackageSpec {
+	pkgs := result.Packages
 	rpmDependencies := make([]rpmmd.PackageSpec, len(pkgs))
 	for i, dep := range pkgs {
 		repo, ok := repos[dep.RepoID]

--- a/pkg/dnfjson/dnfjson_test.go
+++ b/pkg/dnfjson/dnfjson_test.go
@@ -108,7 +108,7 @@ func TestDepsolver(t *testing.T) {
 			}
 
 			solver.SetRootDir(tc.rootDir)
-			deps, err := solver.Depsolve(pkgsets)
+			deps, _, err := solver.Depsolve(pkgsets)
 			assert.Equal(tc.err, err)
 			if err == nil {
 				exp := expectedResult(s.RepoConfig)
@@ -699,7 +699,7 @@ func TestErrorRepoInfo(t *testing.T) {
 	solver := NewSolver("f38", "38", "x86_64", "fedora-38", "/tmp/cache")
 	for idx, tc := range testCases {
 		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
-			_, err := solver.Depsolve([]rpmmd.PackageSet{
+			_, _, err := solver.Depsolve([]rpmmd.PackageSet{
 				{
 					Include:      []string{"osbuild"},
 					Exclude:      nil,

--- a/pkg/dnfjson/dnfjson_test.go
+++ b/pkg/dnfjson/dnfjson_test.go
@@ -699,5 +699,5 @@ func TestRepoConfigMarshalAlsmostEmpty(t *testing.T) {
 	repoCfg := &repoConfig{}
 	js, _ := json.Marshal(repoCfg)
 	// double check here that anything that uses pointers has "omitempty" set
-	assert.Equal(t, string(js), `{"id":"","gpgcheck":false,"check_repogpg":false,"ignoressl":false}`)
+	assert.Equal(t, string(js), `{"id":"","gpgcheck":false,"repo_gpgcheck":false}`)
 }

--- a/pkg/dnfjson/dnfjson_test.go
+++ b/pkg/dnfjson/dnfjson_test.go
@@ -44,6 +44,18 @@ func TestDepsolver(t *testing.T) {
 			packages: [][]string{{"kernel"}, {"vim-minimal", "tmux", "zsh"}},
 			err:      nil,
 		},
+		"bad-flat": {
+			packages: [][]string{{"this-package-does-not-exist"}},
+			err:      Error{Kind: "MarkingErrors", Reason: "Error occurred when marking packages for installation: Problems in request:\nmissing packages: this-package-does-not-exist"},
+		},
+		"bad-chain": {
+			packages: [][]string{{"kernel"}, {"this-package-does-not-exist"}},
+			err:      Error{Kind: "MarkingErrors", Reason: "Error occurred when marking packages for installation: Problems in request:\nmissing packages: this-package-does-not-exist"},
+		},
+		"bad-chain-part-deux": {
+			packages: [][]string{{"this-package-does-not-exist"}, {"vim-minimal", "tmux", "zsh"}},
+			err:      Error{Kind: "MarkingErrors", Reason: "Error occurred when marking packages for installation: Problems in request:\nmissing packages: this-package-does-not-exist"},
+		},
 	}
 
 	for tcName := range testCases {
@@ -57,8 +69,10 @@ func TestDepsolver(t *testing.T) {
 
 			deps, err := solver.Depsolve(pkgsets)
 			assert.Equal(tc.err, err)
-			exp := expectedResult(s.RepoConfig)
-			assert.Equal(deps, exp)
+			if err == nil {
+				exp := expectedResult(s.RepoConfig)
+				assert.Equal(deps, exp)
+			}
 		})
 	}
 }

--- a/pkg/image/bootc_disk_test.go
+++ b/pkg/image/bootc_disk_test.go
@@ -81,7 +81,7 @@ func makeBootcDiskImageOsbuildManifest(t *testing.T, opts *bootcDiskImageTestOpt
 		"image": []container.Spec{{Source: "other-src", Digest: makeFakeDigest(t), ImageID: makeFakeDigest(t)}},
 	}
 
-	osbuildManifest, err := m.Serialize(nil, fakeSourceSpecs, nil)
+	osbuildManifest, err := m.Serialize(nil, fakeSourceSpecs, nil, nil)
 	require.Nil(t, err)
 
 	return osbuildManifest

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -174,7 +174,7 @@ func (p *AnacondaInstaller) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *AnacondaInstaller) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec) {
+func (p *AnacondaInstaller) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
@@ -182,6 +182,7 @@ func (p *AnacondaInstaller) serializeStart(packages []rpmmd.PackageSpec, _ []con
 	if p.kernelName != "" {
 		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.kernelName)
 	}
+	p.repos = append(p.repos, rpmRepos...)
 }
 
 func (p *AnacondaInstaller) serializeEnd() {

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -156,7 +156,7 @@ func (p *AnacondaInstallerISOTree) getBuildPackages(_ Distro) []string {
 	return packages
 }
 
-func (p *AnacondaInstallerISOTree) serializeStart(_ []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec) {
+func (p *AnacondaInstallerISOTree) serializeStart(_ []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec, _ []rpmmd.RepoConfig) {
 	if p.ostreeCommitSpec != nil || p.containerSpec != nil {
 		panic("double call to serializeStart()")
 	}

--- a/pkg/manifest/anaconda_installer_iso_tree_test.go
+++ b/pkg/manifest/anaconda_installer_iso_tree_test.go
@@ -192,11 +192,11 @@ func TestAnacondaISOTreePayloadsBad(t *testing.T) {
 
 	assert.PanicsWithValue(
 		"pipeline supports at most one ostree commit",
-		func() { pipeline.serializeStart(nil, nil, make([]ostree.CommitSpec, 2)) },
+		func() { pipeline.serializeStart(nil, nil, make([]ostree.CommitSpec, 2), nil) },
 	)
 	assert.PanicsWithValue(
 		"pipeline supports at most one container",
-		func() { pipeline.serializeStart(nil, make([]container.Spec, 2), nil) },
+		func() { pipeline.serializeStart(nil, make([]container.Spec, 2), nil, nil) },
 	)
 }
 
@@ -216,7 +216,7 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 	t.Run("plain", func(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.OSPipeline = osPayload
-		pipeline.serializeStart(nil, nil, nil)
+		pipeline.serializeStart(nil, nil, nil, nil)
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, payloadStages,
@@ -229,7 +229,7 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.OSPipeline = osPayload
 		pipeline.KSPath = testKsPath
-		pipeline.serializeStart(nil, nil, nil)
+		pipeline.serializeStart(nil, nil, nil, nil)
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.kickstart"),
@@ -242,7 +242,7 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 		pipeline.OSPipeline = osPayload
 		pipeline.KSPath = testKsPath
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, nil, nil)
+		pipeline.serializeStart(nil, nil, nil, nil)
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux", "org.osbuild.kickstart"),
@@ -255,7 +255,7 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 		pipeline.KSPath = testKsPath
 		pipeline.ISOLinux = true
 		pipeline.UnattendedKickstart = true
-		pipeline.serializeStart(nil, nil, nil)
+		pipeline.serializeStart(nil, nil, nil, nil)
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux", "org.osbuild.kickstart"),
@@ -270,7 +270,7 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 		pipeline.ISOLinux = true
 		pipeline.UnattendedKickstart = true
 		pipeline.NoPasswd = []string{`%wheel`, `%sudo`}
-		pipeline.serializeStart(nil, nil, nil)
+		pipeline.serializeStart(nil, nil, nil, nil)
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux", "org.osbuild.kickstart"),
@@ -302,7 +302,7 @@ func TestAnacondaISOTreeSerializeWithOSTree(t *testing.T) {
 	t.Run("plain", func(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.KSPath = testKsPath
-		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit})
+		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit}, nil)
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, payloadStages,
@@ -314,7 +314,7 @@ func TestAnacondaISOTreeSerializeWithOSTree(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.KSPath = testKsPath
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit})
+		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit}, nil)
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux"), variantStages))
@@ -325,7 +325,7 @@ func TestAnacondaISOTreeSerializeWithOSTree(t *testing.T) {
 		pipeline.KSPath = testKsPath
 		pipeline.ISOLinux = true
 		pipeline.UnattendedKickstart = true
-		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit})
+		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit}, nil)
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux"), variantStages))
@@ -338,7 +338,7 @@ func TestAnacondaISOTreeSerializeWithOSTree(t *testing.T) {
 		pipeline.ISOLinux = true
 		pipeline.UnattendedKickstart = true
 		pipeline.NoPasswd = []string{`%wheel`, `%sudo`}
-		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit})
+		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit}, nil)
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux"), variantStages))
@@ -369,7 +369,7 @@ func TestAnacondaISOTreeSerializeWithContainer(t *testing.T) {
 	t.Run("kspath", func(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.KSPath = testKsPath
-		pipeline.serializeStart(nil, []container.Spec{containerPayload}, nil)
+		pipeline.serializeStart(nil, []container.Spec{containerPayload}, nil, nil)
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, payloadStages,
@@ -381,7 +381,7 @@ func TestAnacondaISOTreeSerializeWithContainer(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.KSPath = testKsPath
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, []container.Spec{containerPayload}, nil)
+		pipeline.serializeStart(nil, []container.Spec{containerPayload}, nil, nil)
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux"), variantStages))

--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -99,11 +99,12 @@ func (p *BuildrootFromPackages) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *BuildrootFromPackages) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec) {
+func (p *BuildrootFromPackages) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
 	p.packageSpecs = packages
+	p.repos = append(p.repos, rpmRepos...)
 }
 
 func (p *BuildrootFromPackages) serializeEnd() {
@@ -198,7 +199,7 @@ func (p *BuildrootFromContainer) getContainerSpecs() []container.Spec {
 	return p.containerSpecs
 }
 
-func (p *BuildrootFromContainer) serializeStart(_ []rpmmd.PackageSpec, containerSpecs []container.Spec, _ []ostree.CommitSpec) {
+func (p *BuildrootFromContainer) serializeStart(_ []rpmmd.PackageSpec, containerSpecs []container.Spec, _ []ostree.CommitSpec, _ []rpmmd.RepoConfig) {
 	if len(p.containerSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}

--- a/pkg/manifest/build_test.go
+++ b/pkg/manifest/build_test.go
@@ -109,7 +109,7 @@ func TestNewBuildFromContainerSpecs(t *testing.T) {
 	}
 	// containerSpecs is "nil" until serializeStart populates it
 	require.Nil(t, build.getContainerSpecs())
-	build.serializeStart(nil, fakeContainerSpecs, nil)
+	build.serializeStart(nil, fakeContainerSpecs, nil, nil)
 	assert.Equal(t, build.getContainerSpecs(), fakeContainerSpecs)
 
 	osbuildPipeline := build.serialize()

--- a/pkg/manifest/commit_server_tree.go
+++ b/pkg/manifest/commit_server_tree.go
@@ -80,11 +80,12 @@ func (p *OSTreeCommitServer) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *OSTreeCommitServer) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec) {
+func (p *OSTreeCommitServer) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
 	p.packageSpecs = packages
+	p.repos = append(p.repos, rpmRepos...)
 }
 
 func (p *OSTreeCommitServer) serializeEnd() {

--- a/pkg/manifest/coreos_installer.go
+++ b/pkg/manifest/coreos_installer.go
@@ -136,7 +136,7 @@ func (p *CoreOSInstaller) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *CoreOSInstaller) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec) {
+func (p *CoreOSInstaller) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
@@ -144,6 +144,7 @@ func (p *CoreOSInstaller) serializeStart(packages []rpmmd.PackageSpec, _ []conta
 	if p.kernelName != "" {
 		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.kernelName)
 	}
+	p.repos = append(p.repos, rpmRepos...)
 }
 
 func (p *CoreOSInstaller) getInline() []string {

--- a/pkg/manifest/empty.go
+++ b/pkg/manifest/empty.go
@@ -22,6 +22,8 @@ type ContentTest struct {
 	containerSpecs []container.Spec
 	commitSpecs    []ostree.CommitSpec
 
+	repos []rpmmd.RepoConfig
+
 	// serialization flag
 	serializing bool
 }
@@ -63,13 +65,14 @@ func (p *ContentTest) getOSTreeCommits() []ostree.CommitSpec {
 	return p.commitSpecs
 }
 
-func (p *ContentTest) serializeStart(pkgs []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec) {
+func (p *ContentTest) serializeStart(pkgs []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
 	if p.serializing {
 		panic("double call to serializeStart()")
 	}
 	p.packageSpecs = pkgs
 	p.containerSpecs = containers
 	p.commitSpecs = commits
+	p.repos = rpmRepos
 
 	p.serializing = true
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -138,14 +138,14 @@ func (m Manifest) GetOSTreeSourceSpecs() map[string][]ostree.SourceSpec {
 	return ostreeSpecs
 }
 
-func (m Manifest) Serialize(packageSets map[string][]rpmmd.PackageSpec, containerSpecs map[string][]container.Spec, ostreeCommits map[string][]ostree.CommitSpec) (OSBuildManifest, error) {
+func (m Manifest) Serialize(packageSets map[string][]rpmmd.PackageSpec, containerSpecs map[string][]container.Spec, ostreeCommits map[string][]ostree.CommitSpec, rpmRepos map[string][]rpmmd.RepoConfig) (OSBuildManifest, error) {
 	pipelines := make([]osbuild.Pipeline, 0)
 	packages := make([]rpmmd.PackageSpec, 0)
 	commits := make([]ostree.CommitSpec, 0)
 	inline := make([]string, 0)
 	containers := make([]container.Spec, 0)
 	for _, pipeline := range m.pipelines {
-		pipeline.serializeStart(packageSets[pipeline.Name()], containerSpecs[pipeline.Name()], ostreeCommits[pipeline.Name()])
+		pipeline.serializeStart(packageSets[pipeline.Name()], containerSpecs[pipeline.Name()], ostreeCommits[pipeline.Name()], rpmRepos[pipeline.Name()])
 	}
 	for _, pipeline := range m.pipelines {
 		commits = append(commits, pipeline.getOSTreeCommits()...)

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -338,7 +338,7 @@ func (p *OS) getContainerSpecs() []container.Spec {
 	return p.containerSpecs
 }
 
-func (p *OS) serializeStart(packages []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec) {
+func (p *OS) serializeStart(packages []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
@@ -355,6 +355,8 @@ func (p *OS) serializeStart(packages []rpmmd.PackageSpec, containers []container
 	if p.KernelName != "" {
 		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.KernelName)
 	}
+
+	p.repos = append(p.repos, rpmRepos...)
 }
 
 func (p *OS) serializeEnd() {

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -30,7 +30,7 @@ func NewTestOS() *OS {
 	packages := []rpmmd.PackageSpec{
 		{Name: "pkg1", Checksum: "sha1:c02524e2bd19490f2a7167958f792262754c5f46"},
 	}
-	os.serializeStart(packages, nil, nil)
+	os.serializeStart(packages, nil, nil, repos)
 
 	return os
 }

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -161,7 +161,7 @@ func (p *OSTreeDeployment) getContainerSources() []container.SourceSpec {
 	}
 }
 
-func (p *OSTreeDeployment) serializeStart(packages []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec) {
+func (p *OSTreeDeployment) serializeStart(_ []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec, _ []rpmmd.RepoConfig) {
 	if p.ostreeSpec != nil || p.containerSpec != nil {
 		panic("double call to serializeStart()")
 	}

--- a/pkg/manifest/pipeline.go
+++ b/pkg/manifest/pipeline.go
@@ -53,7 +53,7 @@ type Pipeline interface {
 	// its full Spec. See the ostree package for more details.
 	getOSTreeCommitSources() []ostree.SourceSpec
 
-	serializeStart([]rpmmd.PackageSpec, []container.Spec, []ostree.CommitSpec)
+	serializeStart([]rpmmd.PackageSpec, []container.Spec, []ostree.CommitSpec, []rpmmd.RepoConfig)
 	serializeEnd()
 	serialize() osbuild.Pipeline
 
@@ -166,7 +166,7 @@ func NewBase(name string, build Build) Base {
 
 // serializeStart must be called exactly once before each call
 // to serialize().
-func (p Base) serializeStart([]rpmmd.PackageSpec, []container.Spec, []ostree.CommitSpec) {
+func (p Base) serializeStart([]rpmmd.PackageSpec, []container.Spec, []ostree.CommitSpec, []rpmmd.RepoConfig) {
 }
 
 // serializeEnd must be called exactly once after each call to

--- a/pkg/manifest/raw_bootc.go
+++ b/pkg/manifest/raw_bootc.go
@@ -66,7 +66,7 @@ func (p *RawBootcImage) getContainerSpecs() []container.Spec {
 	return p.containerSpecs
 }
 
-func (p *RawBootcImage) serializeStart(_ []rpmmd.PackageSpec, containerSpecs []container.Spec, _ []ostree.CommitSpec) {
+func (p *RawBootcImage) serializeStart(_ []rpmmd.PackageSpec, containerSpecs []container.Spec, _ []ostree.CommitSpec, _ []rpmmd.RepoConfig) {
 	if len(p.containerSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}

--- a/pkg/manifest/raw_bootc_export_test.go
+++ b/pkg/manifest/raw_bootc_export_test.go
@@ -15,6 +15,6 @@ func (rbc *RawBootcImage) Serialize() osbuild.Pipeline {
 	return rbc.serialize()
 }
 
-func (rbc *RawBootcImage) SerializeStart(a []rpmmd.PackageSpec, b []container.Spec, c []ostree.CommitSpec) {
-	rbc.serializeStart(a, b, c)
+func (rbc *RawBootcImage) SerializeStart(a []rpmmd.PackageSpec, b []container.Spec, c []ostree.CommitSpec, r []rpmmd.RepoConfig) {
+	rbc.serializeStart(a, b, c, r)
 }

--- a/pkg/manifest/raw_bootc_test.go
+++ b/pkg/manifest/raw_bootc_test.go
@@ -51,7 +51,7 @@ func TestRawBootcImageSerialize(t *testing.T) {
 	rawBootcPipeline.Users = []users.User{{Name: "root", Key: common.ToPtr("some-ssh-key")}}
 	rawBootcPipeline.KernelOptionsAppend = []string{"karg1", "karg2"}
 
-	rawBootcPipeline.SerializeStart(nil, []container.Spec{{Source: "foo"}}, nil)
+	rawBootcPipeline.SerializeStart(nil, []container.Spec{{Source: "foo"}}, nil, nil)
 	imagePipeline := rawBootcPipeline.Serialize()
 	assert.Equal(t, "image", imagePipeline.Name)
 
@@ -70,7 +70,7 @@ func TestRawBootcImageSerializeMountsValidated(t *testing.T) {
 	rawBootcPipeline := manifest.NewRawBootcImage(build, nil, nil)
 	// note that we create a partition table without /boot here
 	rawBootcPipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/missing-boot")
-	rawBootcPipeline.SerializeStart(nil, []container.Spec{{Source: "foo"}}, nil)
+	rawBootcPipeline.SerializeStart(nil, []container.Spec{{Source: "foo"}}, nil, nil)
 	assert.PanicsWithError(t, `required mounts for bootupd stage [/boot /boot/efi] missing`, func() {
 		rawBootcPipeline.Serialize()
 	})
@@ -83,7 +83,7 @@ func TestRawBootcImageSerializeValidatesUsers(t *testing.T) {
 
 	rawBootcPipeline := manifest.NewRawBootcImage(build, nil, nil)
 	rawBootcPipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
-	rawBootcPipeline.SerializeStart(nil, []container.Spec{{Source: "foo"}}, nil)
+	rawBootcPipeline.SerializeStart(nil, []container.Spec{{Source: "foo"}}, nil, nil)
 
 	for _, tc := range []struct {
 		users       []users.User

--- a/test/scripts/generate-gitlab-ci
+++ b/test/scripts/generate-gitlab-ci
@@ -139,6 +139,7 @@ generate-manifests-{distro}-{arch}:
     RUNNER: aws/fedora-39-x86_64
     INTERNAL_NETWORK: "true"
   script:
+    - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches {arch} --distros {distro} --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -432,12 +432,10 @@ def rng_seed_env():
 
 def host_container_arch():
     host_arch = os.uname().machine
-    match host_arch:
-        case "x86_64":
-            return "amd64"
-        case "aarch64":
-            return "arm64"
-    return host_arch
+    return {
+        "x86_64": "amd64",
+        "aarch64": "arm64"
+    }.get(host_arch, host_arch)
 
 
 def is_manifest_list(data):


### PR DESCRIPTION
Support setting a repos directory on the Solver and add it to the depsolve request when set.

Depends on https://github.com/osbuild/osbuild/pull/1674