### PR TITLE
Distro/RHEL-7: support EC2 (RHUI) image (COMPOSER-2060)

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -8,21 +8,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "f26e62b23f547fc5ad665cb08cc52e6431657779"
+        "commit": "5b75592fefc4ee2d9e240a15b7002f2537de31b0"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "f26e62b23f547fc5ad665cb08cc52e6431657779"
+        "commit": "5b75592fefc4ee2d9e240a15b7002f2537de31b0"
       }
     }
   },
   "fedora-39": {
     "dependencies": {
       "osbuild": {
-        "commit": "f26e62b23f547fc5ad665cb08cc52e6431657779"
+        "commit": "5b75592fefc4ee2d9e240a15b7002f2537de31b0"
       }
     },
     "repos": [

--- a/pkg/distro/rhel/rhel7/ami.go
+++ b/pkg/distro/rhel/rhel7/ami.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	ec2KernelOptions = "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295"
+	ec2KernelOptions = "ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto LANG=en_US.UTF-8"
 )
 
 func mkEc2ImgTypeX86_64() *rhel.ImageType {

--- a/pkg/distro/rhel/rhel7/ami.go
+++ b/pkg/distro/rhel/rhel7/ami.go
@@ -1,0 +1,289 @@
+package rhel7
+
+import (
+	"os"
+
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/pkg/customizations/fsnode"
+	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distro/rhel"
+	"github.com/osbuild/images/pkg/osbuild"
+	"github.com/osbuild/images/pkg/rpmmd"
+)
+
+const (
+	ec2KernelOptions = "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295"
+)
+
+func mkEc2ImgTypeX86_64() *rhel.ImageType {
+	it := rhel.NewImageType(
+		"ec2",
+		"image.raw.xz",
+		"application/xz",
+		map[string]rhel.PackageSetFunc{
+			rhel.OSPkgsKey: ec2PackageSet,
+		},
+		rhel.DiskImage,
+		[]string{"build"},
+		[]string{"os", "image", "xz"},
+		[]string{"xz"},
+	)
+
+	// all RHEL 7 images should use sgdisk
+	it.DiskImagePartTool = common.ToPtr(osbuild.PTSgdisk)
+
+	it.Compression = "xz"
+	it.DefaultImageConfig = ec2ImageConfig()
+	it.KernelOptions = ec2KernelOptions
+	it.Bootable = true
+	it.DefaultSize = 10 * common.GibiByte
+	it.BasePartitionTables = ec2PartitionTables
+
+	return it
+}
+
+// default EC2 images config (common for all architectures)
+func ec2ImageConfig() *distro.ImageConfig {
+
+	// systemd-firstboot on el7 does not support --keymap option
+	vconsoleFile, err := fsnode.NewFile("/etc/vconsole.conf", nil, nil, nil, []byte("FONT=latarcyrheb-sun16\nKEYMAP=us\n"))
+	if err != nil {
+		panic(err)
+	}
+
+	// This is needed to disable predictable network interface names.
+	// The org.osbuild.udev.rules stage can't create empty files.
+	udevNetNameSlotRulesFile, err := fsnode.NewFile("/etc/udev/rules.d/80-net-name-slot.rules", nil, nil, nil, []byte{})
+	if err != nil {
+		panic(err)
+	}
+
+	// While cloud-init does this automatically on first boot for the specified user,
+	// this was in the original KS.
+	ec2UserSudoers, err := fsnode.NewFile("/etc/sudoers.d/ec2-user", common.ToPtr(os.FileMode(0o440)), nil, nil, []byte("ec2-user\tALL=(ALL)\tNOPASSWD: ALL\n"))
+	if err != nil {
+		panic(err)
+	}
+
+	// The image built from the original KS has this file with this content.
+	hostnameFile, err := fsnode.NewFile("/etc/hostname", nil, nil, nil, []byte("localhost.localdomain\n"))
+	if err != nil {
+		panic(err)
+	}
+
+	return &distro.ImageConfig{
+		Timezone: common.ToPtr("UTC"),
+		TimeSynchronization: &osbuild.ChronyStageOptions{
+			Servers: []osbuild.ChronyConfigServer{
+				{
+					Hostname: "0.rhel.pool.ntp.org",
+					Iburst:   common.ToPtr(true),
+				},
+				{
+					Hostname: "1.rhel.pool.ntp.org",
+					Iburst:   common.ToPtr(true),
+				},
+				{
+					Hostname: "2.rhel.pool.ntp.org",
+					Iburst:   common.ToPtr(true),
+				},
+				{
+					Hostname: "3.rhel.pool.ntp.org",
+					Iburst:   common.ToPtr(true),
+				},
+				{
+					Hostname: "169.254.169.123",
+					Prefer:   common.ToPtr(true),
+					Iburst:   common.ToPtr(true),
+					Minpoll:  common.ToPtr(4),
+					Maxpoll:  common.ToPtr(4),
+				},
+			},
+			// empty string will remove any occurrences of the option from the configuration
+			LeapsecTz: common.ToPtr(""),
+		},
+		EnabledServices: []string{
+			"sshd",
+			"rsyslog",
+		},
+		DefaultTarget: common.ToPtr("multi-user.target"),
+		Sysconfig: []*osbuild.SysconfigStageOptions{
+			{
+				Kernel: &osbuild.SysconfigKernelOptions{
+					UpdateDefault: true,
+					DefaultKernel: "kernel",
+				},
+				Network: &osbuild.SysconfigNetworkOptions{
+					Networking: true,
+					NoZeroConf: true,
+				},
+				NetworkScripts: &osbuild.NetworkScriptsOptions{
+					IfcfgFiles: map[string]osbuild.IfcfgFile{
+						"eth0": {
+							Device:    "eth0",
+							Bootproto: osbuild.IfcfgBootprotoDHCP,
+							OnBoot:    common.ToPtr(true),
+							Type:      osbuild.IfcfgTypeEthernet,
+							UserCtl:   common.ToPtr(true),
+							PeerDNS:   common.ToPtr(true),
+							IPv6Init:  common.ToPtr(false),
+						},
+					},
+				},
+			},
+		},
+		SystemdLogind: []*osbuild.SystemdLogindStageOptions{
+			{
+				Filename: "logind.conf",
+				Config: osbuild.SystemdLogindConfigDropin{
+					Login: osbuild.SystemdLogindConfigLoginSection{
+						NAutoVTs: common.ToPtr(0),
+					},
+				},
+			},
+		},
+		CloudInit: []*osbuild.CloudInitStageOptions{
+			{
+				Filename: "00-rhel-default-user.cfg",
+				Config: osbuild.CloudInitConfigFile{
+					SystemInfo: &osbuild.CloudInitConfigSystemInfo{
+						DefaultUser: &osbuild.CloudInitConfigDefaultUser{
+							Name: "ec2-user",
+						},
+					},
+				},
+			},
+			{
+				Filename: "99-datasource.cfg",
+				Config: osbuild.CloudInitConfigFile{
+					DatasourceList: []string{
+						"Ec2",
+						"None",
+					},
+				},
+			},
+		},
+		Modprobe: []*osbuild.ModprobeStageOptions{
+			{
+				Filename: "blacklist-nouveau.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
+				},
+			},
+		},
+		DracutConf: []*osbuild.DracutConfStageOptions{
+			{
+				Filename: "sgdisk.conf",
+				Config: osbuild.DracutConfigFile{
+					Install: []string{"sgdisk"},
+				},
+			},
+		},
+		SshdConfig: &osbuild.SshdConfigStageOptions{
+			Config: osbuild.SshdConfigConfig{
+				PasswordAuthentication: common.ToPtr(false),
+			},
+		},
+		Files: []*fsnode.File{
+			vconsoleFile,
+			udevNetNameSlotRulesFile,
+			ec2UserSudoers,
+			hostnameFile,
+		},
+		SELinuxForceRelabel: common.ToPtr(true),
+	}
+}
+
+func ec2PackageSet(t *rhel.ImageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"@core",
+			"authconfig",
+			"kernel",
+			"yum-utils",
+			"cloud-init",
+			"dracut-config-generic",
+			"dracut-norescue",
+			"grub2",
+			"tar",
+			"rsync",
+			"rh-amazon-rhui-client",
+			"redhat-cloud-client-configuration",
+			"chrony",
+			"cloud-utils-growpart",
+			"gdisk",
+		},
+		Exclude: []string{
+			"aic94xx-firmware",
+			"alsa-firmware",
+			"alsa-lib",
+			"alsa-tools-firmware",
+			"ivtv-firmware",
+			"iwl1000-firmware",
+			"iwl100-firmware",
+			"iwl105-firmware",
+			"iwl135-firmware",
+			"iwl2000-firmware",
+			"iwl2030-firmware",
+			"iwl3160-firmware",
+			"iwl3945-firmware",
+			"iwl4965-firmware",
+			"iwl5000-firmware",
+			"iwl5150-firmware",
+			"iwl6000-firmware",
+			"iwl6000g2a-firmware",
+			"iwl6000g2b-firmware",
+			"iwl6050-firmware",
+			"iwl7260-firmware",
+			"libertas-sd8686-firmware",
+			"libertas-sd8787-firmware",
+			"libertas-usb8388-firmware",
+			"biosdevname",
+			"plymouth",
+			// NM is excluded by the original KS, but it is in the image built from it.
+			// "NetworkManager",
+			"iprutils",
+			// linux-firmware is uninstalled by the original KS, but it is a direct dependency of kernel,
+			// so we can't exclude it.
+			// "linux-firmware",
+			"firewalld",
+		},
+	}
+}
+
+func ec2PartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
+	switch t.Arch().Name() {
+	case arch.ARCH_X86_64.String():
+		return disk.PartitionTable{
+			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+			Type: "gpt",
+			Size: 10 * common.GibiByte,
+			Partitions: []disk.Partition{
+				{
+					Size:     1 * common.MebiByte,
+					Bootable: true,
+					Type:     disk.BIOSBootPartitionGUID,
+					UUID:     disk.BIOSBootPartitionUUID,
+				},
+				{
+					Size: 6144 * common.MebiByte,
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.RootPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Label:        "root",
+						Mountpoint:   "/",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
+				},
+			},
+		}, true
+
+	default:
+		return disk.PartitionTable{}, false
+	}
+}

--- a/pkg/distro/rhel/rhel7/distro.go
+++ b/pkg/distro/rhel/rhel7/distro.go
@@ -72,6 +72,16 @@ func newDistro(name string, minor int) *rhel.Distribution {
 		mkAzureRhuiImgType(),
 	)
 
+	x86_64.AddImageTypes(
+		&platform.X86{
+			BIOS: true,
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_RAW,
+			},
+		},
+		mkEc2ImgTypeX86_64(),
+	)
+
 	rd.AddArches(
 		x86_64,
 	)

--- a/pkg/distro/rhel/rhel7/distro_test.go
+++ b/pkg/distro/rhel/rhel7/distro_test.go
@@ -55,6 +55,14 @@ func TestFilenameFromType(t *testing.T) {
 			},
 		},
 		{
+			name: "ec2",
+			args: args{"ec2"},
+			want: wantResult{
+				filename: "image.raw.xz",
+				mimeType: "application/xz",
+			},
+		},
+		{
 			name: "invalid-output-type",
 			args: args{"foobar"},
 			want: wantResult{wantErr: true},
@@ -137,6 +145,7 @@ func TestImageType_Name(t *testing.T) {
 		{
 			arch: "x86_64",
 			imgNames: []string{
+				"ec2",
 				"qcow2",
 				"azure-rhui",
 			},
@@ -194,6 +203,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 		{
 			arch: "x86_64",
 			imgNames: []string{
+				"ec2",
 				"qcow2",
 				"azure-rhui",
 			},

--- a/pkg/osbuild/cloud_init_stage.go
+++ b/pkg/osbuild/cloud_init_stage.go
@@ -2,6 +2,8 @@ package osbuild
 
 import (
 	"fmt"
+
+	"golang.org/x/exp/slices"
 )
 
 type CloudInitStageOptions struct {
@@ -86,10 +88,12 @@ func (c CloudInitConfigFile) validate() error {
 			return err
 		}
 	}
+
+	allowedDatasources := []string{"Azure", "Ec2", "None"}
 	if len(c.DatasourceList) > 0 {
 		for _, d := range c.DatasourceList {
-			if d != "Azure" {
-				return fmt.Errorf("only 'Azure' is allowed as an item in the datasource_list")
+			if !slices.Contains(allowedDatasources, d) {
+				return fmt.Errorf("datasource %s is not allowed, only %v are allowed", d, allowedDatasources)
 			}
 		}
 	}

--- a/pkg/rpmmd/repository.go
+++ b/pkg/rpmmd/repository.go
@@ -25,6 +25,7 @@ type repository struct {
 	ModuleHotfixes *bool    `json:"module_hotfixes,omitempty"`
 	MetadataExpire string   `json:"metadata_expire,omitempty"`
 	ImageTypeTags  []string `json:"image_type_tags,omitempty"`
+	PackageSets    []string `json:"package_sets,omitempty"`
 }
 
 type RepoConfig struct {
@@ -264,6 +265,7 @@ func LoadRepositoriesFromFile(filename string) (map[string][]RepoConfig, error) 
 				MetadataExpire: repo.MetadataExpire,
 				ModuleHotfixes: repo.ModuleHotfixes,
 				ImageTypeTags:  repo.ImageTypeTags,
+				PackageSets:    repo.PackageSets,
 			}
 
 			repoConfigs[arch] = append(repoConfigs[arch], config)

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -38,7 +38,6 @@
       "fedora-38",
       "fedora-39",
       "fedora-40",
-      "rhel-7.9",
       "rhel-8.10",
       "rhel-8.5",
       "rhel-8.6",

--- a/test/data/repositories/rhel-7.9.json
+++ b/test/data/repositories/rhel-7.9.json
@@ -5,6 +5,10 @@
       "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20230809"
     },
     {
+      "name": "server-updates",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-updates-7.9-20240415"
+    },
+    {
       "name": "server-extras",
       "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-extras-r7.9-20240401"
     },
@@ -25,7 +29,17 @@
     },
     {
       "name": "azure-rhui-7",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-rhui-azure-20240401"
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-rhui-azure-20240401",
+      "image_type_tags": [
+        "azure-rhui"
+      ]
+    },
+    {
+      "name": "rhui-3",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-rhui-3-20240415",
+      "image_type_tags": [
+        "ec2"
+      ]
     }
   ]
 }

--- a/test/data/repositories/rhel-7.9.json
+++ b/test/data/repositories/rhel-7.9.json
@@ -19,7 +19,7 @@
     {
       "name": "rhel-eng",
       "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20230328",
-      "package-sets": [
+      "package_sets": [
         "build"
       ]
     },


### PR DESCRIPTION
Add support for building EC2 (RHUI) image on RHEL-7. It is based on the internal KS previously used for building it using ImageFactory.

Depends on https://github.com/osbuild/osbuild/pull/1729

Notable differences:

- Boot entry: the original image used a nice title as the boot entry ID. osbuild grub2.legacy stage instead uses a generic entry ID as the boot entry and then specifies the same "nice" title in grub.cfg in the menuentry.
- Cloud-init default user: the original image modified the main cloud-init config, while in the ported image, we use a drop-in config.
- Dracut config: original image placed config files in `/etc/dracut.conf.d`, while osbuild stage puts it in `/usr/lib/dracut/dracut.conf.d`.
- Firewall config: original image installed firewalld and then uninstalled it in the %post section. The FW config in the original image was a result of this. Since we do not install firewalld at all in the image, there is no side-effect.
- Modprobe config: original image placed config files in `/etc/modprobe.d`, while osbuild stage puts it in `/usr/lib/modprobe.d`.
- Package set: original image contained `qemu-guest-agent`, which is a side-effect of building the image using Anaconda. Ported image does not contain it. Ported image contains `linux-firmware`, which is a direct dependency of `kernel` and can't be excluded. The original image did a hack in %post, which uninstalled the package, but it would get pulled in on future updates. Ported image also has GPG keys imported.
- Services: `qemu-guest-agent.service` is not enabled on the ported image, because the package is not installed at all.
- Sudoers: original image added `ec2-user` to the `/etc/sudoers`, while the ported image adds a dropin config `/etc/sudoers.d/ec2-user`.
- SELinux ctx mismatch: there are many incorrectly labeled files in the ported image. This is workarounded by forcing the auto-relabel on first boot, which is the case for all RHEL-7 images.