### PR TITLE
distro/rhel: unify osname for edge deployments (HMS-4011)

### DIFF
--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -524,7 +524,7 @@ func EdgeInstallerImage(workload workload.Workload,
 
 	img.Product = t.Arch().Distro().Product()
 	img.Variant = "edge"
-	img.OSName = "rhel"
+	img.OSName = "rhel-edge"
 	img.OSVersion = t.Arch().Distro().OsVersion()
 	img.Release = fmt.Sprintf("%s %s", t.Arch().Distro().Product(), t.Arch().Distro().OsVersion())
 	img.FIPS = customizations.GetFIPS()
@@ -561,7 +561,7 @@ func EdgeRawImage(workload workload.Workload,
 		URL:        options.OSTree.URL,
 		ContentURL: options.OSTree.ContentURL,
 	}
-	img.OSName = "redhat"
+	img.OSName = "rhel-edge"
 
 	// TODO: move generation into LiveImage
 	pt, err := t.GetPartitionTable(customizations.GetFilesystems(), options, rng)
@@ -603,7 +603,7 @@ func EdgeSimplifiedInstallerImage(workload workload.Workload,
 		URL:        options.OSTree.URL,
 		ContentURL: options.OSTree.ContentURL,
 	}
-	rawImg.OSName = "redhat"
+	rawImg.OSName = "rhel-edge"
 
 	// TODO: move generation into LiveImage
 	pt, err := t.GetPartitionTable(customizations.GetFilesystems(), options, rng)
@@ -641,7 +641,7 @@ func EdgeSimplifiedInstallerImage(workload workload.Workload,
 	d := t.arch.distro
 	img.Product = d.product
 	img.Variant = "edge"
-	img.OSName = "redhat"
+	img.OSName = "rhel-edge"
 	img.OSVersion = d.osVersion
 
 	installerConfig, err := t.getDefaultInstallerConfig()
@@ -708,7 +708,6 @@ func ImageInstallerImage(workload workload.Workload,
 
 	d := t.arch.distro
 	img.Product = d.product
-	img.OSName = "redhat"
 	img.OSVersion = d.osVersion
 	img.Release = fmt.Sprintf("%s %s", d.product, d.osVersion)
 


### PR DESCRIPTION
Our RHEL Edge deployments (ISOs and disk images) had inconsistent osnames set.  The edge-installer used "rhel" while the simplified installer and disk image used "redhat".

For bonus inconsistency, the RHEL Edge ISOs created by the Edge Service modify the kickstart file to set the osname to "rhel-edge".

Meanwhile, Fedora IoT images all set the osname to "fedora-iot".

To make everything consistent and unify the names, let's set all osnames to "rhel-edge".  This aligns better with Fedora (the equivalent to "fedora-iot" in the RHEL world is "rhel-edge") and with what has already been happening in the service.

Practically, the osname sets the deployment path:

  /ostree/deploy/$OSNAME

so this will affect new deployments, but will have no effect on existing installations and upgrades.