### PR TITLE
Resolve local container manifests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,34 @@ jobs:
       - name: Run depsolver tests with force-dnf to make sure it's not skipped for any reason
         run: go test -race ./pkg/dnfjson/... -force-dnf
 
+  container-resolver-tests:
+    name: "🛃 Container resolver tests"
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Go 1.20
+      uses: actions/setup-go@v5
+      with:
+        go-version: "1.20"
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Apt update
+      run: sudo apt update
+
+    # This is needed for the container resolver dependencies
+    - name: Install libgpgme devel package
+      run: sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev podman
+
+    # We need to run the test as root, since we use the root
+    # containers-storage for the local resolvers
+    - name: Run unit tests
+      run: sudo go test ./pkg/container/...
+
   unit-tests-c9s:
     name: "🛃 Unit tests (CentOS Stream 9)"
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go v1.51.26
 	github.com/containers/common v0.58.2
 	github.com/containers/image/v5 v5.30.0
+	github.com/containers/storage v1.53.0
 	github.com/gobwas/glob v0.2.3
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/go-cmp v0.6.0
@@ -65,7 +66,6 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.15.1 // indirect
 	github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 // indirect
 	github.com/containers/ocicrypt v1.1.9 // indirect
-	github.com/containers/storage v1.53.0 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20231217050601-ba74d44ecf5f // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/containers/image/v5/docker/archive"
 	_ "github.com/containers/image/v5/oci/archive"
 	_ "github.com/containers/image/v5/oci/layout"
+	"github.com/containers/storage"
 	"golang.org/x/sys/unix"
 
 	"github.com/containers/common/pkg/retry"
@@ -343,9 +344,17 @@ func (m RawManifest) Digest() (digest.Digest, error) {
 	return manifest.Digest(m.Data)
 }
 
-func getImageRef(target reference.Named, local bool) (types.ImageReference, error) {
+func getImageRef(target reference.Named, id string, local bool) (types.ImageReference, error) {
 	if local {
-		return alltransports.ParseImageName(fmt.Sprintf("containers-storage:%s", target))
+		imageName := target.String()
+		if id != "" {
+			imageName = id
+		}
+		return alltransports.ParseImageName(fmt.Sprintf("containers-storage:%s", imageName))
+	}
+
+	if target == nil {
+		return nil, fmt.Errorf("target cannot be nil for remote image")
 	}
 
 	return docker.NewReference(target)
@@ -365,12 +374,39 @@ func (cl *Client) resolveContainerImageArch(ctx context.Context, ref types.Image
 	return &a, nil
 }
 
+func (cl *Client) getLocalImageIDFromDigest(instance digest.Digest) (string, error) {
+	store, err := storage.GetStore(storage.StoreOptions{})
+	if err != nil {
+		return "", err
+	}
+	images, err := store.ImagesByDigest(instance)
+	if err != nil {
+		return "", err
+	}
+	if len(images) == 0 {
+		return "", fmt.Errorf("Unable to find image id for digest: %v", instance)
+	}
+	// the `ImagesByDigest` function always returns a list
+	// of images. The list could be larger than 1 in the case
+	// since it searches all stores for the matching digest,
+	// so it is okay to return the first item.
+	return images[0].ID, nil
+}
+
 // GetManifest fetches the raw manifest data from the server. If digest is not empty
 // it will override any given tag for the Client's Target.
 func (cl *Client) GetManifest(ctx context.Context, instanceDigest digest.Digest, local bool) (r RawManifest, err error) {
 	target := cl.Target
 
-	ref, err := getImageRef(target, local)
+	var id string
+	if instanceDigest != "" && local {
+		id, err = cl.getLocalImageIDFromDigest(instanceDigest)
+		if err != nil {
+			return r, err
+		}
+	}
+
+	ref, err := getImageRef(target, id, local)
 	if err != nil {
 		return
 	}
@@ -392,7 +428,8 @@ func (cl *Client) GetManifest(ctx context.Context, instanceDigest digest.Digest,
 
 	if err = retry.RetryIfNecessary(ctx, func() error {
 		var secondaryDigest *digest.Digest
-		if instanceDigest != "" {
+		// passing in a digest for a local manifest list will break
+		if instanceDigest != "" && !local {
 			// We can pass the instance digest, if it is nil, then this is the primary manifest.
 			// If it is not nil, then this is the instance digest and the primary manifest is a
 			// manifest list. The `GetManifest` call will then retrieve the manifest for the
@@ -434,18 +471,18 @@ type resolvedIds struct {
 	ListManifest digest.Digest
 }
 
-func (cl *Client) resolveManifestList(ctx context.Context, list manifestList) (resolvedIds, error) {
+func (cl *Client) resolveManifestList(ctx context.Context, list manifestList, local bool) (resolvedIds, error) {
 	digest, err := list.ChooseInstance(cl.sysCtx)
 	if err != nil {
 		return resolvedIds{}, err
 	}
 
-	raw, err := cl.GetManifest(ctx, digest, false)
+	raw, err := cl.GetManifest(ctx, digest, local)
 	if err != nil {
 		return resolvedIds{}, fmt.Errorf("error getting manifest: %w", err)
 	}
 
-	ids, err := cl.resolveRawManifest(ctx, raw)
+	ids, err := cl.resolveRawManifest(ctx, raw, local)
 	if err != nil {
 		return resolvedIds{}, err
 	}
@@ -453,7 +490,7 @@ func (cl *Client) resolveManifestList(ctx context.Context, list manifestList) (r
 	return ids, err
 }
 
-func (cl *Client) resolveRawManifest(ctx context.Context, rm RawManifest) (resolvedIds, error) {
+func (cl *Client) resolveRawManifest(ctx context.Context, rm RawManifest, local bool) (resolvedIds, error) {
 
 	var imageID digest.Digest
 
@@ -465,7 +502,7 @@ func (cl *Client) resolveRawManifest(ctx context.Context, rm RawManifest) (resol
 		}
 
 		// Save digest of the manifest list as well.
-		ids, err := cl.resolveManifestList(ctx, list)
+		ids, err := cl.resolveManifestList(ctx, list, local)
 		if err != nil {
 			return resolvedIds{}, err
 		}
@@ -480,7 +517,7 @@ func (cl *Client) resolveRawManifest(ctx context.Context, rm RawManifest) (resol
 		}
 
 		// Save digest of the manifest list as well.
-		ids, err := cl.resolveManifestList(ctx, index)
+		ids, err := cl.resolveManifestList(ctx, index, local)
 		if err != nil {
 			return resolvedIds{}, err
 		}
@@ -531,7 +568,7 @@ func (cl *Client) Resolve(ctx context.Context, name string, local bool) (Spec, e
 		return Spec{}, fmt.Errorf("error getting manifest: %w", err)
 	}
 
-	ids, err := cl.resolveRawManifest(ctx, raw)
+	ids, err := cl.resolveRawManifest(ctx, raw, local)
 	if err != nil {
 		return Spec{}, err
 	}

--- a/pkg/container/resolver.go
+++ b/pkg/container/resolver.go
@@ -28,6 +28,7 @@ type SourceSpec struct {
 	Digest    *string
 	TLSVerify *bool
 	Local     bool
+	Store     *string
 }
 
 // XXX: use arch.Arch here?
@@ -52,6 +53,10 @@ func (r *Resolver) Add(spec SourceSpec) {
 	client.SetArchitectureChoice(r.Arch)
 	if r.AuthFilePath != "" {
 		client.SetAuthFilePath(r.AuthFilePath)
+	}
+
+	if spec.Store != nil {
+		client.SetContainersStore(*spec.Store)
 	}
 
 	go func() {

--- a/pkg/container/resolver_test.go
+++ b/pkg/container/resolver_test.go
@@ -41,6 +41,7 @@ func TestResolver(t *testing.T) {
 			common.ToPtr(""),
 			common.ToPtr(false),
 			false,
+			nil,
 		})
 	}
 
@@ -69,6 +70,7 @@ func TestResolverFail(t *testing.T) {
 		common.ToPtr(""),
 		common.ToPtr(false),
 		false,
+		nil,
 	})
 	specs, err := resolver.Finish()
 	assert.Error(t, err)
@@ -83,6 +85,7 @@ func TestResolverFail(t *testing.T) {
 		common.ToPtr(""),
 		common.ToPtr(false),
 		false,
+		nil,
 	})
 	specs, err = resolver.Finish()
 	assert.Error(t, err)
@@ -94,6 +97,7 @@ func TestResolverFail(t *testing.T) {
 		common.ToPtr(""),
 		common.ToPtr(false),
 		false,
+		nil,
 	})
 	specs, err = resolver.Finish()
 	assert.Error(t, err)
@@ -104,6 +108,7 @@ func TestResolverFail(t *testing.T) {
 		common.ToPtr(""),
 		common.ToPtr(false),
 		false,
+		nil,
 	})
 	specs, err = resolver.Finish()
 	assert.Error(t, err)


### PR DESCRIPTION
This is a POC to resolve local containers by their ID rather than by their name, the podman desktop team
asked if this was possible since local manifests are not.