### PR TITLE
manifest,osbuild: support `bootc install to-filesystem --target-imgref`

### DIFF
--- a/pkg/manifest/raw_bootc.go
+++ b/pkg/manifest/raw_bootc.go
@@ -103,6 +103,9 @@ func (p *RawBootcImage) serialize() osbuild.Pipeline {
 	opts := &osbuild.BootcInstallToFilesystemOptions{
 		Kargs: p.KernelOptionsAppend,
 	}
+	if len(p.containers) > 0 {
+		opts.TargetImgref = p.containers[0].Name
+	}
 	inputs := osbuild.ContainerDeployInputs{
 		Images: osbuild.NewContainersInputForSingleSource(p.containerSpecs[0]),
 	}

--- a/pkg/manifest/raw_bootc_test.go
+++ b/pkg/manifest/raw_bootc_test.go
@@ -15,6 +15,12 @@ import (
 	"github.com/osbuild/images/pkg/runner"
 )
 
+var containers = []container.SourceSpec{
+	{
+		Name: "quay.io/centos-bootc/centos-bootc-dev:stream9",
+	},
+}
+
 func hasPipeline(haystack []manifest.Pipeline, needle manifest.Pipeline) bool {
 	for _, p := range haystack {
 		if p == needle {
@@ -30,7 +36,7 @@ func TestNewRawBootcImage(t *testing.T) {
 	buildIf := manifest.NewBuildFromContainer(&mani, runner, nil, nil)
 	build := buildIf.(*manifest.BuildrootFromContainer)
 
-	rawBootcPipeline := manifest.NewRawBootcImage(build, nil, nil)
+	rawBootcPipeline := manifest.NewRawBootcImage(build, containers, nil)
 	require.NotNil(t, rawBootcPipeline)
 
 	assert.True(t, hasPipeline(build.Dependents(), rawBootcPipeline))
@@ -44,7 +50,7 @@ func TestRawBootcImageSerialize(t *testing.T) {
 	runner := &runner.Linux{}
 	build := manifest.NewBuildFromContainer(&mani, runner, nil, nil)
 
-	rawBootcPipeline := manifest.NewRawBootcImage(build, nil, nil)
+	rawBootcPipeline := manifest.NewRawBootcImage(build, containers, nil)
 	rawBootcPipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
 	rawBootcPipeline.Users = []users.User{{Name: "root", Key: common.ToPtr("some-ssh-key")}}
 	rawBootcPipeline.KernelOptionsAppend = []string{"karg1", "karg2"}
@@ -60,6 +66,7 @@ func TestRawBootcImageSerialize(t *testing.T) {
 	// (mostly for uniformity)
 	assert.Equal(t, len(opts.RootSSHAuthorizedKeys), 0)
 	assert.Equal(t, []string{"karg1", "karg2"}, opts.Kargs)
+	assert.Equal(t, "quay.io/centos-bootc/centos-bootc-dev:stream9", opts.TargetImgref)
 }
 
 func TestRawBootcImageSerializeMountsValidated(t *testing.T) {

--- a/pkg/osbuild/bootc_install_to_filesystem_stage.go
+++ b/pkg/osbuild/bootc_install_to_filesystem_stage.go
@@ -9,6 +9,9 @@ type BootcInstallToFilesystemOptions struct {
 	RootSSHAuthorizedKeys []string `json:"root-ssh-authorized-keys,omitempty"`
 	// options for --karg
 	Kargs []string `json:"kernel-args,omitempty"`
+
+	// option for --target-imgref
+	TargetImgref string `json:"target-imgref"`
 }
 
 func (BootcInstallToFilesystemOptions) isStageOptions() {}

--- a/pkg/osbuild/bootc_install_to_filesystem_stage_test.go
+++ b/pkg/osbuild/bootc_install_to_filesystem_stage_test.go
@@ -82,7 +82,10 @@ func TestBootcInstallToFilesystemStageJsonHappy(t *testing.T) {
 	mounts := makeOsbuildMounts("/", "/boot", "/boot/efi")
 	inputs := makeFakeContainerInputs()
 
-	stage, err := osbuild.NewBootcInstallToFilesystemStage(nil, inputs, devices, mounts)
+	opts := &osbuild.BootcInstallToFilesystemOptions{
+		TargetImgref: "quay.io/centos-bootc/centos-bootc-dev:stream9",
+	}
+	stage, err := osbuild.NewBootcInstallToFilesystemStage(opts, inputs, devices, mounts)
 	require.Nil(t, err)
 	stageJson, err := json.MarshalIndent(stage, "", "  ")
 	require.Nil(t, err)
@@ -99,7 +102,9 @@ func TestBootcInstallToFilesystemStageJsonHappy(t *testing.T) {
       }
     }
   },
-  "options": null,
+  "options": {
+    "target-imgref": "quay.io/centos-bootc/centos-bootc-dev:stream9"
+  },
   "devices": {
     "dev-for-/": {
       "type": "org.osbuild.loopback"


### PR DESCRIPTION
We currently do not set the `--target-imgref` when using bootc install to-filesystem. This commit fixes this.

(this may be too naive?)

[edit: manual test shows that it seems to work:
```
metadata:
  name: host
spec:
  image:
    image: quay.io/centos-bootc/centos-bootc-dev:stream9
    transport: registry
  bootOrder: default
status:
  staged: null
  booted:
    image:
      image:
        image: quay.io/centos-bootc/centos-bootc-dev:stream9
        transport: registry
      version: stream9.20240411.0
      timestamp: null
      imageDigest: sha256:1b19a29cb3c93d68f2f8581af94bafc0e58ad57bc941fc2915006823866d7fbc
    cachedUpdate: null
    incompatible: false
    pinned: false
    ostree:
      checksum: 30ade360312603e3a18d4d43fdbeeaddbc37851b130a8d9c29129da7302fdced
      deploySerial: 0
  rollback: null
  rollbackQueued: false
```

The test in bib is added in https://github.com/osbuild/bootc-image-builder/pull/357