### PR TITLE
Minor fix in check-build-coverage PR reporting

### DIFF
--- a/test/scripts/check-build-coverage
+++ b/test/scripts/check-build-coverage
@@ -14,7 +14,7 @@ SKIPS = [
 
 def check_build_coverage(cachedir):
     ci_commit = os.environ.get("CI_COMMIT_SHA")
-    ci_branch = os.environ.get("CI_COMMIT_BRANCH")
+    ci_branch = os.environ.get("CI_COMMIT_BRANCH", "")
     tests = set()
     built_now = set()
     built_pr = set()
@@ -38,7 +38,7 @@ def check_build_coverage(cachedir):
             if commit == ci_commit:
                 # config was rebuilt in this run: collect and report
                 built_now.add((distro, arch, image, config))
-            if pr is not None and pr == ci_branch:  # make sure we don't print it when both are None
+            if pr is not None and pr == ci_branch.removeprefix("PR-"):
                 # config was rebuilt in this PR (potentially in another run): collect and report
                 built_pr.add((distro, arch, image, config, commit))
 

--- a/test/scripts/upload-results
+++ b/test/scripts/upload-results
@@ -37,7 +37,7 @@ def main():
         with open(info_path, "r", encoding="utf-8") as info_fp:
             build_info = json.load(info_fp)
         # strip the PR prefix
-        build_info["pr"] = pr_number.lstrip("PR-")
+        build_info["pr"] = pr_number.removeprefix("PR-")
         with open(info_path, "w", encoding="utf-8") as info_fp:
             json.dump(build_info, info_fp, indent=2)
 


### PR DESCRIPTION
**test/check-build-coverage: fix branch comparison**

The PR number is stored in the build info without the "PR-" prefix that
we set in GitLab CI.  We need to remove the prefix for the comparison.

---

**test/upload-results: use removeprefix() instead of lstrip()**

lstrip() is for stripping a class of characters, not removing a string
of text.

---
