### PR TITLE
go.mod: update to go v1.20

### DIFF
--- a/.github/workflows/test-osbuild-composer-intergation.yml
+++ b/.github/workflows/test-osbuild-composer-intergation.yml
@@ -49,10 +49,10 @@ jobs:
     name: "⌨ osbuild-composer Golang Lint"
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: "1.20"
         id: go
 
       - name: Check out osbuild-composer main branch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,10 +108,10 @@ jobs:
     name: "⌨ Lint"
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: "1.20"
         id: go
 
       - name: Check out code into the Go module directory
@@ -141,10 +141,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: "1.20"
         id: go
 
       - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/images
 
-go 1.19
+go 1.20
 
 exclude github.com/mattn/go-sqlite3 v2.0.3+incompatible
 

--- a/pkg/image/bootc_disk_test.go
+++ b/pkg/image/bootc_disk_test.go
@@ -1,9 +1,9 @@
 package image_test
 
 import (
+	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,7 +30,7 @@ func TestBootcDiskImageNew(t *testing.T) {
 
 func makeFakeDigest(t *testing.T) string {
 	data := make([]byte, 32)
-	_, err := rand.Read(data) // nolint:gosec
+	_, err := rand.Read(data)
 	require.Nil(t, err)
 	return "sha256:" + hex.EncodeToString(data[:])
 }

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION=1.19.11
+GO_VERSION=1.20.12
 GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
 
 # this is the official way to get a different version of golang


### PR DESCRIPTION
Go 1.20 is included in all currently supported distro versions.