### PR TITLE
osbuild: add new `osbuild.NewOSTreeDeploymentMountDefault()`

### DIFF
--- a/pkg/osbuild/ostree_deployment_mount.go
+++ b/pkg/osbuild/ostree_deployment_mount.go
@@ -1,6 +1,16 @@
 package osbuild
 
+import "github.com/osbuild/images/internal/common"
+
+type OSTreeMountSource string
+
+const (
+	OSTreeMountSourceTree  OSTreeMountSource = "tree"
+	OSTreeMountSourceMount OSTreeMountSource = "mount"
+)
+
 type OSTreeMountOptions struct {
+	Source     OSTreeMountSource     `json:"source,omitempty"`
 	Deployment OSTreeMountDeployment `json:"deployment"`
 }
 
@@ -8,13 +18,16 @@ func (OSTreeMountOptions) isMountOptions() {}
 
 type OSTreeMountDeployment struct {
 	// Name of the stateroot to be used in the deployment
-	OSName string `json:"osname"`
+	OSName string `json:"osname,omitempty"`
 
 	// OStree ref to create and use for deployment
-	Ref string `json:"ref"`
+	Ref string `json:"ref,omitempty"`
 
 	// The deployment serial (usually '0')
 	Serial *int `json:"serial,omitempty"`
+
+	// When set the OSName/Ref/Serial is detected automatically
+	Default *bool `json:"default,omitempty"`
 }
 
 func NewOSTreeDeploymentMount(name, osName, ref string, serial int) *Mount {
@@ -26,6 +39,19 @@ func NewOSTreeDeploymentMount(name, osName, ref string, serial int) *Mount {
 				OSName: osName,
 				Ref:    ref,
 				Serial: &serial,
+			},
+		},
+	}
+}
+
+func NewOSTreeDeploymentMountDefault(name string, source OSTreeMountSource) *Mount {
+	return &Mount{
+		Type: "org.osbuild.ostree.deployment",
+		Name: name,
+		Options: &OSTreeMountOptions{
+			Source: source,
+			Deployment: OSTreeMountDeployment{
+				Default: common.ToPtr(true),
 			},
 		},
 	}

--- a/pkg/osbuild/ostree_deployment_mount_test.go
+++ b/pkg/osbuild/ostree_deployment_mount_test.go
@@ -1,0 +1,46 @@
+package osbuild_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/osbuild/images/pkg/osbuild"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOSTreeMountDeploymentDefaultSerialized(t *testing.T) {
+	mntStage := osbuild.NewOSTreeDeploymentMountDefault("some-name", osbuild.OSTreeMountSourceMount)
+	json, err := json.MarshalIndent(mntStage, "", "  ")
+	require.Nil(t, err)
+	assert.Equal(t, string(json), `
+{
+  "name": "some-name",
+  "type": "org.osbuild.ostree.deployment",
+  "options": {
+    "source": "mount",
+    "deployment": {
+      "default": true
+    }
+  }
+}`[1:])
+}
+
+func TestOSTreeMountDeploymentSerialized(t *testing.T) {
+	mntStage := osbuild.NewOSTreeDeploymentMount("some-name", "some-osname", "some-ref", 0)
+	json, err := json.MarshalIndent(mntStage, "", "  ")
+	require.Nil(t, err)
+	assert.Equal(t, string(json), `
+{
+  "name": "some-name",
+  "type": "org.osbuild.ostree.deployment",
+  "options": {
+    "deployment": {
+      "osname": "some-osname",
+      "ref": "some-ref",
+      "serial": 0
+    }
+  }
+}`[1:])
+}


### PR DESCRIPTION
Add the "Default" and "Source" options to OSTreeMountDeployment. See
- "default" https://github.com/osbuild/osbuild/pull/1553
- "source"  https://github.com/osbuild/osbuild/pull/1535

