### PR TITLE
fedora: we're building RCs for F40

### DIFF
--- a/pkg/distro/fedora/version.go
+++ b/pkg/distro/fedora/version.go
@@ -1,4 +1,4 @@
 package fedora
 
-const VERSION_BRANCHED = "40"
+const VERSION_BRANCHED = "41"
 const VERSION_RAWHIDE = "41"


### PR DESCRIPTION
In #522 I implemented a naive way to show/not-show pre-releases in installers. Since Fedora 40 is currently building RCs and Finals it should be turned off for 40 now.