### PR TITLE
Schutzfile: update osbuild dependency

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -8,7 +8,7 @@
   "fedora-39": {
     "dependencies": {
       "osbuild": {
-        "commit": "6b4bb850a77feade79d839d9ea075e29ca210ae9"
+        "commit": "ec496769c5905bc07264ffdb26f6facb3cb3cdd6"
       }
     },
     "repos": [


### PR DESCRIPTION
Commit ID for upstream `main` as of right now.

PR #462 adds the new option we included in `org.osbuild.selinux` to the stage options.  This isn't used in any image definition right now except the one for BIB, which we don't attach to any distros so it's not built here or in osbuild-composer.

Let's update osbuild's commit ID separately here so we're consistent (and it's a good opportunity for a mass rebuild).