### PR TITLE
support org.osbuild.mtls secret in curl source (HMS-3798)

### DIFF
--- a/pkg/dnfjson/dnfjson.go
+++ b/pkg/dnfjson/dnfjson.go
@@ -298,6 +298,9 @@ func (s *Solver) reposFromRPMMD(rpmRepos []rpmmd.RepoConfig) ([]repoConfig, erro
 			MirrorList:     rr.MirrorList,
 			GPGKeys:        rr.GPGKeys,
 			MetadataExpire: rr.MetadataExpire,
+			SSLCACert:      rr.SSLCACert,
+			SSLClientKey:   rr.SSLClientKey,
+			SSLClientCert:  rr.SSLClientCert,
 			repoHash:       rr.Hash(),
 		}
 		if rr.ModuleHotfixes != nil {
@@ -502,8 +505,13 @@ func (pkgs packageSpecs) toRPMMD(repos map[string]rpmmd.RepoConfig) []rpmmd.Pack
 		if repo.IgnoreSSL != nil {
 			rpmDependencies[i].IgnoreSSL = *repo.IgnoreSSL
 		}
+
+		// The ssl secrets will also be set if rhsm is true,
+		// which should take priority.
 		if repo.RHSM {
 			rpmDependencies[i].Secrets = "org.osbuild.rhsm"
+		} else if repo.SSLClientKey != "" {
+			rpmDependencies[i].Secrets = "org.osbuild.mtls"
 		}
 	}
 	return rpmDependencies

--- a/pkg/dnfjson/dnfjson_test.go
+++ b/pkg/dnfjson/dnfjson_test.go
@@ -78,6 +78,14 @@ func TestMakeDepsolveRequest(t *testing.T) {
 		BaseURLs:       []string{"https://example.org/nginx"},
 		ModuleHotfixes: common.ToPtr(true),
 	}
+	mtlsRepo := rpmmd.RepoConfig{
+		Name:          "mtls",
+		BaseURLs:      []string{"https://example.org/mtls"},
+		SSLCACert:     "/cacert",
+		SSLClientCert: "/cert",
+		SSLClientKey:  "/key",
+	}
+
 	tests := []struct {
 		packageSets []rpmmd.PackageSet
 		args        []transactionArgs
@@ -398,6 +406,44 @@ func TestMakeDepsolveRequest(t *testing.T) {
 					BaseURLs:       []string{"https://example.org/nginx"},
 					ModuleHotfixes: common.ToPtr(true),
 					repoHash:       "b7d998ee8657964c17709e35ea7eaaffe4c84f9e41cc05250a1d16e8352d52e4",
+				},
+			},
+		},
+		// mtls certs passed
+		{
+			packageSets: []rpmmd.PackageSet{
+				{
+					Include:      []string{"pkg1"},
+					Repositories: []rpmmd.RepoConfig{baseOS, appstream, mtlsRepo},
+				},
+			},
+			args: []transactionArgs{
+				{
+					PackageSpecs: []string{"pkg1"},
+					RepoIDs:      []string{baseOS.Hash(), appstream.Hash(), mtlsRepo.Hash()},
+				},
+			},
+			wantRepos: []repoConfig{
+				{
+					ID:       baseOS.Hash(),
+					Name:     "baseos",
+					BaseURLs: []string{"https://example.org/baseos"},
+					repoHash: "f177f580cf201f52d1c62968d5b85cddae3e06cb9d5058987c07de1dbd769d4b",
+				},
+				{
+					ID:       appstream.Hash(),
+					Name:     "appstream",
+					BaseURLs: []string{"https://example.org/appstream"},
+					repoHash: "5c4a57bbb1b6a1886291819f2ceb25eb7c92e80065bc986a75c5837cf3d55a1f",
+				},
+				{
+					ID:            mtlsRepo.Hash(),
+					Name:          "mtls",
+					BaseURLs:      []string{"https://example.org/mtls"},
+					SSLCACert:     "/cacert",
+					SSLClientCert: "/cert",
+					SSLClientKey:  "/key",
+					repoHash:      "a1e83d633e76a8c6bcf5df21f010f4e97b864f2fa296c3dac214da10efad650a",
 				},
 			},
 		},

--- a/pkg/osbuild/curl_source.go
+++ b/pkg/osbuild/curl_source.go
@@ -39,6 +39,10 @@ func NewCurlPackageItem(pkg rpmmd.PackageSpec) (CurlSourceItem, error) {
 		item.Secrets = &URLSecrets{
 			Name: "org.osbuild.rhsm",
 		}
+	} else if pkg.Secrets == "org.osbuild.mtls" {
+		item.Secrets = &URLSecrets{
+			Name: "org.osbuild.mtls",
+		}
 	}
 	item.Insecure = pkg.IgnoreSSL
 	return item, nil

--- a/pkg/rpmmd/repository.go
+++ b/pkg/rpmmd/repository.go
@@ -47,6 +47,12 @@ type RepoConfig struct {
 	Enabled        *bool    `json:"enabled,omitempty"`
 	ImageTypeTags  []string `json:"image_type_tags,omitempty"`
 	PackageSets    []string `json:"package_sets,omitempty"`
+
+	// These fields are only filled out by the worker during the
+	// depsolve job for certain baseurls.
+	SSLCACert     string `json:"sslcacert,omitempty"`
+	SSLClientKey  string `json:"sslclientkey,omitempty"`
+	SSLClientCert string `json:"sslclientcert,omitempty"`
 }
 
 // Hash calculates an ID string that uniquely represents a repository
@@ -74,7 +80,10 @@ func (r *RepoConfig) Hash() string {
 		bpts(r.IgnoreSSL)+
 		r.MetadataExpire+
 		bts(r.RHSM)+
-		bpts(r.ModuleHotfixes))))
+		bpts(r.ModuleHotfixes)+
+		r.SSLCACert+
+		r.SSLClientKey+
+		r.SSLClientCert)))
 }
 
 type DistrosRepoConfigs map[string]map[string][]RepoConfig


### PR DESCRIPTION
Support the mtls secret in curl sources. If the worker sets mtls data on non-rhsm repos, make sure we add the mtls secret.