### PR TITLE
container: include the architecture of the image in container.Spec

### DIFF
--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -7,7 +7,8 @@ import (
 type Arch uint64
 
 const ( // architecture enum
-	ARCH_AARCH64 Arch = iota
+	ARCH_UNSET Arch = iota
+	ARCH_AARCH64
 	ARCH_PPC64LE
 	ARCH_S390X
 	ARCH_X86_64
@@ -15,6 +16,8 @@ const ( // architecture enum
 
 func (a Arch) String() string {
 	switch a {
+	case ARCH_UNSET:
+		return "unset"
 	case ARCH_AARCH64:
 		return "aarch64"
 	case ARCH_PPC64LE:

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -16,8 +16,6 @@ import (
 	_ "github.com/containers/image/v5/oci/layout"
 	"golang.org/x/sys/unix"
 
-	"github.com/osbuild/images/internal/common"
-
 	"github.com/containers/common/pkg/retry"
 	"github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/docker"
@@ -30,6 +28,9 @@ import (
 	"github.com/opencontainers/go-digest"
 
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 )
 
 const (
@@ -334,7 +335,7 @@ func (cl *Client) UploadImage(ctx context.Context, from, tag string) (digest.Dig
 type RawManifest struct {
 	Data     []byte
 	MimeType string
-	Arch     string
+	Arch     arch.Arch
 }
 
 // Digest computes the digest from the raw manifest data
@@ -379,7 +380,7 @@ func (cl *Client) GetManifest(ctx context.Context, digest digest.Digest, local b
 	if err != nil {
 		return r, err
 	}
-	r.Arch = info.Architecture
+	r.Arch = arch.FromString(info.Architecture)
 
 	src, err := ref.NewImageSource(ctx, cl.sysCtx)
 	if err != nil {

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -334,6 +334,7 @@ func (cl *Client) UploadImage(ctx context.Context, from, tag string) (digest.Dig
 type RawManifest struct {
 	Data     []byte
 	MimeType string
+	Arch     string
 }
 
 // Digest computes the digest from the raw manifest data
@@ -368,6 +369,17 @@ func (cl *Client) GetManifest(ctx context.Context, digest digest.Digest, local b
 	if err != nil {
 		return
 	}
+	img, err := ref.NewImage(ctx, cl.sysCtx)
+	if err != nil {
+		return r, err
+	}
+	defer img.Close()
+
+	info, err := img.Inspect(ctx)
+	if err != nil {
+		return r, err
+	}
+	r.Arch = info.Architecture
 
 	src, err := ref.NewImageSource(ctx, cl.sysCtx)
 	if err != nil {
@@ -515,6 +527,7 @@ func (cl *Client) Resolve(ctx context.Context, name string, local bool) (Spec, e
 		name,
 		local,
 	)
+	spec.Arch = raw.Arch
 
 	return spec, nil
 }

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -45,6 +45,7 @@ func TestClientResolve(t *testing.T) {
 		TLSVerify:  client.GetTLSVerify(),
 		LocalName:  client.Target.String(),
 		ListDigest: listDigest,
+		Arch:       "amd64",
 	}, spec)
 
 	client.SetArchitectureChoice("ppc64le")
@@ -58,6 +59,7 @@ func TestClientResolve(t *testing.T) {
 		TLSVerify:  client.GetTLSVerify(),
 		LocalName:  client.Target.String(),
 		ListDigest: listDigest,
+		Arch:       "ppc64le",
 	}, spec)
 
 	// don't have that architecture

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/osbuild/images/pkg/container"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/pkg/container"
 )
 
 //
@@ -45,7 +47,7 @@ func TestClientResolve(t *testing.T) {
 		TLSVerify:  client.GetTLSVerify(),
 		LocalName:  client.Target.String(),
 		ListDigest: listDigest,
-		Arch:       "amd64",
+		Arch:       arch.ARCH_X86_64,
 	}, spec)
 
 	client.SetArchitectureChoice("ppc64le")
@@ -59,7 +61,7 @@ func TestClientResolve(t *testing.T) {
 		TLSVerify:  client.GetTLSVerify(),
 		LocalName:  client.Target.String(),
 		ListDigest: listDigest,
-		Arch:       "ppc64le",
+		Arch:       arch.ARCH_PPC64LE,
 	}, spec)
 
 	// don't have that architecture

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -377,6 +377,7 @@ func (reg *Registry) Resolve(target, arch string) (container.Spec, error) {
 		LocalName:  target,
 		TLSVerify:  common.ToPtr(false),
 		ListDigest: listDigest,
+		Arch:       arch,
 	}, nil
 }
 

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -14,11 +14,12 @@ import (
 
 	"github.com/opencontainers/go-digest"
 
-	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/container"
-
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/manifest"
+
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/pkg/container"
 )
 
 const rootLayer = `H4sIAAAJbogA/+SWUYqDMBCG53lP4V5g9x8dzRX2Bvtc0VIhEIhKe/wSKxgU6ktjC/O9hMzAQDL8
@@ -308,7 +309,7 @@ func (reg *Registry) GetRef(repo string) string {
 	return fmt.Sprintf("%s/%s", reg.server.Listener.Addr().String(), repo)
 }
 
-func (reg *Registry) Resolve(target, arch string) (container.Spec, error) {
+func (reg *Registry) Resolve(target string, imgArch arch.Arch) (container.Spec, error) {
 
 	ref, err := reference.ParseNormalizedNamed(target)
 	if err != nil {
@@ -354,7 +355,7 @@ func (reg *Registry) Resolve(target, arch string) (container.Spec, error) {
 		checksum = ""
 
 		for _, m := range lst.Manifests {
-			if m.Platform.Architecture == arch {
+			if arch.FromString(m.Platform.Architecture) == imgArch {
 				checksum = m.Digest.String()
 				break
 			}
@@ -377,7 +378,7 @@ func (reg *Registry) Resolve(target, arch string) (container.Spec, error) {
 		LocalName:  target,
 		TLSVerify:  common.ToPtr(false),
 		ListDigest: listDigest,
-		Arch:       arch,
+		Arch:       imgArch,
 	}, nil
 }
 

--- a/pkg/container/resolver.go
+++ b/pkg/container/resolver.go
@@ -30,6 +30,7 @@ type SourceSpec struct {
 	Local     bool
 }
 
+// XXX: use arch.Arch here?
 func NewResolver(arch string) *Resolver {
 	return &Resolver{
 		ctx:   context.Background(),

--- a/pkg/container/resolver_test.go
+++ b/pkg/container/resolver_test.go
@@ -15,7 +15,6 @@ func TestResolver(t *testing.T) {
 
 	registry := NewTestRegistry()
 	defer registry.Close()
-
 	repo := registry.AddRepo("library/osbuild")
 	ref := registry.GetRef("library/osbuild")
 

--- a/pkg/container/resolver_test.go
+++ b/pkg/container/resolver_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/container"
 )
 
@@ -51,7 +52,7 @@ func TestResolver(t *testing.T) {
 
 	want := make([]container.Spec, len(refs))
 	for i, r := range refs {
-		spec, err := registry.Resolve(r, "amd64")
+		spec, err := registry.Resolve(r, arch.ARCH_X86_64)
 		assert.NoError(t, err)
 		want[i] = spec
 	}

--- a/pkg/container/spec.go
+++ b/pkg/container/spec.go
@@ -3,6 +3,8 @@ package container
 import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/opencontainers/go-digest"
+
+	"github.com/osbuild/images/pkg/arch"
 )
 
 // A Spec is the specification of how to get a specific
@@ -19,7 +21,7 @@ type Spec struct {
 	ListDigest   string // digest of the list manifest at the Source (optional)
 	LocalStorage bool
 
-	Arch string // the architecture of the image
+	Arch arch.Arch // the architecture of the image
 }
 
 // NewSpec creates a new Spec from the essential information.

--- a/pkg/container/spec.go
+++ b/pkg/container/spec.go
@@ -18,6 +18,8 @@ type Spec struct {
 	LocalName    string // name to use inside the image
 	ListDigest   string // digest of the list manifest at the Source (optional)
 	LocalStorage bool
+
+	Arch string // the architecture of the image
 }
 
 // NewSpec creates a new Spec from the essential information.


### PR DESCRIPTION
This is a different attempt to resolve the issue that the resolver consider the requested architecture more of a "hint". The initial attempt is in https://github.com/osbuild/images/pull/451 but it caused some issues as this seems to be expected behavior of the library in tests at least.

So this commit is more conservative and just includes the the architecture in the `container.Spec` so that the consumer of the library can inspect and error on mismatch of requested arch and resolved arch.

With that in bib we can check the arch, I outlined this in https://github.com/osbuild/bootc-image-builder/compare/main...mvo5:check-resolved-image-arches?expand=1 what we could have to do there (plus some other changes because the image API has changed quite a bit and a go.mod change to make it trivial to test locally but that will need adjustment of course).
