### PR TITLE
many: redo customizations in a `bootc install to-filesystem` world (HMS-3453) 

### DIFF
--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -26,11 +26,13 @@ type BootcDiskImage struct {
 	// Customizations
 	KernelOptionsAppend []string
 
-	// "Users" is a bit misleading as only root and its ssh key is supported
-	// right now because that is all that bootc gives us by default but that
-	// will most likely change over time.
-	// See https://github.com/containers/bootc/pull/267
+	// The users to put into the image, note that /etc/paswd (and friends)
+	// will become unmanaged state by bootc when used
 	Users []users.User
+
+	// SELinux policy, when set it enables the labeling of the tree with the
+	// selected profile
+	SELinux string
 }
 
 func NewBootcDiskImage(container container.SourceSpec) *BootcDiskImage {
@@ -52,24 +54,23 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 	// this is signified by passing nil to the below pipelines.
 	var hostPipeline manifest.Build
 
-	// TODO: no support for customization right now but minimal support
-	// for root ssh keys is supported
-	baseImage := manifest.NewRawBootcImage(buildPipeline, containers, img.Platform)
-	baseImage.PartitionTable = img.PartitionTable
-	baseImage.Users = img.Users
-	baseImage.KernelOptionsAppend = img.KernelOptionsAppend
+	rawImage := manifest.NewRawBootcImage(buildPipeline, containers, img.Platform)
+	rawImage.PartitionTable = img.PartitionTable
+	rawImage.Users = img.Users
+	rawImage.KernelOptionsAppend = img.KernelOptionsAppend
+	rawImage.SELinux = img.SELinux
 
 	// In BIB, we export multiple images from the same pipeline so we use the
 	// filename as the basename for each export and set the extensions based on
 	// each file format.
 	fileBasename := img.Filename
-	baseImage.SetFilename(fmt.Sprintf("%s.raw", fileBasename))
+	rawImage.SetFilename(fmt.Sprintf("%s.raw", fileBasename))
 
-	qcow2Pipeline := manifest.NewQCOW2(hostPipeline, baseImage)
+	qcow2Pipeline := manifest.NewQCOW2(hostPipeline, rawImage)
 	qcow2Pipeline.Compat = img.Platform.GetQCOW2Compat()
 	qcow2Pipeline.SetFilename(fmt.Sprintf("%s.qcow2", fileBasename))
 
-	vmdkPipeline := manifest.NewVMDK(hostPipeline, baseImage)
+	vmdkPipeline := manifest.NewVMDK(hostPipeline, rawImage)
 	vmdkPipeline.SetFilename(fmt.Sprintf("%s.vmdk", fileBasename))
 
 	ovfPipeline := manifest.NewOVF(hostPipeline, vmdkPipeline)

--- a/pkg/osbuild/bind_mount.go
+++ b/pkg/osbuild/bind_mount.go
@@ -1,0 +1,30 @@
+package osbuild
+
+import (
+	"fmt"
+	"strings"
+)
+
+type BindMountOptions struct {
+	Source string `json:"source,omitempty"`
+}
+
+func (BindMountOptions) isMountOptions() {}
+
+func NewBindMount(name, source, target string) *Mount {
+	if !strings.HasPrefix(source, "mount://") {
+		panic(fmt.Errorf(`bind mount source must start with "mount://", got %q`, source))
+	}
+	if !strings.HasPrefix(target, "tree://") {
+		panic(fmt.Errorf(`bind mount target must start with "tree://", got %q`, target))
+	}
+
+	return &Mount{
+		Type:   "org.osbuild.bind",
+		Name:   name,
+		Target: target,
+		Options: &BindMountOptions{
+			Source: source,
+		},
+	}
+}

--- a/pkg/osbuild/bind_mount_test.go
+++ b/pkg/osbuild/bind_mount_test.go
@@ -1,0 +1,38 @@
+package osbuild_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+func TestBindMountSerialized(t *testing.T) {
+	mntStage := osbuild.NewBindMount("some-name", "mount://", "tree://")
+	json, err := json.MarshalIndent(mntStage, "", "  ")
+	require.Nil(t, err)
+	assert.Equal(t, string(json), `
+{
+  "name": "some-name",
+  "type": "org.osbuild.bind",
+  "target": "tree://",
+  "options": {
+    "source": "mount://"
+  }
+}`[1:])
+}
+
+func TestBindMountErrorCheckingSrc(t *testing.T) {
+	assert.PanicsWithError(t, `bind mount source must start with "mount://", got "invalid-src"`, func() {
+		osbuild.NewBindMount("some-name", "invalid-src", "tree://")
+	})
+}
+
+func TestBindMountErrorCheckingDst(t *testing.T) {
+	assert.PanicsWithError(t, `bind mount target must start with "tree://", got "invalid-target"`, func() {
+		osbuild.NewBindMount("some-name", "mount://", "invalid-target")
+	})
+}


### PR DESCRIPTION
[draft as this needs https://github.com/osbuild/osbuild/pull/1711 first (and agreement that this is the way to do it]
[draft also because it should have *some* tests at least that the right pipeline is generated]

This commit implements filesystem customizations for images that got generated via `bootc install to-filesystem` via the new `org.osbuild.bind` mechanism.

First the image is written via the `bootc.install-to-fs` stage, then the image is mounted, the ostree.deployment stage is used to get the right deployment and finally the mount is put over the "tree" directory via the bind mount module. This way for the users and selinux stages nothing changes, they work as before on a normal tree (that just happens to be mounted from an image this time).

It also includes a stage to make the /var/home directory that is missing by default on the generic images.