### PR TITLE
Re-enable F40 in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -257,6 +257,44 @@ generate-build-config-fedora-39-x86_64:
       - .cache/osbuild-images
 
 
+generate-build-config-fedora-40-aarch64:
+  stage: gen
+  extends: .terraform
+  variables:
+    RUNNER: aws/fedora-39-aarch64
+    INTERNAL_NETWORK: "true"
+  script:
+    - sudo ./test/scripts/setup-osbuild-repo
+    - sudo ./test/scripts/install-dependencies
+    - ./test/scripts/generate-build-config --distro fedora-40 --arch aarch64 build-config.yml
+  artifacts:
+    paths:
+      - build-config.yml
+  cache:
+    key: testcache
+    paths:
+      - .cache/osbuild-images
+
+
+generate-build-config-fedora-40-x86_64:
+  stage: gen
+  extends: .terraform
+  variables:
+    RUNNER: aws/fedora-39-x86_64
+    INTERNAL_NETWORK: "true"
+  script:
+    - sudo ./test/scripts/setup-osbuild-repo
+    - sudo ./test/scripts/install-dependencies
+    - ./test/scripts/generate-build-config --distro fedora-40 --arch x86_64 build-config.yml
+  artifacts:
+    paths:
+      - build-config.yml
+  cache:
+    key: testcache
+    paths:
+      - .cache/osbuild-images
+
+
 generate-build-config-rhel-10.0-aarch64:
   stage: gen
   extends: .terraform
@@ -879,6 +917,28 @@ image-build-trigger-fedora-39-x86_64:
     - generate-build-config-fedora-39-x86_64
 
 
+image-build-trigger-fedora-40-aarch64:
+  stage: build
+  trigger:
+    include:
+      - artifact: build-config.yml
+        job: generate-build-config-fedora-40-aarch64
+    strategy: depend
+  needs:
+    - generate-build-config-fedora-40-aarch64
+
+
+image-build-trigger-fedora-40-x86_64:
+  stage: build
+  trigger:
+    include:
+      - artifact: build-config.yml
+        job: generate-build-config-fedora-40-x86_64
+    strategy: depend
+  needs:
+    - generate-build-config-fedora-40-x86_64
+
+
 image-build-trigger-rhel-10.0-aarch64:
   stage: build
   trigger:
@@ -1389,6 +1449,50 @@ generate-ostree-build-config-fedora-39-x86_64:
       - build-configs
   needs:
     - image-build-trigger-fedora-39-x86_64
+  cache:
+    key: testcache
+    paths:
+      - .cache/osbuild-images
+
+
+generate-ostree-build-config-fedora-40-aarch64:
+  stage: ostree-gen
+  extends: .terraform
+  variables:
+    RUNNER: aws/fedora-39-aarch64
+    INTERNAL_NETWORK: "true"
+  script:
+    - sudo ./test/scripts/setup-osbuild-repo
+    - sudo ./test/scripts/install-dependencies
+    - ./test/scripts/generate-ostree-build-config --distro fedora-40 --arch aarch64 build-config.yml build-configs
+  artifacts:
+    paths:
+      - build-config.yml
+      - build-configs
+  needs:
+    - image-build-trigger-fedora-40-aarch64
+  cache:
+    key: testcache
+    paths:
+      - .cache/osbuild-images
+
+
+generate-ostree-build-config-fedora-40-x86_64:
+  stage: ostree-gen
+  extends: .terraform
+  variables:
+    RUNNER: aws/fedora-39-x86_64
+    INTERNAL_NETWORK: "true"
+  script:
+    - sudo ./test/scripts/setup-osbuild-repo
+    - sudo ./test/scripts/install-dependencies
+    - ./test/scripts/generate-ostree-build-config --distro fedora-40 --arch x86_64 build-config.yml build-configs
+  artifacts:
+    paths:
+      - build-config.yml
+      - build-configs
+  needs:
+    - image-build-trigger-fedora-40-x86_64
   cache:
     key: testcache
     paths:
@@ -2098,6 +2202,28 @@ image-build-ostree-trigger-fedora-39-x86_64:
     - generate-ostree-build-config-fedora-39-x86_64
 
 
+image-build-ostree-trigger-fedora-40-aarch64:
+  stage: ostree-build
+  trigger:
+    include:
+      - artifact: build-config.yml
+        job: generate-ostree-build-config-fedora-40-aarch64
+    strategy: depend
+  needs:
+    - generate-ostree-build-config-fedora-40-aarch64
+
+
+image-build-ostree-trigger-fedora-40-x86_64:
+  stage: ostree-build
+  trigger:
+    include:
+      - artifact: build-config.yml
+        job: generate-ostree-build-config-fedora-40-x86_64
+    strategy: depend
+  needs:
+    - generate-ostree-build-config-fedora-40-x86_64
+
+
 image-build-ostree-trigger-rhel-10.0-aarch64:
   stage: ostree-build
   trigger:
@@ -2556,6 +2682,44 @@ generate-manifests-fedora-39-s390x:
     - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - go run ./cmd/gen-manifests --arches s390x --distros fedora-39 --workers 10 --metadata=false --output ./manifests
+    - for manifest in ./manifests/*; do
+        if osbuild --inspect $manifest > output; then
+          echo "$manifest OK";
+        else
+          cat output;
+        fi;
+      done
+
+
+generate-manifests-fedora-40-ppc64le:
+  stage: gen
+  extends: .terraform
+  variables:
+    RUNNER: aws/fedora-39-x86_64
+    INTERNAL_NETWORK: "true"
+  script:
+    - sudo ./test/scripts/setup-osbuild-repo
+    - sudo ./test/scripts/install-dependencies
+    - go run ./cmd/gen-manifests --arches ppc64le --distros fedora-40 --workers 10 --metadata=false --output ./manifests
+    - for manifest in ./manifests/*; do
+        if osbuild --inspect $manifest > output; then
+          echo "$manifest OK";
+        else
+          cat output;
+        fi;
+      done
+
+
+generate-manifests-fedora-40-s390x:
+  stage: gen
+  extends: .terraform
+  variables:
+    RUNNER: aws/fedora-39-x86_64
+    INTERNAL_NETWORK: "true"
+  script:
+    - sudo ./test/scripts/setup-osbuild-repo
+    - sudo ./test/scripts/install-dependencies
+    - go run ./cmd/gen-manifests --arches s390x --distros fedora-40 --workers 10 --metadata=false --output ./manifests
     - for manifest in ./manifests/*; do
         if osbuild --inspect $manifest > output; then
           echo "$manifest OK";

--- a/test/data/repositories/fedora-40.json
+++ b/test/data/repositories/fedora-40.json
@@ -1,0 +1,42 @@
+{
+  "x86_64": [
+    {
+      "name": "fedora",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-x86_64-branched-20240415",
+      "check_gpg": true,
+      "gpgkeys": [
+        "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGPQTCwBEADFUL0EQLzwpKHtlPkacVI156F2LnWp6K69g/6yzllidHI3b7EV\nQgQ9/Kdou6wNuOahNKa6WcEi6grEXexD7pAcu4xdRUp79XxQy5pC7Aq2/Dwf0vRL\n2y0kqof+C7iSzhHsfLoaqKKeh2njAo1KLZXYTHAWAMbXEyO/FJevaHLXe2+yYd7j\nluD58gyXgGDXXJ2lymLqs2jobjWdmGPNZGFl36RP3Dnk0FpbdH78kyIIsc2foYuF\n00rnuumwCtK3V58VOZo6IkaYk2irdyeetmJjVHwLHwJB3EaAwGy9Z2oAH3LxxFfk\nrQb0DH0Nzb3fpEziopOOqSi+6guV4RHUKAkCUMu+Mo5XwFVPUAIfNRTVqoIaEasC\nWO26lhkB87wwIvyb/TPGSeh6laHPRf0QOUOLkugdkSHoaJFWoTCcu9Y4aeDpf+ZQ\nfMVmkJNRS1tXONgz+pDk1rro/tNrkusYG18xjvSZTB0P0C4b4+jgK5l7me0NU6G3\nWw/hIng5lxWfXgE9bpxlN834v1xy5Z3v17guJu1ec/jzKzQQ4356wyegXURjYoWe\nawcnK1S+9gxivnkOk1bGLNxrEh5vB6PDcI1VQ1ECH50EHyvE1IXJDaaStdAkacv2\nqHcd15CnlBW1LYFj0CHs/sGu9FD0iSF95OVRX4gjg9Wa4f8KvtEO/f+FeQARAQAB\ntDFGZWRvcmEgKDQwKSA8ZmVkb3JhLTQwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEEV35rvhXhT7oRF0KBydwfqFbecwFAmPQTCwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQBydwfqFbecxJOw//XaoJG3zN01bVM63H\nnFmMW/EnLzKrZqH8ZNq8CP9ycoc4q8SYcMprHKG9jufzj5/FhtpYecp3kBMpSYHt\nVu46LS9NajJDwdfvUMezVbieNIQ8icTR5s5IUYFlc47eG6PRe3k0n5fOPcIb6q82\nbyrK3dQnanOcVdoGU7QO9LAAHO9hg0zgZa0MxQAlDQov3dZcr7u7qGcQmU5JzcRS\nJgfDxHxDuMjmq6Kd0/UwD00kd2ptZgRls0ntXdm9CZGtQ/Q0baJ3eRzccpd/8bxy\nRWF9MnOdmV6ojcFKYECjEzcuheUlcKQH9rLkeBSfgrIlK3L7LG8bg5ouZLdx17rQ\nXABNQGmJTaGAiEnS/48G3roMS8R7fhUljcKr6t63QQQJ2qWdPvI6EMC2xKZsLHK4\nXiUvrmJpUprvEQSKBUOf/2zuXDBshtAnoKh7h5aG+TvozL4yNG5DKpSH3MRj1E43\nKoMsP/GN/X5h+vJnvhiCWxNMPP81Op0czBAgukBm627FTnsvieJOOrzyxb1s75+W\n56gJombmhzUfzr88AYY9mFy7diTw/oldDZcfwa8rvOAGJVDlyr2hqkLoGl+5jPex\nslt3NF4caE/wP9wPMgFRkmMOr8eiRhjlWLrO6mQdBp7Qsj3kEXioP+CZ1cv/sbaK\n4DM7VidB4PLrMFQMaf0LpjpC2DM=\n=wOl2\n-----END PGP PUBLIC KEY BLOCK-----"
+      ]
+    }
+  ],
+  "aarch64": [
+    {
+      "name": "fedora",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-aarch64-branched-20240415",
+      "check_gpg": true,
+      "gpgkeys": [
+        "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGPQTCwBEADFUL0EQLzwpKHtlPkacVI156F2LnWp6K69g/6yzllidHI3b7EV\nQgQ9/Kdou6wNuOahNKa6WcEi6grEXexD7pAcu4xdRUp79XxQy5pC7Aq2/Dwf0vRL\n2y0kqof+C7iSzhHsfLoaqKKeh2njAo1KLZXYTHAWAMbXEyO/FJevaHLXe2+yYd7j\nluD58gyXgGDXXJ2lymLqs2jobjWdmGPNZGFl36RP3Dnk0FpbdH78kyIIsc2foYuF\n00rnuumwCtK3V58VOZo6IkaYk2irdyeetmJjVHwLHwJB3EaAwGy9Z2oAH3LxxFfk\nrQb0DH0Nzb3fpEziopOOqSi+6guV4RHUKAkCUMu+Mo5XwFVPUAIfNRTVqoIaEasC\nWO26lhkB87wwIvyb/TPGSeh6laHPRf0QOUOLkugdkSHoaJFWoTCcu9Y4aeDpf+ZQ\nfMVmkJNRS1tXONgz+pDk1rro/tNrkusYG18xjvSZTB0P0C4b4+jgK5l7me0NU6G3\nWw/hIng5lxWfXgE9bpxlN834v1xy5Z3v17guJu1ec/jzKzQQ4356wyegXURjYoWe\nawcnK1S+9gxivnkOk1bGLNxrEh5vB6PDcI1VQ1ECH50EHyvE1IXJDaaStdAkacv2\nqHcd15CnlBW1LYFj0CHs/sGu9FD0iSF95OVRX4gjg9Wa4f8KvtEO/f+FeQARAQAB\ntDFGZWRvcmEgKDQwKSA8ZmVkb3JhLTQwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEEV35rvhXhT7oRF0KBydwfqFbecwFAmPQTCwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQBydwfqFbecxJOw//XaoJG3zN01bVM63H\nnFmMW/EnLzKrZqH8ZNq8CP9ycoc4q8SYcMprHKG9jufzj5/FhtpYecp3kBMpSYHt\nVu46LS9NajJDwdfvUMezVbieNIQ8icTR5s5IUYFlc47eG6PRe3k0n5fOPcIb6q82\nbyrK3dQnanOcVdoGU7QO9LAAHO9hg0zgZa0MxQAlDQov3dZcr7u7qGcQmU5JzcRS\nJgfDxHxDuMjmq6Kd0/UwD00kd2ptZgRls0ntXdm9CZGtQ/Q0baJ3eRzccpd/8bxy\nRWF9MnOdmV6ojcFKYECjEzcuheUlcKQH9rLkeBSfgrIlK3L7LG8bg5ouZLdx17rQ\nXABNQGmJTaGAiEnS/48G3roMS8R7fhUljcKr6t63QQQJ2qWdPvI6EMC2xKZsLHK4\nXiUvrmJpUprvEQSKBUOf/2zuXDBshtAnoKh7h5aG+TvozL4yNG5DKpSH3MRj1E43\nKoMsP/GN/X5h+vJnvhiCWxNMPP81Op0czBAgukBm627FTnsvieJOOrzyxb1s75+W\n56gJombmhzUfzr88AYY9mFy7diTw/oldDZcfwa8rvOAGJVDlyr2hqkLoGl+5jPex\nslt3NF4caE/wP9wPMgFRkmMOr8eiRhjlWLrO6mQdBp7Qsj3kEXioP+CZ1cv/sbaK\n4DM7VidB4PLrMFQMaf0LpjpC2DM=\n=wOl2\n-----END PGP PUBLIC KEY BLOCK-----"
+      ]
+    }
+  ],
+  "ppc64le": [
+    {
+      "name": "fedora",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-ppc64le-branched-20240415",
+      "check_gpg": true,
+      "gpgkeys": [
+        "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGPQTCwBEADFUL0EQLzwpKHtlPkacVI156F2LnWp6K69g/6yzllidHI3b7EV\nQgQ9/Kdou6wNuOahNKa6WcEi6grEXexD7pAcu4xdRUp79XxQy5pC7Aq2/Dwf0vRL\n2y0kqof+C7iSzhHsfLoaqKKeh2njAo1KLZXYTHAWAMbXEyO/FJevaHLXe2+yYd7j\nluD58gyXgGDXXJ2lymLqs2jobjWdmGPNZGFl36RP3Dnk0FpbdH78kyIIsc2foYuF\n00rnuumwCtK3V58VOZo6IkaYk2irdyeetmJjVHwLHwJB3EaAwGy9Z2oAH3LxxFfk\nrQb0DH0Nzb3fpEziopOOqSi+6guV4RHUKAkCUMu+Mo5XwFVPUAIfNRTVqoIaEasC\nWO26lhkB87wwIvyb/TPGSeh6laHPRf0QOUOLkugdkSHoaJFWoTCcu9Y4aeDpf+ZQ\nfMVmkJNRS1tXONgz+pDk1rro/tNrkusYG18xjvSZTB0P0C4b4+jgK5l7me0NU6G3\nWw/hIng5lxWfXgE9bpxlN834v1xy5Z3v17guJu1ec/jzKzQQ4356wyegXURjYoWe\nawcnK1S+9gxivnkOk1bGLNxrEh5vB6PDcI1VQ1ECH50EHyvE1IXJDaaStdAkacv2\nqHcd15CnlBW1LYFj0CHs/sGu9FD0iSF95OVRX4gjg9Wa4f8KvtEO/f+FeQARAQAB\ntDFGZWRvcmEgKDQwKSA8ZmVkb3JhLTQwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEEV35rvhXhT7oRF0KBydwfqFbecwFAmPQTCwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQBydwfqFbecxJOw//XaoJG3zN01bVM63H\nnFmMW/EnLzKrZqH8ZNq8CP9ycoc4q8SYcMprHKG9jufzj5/FhtpYecp3kBMpSYHt\nVu46LS9NajJDwdfvUMezVbieNIQ8icTR5s5IUYFlc47eG6PRe3k0n5fOPcIb6q82\nbyrK3dQnanOcVdoGU7QO9LAAHO9hg0zgZa0MxQAlDQov3dZcr7u7qGcQmU5JzcRS\nJgfDxHxDuMjmq6Kd0/UwD00kd2ptZgRls0ntXdm9CZGtQ/Q0baJ3eRzccpd/8bxy\nRWF9MnOdmV6ojcFKYECjEzcuheUlcKQH9rLkeBSfgrIlK3L7LG8bg5ouZLdx17rQ\nXABNQGmJTaGAiEnS/48G3roMS8R7fhUljcKr6t63QQQJ2qWdPvI6EMC2xKZsLHK4\nXiUvrmJpUprvEQSKBUOf/2zuXDBshtAnoKh7h5aG+TvozL4yNG5DKpSH3MRj1E43\nKoMsP/GN/X5h+vJnvhiCWxNMPP81Op0czBAgukBm627FTnsvieJOOrzyxb1s75+W\n56gJombmhzUfzr88AYY9mFy7diTw/oldDZcfwa8rvOAGJVDlyr2hqkLoGl+5jPex\nslt3NF4caE/wP9wPMgFRkmMOr8eiRhjlWLrO6mQdBp7Qsj3kEXioP+CZ1cv/sbaK\n4DM7VidB4PLrMFQMaf0LpjpC2DM=\n=wOl2\n-----END PGP PUBLIC KEY BLOCK-----"
+      ]
+    }
+  ],
+  "s390x": [
+    {
+      "name": "fedora",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-s390x-branched-20240415",
+      "check_gpg": true,
+      "gpgkeys": [
+        "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGPQTCwBEADFUL0EQLzwpKHtlPkacVI156F2LnWp6K69g/6yzllidHI3b7EV\nQgQ9/Kdou6wNuOahNKa6WcEi6grEXexD7pAcu4xdRUp79XxQy5pC7Aq2/Dwf0vRL\n2y0kqof+C7iSzhHsfLoaqKKeh2njAo1KLZXYTHAWAMbXEyO/FJevaHLXe2+yYd7j\nluD58gyXgGDXXJ2lymLqs2jobjWdmGPNZGFl36RP3Dnk0FpbdH78kyIIsc2foYuF\n00rnuumwCtK3V58VOZo6IkaYk2irdyeetmJjVHwLHwJB3EaAwGy9Z2oAH3LxxFfk\nrQb0DH0Nzb3fpEziopOOqSi+6guV4RHUKAkCUMu+Mo5XwFVPUAIfNRTVqoIaEasC\nWO26lhkB87wwIvyb/TPGSeh6laHPRf0QOUOLkugdkSHoaJFWoTCcu9Y4aeDpf+ZQ\nfMVmkJNRS1tXONgz+pDk1rro/tNrkusYG18xjvSZTB0P0C4b4+jgK5l7me0NU6G3\nWw/hIng5lxWfXgE9bpxlN834v1xy5Z3v17guJu1ec/jzKzQQ4356wyegXURjYoWe\nawcnK1S+9gxivnkOk1bGLNxrEh5vB6PDcI1VQ1ECH50EHyvE1IXJDaaStdAkacv2\nqHcd15CnlBW1LYFj0CHs/sGu9FD0iSF95OVRX4gjg9Wa4f8KvtEO/f+FeQARAQAB\ntDFGZWRvcmEgKDQwKSA8ZmVkb3JhLTQwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEEV35rvhXhT7oRF0KBydwfqFbecwFAmPQTCwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQBydwfqFbecxJOw//XaoJG3zN01bVM63H\nnFmMW/EnLzKrZqH8ZNq8CP9ycoc4q8SYcMprHKG9jufzj5/FhtpYecp3kBMpSYHt\nVu46LS9NajJDwdfvUMezVbieNIQ8icTR5s5IUYFlc47eG6PRe3k0n5fOPcIb6q82\nbyrK3dQnanOcVdoGU7QO9LAAHO9hg0zgZa0MxQAlDQov3dZcr7u7qGcQmU5JzcRS\nJgfDxHxDuMjmq6Kd0/UwD00kd2ptZgRls0ntXdm9CZGtQ/Q0baJ3eRzccpd/8bxy\nRWF9MnOdmV6ojcFKYECjEzcuheUlcKQH9rLkeBSfgrIlK3L7LG8bg5ouZLdx17rQ\nXABNQGmJTaGAiEnS/48G3roMS8R7fhUljcKr6t63QQQJ2qWdPvI6EMC2xKZsLHK4\nXiUvrmJpUprvEQSKBUOf/2zuXDBshtAnoKh7h5aG+TvozL4yNG5DKpSH3MRj1E43\nKoMsP/GN/X5h+vJnvhiCWxNMPP81Op0czBAgukBm627FTnsvieJOOrzyxb1s75+W\n56gJombmhzUfzr88AYY9mFy7diTw/oldDZcfwa8rvOAGJVDlyr2hqkLoGl+5jPex\nslt3NF4caE/wP9wPMgFRkmMOr8eiRhjlWLrO6mQdBp7Qsj3kEXioP+CZ1cv/sbaK\n4DM7VidB4PLrMFQMaf0LpjpC2DM=\n=wOl2\n-----END PGP PUBLIC KEY BLOCK-----"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Was removed for CVE-2024-3094.

This reverts commit f8630c4b287a13bd6c7b90b7b25c8c4720b0b729 but with newer snapshots that don't contain the exploited package.