### PR TITLE
Run unit tests on Fedora 40

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,37 @@ jobs:
     name: "🛃 Unit tests"
     runs-on: ubuntu-latest
     container:
-      image: registry.fedoraproject.org/fedora:latest
+      image: registry.fedoraproject.org/fedora:39
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up repository for pinned osbuild commit
+        run: ./test/scripts/setup-osbuild-repo
+
+        # krb5-devel is needed to test internal/upload/koji package
+        # gcc is needed to build the mock depsolver binary for the unit tests
+        # gpgme-devel is needed for container upload dependencies
+      - name: Install build and test dependencies
+        run: dnf -y install krb5-devel gcc git-core go gpgme-devel osbuild-depsolve-dnf btrfs-progs-devel device-mapper-devel
+
+      - name: Mark the working directory as safe for git
+        run: git config --global --add safe.directory "$(pwd)"
+
+      - name: Run unit tests
+        run: go test -race  ./...
+
+      - name: Run depsolver tests with force-dnf to make sure it's not skipped for any reason
+        run: go test -race ./pkg/dnfjson/... -force-dnf
+
+  unit-tests-f40:
+    name: "🛃 Unit tests (Fedora 40)"
+    runs-on: ubuntu-latest
+    container:
+      image: registry.fedoraproject.org/fedora:40
 
     steps:
       - name: Check out code into the Go module directory

--- a/Schutzfile
+++ b/Schutzfile
@@ -24,6 +24,13 @@
       "osbuild": {
         "commit": "5b75592fefc4ee2d9e240a15b7002f2537de31b0"
       }
+    }
+  },
+  "fedora-40": {
+    "dependencies": {
+      "osbuild": {
+        "commit": "5b75592fefc4ee2d9e240a15b7002f2537de31b0"
+      }
     },
     "repos": [
       {

--- a/pkg/dnfjson/dnfjson_test.go
+++ b/pkg/dnfjson/dnfjson_test.go
@@ -696,7 +696,7 @@ func TestErrorRepoInfo(t *testing.T) {
 		},
 	}
 
-	solver := NewSolver("f38", "38", "x86_64", "fedora-38", "/tmp/cache")
+	solver := NewSolver("platform:f38", "38", "x86_64", "fedora-38", "/tmp/cache")
 	for idx, tc := range testCases {
 		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
 			_, _, err := solver.Depsolve([]rpmmd.PackageSet{
@@ -725,7 +725,7 @@ func TestRepoConfigHash(t *testing.T) {
 		},
 	}
 
-	solver := NewSolver("f38", "38", "x86_64", "fedora-38", "/tmp/cache")
+	solver := NewSolver("platform:f38", "38", "x86_64", "fedora-38", "/tmp/cache")
 
 	rcs, err := solver.reposFromRPMMD(repos)
 	assert.Nil(t, err)
@@ -737,7 +737,7 @@ func TestRepoConfigHash(t *testing.T) {
 }
 
 func TestRequestHash(t *testing.T) {
-	solver := NewSolver("f38", "38", "x86_64", "fedora-38", "/tmp/cache")
+	solver := NewSolver("platform:f38", "38", "x86_64", "fedora-38", "/tmp/cache")
 	repos := []rpmmd.RepoConfig{
 		rpmmd.RepoConfig{
 			Name:      "A test repository",


### PR DESCRIPTION
Fedora 40 has been released and the fedora:latest container changed to
F40, breaking our unit tests because the 'setup-osbuild-repo' wasn't
setting up a pinned repository for osbuild on F40.

Let's run unit tests on both F39 and F40.