### PR TITLE
pkg/osbuild: Simplify GenMkfsStages arguments

### DIFF
--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -320,8 +320,7 @@ func (p *AnacondaInstallerISOTree) serialize() osbuild.Pipeline {
 		Size:     fmt.Sprintf("%d", p.PartitionTable.Size),
 	}))
 
-	efibootDevice := osbuild.NewLoopbackDevice(&osbuild.LoopbackDeviceOptions{Filename: filename})
-	for _, stage := range osbuild.GenMkfsStages(p.PartitionTable, efibootDevice) {
+	for _, stage := range osbuild.GenMkfsStages(p.PartitionTable, filename) {
 		pipeline.AddStage(stage)
 	}
 

--- a/pkg/manifest/coi_iso_tree.go
+++ b/pkg/manifest/coi_iso_tree.go
@@ -111,8 +111,7 @@ func (p *CoreOSISOTree) serialize() osbuild.Pipeline {
 		Size:     fmt.Sprintf("%d", p.PartitionTable.Size),
 	}))
 
-	efibootDevice := osbuild.NewLoopbackDevice(&osbuild.LoopbackDeviceOptions{Filename: filename})
-	for _, stage := range osbuild.GenMkfsStages(p.PartitionTable, efibootDevice) {
+	for _, stage := range osbuild.GenMkfsStages(p.PartitionTable, filename) {
 		pipeline.AddStage(stage)
 	}
 

--- a/pkg/osbuild/disk.go
+++ b/pkg/osbuild/disk.go
@@ -99,7 +99,7 @@ func GenImagePrepareStages(pt *disk.PartitionTable, filename string, partTool Pa
 	stages = append(stages, s...)
 
 	// Generate all the filesystems on partitons and devices
-	s = GenMkfsStages(pt, loopback)
+	s = GenMkfsStages(pt, filename)
 	stages = append(stages, s...)
 
 	return stages


### PR DESCRIPTION
Prior this commit, the implementation was slightly confusing: GenMkfsStages accepted a generic device as the source of the underlying disk image. However, the function could only operate on a loopback, otherwise it panicked. Moreover, the function didn't actually use the given device: it just used the filename from the given loopback device. The actual device for generated stages is created in getDevices.

Let's simplify this: The function now accepts just the filename, since this is actually the only thing that it needs.

Also added tests. The unhappy path still relies on a panic, but this is a huge rabbit hole that I don't want to explore at this point.