### PR TITLE
go.mod: remove `exclude github.com/mattn/go-sqlite3`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/osbuild/images
 
 go 1.20
 
-exclude github.com/mattn/go-sqlite3 v2.0.3+incompatible
-
 require (
 	cloud.google.com/go/compute v1.26.0
 	cloud.google.com/go/storage v1.41.0


### PR DESCRIPTION
This directive was added in commit 29f66a251f to workaround an issue with the github.com/containers/image/v5 v5.22 where some misconfiguration/misrelease of go-sqlite caused problems.

This seems to be no longer necessary, I followed the reproducer steps from the original commit and see no errors (anymore).

The reason this is useful is so that we run the gen-manifests command directly via `go run`. Right now it will error with:
```
$ go run github.com/osbuild/images/cmd/gen-manifests@latest
go: github.com/osbuild/images/cmd/gen-manifests@latest (in github.com/osbuild/images@v0.61.0):
	The go.mod file for the module providing named packages contains one or
	more exclude directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```
(c.f. https://github.com/golang/go/issues/40276).

Removing the `exclude` shoudl fix that.