### PR TITLE
github: update bib ref every week

### DIFF
--- a/.github/workflows/update-bootc-image-builder.yml
+++ b/.github/workflows/update-bootc-image-builder.yml
@@ -5,8 +5,8 @@ name: "Update bootc-image-builder ref"
 on:
   workflow_dispatch:
   schedule:
-    # Every day at 05:00
-    - cron: "0 5 * * *"
+    # Every Sunday at 12:00
+    - cron: "0 12 * * 0"
 
 jobs:
   update-and-push:


### PR DESCRIPTION
With things slowing down a bit, we don't need to have daily updates of the BIB ref here.  Weekly updates should be enough.

I set it to run every Sunday at noon, so CI jobs can run when there's not much other activity and we can deal with failures on Monday.