### PR TITLE
cmd: add helper for seed generation

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -42,7 +42,6 @@ func makeManifest(
 	distribution distro.Distro,
 	repos []rpmmd.RepoConfig,
 	archName string,
-	seedArg int64,
 	cacheRoot string,
 ) (manifest.OSBuildManifest, error) {
 	cacheDir := filepath.Join(cacheRoot, archName+distribution.Name())
@@ -57,6 +56,10 @@ func makeManifest(
 	var bp blueprint.Blueprint
 	if config.Blueprint != nil {
 		bp = blueprint.Blueprint(*config.Blueprint)
+	}
+	seedArg, err := cmdutil.SeedArgFor(config, imgType, distribution, archName)
+	if err != nil {
+		return nil, err
 	}
 
 	manifest, warnings, err := imgType.Manifest(&bp, options, repos, seedArg)
@@ -209,9 +212,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	rngSeed, err := cmdutil.NewRNGSeed()
-	check(err)
-
 	testedRepoRegistry, err := reporegistry.NewTestedDefault()
 	if err != nil {
 		panic(fmt.Sprintf("failed to create repo registry with tested distros: %v", err))
@@ -258,7 +258,7 @@ func main() {
 	}
 
 	fmt.Printf("Generating manifest for %s: ", config.Name)
-	mf, err := makeManifest(config, imgType, distribution, repos, archName, rngSeed, rpmCacheRoot)
+	mf, err := makeManifest(config, imgType, distribution, repos, archName, rpmCacheRoot)
 	check(err)
 	fmt.Print("DONE\n")
 

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -57,7 +57,7 @@ func makeManifest(
 	if config.Blueprint != nil {
 		bp = blueprint.Blueprint(*config.Blueprint)
 	}
-	seedArg, err := cmdutil.SeedArgFor(config, imgType, distribution, archName)
+	seedArg, err := cmdutil.SeedArgFor(config, imgType.Name(), distribution.Name(), archName)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -179,7 +179,6 @@ func makeManifestJob(
 	distribution distro.Distro,
 	repos []rpmmd.RepoConfig,
 	archName string,
-	seedArg int64,
 	cacheRoot string,
 	path string,
 	content map[string]bool,
@@ -189,6 +188,12 @@ func makeManifestJob(
 	distroName := distribution.Name()
 	filename := fmt.Sprintf("%s-%s-%s-%s.json", u(distroName), u(archName), u(imgType.Name()), u(name))
 	cacheDir := filepath.Join(cacheRoot, archName+distribution.Name())
+
+	// ensure that each file has a unique seed based on filename
+	seedArg, err := cmdutil.SeedArgFor(bc, imgType, distribution, archName)
+	if err != nil {
+		panic(err)
+	}
 
 	options := bc.Options
 
@@ -508,11 +513,6 @@ func main() {
 
 	flag.Parse()
 
-	rngSeed, err := cmdutil.NewRNGSeed()
-	if err != nil {
-		panic(err)
-	}
-
 	testedRepoRegistry, err := reporegistry.NewTestedDefault()
 	if err != nil {
 		panic(fmt.Sprintf("failed to create repo registry with tested distros: %v", err))
@@ -598,7 +598,7 @@ func main() {
 				}
 
 				for _, itConfig := range imgTypeConfigs {
-					job := makeManifestJob(itConfig, imgType, distribution, repos, archName, rngSeed, cacheRoot, outputDir, contentResolve, metadata)
+					job := makeManifestJob(itConfig, imgType, distribution, repos, archName, cacheRoot, outputDir, contentResolve, metadata)
 					jobs = append(jobs, job)
 				}
 			}

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -190,7 +190,7 @@ func makeManifestJob(
 	cacheDir := filepath.Join(cacheRoot, archName+distribution.Name())
 
 	// ensure that each file has a unique seed based on filename
-	seedArg, err := cmdutil.SeedArgFor(bc, imgType, distribution, archName)
+	seedArg, err := cmdutil.SeedArgFor(bc, imgType.Name(), distribution.Name(), archName)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/cmdutil/export_test.go
+++ b/internal/cmdutil/export_test.go
@@ -1,0 +1,3 @@
+package cmdutil
+
+var NewRNGSeed = newRNGSeed

--- a/internal/cmdutil/rand.go
+++ b/internal/cmdutil/rand.go
@@ -3,17 +3,20 @@ package cmdutil
 import (
 	"crypto/rand"
 	"fmt"
+	"hash/fnv"
 	"math"
 	"math/big"
 	"os"
 	"strconv"
+
+	"github.com/osbuild/images/internal/buildconfig"
 )
 
 const RNG_SEED_ENV_KEY = "OSBUILD_TESTING_RNG_SEED"
 
-// NewRNGSeed generates a random seed value unless the env var
+// newRNGSeed generates a random seed value unless the env var
 // OSBUILD_TESTING_RNG_SEED is set.
-func NewRNGSeed() (int64, error) {
+func newRNGSeed() (int64, error) {
 	if envSeedStr := os.Getenv(RNG_SEED_ENV_KEY); envSeedStr != "" {
 		envSeedInt, err := strconv.ParseInt(envSeedStr, 10, 64)
 		if err != nil {
@@ -27,4 +30,23 @@ func NewRNGSeed() (int64, error) {
 		return 0, fmt.Errorf("failed to generate random seed: %s", err)
 	}
 	return randSeed.Int64(), nil
+}
+
+type namer interface {
+	Name() string
+}
+
+func SeedArgFor(bc *buildconfig.BuildConfig, imgType namer, distribution namer, archName string) (int64, error) {
+	rngSeed, err := newRNGSeed()
+	if err != nil {
+		return 0, err
+	}
+
+	h := fnv.New64()
+	h.Write([]byte(distribution.Name()))
+	h.Write([]byte(archName))
+	h.Write([]byte(imgType.Name()))
+	h.Write([]byte(bc.Name))
+
+	return rngSeed + int64(h.Sum64()), nil
 }

--- a/internal/cmdutil/rand.go
+++ b/internal/cmdutil/rand.go
@@ -32,20 +32,16 @@ func newRNGSeed() (int64, error) {
 	return randSeed.Int64(), nil
 }
 
-type namer interface {
-	Name() string
-}
-
-func SeedArgFor(bc *buildconfig.BuildConfig, imgType namer, distribution namer, archName string) (int64, error) {
+func SeedArgFor(bc *buildconfig.BuildConfig, imgTypeName, distributionName, archName string) (int64, error) {
 	rngSeed, err := newRNGSeed()
 	if err != nil {
 		return 0, err
 	}
 
 	h := fnv.New64()
-	h.Write([]byte(distribution.Name()))
+	h.Write([]byte(distributionName))
 	h.Write([]byte(archName))
-	h.Write([]byte(imgType.Name()))
+	h.Write([]byte(imgTypeName))
 	h.Write([]byte(bc.Name))
 
 	return rngSeed + int64(h.Sum64()), nil

--- a/internal/cmdutil/rand_test.go
+++ b/internal/cmdutil/rand_test.go
@@ -40,20 +40,12 @@ func TestNewRNGSeed(t *testing.T) {
 	})
 }
 
-type fakeNamer struct {
-	fakeName string
-}
-
-func (fn fakeNamer) Name() string {
-	return fn.fakeName
-}
-
 func TestSeedArgFor(t *testing.T) {
 	t.Setenv(cmdutil.RNG_SEED_ENV_KEY, "1234")
 
 	for _, tc := range []struct {
-		bcName, imgType, distro, archName string
-		expectedSeed                      int64
+		bcName, imgTypeName, distroName, archName string
+		expectedSeed                              int64
 	}{
 		{"bcName", "fakeImgType", "fakeDistro", "x86_64", 9170052743323116054},
 		{"bcName1", "fakeImgType", "fakeDistro", "x86_64", -7134826073208782961},
@@ -62,7 +54,7 @@ func TestSeedArgFor(t *testing.T) {
 		{"bcName", "fakeImgType", "fakeDistro1", "aarch64", 47752167762999679},
 	} {
 		bc := &buildconfig.BuildConfig{Name: tc.bcName}
-		seedArg, err := cmdutil.SeedArgFor(bc, fakeNamer{tc.imgType}, fakeNamer{tc.distro}, tc.archName)
+		seedArg, err := cmdutil.SeedArgFor(bc, tc.imgTypeName, tc.distroName, tc.archName)
 		assert.NoError(t, err)
 		assert.Equal(t, tc.expectedSeed, seedArg)
 	}


### PR DESCRIPTION
To ensure that manifests get random(ish) and stable UUIDs we set the rng seed arg based on the filename.

This should fix the issue discovered in
osbuild/manifest-db#124

that duplicated UUIDs for xfs/btrfs can trigger random(ish) and hard to diagnose errors.

This is the same as
osbuild/osbuild-composer#4124 hopefully for the right place this time.

