### PR TITLE
pkg/osbuild: clean up genMountsForBootupd

### DIFF
--- a/pkg/osbuild/bootupd_stage.go
+++ b/pkg/osbuild/bootupd_stage.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/disk"
 )
 
@@ -85,19 +86,19 @@ func genMountsForBootupd(source string, pt *disk.PartitionTable) ([]Mount, error
 		if part.Payload == nil {
 			continue
 		}
-		// TODO: support things like LVM here via supporting "disk.Container"
-		mnt, ok := part.Payload.(disk.Mountable)
-		if !ok {
-			return nil, fmt.Errorf("type %v not supported by bootupd handling yet", mnt)
-		}
 
-		partNum := idx + 1
-		mount, err := genOsbuildMount(source, mnt)
-		if err != nil {
-			return nil, err
+		// TODO: support things like LVM here via supporting "disk.Container"
+		switch payload := part.Payload.(type) {
+		case disk.Mountable:
+			mount, err := genOsbuildMount(source, payload)
+			if err != nil {
+				return nil, err
+			}
+			mount.Partition = common.ToPtr(idx + 1)
+			mounts = append(mounts, *mount)
+		default:
+			return nil, fmt.Errorf("type %T not supported by bootupd handling yet", part.Payload)
 		}
-		mount.Partition = &partNum
-		mounts = append(mounts, *mount)
 	}
 	// this must be sorted in so that mounts do not shadow each other
 	sort.Slice(mounts, func(i, j int) bool {

--- a/pkg/osbuild/bootupd_stage_test.go
+++ b/pkg/osbuild/bootupd_stage_test.go
@@ -153,6 +153,19 @@ func TestGenBootupdDevicesMountsMissingRoot(t *testing.T) {
 	assert.EqualError(t, err, "required mounts for bootupd stage [/ /boot /boot/efi] missing")
 }
 
+func TestGenBootupdDevicesMountsUnexpectedEntity(t *testing.T) {
+	filename := "fake-disk.img"
+	pt := &disk.PartitionTable{
+		Partitions: []disk.Partition{
+			{
+				Payload: &disk.LVMVolumeGroup{},
+			},
+		},
+	}
+	_, _, err := osbuild.GenBootupdDevicesMounts(filename, pt)
+	assert.EqualError(t, err, "type *disk.LVMVolumeGroup not supported by bootupd handling yet")
+}
+
 var fakePt = &disk.PartitionTable{
 	UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 	Type: "gpt",


### PR DESCRIPTION
Instead of the if statement, I switched to switch (pun absolutely intended). Also, I fixed the error message, previously it always printed type <nil>, because mnt is set to nil, if ok == false.