### PR TITLE
pkg/osbuild: move mount name generation into getOsbuildMount

### DIFF
--- a/pkg/osbuild/bootupd_stage.go
+++ b/pkg/osbuild/bootupd_stage.go
@@ -92,8 +92,7 @@ func genMountsForBootupd(source string, pt *disk.PartitionTable) ([]Mount, error
 		}
 
 		partNum := idx + 1
-		name := fmt.Sprintf("part%v", partNum)
-		mount, err := genOsbuildMount(name, source, mnt)
+		mount, err := genOsbuildMount(source, mnt)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/osbuild/bootupd_stage_test.go
+++ b/pkg/osbuild/bootupd_stage_test.go
@@ -222,21 +222,21 @@ func TestGenBootupdDevicesMountsHappy(t *testing.T) {
 	})
 	assert.Equal(t, mounts, []osbuild.Mount{
 		{
-			Name:      "part4",
+			Name:      "-",
 			Type:      "org.osbuild.ext4",
 			Source:    "disk",
 			Target:    "/",
 			Partition: common.ToPtr(4),
 		},
 		{
-			Name:      "part3",
+			Name:      "boot",
 			Type:      "org.osbuild.ext4",
 			Source:    "disk",
 			Target:    "/boot",
 			Partition: common.ToPtr(3),
 		},
 		{
-			Name:      "part2",
+			Name:      "boot-efi",
 			Type:      "org.osbuild.fat",
 			Source:    "disk",
 			Target:    "/boot/efi",

--- a/pkg/osbuild/device.go
+++ b/pkg/osbuild/device.go
@@ -164,6 +164,18 @@ func deviceName(p disk.Entity) string {
 	panic(fmt.Sprintf("unsupported device type in deviceName: '%T'", p))
 }
 
+// getDevices takes an entity path, and returns osbuild devices required before being able to mount the leaf Mountable
+//
+// - path is an entity path as defined by the disk.entityPath function
+// - filename is the name of an underlying image file (which will get loop-mounted)
+// - lockLoopback determines whether the loop device will get locked after creation
+//
+// The device names are created from the payload that they are holding. This is useful to easily visually map e.g.
+// a loopback device and its mount (in the case of ordinary partitions): they should have the same, or similar name.
+//
+// The first returned value is a map of devices for the given path.
+// The second returned value is the name of the last device in the path. This is the device that should be used as the
+// source for the mount.
 func getDevices(path []disk.Entity, filename string, lockLoopback bool) (map[string]Device, string) {
 	var pt *disk.PartitionTable
 

--- a/pkg/osbuild/device_test.go
+++ b/pkg/osbuild/device_test.go
@@ -188,15 +188,31 @@ func TestMountsDeviceFromPtNoRootErrors(t *testing.T) {
 
 func TestMountsDeviceFromPtHappy(t *testing.T) {
 	filename := "fake-disk.img"
-	fakePt := testdisk.MakeFakePartitionTable("/")
+	fakePt := testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
 	fsRootMntName, mounts, devices, err := genMountsDevicesFromPt(filename, fakePt)
 	require.Nil(t, err)
 	assert.Equal(t, fsRootMntName, "-")
 	assert.Equal(t, mounts, []Mount{
 		{Name: "-", Type: "org.osbuild.ext4", Source: "-", Target: "/"},
+		{Name: "boot", Type: "org.osbuild.ext4", Source: "boot", Target: "/boot"},
+		{Name: "boot-efi", Type: "org.osbuild.fat", Source: "boot-efi", Target: "/boot/efi"},
 	})
 	assert.Equal(t, devices, map[string]Device{
 		"-": {
+			Type: "org.osbuild.loopback",
+			Options: &LoopbackDeviceOptions{
+				Filename: "fake-disk.img",
+				Size:     testdisk.FakePartitionSize / 512,
+			},
+		},
+		"boot": {
+			Type: "org.osbuild.loopback",
+			Options: &LoopbackDeviceOptions{
+				Filename: "fake-disk.img",
+				Size:     testdisk.FakePartitionSize / 512,
+			},
+		},
+		"boot-efi": {
 			Type: "org.osbuild.loopback",
 			Options: &LoopbackDeviceOptions{
 				Filename: "fake-disk.img",


### PR DESCRIPTION
Mount names are just identifiers. They don't have any other real
meaning.

Prior this commit, callers of genOsbuildMount had to supply the mount
name, which led to inconsistencies: genMountsDevicesFromPt used the
name of the leaf device, genMountsForBootupd used synthetic names
constructed from a partition number.

The issue with the genMountsDevicesFromPt's approch is that multiple
mounts can be created from a simple device. This is not currently
used, but it will come with btrfs (single device) and its subvolumes
(multiple mounts). The genMountsForBootupd's approach has a similar
flaw.

This commit implements the mount name generation directly in
genOsbuildMount. The new name is no longer referring to the source,
but it's rather constructed from the mountpoint (by using pathEscape).
This has two benefits:
- Every mount obviously must have a mountpoint
- Mountpoints are unique(*), so names will be also unique

I also added some docstrings, because these functions signatures are
quite hard to comprehend.

(*) Yeah, you can stack mounts, but this is not something supported
by our disk library.