### PR TITLE
test/scripts: chown `results.xml`

### DIFF
--- a/test/scripts/base-host-check.sh
+++ b/test/scripts/base-host-check.sh
@@ -47,6 +47,7 @@ get_oscap_score() {
         "${datastream}" || true # oscap returns exit code 2 for any failed rules
 
     echo "📄 Saving results"
+    sudo chown "$UID" results.xml
 
     echo "📗 Checking oscap score"
     hardened_score=$(xmlstarlet sel -N x="http://checklists.nist.gov/xccdf/1.2" -t -v "//x:score" results.xml)


### PR DESCRIPTION
The `results.xml` file is owned by root, chown the file so we can read the results.

Cherry-picked this commit from #547 into it's own PR. See comments in #546