### PR TITLE
github: don't fail workflow if BIB ref hasn't changed

### DIFF
--- a/.github/workflows/update-bootc-image-builder.yml
+++ b/.github/workflows/update-bootc-image-builder.yml
@@ -28,13 +28,13 @@ jobs:
         working-directory: ./images
         run: |
           ./test/scripts/update-schutzfile-bib
-          git diff
 
       - name: Open PR
         working-directory: ./images
         env:
           GITHUB_TOKEN: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
         run: |
+          if git diff --exit-code; then echo "No changes"; exit 0; fi
           git config --unset-all http.https://github.com/.extraheader
           git config user.name "schutzbot"
           git config user.email "schutzbot@gmail.com"


### PR DESCRIPTION
The workflow runs daily and the BIB ref doesn't always get updated.  To avoid having workflow failures for this expected use case, which can make it hard to see actual failures, let's just exit early with success when the diff is empty.

Workflow run on this branch: https://github.com/osbuild/images/actions/runs/8402128400/job/23011182941