### PR TITLE
osbuild/systemd-unit-create: fix DefaultDependencies option

### DIFF
--- a/internal/common/helpers_test.go
+++ b/internal/common/helpers_test.go
@@ -56,3 +56,18 @@ func TestDataSizeToUint64(t *testing.T) {
 		}
 	}
 }
+
+func TestSystemdMountUnit(t *testing.T) {
+	for _, tc := range []struct {
+		mountpoint   string
+		expectedName string
+	}{
+		{"/", "-.mount"},
+		{"/boot", "boot.mount"},
+		{"/boot/efi", "boot-efi.mount"},
+	} {
+		name, err := MountUnitNameFor(tc.mountpoint)
+		assert.NoError(t, err)
+		assert.Equal(t, tc.expectedName, name)
+	}
+}

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -515,6 +515,7 @@ func createMountpointService(serviceName string, mountpoints []string) *osbuild.
 		Description:              "Ensure custom filesystem mountpoints exist",
 		DefaultDependencies:      common.ToPtr(false),
 		ConditionPathIsDirectory: conditionPathIsDirectory,
+		After:                    []string{"ostree-remount.service"},
 	}
 	service := osbuild.Service{
 		Type:            osbuild.Oneshot,

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -513,7 +513,7 @@ func createMountpointService(serviceName string, mountpoints []string) *osbuild.
 	}
 	unit := osbuild.Unit{
 		Description:              "Ensure custom filesystem mountpoints exist",
-		DefaultDependencies:      common.ToPtr(false),
+		DefaultDependencies:      common.ToPtr(false), // Default dependencies would interfere with our custom order (before mountpoints)
 		ConditionPathIsDirectory: conditionPathIsDirectory,
 		After:                    []string{"ostree-remount.service"},
 	}
@@ -523,7 +523,7 @@ func createMountpointService(serviceName string, mountpoints []string) *osbuild.
 		// compatibility with composefs, will require transient rootfs to be enabled too.
 		ExecStartPre: []string{"/bin/sh -c \"if grep -Uq composefs /run/ostree-booted; then chattr -i /; fi\""},
 		ExecStopPost: []string{"/bin/sh -c \"if grep -Uq composefs /run/ostree-booted; then chattr +i /; fi\""},
-		ExecStart:    []string{"mkdir -p " + strings.Join(mountpoints[:], " ")},
+		ExecStart:    []string{"mkdir -p " + strings.Join(mountpoints, " ")},
 	}
 
 	// For every mountpoint we want to ensure, we need to set a Before order on

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -519,9 +519,9 @@ func createMountpointService(serviceName string, mountpoints []string) *osbuild.
 	service := osbuild.Service{
 		Type:            osbuild.Oneshot,
 		RemainAfterExit: true,
-		//compatibility with composefs, will require transient rootfs to be enabled too.
-		ExecStartPre: []string{"/bin/sh -c \"if [ -z \"$(grep -Uq composefs /run/ostree-booted)\" ]; then chattr -i /; fi\""},
-		ExecStopPost: []string{"/bin/sh -c \"if [ -z \"$(grep -Uq composefs /run/ostree-booted)\" ]; then chattr +i /; fi\""},
+		// compatibility with composefs, will require transient rootfs to be enabled too.
+		ExecStartPre: []string{"/bin/sh -c \"if grep -Uq composefs /run/ostree-booted; then chattr -i /; fi\""},
+		ExecStopPost: []string{"/bin/sh -c \"if grep -Uq composefs /run/ostree-booted; then chattr +i /; fi\""},
 		ExecStart:    []string{"mkdir -p " + strings.Join(mountpoints[:], " ")},
 	}
 	install := osbuild.Install{

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -518,7 +518,7 @@ func createMountpointService(serviceName string, mountpoints []string) *osbuild.
 	}
 	service := osbuild.Service{
 		Type:            osbuild.Oneshot,
-		RemainAfterExit: true,
+		RemainAfterExit: false,
 		// compatibility with composefs, will require transient rootfs to be enabled too.
 		ExecStartPre: []string{"/bin/sh -c \"if grep -Uq composefs /run/ostree-booted; then chattr -i /; fi\""},
 		ExecStopPost: []string{"/bin/sh -c \"if grep -Uq composefs /run/ostree-booted; then chattr +i /; fi\""},

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -513,7 +513,7 @@ func createMountpointService(serviceName string, mountpoints []string) *osbuild.
 	}
 	unit := osbuild.Unit{
 		Description:              "Ensure custom filesystem mountpoints exist",
-		DefaultDependencies:      false,
+		DefaultDependencies:      common.ToPtr(false),
 		ConditionPathIsDirectory: conditionPathIsDirectory,
 	}
 	service := osbuild.Service{

--- a/pkg/osbuild/systemd_unit_create_stage.go
+++ b/pkg/osbuild/systemd_unit_create_stage.go
@@ -29,6 +29,7 @@ type Unit struct {
 	Requires                 []string `json:"Requires,omitempty"`
 	Wants                    []string `json:"Wants,omitempty"`
 	After                    []string `json:"After,omitempty"`
+	Before                   []string `json:"Before,omitempty"`
 }
 
 type Service struct {

--- a/pkg/osbuild/systemd_unit_create_stage.go
+++ b/pkg/osbuild/systemd_unit_create_stage.go
@@ -23,7 +23,7 @@ const (
 
 type Unit struct {
 	Description              string   `json:"Description,omitempty"`
-	DefaultDependencies      bool     `json:"DefaultDependencies,omitempty"`
+	DefaultDependencies      *bool    `json:"DefaultDependencies,omitempty"`
 	ConditionPathExists      []string `json:"ConditionPathExists,omitempty"`
 	ConditionPathIsDirectory []string `json:"ConditionPathIsDirectory,omitempty"`
 	Requires                 []string `json:"Requires,omitempty"`

--- a/pkg/osbuild/systemd_unit_create_stage_test.go
+++ b/pkg/osbuild/systemd_unit_create_stage_test.go
@@ -3,6 +3,7 @@ package osbuild
 import (
 	"testing"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -10,6 +11,7 @@ func createSystemdUnit() SystemdServiceUnit {
 
 	var unit = Unit{
 		Description:              "Create directory and files",
+		DefaultDependencies:      common.ToPtr(true),
 		ConditionPathExists:      []string{"!/etc/myfile"},
 		ConditionPathIsDirectory: []string{"!/etc/mydir"},
 		Requires:                 []string{"dbus.service", "libvirtd.service"},

--- a/pkg/policies/policies.go
+++ b/pkg/policies/policies.go
@@ -85,14 +85,18 @@ var CustomFilesPolicies = pathpolicy.NewPathPolicies(map[string]pathpolicy.PathP
 // MountpointPolicies for ostree
 var OstreeMountpointPolicies = pathpolicy.NewPathPolicies(map[string]pathpolicy.PathPolicy{
 	"/":             {},
-	"/ostree":       {Deny: true},
-	"/home":         {Deny: true},
+	"/home":         {Deny: true}, // symlink to var/home
+	"/mnt":          {Deny: true}, // symlink to var/mnt
+	"/opt":          {Deny: true}, // symlink to var/opt
+	"/ostree":       {Deny: true}, // symlink to sysroot/ostree
+	"/root":         {Deny: true}, // symlink to var/roothome
+	"/srv":          {Deny: true}, // symlink to var/srv
 	"/var/home":     {Deny: true},
-	"/var/opt":      {Deny: true},
-	"/var/srv":      {Deny: true},
-	"/var/roothome": {Deny: true},
-	"/var/usrlocal": {Deny: true},
 	"/var/mnt":      {Deny: true},
+	"/var/opt":      {Deny: true},
+	"/var/roothome": {Deny: true},
+	"/var/srv":      {Deny: true},
+	"/var/usrlocal": {Deny: true},
 })
 
 // CustomDirectoriesPolicies for ostree

--- a/test/configs/ostree-filesystem-customizations-installer.json
+++ b/test/configs/ostree-filesystem-customizations-installer.json
@@ -19,28 +19,12 @@
       "installation_device": "/dev/vda",
       "filesystem": [
         {
-          "mountpoint": "/foo",
+          "mountpoint": "/data",
           "minsize": "2147483648"
         },
         {
-          "mountpoint": "/foo/bar",
+          "mountpoint": "/data/extra",
           "minsize": "2 GiB"
-        },
-        {
-          "mountpoint": "/root",
-          "minsize": "1 GiB"
-        },
-        {
-          "mountpoint": "/mnt",
-          "minsize": "3 GiB"
-        },
-        {
-          "mountpoint": "/srv",
-          "minsize": "4 GiB"
-        },
-        {
-          "mountpoint": "/opt",
-          "minsize": "1 GiB"
         },
         {
           "mountpoint": "/var/mydata",

--- a/test/configs/ostree-filesystem-customizations.json
+++ b/test/configs/ostree-filesystem-customizations.json
@@ -18,28 +18,12 @@
       ],
       "filesystem": [
         {
-          "mountpoint": "/foo",
+          "mountpoint": "/data",
           "minsize": "2147483648"
         },
         {
-          "mountpoint": "/foo/bar",
+          "mountpoint": "/data/extra",
           "minsize": "2 GiB"
-        },
-        {
-          "mountpoint": "/root",
-          "minsize": "1 GiB"
-        },
-        {
-          "mountpoint": "/mnt",
-          "minsize": "3 GiB"
-        },
-        {
-          "mountpoint": "/srv",
-          "minsize": "4 GiB"
-        },
-        {
-          "mountpoint": "/opt",
-          "minsize": "1 GiB"
         },
         {
           "mountpoint": "/var/mydata",


### PR DESCRIPTION
The original purpose of this PR was to make the DefaultDependencies option an optional property that defaults to 'true'.  The original PR also had a small fix for the mountpoint creation service.  While working on updating the previous PR, I found that the mountpoint creation service for ostree-based images needed more work, including additions to the osbuild stage that creates it.

Replaces #608.

Changes to the systemd unit:
- [x] The unit must run *after* the ostree-remount.service.
- [x] The unit must run *before* the .mount units for each mountpoint (needs new option in systemd stage).
- [x] The `chattr +i /` command in `ExecStartPost` isn't run because `RemainAfterExit` is enabled, so the service doesn't "stop".  `RemainAfterExit` should be disabled.
- [ ] ~~Instead of checking for `composefs` by grepping a binary, perhaps it's more reliable to check for the symptom, the thing we want to toggle, with `lsattr -ld / | grep -q Immutable`.~~

The last item was abandoned because we don't have a clean way of toggling the immutable flag back on without communicating info from the Pre command to the Post command.

This PR also updates the mountpoint policy for ostree-based systems to disallow paths that are top-level symlinks on a booted system.

Requires https://github.com/osbuild/osbuild/pull/1782