### PR TITLE
distro/rhel10: replace dhcp-client with dhcpcd

### DIFF
--- a/pkg/distro/rhel/rhel10/ami.go
+++ b/pkg/distro/rhel/rhel10/ami.go
@@ -173,7 +173,7 @@ func ec2CommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 			"chrony",
 			"cloud-init",
 			"cloud-utils-growpart",
-			"dhcp-client",
+			"dhcpcd",
 			"yum-utils",
 			"dracut-config-generic",
 			"gdisk",


### PR DESCRIPTION
The dhcp-client was dropped from RHEL 10.  As a cloud-init dependency, it has been replaced by dhcpcd.

See RHEL-26304