### PR TITLE
gen-manifests: derive seedArg from filename and env

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"os"
 	"path/filepath"
@@ -189,6 +190,14 @@ func makeManifestJob(
 	distroName := distribution.Name()
 	filename := fmt.Sprintf("%s-%s-%s-%s.json", u(distroName), u(archName), u(imgType.Name()), u(name))
 	cacheDir := filepath.Join(cacheRoot, archName+distribution.Name())
+
+	// ensure that each file has a unique seed based on filename
+	hash := func(s string) int64 {
+		h := fnv.New64()
+		h.Write([]byte(filename))
+		return int64(h.Sum64())
+	}
+	seedArg += hash(filename)
 
 	options := bc.Options
 


### PR DESCRIPTION
To ensure that manifests get random(ish) and stable UUIDs we set the rng seed arg based on the filename.

This should fix the issue discovered in
osbuild/manifest-db#124

that duplicated UUIDs for xfs/btrfs can trigger random(ish) and hard to diagnose errors.

This is the same as
https://github.com/osbuild/osbuild-composer/pull/4124 hopefully for the right place this time.