### PR TITLE
Change dnf-yum to yum in Fedora package sets

### DIFF
--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -582,7 +582,7 @@ func containerPackageSet(t *imageType) rpmmd.PackageSet {
 		Include: []string{
 			"bash",
 			"coreutils",
-			"dnf-yum",
+			"yum",
 			"dnf",
 			"fedora-release-container",
 			"glibc-minimal-langpack",


### PR DESCRIPTION
In Fedora, there is no 'dnf-yum' package. dnf-yum is provided by yum (which is a subpackage of dnf, confused yet?)

With the dnf5-replacing-dnf transition, dnf5 includes the file /usr/bin/yum and provides and obsoletes 'yum', but it does not provide 'dnf-yum'. In a test of a Kiwi image build using a config which specified 'dnf-yum', this caused a failure, because dnf wanted to pull in 'yum' to satisfy the 'dnf-yum' specification, but it was obsoleted by dnf5 (which it was pulling in as the provider of 'dnf'), so it gave up. I suspect we'd have the same problem with osbuild builds that specify 'dnf-yum'. I think changing it to just 'yum' will solve the problem while remaining compatible across Fedora releases before and after the dnf5 switchover, because in earlier releases, this will pull in the 'yum' package as before, and in later releases, dnf should decide that the 'dnf5' package provides both it and 'dnf', and be happy installing that.