### PR TITLE
Fix local manifest arch not being set

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
     # We need to run the test as root, since we use the root
     # containers-storage for the local resolvers
     - name: Run unit tests
-      run: sudo go test ./pkg/container/...
+      run: sudo go test ./pkg/container/... --force-local-resolver
 
   unit-tests-c9s:
     name: "🛃 Unit tests (CentOS Stream 9)"

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -357,9 +357,9 @@ func (m RawManifest) Digest() (digest.Digest, error) {
 	return manifest.Digest(m.Data)
 }
 
-func (cl *Client) getImageRef(target reference.Named, id string, local bool) (types.ImageReference, error) {
+func (cl *Client) getImageRef(id string, local bool) (types.ImageReference, error) {
 	if local {
-		imageName := target.String()
+		imageName := cl.Target.String()
 		if id != "" {
 			imageName = id
 		}
@@ -367,11 +367,7 @@ func (cl *Client) getImageRef(target reference.Named, id string, local bool) (ty
 		return alltransports.ParseImageName(options)
 	}
 
-	if target == nil {
-		return nil, fmt.Errorf("target cannot be nil for remote image")
-	}
-
-	return docker.NewReference(target)
+	return docker.NewReference(cl.Target)
 }
 
 func (cl *Client) resolveContainerImageArch(ctx context.Context, ref types.ImageReference) (*arch.Arch, error) {
@@ -410,8 +406,6 @@ func (cl *Client) getLocalImageIDFromDigest(instance digest.Digest) (string, err
 // GetManifest fetches the raw manifest data from the server. If digest is not empty
 // it will override any given tag for the Client's Target.
 func (cl *Client) GetManifest(ctx context.Context, instanceDigest digest.Digest, local bool) (r RawManifest, err error) {
-	target := cl.Target
-
 	var id string
 	if instanceDigest != "" && local {
 		id, err = cl.getLocalImageIDFromDigest(instanceDigest)
@@ -420,7 +414,7 @@ func (cl *Client) GetManifest(ctx context.Context, instanceDigest digest.Digest,
 		}
 	}
 
-	ref, err := cl.getImageRef(target, id, local)
+	ref, err := cl.getImageRef(id, local)
 	if err != nil {
 		return
 	}

--- a/pkg/container/export_test.go
+++ b/pkg/container/export_test.go
@@ -1,0 +1,13 @@
+package container
+
+func NewResolverWithTestClient(arch string, f func(string) (*Client, error)) *Resolver {
+	resolver := NewResolver(arch)
+	resolver.newClient = f
+	return resolver
+}
+
+func NewClientWithTestStorage(target, storage string) (*Client, error) {
+	client, err := NewClient(target)
+	client.store = storage
+	return client, err
+}

--- a/pkg/container/resolver_test.go
+++ b/pkg/container/resolver_test.go
@@ -51,7 +51,6 @@ func TestResolver(t *testing.T) {
 			Digest:    common.ToPtr(""),
 			TLSVerify: common.ToPtr(false),
 			Local:     false,
-			Store:     nil,
 		})
 	}
 
@@ -80,7 +79,6 @@ func TestResolverFail(t *testing.T) {
 		Digest:    common.ToPtr(""),
 		TLSVerify: common.ToPtr(false),
 		Local:     false,
-		Store:     nil,
 	})
 	specs, err := resolver.Finish()
 	assert.Error(t, err)
@@ -95,7 +93,6 @@ func TestResolverFail(t *testing.T) {
 		Digest:    common.ToPtr(""),
 		TLSVerify: common.ToPtr(false),
 		Local:     false,
-		Store:     nil,
 	})
 	specs, err = resolver.Finish()
 	assert.Error(t, err)
@@ -107,7 +104,6 @@ func TestResolverFail(t *testing.T) {
 		Digest:    common.ToPtr(""),
 		TLSVerify: common.ToPtr(false),
 		Local:     false,
-		Store:     nil,
 	})
 	specs, err = resolver.Finish()
 	assert.Error(t, err)
@@ -119,7 +115,6 @@ func TestResolverFail(t *testing.T) {
 		Digest:    common.ToPtr(""),
 		TLSVerify: common.ToPtr(false),
 		Local:     false,
-		Store:     nil,
 	})
 	specs, err = resolver.Finish()
 	assert.Error(t, err)
@@ -175,14 +170,16 @@ func TestResolverLocalManifest(t *testing.T) {
 	assert.NoError(t, err)
 
 	// try resolve an x86_64 container using a local manifest list
-	resolver := container.NewResolver("amd64")
+	resolver := container.NewResolverWithTestClient("amd64", func(target string) (*container.Client, error) {
+		return container.NewClientWithTestStorage(target, tmpStorage)
+	})
+
 	resolver.Add(container.SourceSpec{
 		Source:    "localhost/multi-arch",
 		Name:      "",
 		Digest:    common.ToPtr(""),
 		TLSVerify: common.ToPtr(false),
 		Local:     true,
-		Store:     &tmpStorage,
 	})
 	specs, err := resolver.Finish()
 	assert.NoError(t, err)
@@ -191,14 +188,16 @@ func TestResolverLocalManifest(t *testing.T) {
 	assert.Equal(t, specs[0].Arch.String(), arch.ARCH_X86_64.String())
 
 	// try resolve an  aarch64 container using a local manifest list
-	resolver = container.NewResolver("arm64")
+	resolver = container.NewResolverWithTestClient("arm64", func(target string) (*container.Client, error) {
+		return container.NewClientWithTestStorage(target, tmpStorage)
+	})
+
 	resolver.Add(container.SourceSpec{
 		Source:    "localhost/multi-arch",
 		Name:      "",
 		Digest:    common.ToPtr(""),
 		TLSVerify: common.ToPtr(false),
 		Local:     true,
-		Store:     &tmpStorage,
 	})
 	specs, err = resolver.Finish()
 	assert.NoError(t, err)

--- a/pkg/container/resolver_test.go
+++ b/pkg/container/resolver_test.go
@@ -176,6 +176,7 @@ func TestResolverLocalManifest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, specs, 1)
 	assert.Equal(t, specs[0].LocalName, "localhost/multi-arch:latest")
+	assert.Equal(t, specs[0].Arch.String(), arch.ARCH_X86_64.String())
 
 	// try resolve an  aarch64 container using a local manifest list
 	resolver = container.NewResolver("arm64")
@@ -191,4 +192,5 @@ func TestResolverLocalManifest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, specs, 1)
 	assert.Equal(t, specs[0].LocalName, "localhost/multi-arch:latest")
+	assert.Equal(t, specs[0].Arch.String(), arch.ARCH_AARCH64.String())
 }

--- a/pkg/container/resolver_test.go
+++ b/pkg/container/resolver_test.go
@@ -39,12 +39,12 @@ func TestResolver(t *testing.T) {
 
 	for _, r := range refs {
 		resolver.Add(container.SourceSpec{
-			r,
-			"",
-			common.ToPtr(""),
-			common.ToPtr(false),
-			false,
-			nil,
+			Source:    r,
+			Name:      "",
+			Digest:    common.ToPtr(""),
+			TLSVerify: common.ToPtr(false),
+			Local:     false,
+			Store:     nil,
 		})
 	}
 
@@ -68,12 +68,12 @@ func TestResolverFail(t *testing.T) {
 	resolver := container.NewResolver("amd64")
 
 	resolver.Add(container.SourceSpec{
-		"invalid-reference@${IMAGE_DIGEST}",
-		"",
-		common.ToPtr(""),
-		common.ToPtr(false),
-		false,
-		nil,
+		Source:    "invalid-reference@${IMAGE_DIGEST}",
+		Name:      "",
+		Digest:    common.ToPtr(""),
+		TLSVerify: common.ToPtr(false),
+		Local:     false,
+		Store:     nil,
 	})
 	specs, err := resolver.Finish()
 	assert.Error(t, err)
@@ -83,35 +83,36 @@ func TestResolverFail(t *testing.T) {
 	defer registry.Close()
 
 	resolver.Add(container.SourceSpec{
-		registry.GetRef("repo"),
-		"",
-		common.ToPtr(""),
-		common.ToPtr(false),
-		false,
-		nil,
+		Source:    registry.GetRef("repo"),
+		Name:      "",
+		Digest:    common.ToPtr(""),
+		TLSVerify: common.ToPtr(false),
+		Local:     false,
+		Store:     nil,
 	})
 	specs, err = resolver.Finish()
 	assert.Error(t, err)
 	assert.Len(t, specs, 0)
 
 	resolver.Add(container.SourceSpec{
-		registry.GetRef("repo"),
-		"",
-		common.ToPtr(""),
-		common.ToPtr(false),
-		false,
-		nil,
+		Source:    registry.GetRef("repo"),
+		Name:      "",
+		Digest:    common.ToPtr(""),
+		TLSVerify: common.ToPtr(false),
+		Local:     false,
+		Store:     nil,
 	})
 	specs, err = resolver.Finish()
 	assert.Error(t, err)
 	assert.Len(t, specs, 0)
 
-	resolver.Add(container.SourceSpec{registry.GetRef("repo"),
-		"",
-		common.ToPtr(""),
-		common.ToPtr(false),
-		false,
-		nil,
+	resolver.Add(container.SourceSpec{
+		Source:    registry.GetRef("repo"),
+		Name:      "",
+		Digest:    common.ToPtr(""),
+		TLSVerify: common.ToPtr(false),
+		Local:     false,
+		Store:     nil,
 	})
 	specs, err = resolver.Finish()
 	assert.Error(t, err)
@@ -161,16 +162,15 @@ func TestResolverLocalManifest(t *testing.T) {
 	err = cmd.Run()
 	assert.NoError(t, err)
 
-	local := true
 	// try resolve an x86_64 container using a local manifest list
 	resolver := container.NewResolver("amd64")
 	resolver.Add(container.SourceSpec{
-		"localhost/multi-arch",
-		"",
-		common.ToPtr(""),
-		common.ToPtr(false),
-		local,
-		&tmpStorage,
+		Source:    "localhost/multi-arch",
+		Name:      "",
+		Digest:    common.ToPtr(""),
+		TLSVerify: common.ToPtr(false),
+		Local:     true,
+		Store:     &tmpStorage,
 	})
 	specs, err := resolver.Finish()
 	assert.NoError(t, err)
@@ -181,12 +181,12 @@ func TestResolverLocalManifest(t *testing.T) {
 	// try resolve an  aarch64 container using a local manifest list
 	resolver = container.NewResolver("arm64")
 	resolver.Add(container.SourceSpec{
-		"localhost/multi-arch",
-		"",
-		common.ToPtr(""),
-		common.ToPtr(false),
-		local,
-		&tmpStorage,
+		Source:    "localhost/multi-arch",
+		Name:      "",
+		Digest:    common.ToPtr(""),
+		TLSVerify: common.ToPtr(false),
+		Local:     true,
+		Store:     &tmpStorage,
 	})
 	specs, err = resolver.Finish()
 	assert.NoError(t, err)


### PR DESCRIPTION
This is a follow up to #595. Local manifest lists resulted in the `arch` being `unset`. This pr adds
the fix for this as well as a check in the unit test.
