### PR TITLE
test: minor fix in check-build-coverage

### DIFF
--- a/test/scripts/check-build-coverage
+++ b/test/scripts/check-build-coverage
@@ -75,7 +75,7 @@ def main():
     else:
         print("⭕ No images were built in this pipeline")
 
-    if now:
+    if pr:
         print("Configurations built in this PR")
         for build in pr:
             distro, arch, image, config, commit = build


### PR DESCRIPTION
The script would check if `now` was not empty when it should have been checking `pr` when listing PRs.