### PR TITLE
Add ReadOSReleaseFromTree (HMS-3783)

### DIFF
--- a/pkg/distro/host_test.go
+++ b/pkg/distro/host_test.go
@@ -1,9 +1,13 @@
 package distro
 
 import (
+	"os"
+	"path"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestOSRelease(t *testing.T) {
@@ -51,4 +55,37 @@ VARIANT_ID=workstation`,
 			t.Fatalf("%d: readOSRelease returned unexpected result: %#v", i, osrelease)
 		}
 	}
+}
+
+func TestReadOSReleaseFromTree(t *testing.T) {
+	tree := t.TempDir()
+
+	// initialize dirs
+	require.NoError(t, os.MkdirAll(path.Join(tree, "usr/lib"), 0755))
+	require.NoError(t, os.MkdirAll(path.Join(tree, "etc"), 0755))
+
+	// firstly, let's write a simple /usr/lib/os-release
+	require.NoError(t,
+		os.WriteFile(path.Join(tree, "usr/lib/os-release"), []byte("ID=toucan\n"), 0600),
+	)
+
+	osRelease, err := ReadOSReleaseFromTree(tree)
+	require.NoError(t, err)
+	require.Equal(t, "toucan", osRelease["ID"])
+
+	// secondly, let's override it with /etc/os-release
+	require.NoError(t,
+		os.WriteFile(path.Join(tree, "etc/os-release"), []byte("ID=kingfisher\n"), 0600),
+	)
+
+	osRelease, err = ReadOSReleaseFromTree(tree)
+	require.NoError(t, err)
+	require.Equal(t, "kingfisher", osRelease["ID"])
+}
+
+func TestReadOSReleaseFromTreeUnhappy(t *testing.T) {
+	tree := t.TempDir()
+
+	_, err := ReadOSReleaseFromTree(tree)
+	require.ErrorContains(t, err, "failed to read os-release")
 }


### PR DESCRIPTION
This PR adds a new function`distro.ReadOSReleaseFromTree` that can read an os-release(5) from a given tree. This is needed for https://github.com/osbuild/bootc-image-builder/pull/338