### PR TITLE
image: add NetworkOnBoot to container installer for bib

### DIFF
--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -46,6 +46,8 @@ type AnacondaContainerInstaller struct {
 	// Kernel options that will be apended to the installed system
 	// (not the iso)
 	KickstartKernelOptionsAppend []string
+	// Enable networking on on boot in the installed system
+	KickstartNetworkOnBoot bool
 }
 
 func NewAnacondaContainerInstaller(container container.SourceSpec, ref string) *AnacondaContainerInstaller {
@@ -119,6 +121,8 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.Users = img.Users
 	isoTreePipeline.Groups = img.Groups
 	isoTreePipeline.KickstartKernelOptionsAppend = img.KickstartKernelOptionsAppend
+
+	isoTreePipeline.KickstartNetworkOnBoot = img.KickstartNetworkOnBoot
 
 	isoTreePipeline.SquashfsCompression = img.SquashfsCompression
 

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -37,6 +37,8 @@ type AnacondaInstallerISOTree struct {
 	// Kernel options that will be apended to the installed system
 	// (not the iso)
 	KickstartKernelOptionsAppend []string
+	// Enable networking on on boot in the installed system
+	KickstartNetworkOnBoot bool
 
 	// Create a sudoers drop-in file for each user or group to enable the
 	// NOPASSWD option
@@ -451,6 +453,11 @@ func (p *AnacondaInstallerISOTree) ostreeContainerStages() []*osbuild.Stage {
 			// https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html
 			// and lib/cmdline.c in the kernel source
 			Append: strings.Join(p.KickstartKernelOptionsAppend, " "),
+		}
+	}
+	if p.KickstartNetworkOnBoot {
+		kickstartOptions.Network = []osbuild.NetworkOptions{
+			{BootProto: "dhcp", Device: "link", Activate: common.ToPtr(true), OnBoot: "on"},
 		}
 	}
 

--- a/pkg/manifest/anaconda_installer_iso_tree_test.go
+++ b/pkg/manifest/anaconda_installer_iso_tree_test.go
@@ -400,6 +400,19 @@ func TestAnacondaISOTreeSerializeWithContainer(t *testing.T) {
 		assert.Equal(t, "kernel.opt=1 debug", opts.Bootloader.Append)
 	})
 
+	t.Run("network-on-boot", func(t *testing.T) {
+		pipeline := newTestAnacondaISOTree()
+		pipeline.KSPath = testKsPath
+		pipeline.KickstartNetworkOnBoot = true
+		pipeline.serializeStart(nil, []container.Spec{containerPayload}, nil, nil)
+		sp := pipeline.serialize()
+		pipeline.serializeEnd()
+		kickstartSt := findStage("org.osbuild.kickstart", sp.Stages)
+		assert.NotNil(t, kickstartSt)
+		opts := kickstartSt.Options.(*osbuild.KickstartStageOptions)
+		assert.Equal(t, 1, len(opts.Network))
+		assert.Equal(t, "on", opts.Network[0].OnBoot)
+	})
 }
 
 func TestMakeKickstartSudoersPostEmpty(t *testing.T) {


### PR DESCRIPTION
With this and https://github.com/osbuild/bootc-image-builder/pull/368 and https://github.com/osbuild/images/pull/614/commits it seems we have a full iso installer for centos9 (user, networking, kargs).

[Build on top of https://github.com/osbuild/images/pull/614]