### PR TITLE
Remove RHC credentials from the system after registration (HMS-3814)

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -8,21 +8,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "5b75592fefc4ee2d9e240a15b7002f2537de31b0"
+        "commit": "f255fba09f2f0c879d92df37e3d9f8e31903720d"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "5b75592fefc4ee2d9e240a15b7002f2537de31b0"
+        "commit": "f255fba09f2f0c879d92df37e3d9f8e31903720d"
       }
     }
   },
   "fedora-39": {
     "dependencies": {
       "osbuild": {
-        "commit": "5b75592fefc4ee2d9e240a15b7002f2537de31b0"
+        "commit": "f255fba09f2f0c879d92df37e3d9f8e31903720d"
       }
     },
     "repos": [

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -37,8 +37,8 @@ func check(err error) {
 
 type BuildConfig struct {
 	Name      string               `json:"name"`
-	OSTree    *ostree.ImageOptions `json:"ostree,omitempty"`
 	Blueprint *blueprint.Blueprint `json:"blueprint,omitempty"`
+	Options   distro.ImageOptions  `json:"options"`
 	Depends   interface{}          `json:"depends,omitempty"` // ignored
 }
 
@@ -61,8 +61,7 @@ func loadConfig(path string) BuildConfig {
 func makeManifest(imgType distro.ImageType, config BuildConfig, distribution distro.Distro, repos []rpmmd.RepoConfig, archName string, seedArg int64, cacheRoot string) (manifest.OSBuildManifest, error) {
 	cacheDir := filepath.Join(cacheRoot, archName+distribution.Name())
 
-	options := distro.ImageOptions{Size: 0}
-	options.OSTree = config.OSTree
+	options := config.Options
 
 	// add RHSM fact to detect changes
 	options.Facts = &facts.ImageOptions{

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -52,9 +52,9 @@ type buildRequest struct {
 
 type BuildConfig struct {
 	Name      string               `json:"name"`
-	OSTree    *ostree.ImageOptions `json:"ostree,omitempty"`
 	Blueprint *blueprint.Blueprint `json:"blueprint,omitempty"`
-	Depends   BuildDependency      `json:"depends,omitempty"`
+	Options   distro.ImageOptions  `json:"options"`
+	Depends   interface{}          `json:"depends,omitempty"` // ignored
 }
 
 type BuildDependency struct {
@@ -210,8 +210,7 @@ func makeManifestJob(
 	filename := fmt.Sprintf("%s-%s-%s-%s.json", u(distroName), u(archName), u(imgType.Name()), u(name))
 	cacheDir := filepath.Join(cacheRoot, archName+distribution.Name())
 
-	options := distro.ImageOptions{Size: 0}
-	options.OSTree = bc.OSTree
+	options := bc.Options
 
 	var bp blueprint.Blueprint
 	if bc.Blueprint != nil {

--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -148,11 +148,11 @@ type ImageType interface {
 
 // The ImageOptions specify options for a specific image build
 type ImageOptions struct {
-	Size             uint64
-	OSTree           *ostree.ImageOptions
-	Subscription     *subscription.ImageOptions
-	Facts            *facts.ImageOptions
-	PartitioningMode disk.PartitioningMode
+	Size             uint64                     `json:"size"`
+	OSTree           *ostree.ImageOptions       `json:"ostree,omitempty"`
+	Subscription     *subscription.ImageOptions `json:"subscription,omitempty"`
+	Facts            *facts.ImageOptions        `json:"facts,omitempty"`
+	PartitioningMode disk.PartitioningMode      `json:"partitioning-mode,omitempty"`
 }
 
 type BasePartitionTableMap map[string]disk.PartitionTable

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -558,17 +558,27 @@ func (p *OS) serialize() osbuild.Pipeline {
 	// - Register with subscription-manager, no Insights or rhc
 	// - Register with subscription-manager and enable Insights, no rhc
 	if p.Subscription != nil {
-		subkeyFilepath := "/etc/osbuild-first-boot"
+		// Write a key file that will contain the org ID and activation key to be sourced in the systemd service.
+		// The file will also act as the ConditionFirstBoot file.
+		subkeyFilepath := "/etc/osbuild-subscription-register.env"
+		subkeyContent := fmt.Sprintf("ORG_ID=%s\nACTIVATION_KEY=%s", p.Subscription.Organization, p.Subscription.ActivationKey)
+		if subkeyFile, err := fsnode.NewFile(subkeyFilepath, nil, "root", "root", []byte(subkeyContent)); err == nil {
+			p.Files = append(p.Files, subkeyFile)
+		} else {
+			panic(err)
+		}
+
 		var commands []string
 		if p.Subscription.Rhc {
+			// TODO: replace org ID and activation key with env vars
 			// Use rhc for registration instead of subscription manager
-			commands = []string{fmt.Sprintf("/usr/bin/rhc connect -o=%s -a=%s --server %s", p.Subscription.Organization, p.Subscription.ActivationKey, p.Subscription.ServerUrl)}
+			commands = []string{fmt.Sprintf("/usr/bin/rhc connect -o=${ORG_ID} -a=${ACTIVATION_KEY} --server %s", p.Subscription.ServerUrl)}
 			// insights-client creates the .gnupg directory during boot process, and is labeled incorrectly
 			commands = append(commands, "restorecon -R /root/.gnupg")
 			// execute the rhc post install script as the selinuxenabled check doesn't work in the buildroot container
 			commands = append(commands, "/usr/sbin/semanage permissive --add rhcd_t")
 		} else {
-			commands = []string{fmt.Sprintf("/usr/sbin/subscription-manager register --org=%s --activationkey=%s --serverurl %s --baseurl %s", p.Subscription.Organization, p.Subscription.ActivationKey, p.Subscription.ServerUrl, p.Subscription.BaseUrl)}
+			commands = []string{fmt.Sprintf("/usr/sbin/subscription-manager register --org=${ORG_ID} --activationkey=${ACTIVATION_KEY} --serverurl %s --baseurl %s", p.Subscription.ServerUrl, p.Subscription.BaseUrl)}
 
 			// Insights is optional when using subscription-manager
 			if p.Subscription.Insights {
@@ -596,6 +606,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 					Type:            osbuild.Oneshot,
 					RemainAfterExit: false,
 					ExecStart:       commands,
+					EnvironmentFile: []string{subkeyFilepath},
 				},
 				Install: &osbuild.Install{
 					WantedBy: []string{"default.target"},

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -572,7 +572,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 		if p.Subscription.Rhc {
 			// TODO: replace org ID and activation key with env vars
 			// Use rhc for registration instead of subscription manager
-			commands = []string{fmt.Sprintf("/usr/bin/rhc connect -o=${ORG_ID} -a=${ACTIVATION_KEY} --server %s", p.Subscription.ServerUrl)}
+			commands = []string{fmt.Sprintf("/usr/bin/rhc connect --organization=${ORG_ID} --activation-key=${ACTIVATION_KEY} --server %s", p.Subscription.ServerUrl)}
 			// insights-client creates the .gnupg directory during boot process, and is labeled incorrectly
 			commands = append(commands, "restorecon -R /root/.gnupg")
 			// execute the rhc post install script as the selinuxenabled check doesn't work in the buildroot container

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -130,7 +130,7 @@ func TestRhcInsightsCommands(t *testing.T) {
 	}
 	pipeline := os.serialize()
 	CheckSystemdStageOptions(t, pipeline.Stages, []string{
-		"/usr/bin/rhc connect -o=${ORG_ID} -a=${ACTIVATION_KEY} --server subscription.rhsm.redhat.com",
+		"/usr/bin/rhc connect --organization=${ORG_ID} --activation-key=${ACTIVATION_KEY} --server subscription.rhsm.redhat.com",
 		"restorecon -R /root/.gnupg",
 		"/usr/sbin/semanage permissive --add rhcd_t",
 	})

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -370,7 +370,7 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 		// issue # https://github.com/osbuild/images/issues/352
 		if len(p.CustomFileSystems) != 0 {
 			serviceName := "osbuild-ostree-mountpoints.service"
-			stageOption := osbuild.NewSystemdUnitCreateStageOptions(createMountpointService(serviceName, p.CustomFileSystems))
+			stageOption := osbuild.NewSystemdUnitCreateStage(createMountpointService(serviceName, p.CustomFileSystems))
 			stageOption.MountOSTree(p.osName, ref, 0)
 			pipeline.AddStage(stageOption)
 			p.EnabledServices = append(p.EnabledServices, serviceName)

--- a/pkg/osbuild/systemd_unit_create_stage.go
+++ b/pkg/osbuild/systemd_unit_create_stage.go
@@ -28,6 +28,7 @@ type Unit struct {
 	ConditionPathIsDirectory []string `json:"ConditionPathIsDirectory,omitempty"`
 	Requires                 []string `json:"Requires,omitempty"`
 	Wants                    []string `json:"Wants,omitempty"`
+	After                    []string `json:"After,omitempty"`
 }
 
 type Service struct {
@@ -61,6 +62,15 @@ type SystemdUnitCreateStageOptions struct {
 func (SystemdUnitCreateStageOptions) isStageOptions() {}
 
 func (o *SystemdUnitCreateStageOptions) validate() error {
+	fre := regexp.MustCompile(filenameRegex)
+	if !fre.MatchString(o.Filename) {
+		return fmt.Errorf("filename %q doesn't conform to schema (%s)", o.Filename, filenameRegex)
+	}
+
+	if o.Config.Install == nil {
+		return fmt.Errorf("Install section of systemd unit is required")
+	}
+
 	vre := regexp.MustCompile(envVarRegex)
 	if service := o.Config.Service; service != nil {
 		for _, envVar := range service.Environment {

--- a/pkg/osbuild/systemd_unit_create_stage.go
+++ b/pkg/osbuild/systemd_unit_create_stage.go
@@ -72,7 +72,7 @@ func (o *SystemdUnitCreateStageOptions) validate() error {
 	return nil
 }
 
-func NewSystemdUnitCreateStageOptions(options *SystemdUnitCreateStageOptions) *Stage {
+func NewSystemdUnitCreateStage(options *SystemdUnitCreateStageOptions) *Stage {
 	if err := options.validate(); err != nil {
 		panic(err)
 	}

--- a/pkg/osbuild/systemd_unit_create_stage_test.go
+++ b/pkg/osbuild/systemd_unit_create_stage_test.go
@@ -48,7 +48,7 @@ func TestNewSystemdUnitCreateStage(t *testing.T) {
 		Options: &options,
 	}
 
-	actualStage := NewSystemdUnitCreateStageOptions(&options)
+	actualStage := NewSystemdUnitCreateStage(&options)
 	assert.Equal(t, expectedStage, actualStage)
 }
 
@@ -65,6 +65,6 @@ func TestNewSystemdUnitCreateStageInEtc(t *testing.T) {
 		Options: &options,
 	}
 
-	actualStage := NewSystemdUnitCreateStageOptions(&options)
+	actualStage := NewSystemdUnitCreateStage(&options)
 	assert.Equal(t, expectedStage, actualStage)
 }

--- a/pkg/subscription/subscription.go
+++ b/pkg/subscription/subscription.go
@@ -4,12 +4,12 @@ package subscription
 // ServerUrl denotes the host to register the system with
 // BaseUrl specifies the repository URL for DNF
 type ImageOptions struct {
-	Organization  string
-	ActivationKey string
-	ServerUrl     string
-	BaseUrl       string
-	Insights      bool
-	Rhc           bool
+	Organization  string `json:"organization"`
+	ActivationKey string `json:"activation_key"`
+	ServerUrl     string `json:"server_url"`
+	BaseUrl       string `json:"base_url"`
+	Insights      bool   `json:"insights"`
+	Rhc           bool   `json:"rhc"`
 }
 
 type RHSMStatus string

--- a/test/configs/edge-ostree-pull-device-fips.json
+++ b/test/configs/edge-ostree-pull-device-fips.json
@@ -6,8 +6,10 @@
       "installation_device": "/dev/vda"
     }
   },
-  "ostree": {
-    "url": "http://example.com/repo"
+  "options": {
+    "ostree": {
+      "url": "http://example.com/repo"
+    }
   },
   "depends": {
     "image-type": "edge-container",

--- a/test/configs/edge-ostree-pull-device.json
+++ b/test/configs/edge-ostree-pull-device.json
@@ -5,8 +5,10 @@
       "installation_device": "/dev/sda"
     }
   },
-  "ostree": {
-    "url": "http://example.com/repo"
+  "options": {
+    "ostree": {
+      "url": "http://example.com/repo"
+    }
   },
   "depends": {
     "image-type": "edge-container",

--- a/test/configs/edge-ostree-pull-empty.json
+++ b/test/configs/edge-ostree-pull-empty.json
@@ -1,7 +1,9 @@
 {
   "name": "edge-ostree-pull-empty",
-  "ostree": {
-    "url": "http://example.com/repo"
+  "options": {
+    "ostree": {
+      "url": "http://example.com/repo"
+    }
   },
   "depends": {
     "image-type": "edge-container",

--- a/test/configs/edge-ostree-pull-fips.json
+++ b/test/configs/edge-ostree-pull-fips.json
@@ -5,8 +5,10 @@
       "fips": true
     }
   },
-  "ostree": {
-    "url": "http://example.com/repo"
+  "options": {
+    "ostree": {
+      "url": "http://example.com/repo"
+    }
   },
   "depends": {
     "image-type": "edge-container",

--- a/test/configs/edge-ostree-pull-user-fips.json
+++ b/test/configs/edge-ostree-pull-user-fips.json
@@ -18,7 +18,9 @@
     "config": "empty.json",
     "image-type": "edge-container"
   },
-  "ostree": {
-    "url": "http://example.com/repo"
+  "options": {
+    "ostree": {
+      "url": "http://example.com/repo"
+    }
   }
 }

--- a/test/configs/edge-ostree-pull-user.json
+++ b/test/configs/edge-ostree-pull-user.json
@@ -17,7 +17,9 @@
     "config": "empty.json",
     "image-type": "edge-container"
   },
-  "ostree": {
-    "url": "http://example.com/repo"
+  "options": {
+    "ostree": {
+      "url": "http://example.com/repo"
+    }
   }
 }

--- a/test/configs/iot-customizations-full.json
+++ b/test/configs/iot-customizations-full.json
@@ -1,7 +1,9 @@
 {
   "name": "iot-customizations-full",
-  "ostree": {
-    "ref": "test/fedora/iot"
+  "options": {
+    "ostree": {
+      "ref": "test/fedora/iot"
+    }
   },
   "blueprint": {
     "customizations": {

--- a/test/configs/iot-ostree-pull-device.json
+++ b/test/configs/iot-ostree-pull-device.json
@@ -5,8 +5,10 @@
       "installation_device": "/dev/sda"
     }
   },
-  "ostree": {
-    "url": "http://example.com/repo"
+  "options": {
+    "ostree": {
+      "url": "http://example.com/repo"
+    }
   },
   "depends": {
     "image-type": "iot-container",

--- a/test/configs/iot-ostree-pull-empty.json
+++ b/test/configs/iot-ostree-pull-empty.json
@@ -1,7 +1,9 @@
 {
   "name": "iot-ostree-pull-empty",
-  "ostree": {
-    "url": "http://example.com/repo"
+  "options": {
+    "ostree": {
+      "url": "http://example.com/repo"
+    }
   },
   "depends": {
     "image-type": "iot-container",

--- a/test/configs/iot-ostree-pull-user.json
+++ b/test/configs/iot-ostree-pull-user.json
@@ -17,7 +17,9 @@
     "config": "empty.json",
     "image-type": "iot-container"
   },
-  "ostree": {
-    "url": "http://example.com/repo"
+  "options": {
+    "ostree": {
+      "url": "http://example.com/repo"
+    }
   }
 }

--- a/test/configs/ostree-device.json
+++ b/test/configs/ostree-device.json
@@ -5,8 +5,10 @@
       "installation_device": "/dev/null"
     }
   },
-  "ostree": {
-    "ref": "test/fedora/iot",
-    "url": "http://fedora.example.com/repo"
+  "options": {
+    "ostree": {
+      "ref": "test/fedora/iot",
+      "url": "http://fedora.example.com/repo"
+    }
   }
 }

--- a/test/configs/ostree-example.json
+++ b/test/configs/ostree-example.json
@@ -1,7 +1,9 @@
 {
   "name": "ostree-example",
-  "ostree": {
-    "ref": "test/fedora/iot",
-    "url": "http://fedora.example.com/repo"
+  "options": {
+    "ostree": {
+      "ref": "test/fedora/iot",
+      "url": "http://fedora.example.com/repo"
+    }
   }
 }

--- a/test/configs/ostree-filesystem-customizations-installer.json
+++ b/test/configs/ostree-filesystem-customizations-installer.json
@@ -1,7 +1,9 @@
 {
   "name": "ostree-filesystem-customizations-installer",
-  "ostree": {
-    "url": "http://example.com/repo"
+  "options": {
+    "ostree": {
+      "url": "http://example.com/repo"
+    }
   },
   "blueprint": {
     "customizations": {

--- a/test/configs/ostree-filesystem-customizations.json
+++ b/test/configs/ostree-filesystem-customizations.json
@@ -1,7 +1,9 @@
 {
   "name": "ostree-filesystem-customizations",
-  "ostree": {
-    "url": "http://example.com/repo"
+  "options": {
+    "ostree": {
+      "url": "http://example.com/repo"
+    }
   },
   "blueprint": {
     "customizations": {

--- a/test/configs/ostree-users.json
+++ b/test/configs/ostree-users.json
@@ -1,8 +1,10 @@
 {
   "name": "ostree-users",
-  "ostree": {
-    "ref": "test/iot",
-    "url": "http://iot.example.com/repo"
+  "options": {
+    "ostree": {
+      "ref": "test/iot",
+      "url": "http://iot.example.com/repo"
+    }
   },
   "blueprint": {
     "name": "iot-installer-users",

--- a/test/configs/ostree.json
+++ b/test/configs/ostree.json
@@ -1,6 +1,8 @@
 {
   "name": "ostree",
-  "ostree": {
-    "ref": "osbuild/images/ostree/test"
+  "options": {
+    "ostree": {
+      "ref": "osbuild/images/ostree/test"
+    }
   }
 }

--- a/test/configs/simplified-installer.json
+++ b/test/configs/simplified-installer.json
@@ -1,8 +1,10 @@
 {
   "name": "simplified-installer",
-  "ostree": {
-    "ref": "test/edge",
-    "url": "http://edge.example.com/repo"
+  "options": {
+    "ostree": {
+      "ref": "test/edge",
+      "url": "http://edge.example.com/repo"
+    }
   },
   "blueprint": {
     "customizations": {

--- a/test/configs/unattended-iso-edge.json
+++ b/test/configs/unattended-iso-edge.json
@@ -23,7 +23,9 @@
     "config": "empty.json",
     "image-type": "edge-container"
   },
-  "ostree": {
-    "url": "http://example.com/repo"
+  "options": {
+    "ostree": {
+      "url": "http://example.com/repo"
+    }
   }
 }

--- a/test/configs/unattended-iso-iot.json
+++ b/test/configs/unattended-iso-iot.json
@@ -23,7 +23,9 @@
     "config": "empty.json",
     "image-type": "iot-container"
   },
-  "ostree": {
-    "url": "http://example.com/repo"
+  "options": {
+    "ostree": {
+      "url": "http://example.com/repo"
+    }
   }
 }

--- a/test/scripts/generate-ostree-build-config
+++ b/test/scripts/generate-ostree-build-config
@@ -231,12 +231,15 @@ def setup_dependencies(manifests, config_map, distro, arch):
             # modify image config with container address and ref
             config_name = config_data["name"]
             config_name = f"{config_name}-{port}"
+            # get the ref from the current config, or compute the default if unset
+            ref = config_data.get("options", {}).get("ostree", {}).get("ref", default_ref(ic_distro, ic_arch))
             new_config = {
                 "name": config_name,
-                "ostree": {
-                    "url": f"http://localhost:{port}/repo",
-                    # get the ref from the current config, or compute the default if unset
-                    "ref": config_data.get("ostree", {}).get("ref", default_ref(ic_distro, ic_arch)),
+                "options": {
+                    "ostree": {
+                        "url": f"http://localhost:{port}/repo",
+                        "ref": ref,
+                    }
                 },
                 "blueprint": config_data.get("blueprint"),
             }

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -338,9 +338,10 @@ def filter_builds(manifests, distro=None, arch=None, skip_ostree_pull=True):
         image_type = build_request["image-type"]
         config = build_request["config"]
         config_name = config["name"]
+        options = config.get("options", {})
 
         # check if the config specifies an ostree URL and skip it if requested
-        if skip_ostree_pull and config.get("ostree", {}).get("url"):
+        if skip_ostree_pull and options.get("ostree", {}).get("url"):
             print(f"🦘 Skipping {distro}/{arch}/{image_type}/{config_name} (ostree dependency)")
             continue
 


### PR DESCRIPTION
This PR swaps out the `org.osbuild.first-boot` stage with an `org.osbuild.systemd.unit.create` stage that runs the same commands and explicitly adds the `rm` command for the condition file as the last command.  The file name and service description are changed to describe the purpose of the service.

The stage is functionally identical with the previous one with one main difference: the organisation ID and the activation key are not included in the service file but in a separate environment file in `/etc` which also acts as the condition file and gets removed after the service runs for the first time.

Not that on ostree-based systems, putting the environment file in `/etc` prior to building the commit and then `rm`ing it on boot means that the file remains in `/usr/etc`, in the base system, until a system update removes it.