### PR TITLE
test/imgtestlib: download bib-id files with info files

### DIFF
--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -128,6 +128,7 @@ def dl_build_info(destination, distro=None, arch=None):
                   "--no-progress",  # wont show progress but will print file list
                   "--exclude=*",
                   "--include=*/info.json",
+                  "--include=*/bib-*",
                   s3url, destination],
                  capture_output=True,
                  check=False)


### PR DESCRIPTION
We can't check if a bootable container was tested with a version of bootc-image-builder if we don't download the files.