### PR TITLE
image,manifest,osbuild: support kickstart kernel arguments for the iso container installer

### DIFF
--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -42,6 +42,10 @@ type AnacondaContainerInstaller struct {
 	AdditionalAnacondaModules []string
 	AdditionalDrivers         []string
 	FIPS                      bool
+
+	// Kernel options that will be apended to the installed system
+	// (not the iso)
+	KickstartKernelOptionsAppend []string
 }
 
 func NewAnacondaContainerInstaller(container container.SourceSpec, ref string) *AnacondaContainerInstaller {
@@ -114,6 +118,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.OSName = img.OSName
 	isoTreePipeline.Users = img.Users
 	isoTreePipeline.Groups = img.Groups
+	isoTreePipeline.KickstartKernelOptionsAppend = img.KickstartKernelOptionsAppend
 
 	isoTreePipeline.SquashfsCompression = img.SquashfsCompression
 

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -34,6 +34,10 @@ type AnacondaInstallerISOTree struct {
 	Keyboard *string
 	Timezone *string
 
+	// Kernel options that will be apended to the installed system
+	// (not the iso)
+	KickstartKernelOptionsAppend []string
+
 	// Create a sudoers drop-in file for each user or group to enable the
 	// NOPASSWD option
 	NoPasswd []string
@@ -67,6 +71,7 @@ type AnacondaInstallerISOTree struct {
 	ContainerSource  *container.SourceSpec
 	containerSpec    *container.Spec
 
+	// Kernel options for the ISO image
 	KernelOpts []string
 
 	// Enable ISOLinux stage
@@ -436,6 +441,17 @@ func (p *AnacondaInstallerISOTree) ostreeContainerStages() []*osbuild.Stage {
 	kickstartOptions.Timezone = "UTC"
 	kickstartOptions.ClearPart = &osbuild.ClearPartOptions{
 		All: true,
+	}
+	if len(p.KickstartKernelOptionsAppend) > 0 {
+		kickstartOptions.Bootloader = &osbuild.BootloaderOptions{
+			// We currently leaves quoting to the
+			// user. This is generally ok - to do better
+			// we will have to mimic the kernel arg
+			// parser, see
+			// https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html
+			// and lib/cmdline.c in the kernel source
+			Append: strings.Join(p.KickstartKernelOptionsAppend, " "),
+		}
 	}
 
 	stages = append(stages, osbuild.NewKickstartStage(kickstartOptions))

--- a/pkg/manifest/anaconda_installer_iso_tree_test.go
+++ b/pkg/manifest/anaconda_installer_iso_tree_test.go
@@ -386,6 +386,20 @@ func TestAnacondaISOTreeSerializeWithContainer(t *testing.T) {
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux"), variantStages))
 	})
+
+	t.Run("kernel-options", func(t *testing.T) {
+		pipeline := newTestAnacondaISOTree()
+		pipeline.KSPath = testKsPath
+		pipeline.KickstartKernelOptionsAppend = []string{"kernel.opt=1", "debug"}
+		pipeline.serializeStart(nil, []container.Spec{containerPayload}, nil, nil)
+		sp := pipeline.serialize()
+		pipeline.serializeEnd()
+		kickstartSt := findStage("org.osbuild.kickstart", sp.Stages)
+		assert.NotNil(t, kickstartSt)
+		opts := kickstartSt.Options.(*osbuild.KickstartStageOptions)
+		assert.Equal(t, "kernel.opt=1 debug", opts.Bootloader.Append)
+	})
+
 }
 
 func TestMakeKickstartSudoersPostEmpty(t *testing.T) {

--- a/pkg/osbuild/kickstart_stage.go
+++ b/pkg/osbuild/kickstart_stage.go
@@ -37,6 +37,11 @@ type KickstartStageOptions struct {
 	ClearPart    *ClearPartOptions    `json:"clearpart,omitempty"`
 	AutoPart     *AutoPartOptions     `json:"autopart,omitempty"`
 	Network      []NetworkOptions     `json:"network,omitempty"`
+	Bootloader   *BootloaderOptions   `json:"bootloader,omitempty"`
+}
+
+type BootloaderOptions struct {
+	Append string `json:"append"`
 }
 
 type LiveIMGOptions struct {

--- a/pkg/osbuild/kickstart_stage_test.go
+++ b/pkg/osbuild/kickstart_stage_test.go
@@ -1,0 +1,33 @@
+package osbuild_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+func TestKickstartStageJsonHappy(t *testing.T) {
+	opts := &osbuild.KickstartStageOptions{
+		Path: "/osbuild.ks",
+		Bootloader: &osbuild.BootloaderOptions{
+			Append: "karg1 karg2=0",
+		},
+	}
+	stage := osbuild.NewKickstartStage(opts)
+	require.NotNil(t, stage)
+	stageJson, err := json.MarshalIndent(stage, "", "  ")
+	require.Nil(t, err)
+	assert.Equal(t, string(stageJson), `{
+  "type": "org.osbuild.kickstart",
+  "options": {
+    "path": "/osbuild.ks",
+    "bootloader": {
+      "append": "karg1 karg2=0"
+    }
+  }
+}`)
+}


### PR DESCRIPTION
Support for osbuild for this option landed in https://github.com/osbuild/osbuild/pull/1742

The bib bits are in https://github.com/osbuild/bootc-image-builder/pull/370