### PR TITLE
test/config-maps: re-enable oscap-rhel8 config

### DIFF
--- a/test/config-map.json
+++ b/test/config-map.json
@@ -198,6 +198,14 @@
       "qcow2"
     ]
   },
+  "./configs/oscap-rhel8.json": {
+    "distros": [
+      "rhel-8.10"
+    ],
+    "image-types": [
+      "ami"
+    ]
+  },
   "./configs/oscap-rhel9.json": {
     "distros": [
       "rhel-9.4"

--- a/test/configs/oscap-rhel8.json
+++ b/test/configs/oscap-rhel8.json
@@ -18,7 +18,12 @@
         "datastream": "/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml",
         "tailoring": {
           "unselected": [
-            "grub2_password"
+            "grub2_password",
+            "grub2_uefi_password",
+            "partition_for_dev_shm",
+            "mount_option_dev_shm_nosuid",
+            "mount_option_dev_shm_noexec",
+            "mount_option_dev_shm_nodev"
           ]
         }
       }

--- a/test/scripts/base-host-check.sh
+++ b/test/scripts/base-host-check.sh
@@ -54,8 +54,9 @@ get_oscap_score() {
     echo "Hardened score: ${hardened_score}%"
 
     echo "📗 Checking for failed rules"
-    severity=$(xmlstarlet sel -N x="http://checklists.nist.gov/xccdf/1.2" -t -v "//x:rule-result[@severity='high']" results.xml | grep -c "fail" || true)
-    echo "Severity count: ${severity}"
+    high_severity=$(xmlstarlet sel -N x="http://checklists.nist.gov/xccdf/1.2" -t -v "//x:rule-result[@severity='high']" results.xml)
+    severity_count=$(echo "${high_severity}" | grep -c "fail" || true)
+    echo "Severity count: ${severity_count}"
 
     echo "🎏 Checking for test result"
     echo "Baseline score: ${baseline_score}%"
@@ -68,9 +69,11 @@ get_oscap_score() {
         exit 1
     fi
 
-    if (( severity > 0 )); then
+    if (( severity_count > 0 )); then
         echo "❌ Failed"
         echo "One or more oscap rules with high severity failed"
+        # add a line to print the failed rules
+        echo "${high_severity}" | grep -B 5 "fail"
         exit 1
     fi
 }


### PR DESCRIPTION
Added additional tailoring rule for `partition_for_dev_shm` which appears to be the rule causing the issues with the `RHEL8.10` boot tests for OpenSCAP configs.