### PR TITLE
image,manifest: add support for bootc `groups` customizations

### DIFF
--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -28,7 +28,8 @@ type BootcDiskImage struct {
 
 	// The users to put into the image, note that /etc/paswd (and friends)
 	// will become unmanaged state by bootc when used
-	Users []users.User
+	Users  []users.User
+	Groups []users.Group
 
 	// SELinux policy, when set it enables the labeling of the tree with the
 	// selected profile
@@ -57,6 +58,7 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 	rawImage := manifest.NewRawBootcImage(buildPipeline, containers, img.Platform)
 	rawImage.PartitionTable = img.PartitionTable
 	rawImage.Users = img.Users
+	rawImage.Groups = img.Groups
 	rawImage.KernelOptionsAppend = img.KernelOptionsAppend
 	rawImage.SELinux = img.SELinux
 


### PR DESCRIPTION
[build on top of https://github.com/osbuild/images/pull/571, only the last commit is relevant]

When porting custoizations to the new `bootc install to-filesystem`
world initially only users/kernel-options where added. This commit
adds `org.osbuild.groups` now as well.

Needs:
https://github.com/osbuild/osbuild/pull/1726 or 
https://github.com/osbuild/osbuild/pull/1727