### PR TITLE
manifest: write custom `/etc/fstab` in `RawBootcImage`

### DIFF
--- a/pkg/manifest/raw_bootc.go
+++ b/pkg/manifest/raw_bootc.go
@@ -129,6 +129,12 @@ func (p *RawBootcImage) serialize() osbuild.Pipeline {
 	mounts = append(mounts, *osbuild.NewOSTreeDeploymentMountDefault("ostree.deployment", osbuild.OSTreeMountSourceMount))
 	mounts = append(mounts, *osbuild.NewBindMount("bind-ostree-deployment-to-tree", "mount://", "tree://"))
 
+	// we always include the fstab stage
+	fstabStage := osbuild.NewFSTabStage(osbuild.NewFSTabStageOptions(pt))
+	fstabStage.Mounts = mounts
+	fstabStage.Devices = devices
+	pipeline.AddStage(fstabStage)
+
 	// customize the image
 	if len(p.Groups) > 0 {
 		groupsStage := osbuild.GenGroupsStage(p.Groups)

--- a/pkg/manifest/raw_bootc_test.go
+++ b/pkg/manifest/raw_bootc_test.go
@@ -191,3 +191,32 @@ func TestRawBootcImageSerializeCustomizationGenCorrectStages(t *testing.T) {
 		}
 	}
 }
+
+func RawBootcImageSerializeCommonPipelines(t *testing.T) {
+	expectedCommonStages := []string{
+		"org.osbuild.truncate",
+		"org.osbuild.sfdisk",
+		"org.osbuild.mkfs.ext4",
+		"org.osbuild.mkfs.ext4",
+		"org.osbuild.mkfs.fat",
+		"org.osbuild.bootc.install-to-filesystem",
+		"org.osbuild.fstab",
+	}
+	rawBootcPipeline := makeFakeRawBootcPipeline()
+	pipeline := rawBootcPipeline.Serialize()
+
+	pipelineStages := make([]string, len(pipeline.Stages))
+	for i, st := range pipeline.Stages {
+		pipelineStages[i] = st.Type
+	}
+	assert.Equal(t, expectedCommonStages, pipelineStages[0:len(expectedCommonStages)])
+}
+
+func RawBootcImageSerializeFstabPipelineHasBootcMounts(t *testing.T) {
+	rawBootcPipeline := makeFakeRawBootcPipeline()
+	pipeline := rawBootcPipeline.Serialize()
+
+	stage := manifest.FindStage("org.osbuild.fstab", pipeline.Stages)
+	assert.NotNil(t, stage)
+	assertBootcDeploymentAndBindMount(t, stage)
+}


### PR DESCRIPTION
With the new uniform way to handle writing to the bootc image deployment we can now support a custom `/etc/fstab` again. Similar to what we do for users [0] and groups [1] we allow also writing a custom fstab now.

Now that https://github.com/osbuild/osbuild/pull/1727 is merged is ready too.

[0] https://github.com/osbuild/images/pull/571
[1] https://github.com/osbuild/images/pull/593