### PR TITLE
Add bootc config to iot-bootable-container

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -8,21 +8,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "f255fba09f2f0c879d92df37e3d9f8e31903720d"
+        "commit": "86f3459eeff7c219793c9f01ac904e2dd6431a5a"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "f255fba09f2f0c879d92df37e3d9f8e31903720d"
+        "commit": "86f3459eeff7c219793c9f01ac904e2dd6431a5a"
       }
     }
   },
   "fedora-39": {
     "dependencies": {
       "osbuild": {
-        "commit": "f255fba09f2f0c879d92df37e3d9f8e31903720d"
+        "commit": "86f3459eeff7c219793c9f01ac904e2dd6431a5a"
       }
     },
     "repos": [
@@ -65,7 +65,7 @@
   "fedora-40": {
     "dependencies": {
       "osbuild": {
-        "commit": "226955482912ec4836279b154fa510106fa74c64"
+        "commit": "86f3459eeff7c219793c9f01ac904e2dd6431a5a"
       }
     }
   }

--- a/pkg/customizations/bootc/bootc.go
+++ b/pkg/customizations/bootc/bootc.go
@@ -1,0 +1,12 @@
+package bootc
+
+type Config struct {
+	// Name of the config file
+	Filename string
+
+	// Filesystem type for the root partition
+	RootFilesystemType string
+
+	// Extra kernel args to append
+	KernelArgs []string
+}

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osbuild/images/internal/workload"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/customizations/bootc"
 	"github.com/osbuild/images/pkg/customizations/fdo"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/ignition"
@@ -572,6 +573,10 @@ func bootableContainerImage(workload workload.Workload,
 	img.Filename = t.Filename()
 	img.InstallWeakDeps = false
 	img.BootContainer = true
+	img.BootcConfig = &bootc.Config{
+		Filename:           "20-fedora.toml",
+		RootFilesystemType: "ext4",
+	}
 
 	return img, nil
 }

--- a/pkg/image/ostree_archive.go
+++ b/pkg/image/ostree_archive.go
@@ -6,6 +6,7 @@ import (
 	"github.com/osbuild/images/internal/environment"
 	"github.com/osbuild/images/internal/workload"
 	"github.com/osbuild/images/pkg/artifact"
+	"github.com/osbuild/images/pkg/customizations/bootc"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
@@ -33,6 +34,11 @@ type OSTreeArchive struct {
 	InstallWeakDeps bool
 
 	BootContainer bool
+
+	// bootc install config for defining the preferred filesystem type and
+	// kernel arguments for bootable containers.
+	// This is ignored if BootContainer = false.
+	BootcConfig *bootc.Config
 }
 
 func NewOSTreeArchive(ref string) *OSTreeArchive {
@@ -64,6 +70,7 @@ func (img *OSTreeArchive) InstantiateManifest(m *manifest.Manifest,
 	var artifact *artifact.Artifact
 	if img.BootContainer {
 		osPipeline.Bootupd = true
+		osPipeline.BootcConfig = img.BootcConfig
 		encapsulatePipeline := manifest.NewOSTreeEncapsulate(buildPipeline, ostreeCommitPipeline, "ostree-encapsulate")
 		encapsulatePipeline.SetFilename(img.Filename)
 		artifact = encapsulatePipeline.Export()

--- a/pkg/osbuild/bootc_install_config_stage.go
+++ b/pkg/osbuild/bootc_install_config_stage.go
@@ -1,0 +1,51 @@
+package osbuild
+
+type BootcInstallConfigStageOptions struct {
+	Filename string             `json:"filename"`
+	Config   BootcInstallConfig `json:"config"`
+}
+
+func (BootcInstallConfigStageOptions) isStageOptions() {}
+
+type BootcInstallConfig struct {
+	Install    *BootcInstallConfigInstall `json:"install,omitempty"`
+	KernelArgs []string                   `json:"kargs,omitempty"`
+	Block      []string                   `json:"block,omitempty"`
+}
+
+type BootcInstallConfigInstall struct {
+	Filesystem BootcInstallConfigFilesystem `json:"filesystem"`
+}
+
+type BootcInstallConfigFilesystem struct {
+	Root BootcInstallConfigFilesystemRoot `json:"root"`
+}
+
+type BootcInstallConfigFilesystemRoot struct {
+	Type string `json:"type"`
+}
+
+// GenBootcInstallOptions is a helper function for creating stage options for
+// org.osbuild.bootc.install.config with just the filename and root filesystem
+// type set.
+func GenBootcInstallOptions(filename, rootType string) *BootcInstallConfigStageOptions {
+	return &BootcInstallConfigStageOptions{
+		Filename: filename,
+		Config: BootcInstallConfig{
+			Install: &BootcInstallConfigInstall{
+				Filesystem: BootcInstallConfigFilesystem{
+					Root: BootcInstallConfigFilesystemRoot{
+						Type: rootType,
+					},
+				},
+			},
+		},
+	}
+}
+
+func NewBootcInstallConfigStage(options *BootcInstallConfigStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.bootc.install.config",
+		Options: options,
+	}
+}


### PR DESCRIPTION
Set the preferred root filesystem type for the iot-bootable-container to ext4.
This file is required for the container to work with `bootc install`.

Requires https://github.com/osbuild/osbuild/pull/1747