### PR TITLE
test: inspect manifests in manifest-only jobs

### DIFF
--- a/test/scripts/configure-generators
+++ b/test/scripts/configure-generators
@@ -100,7 +100,14 @@ generate-manifests-{distro}-{arch}:
     INTERNAL_NETWORK: "true"
   script:
     - sudo ./test/scripts/install-dependencies
-    - go run ./cmd/gen-manifests --arches {arch} --distros {distro} --workers 10
+    - go run ./cmd/gen-manifests --arches {arch} --distros {distro} --workers 10 --metadata=false --output ./manifests
+    - for manifest in ./manifests/*; do
+        if osbuild --inspect $manifest > output; then
+          echo "$manifest OK";
+        else
+          cat output;
+        fi;
+      done
 """
 
 


### PR DESCRIPTION
We don't build ppc64le and s390x in gitlab CI, we only generate the manifests to ensure there's no issues with manifest generation and package selection.  However, we can also validate them using 'osbuild --inspect' to make sure they're at least valid manifests.