### PR TITLE
Add the btrfs partitioning mode

### DIFF
--- a/internal/testdisk/partition.go
+++ b/internal/testdisk/partition.go
@@ -36,3 +36,66 @@ func MakeFakePartitionTable(mntPoints ...string) *disk.PartitionTable {
 		Partitions: partitions,
 	}
 }
+
+// MakeFakeBtrfsPartitionTable is similar to MakeFakePartitionTable but
+// creates a btrfs-based partition table.
+func MakeFakeBtrfsPartitionTable(mntPoints ...string) *disk.PartitionTable {
+	var subvolumes []disk.BtrfsSubvolume
+	pt := &disk.PartitionTable{
+		Type:       "gpt",
+		Size:       10 * common.GiB,
+		Partitions: []disk.Partition{},
+	}
+	size := uint64(0)
+	for _, mntPoint := range mntPoints {
+		switch mntPoint {
+		case "/boot":
+			pt.Partitions = append(pt.Partitions, disk.Partition{
+				Start: size,
+				Size:  1 * common.GiB,
+				Payload: &disk.Filesystem{
+					Type:       "ext4",
+					Mountpoint: mntPoint,
+				},
+			})
+			size += 1 * common.GiB
+		case "/boot/efi":
+			pt.Partitions = append(pt.Partitions, disk.Partition{
+				Start: size,
+				Size:  100 * common.MiB,
+				Payload: &disk.Filesystem{
+					Type:       "vfat",
+					Mountpoint: mntPoint,
+					UUID:       disk.EFIFilesystemUUID,
+				},
+			})
+			size += 100 * common.MiB
+		default:
+			name := mntPoint
+			if name == "/" {
+				name = "root"
+			}
+			subvolumes = append(
+				subvolumes,
+				disk.BtrfsSubvolume{
+					Mountpoint: mntPoint,
+					Name:       name,
+					UUID:       disk.RootPartitionUUID},
+			)
+		}
+	}
+
+	pt.Partitions = append(pt.Partitions, disk.Partition{
+		Start: size,
+		Size:  9 * common.GiB,
+		Payload: &disk.Btrfs{
+			UUID:       disk.RootPartitionUUID,
+			Subvolumes: subvolumes,
+		},
+	})
+
+	size += 9 * common.GiB
+	pt.Size = size
+
+	return pt
+}

--- a/internal/testdisk/partition.go
+++ b/internal/testdisk/partition.go
@@ -81,7 +81,7 @@ func MakeFakeBtrfsPartitionTable(mntPoints ...string) *disk.PartitionTable {
 					Mountpoint: mntPoint,
 					Name:       name,
 					UUID:       disk.RootPartitionUUID,
-					Compress:   "zstd:1",
+					Compress:   disk.DefaultBtrfsCompression,
 				},
 			)
 		}

--- a/internal/testdisk/partition.go
+++ b/internal/testdisk/partition.go
@@ -80,7 +80,9 @@ func MakeFakeBtrfsPartitionTable(mntPoints ...string) *disk.PartitionTable {
 				disk.BtrfsSubvolume{
 					Mountpoint: mntPoint,
 					Name:       name,
-					UUID:       disk.RootPartitionUUID},
+					UUID:       disk.RootPartitionUUID,
+					Compress:   "zstd:1",
+				},
 			)
 		}
 	}

--- a/pkg/disk/btrfs.go
+++ b/pkg/disk/btrfs.go
@@ -8,6 +8,8 @@ import (
 	"github.com/google/uuid"
 )
 
+const DefaultBtrfsCompression = "zstd:1"
+
 type Btrfs struct {
 	UUID       string
 	Label      string
@@ -69,6 +71,7 @@ func (b *Btrfs) CreateMountpoint(mountpoint string, size uint64) (Entity, error)
 		GroupID:    0,
 		UUID:       b.UUID, // subvolumes inherit UUID of main volume
 		Name:       name,
+		Compress:   DefaultBtrfsCompression,
 	}
 
 	b.Subvolumes = append(b.Subvolumes, subvolume)

--- a/pkg/disk/btrfs.go
+++ b/pkg/disk/btrfs.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
-	"strings"
 
 	"github.com/google/uuid"
 )
@@ -95,8 +94,7 @@ type BtrfsSubvolume struct {
 	Size       uint64
 	Mountpoint string
 	GroupID    uint64
-
-	MntOps string
+	Compress   string
 
 	// UUID of the parent volume
 	UUID string
@@ -116,7 +114,7 @@ func (bs *BtrfsSubvolume) Clone() Entity {
 		Size:       bs.Size,
 		Mountpoint: bs.Mountpoint,
 		GroupID:    bs.GroupID,
-		MntOps:     bs.MntOps,
+		Compress:   bs.Compress,
 		UUID:       bs.UUID,
 	}
 }
@@ -162,7 +160,10 @@ func (bs *BtrfsSubvolume) GetFSTabOptions() FSTabOptions {
 		return FSTabOptions{}
 	}
 
-	ops := strings.Join([]string{bs.MntOps, fmt.Sprintf("subvol=%s", bs.Name)}, ",")
+	ops := fmt.Sprintf("subvol=%s", bs.Name)
+	if bs.Compress != "" {
+		ops += fmt.Sprintf(",compress=%s", bs.Compress)
+	}
 	return FSTabOptions{
 		MntOps: ops,
 		Freq:   0,

--- a/pkg/disk/btrfs.go
+++ b/pkg/disk/btrfs.go
@@ -84,6 +84,10 @@ func (b *Btrfs) GenUUID(rng *rand.Rand) {
 	if b.UUID == "" {
 		b.UUID = uuid.Must(newRandomUUIDFromReader(rng)).String()
 	}
+
+	for i := range b.Subvolumes {
+		b.Subvolumes[i].UUID = b.UUID
+	}
 }
 
 type BtrfsSubvolume struct {

--- a/pkg/disk/btrfs.go
+++ b/pkg/disk/btrfs.go
@@ -98,6 +98,7 @@ type BtrfsSubvolume struct {
 	Mountpoint string
 	GroupID    uint64
 	Compress   string
+	ReadOnly   bool
 
 	// UUID of the parent volume
 	UUID string
@@ -166,6 +167,9 @@ func (bs *BtrfsSubvolume) GetFSTabOptions() FSTabOptions {
 	ops := fmt.Sprintf("subvol=%s", bs.Name)
 	if bs.Compress != "" {
 		ops += fmt.Sprintf(",compress=%s", bs.Compress)
+	}
+	if bs.ReadOnly {
+		ops += ",ro"
 	}
 	return FSTabOptions{
 		MntOps: ops,

--- a/pkg/disk/btrfs.go
+++ b/pkg/disk/btrfs.go
@@ -164,6 +164,9 @@ func (bs *BtrfsSubvolume) GetFSTabOptions() FSTabOptions {
 		return FSTabOptions{}
 	}
 
+	if bs.Name == "" {
+		panic(fmt.Errorf("internal error: BtrfsSubvolume.GetFSTabOptions() for %+v called without a name", bs))
+	}
 	ops := fmt.Sprintf("subvol=%s", bs.Name)
 	if bs.Compress != "" {
 		ops += fmt.Sprintf(",compress=%s", bs.Compress)

--- a/pkg/disk/btrfs_test.go
+++ b/pkg/disk/btrfs_test.go
@@ -6,14 +6,17 @@ import (
 )
 
 func TestBtrfsSubvolume_GetFSTabOptions(t *testing.T) {
-	subvol := BtrfsSubvolume{
-		Name:       "root",
-		Mountpoint: "/",
-		Compress:   "zstd:1",
-	}
-	actual := subvol.GetFSTabOptions()
+	for _, tc := range []struct {
+		subvol          BtrfsSubvolume
+		expectedMntOpts string
+	}{
+		{BtrfsSubvolume{Name: "name"}, "subvol=name"},
+		{BtrfsSubvolume{Name: "name", Compress: "gzip"}, "subvol=name,compress=gzip"},
+		{BtrfsSubvolume{Name: "root", Compress: "zstd:1", ReadOnly: true},
+			"subvol=root,compress=zstd:1,ro"},
+	} {
+		actual := tc.subvol.GetFSTabOptions()
 
-	assert.Equal(t, FSTabOptions{
-		MntOps: "subvol=root,compress=zstd:1",
-	}, actual)
+		assert.Equal(t, FSTabOptions{MntOps: tc.expectedMntOpts}, actual)
+	}
 }

--- a/pkg/disk/btrfs_test.go
+++ b/pkg/disk/btrfs_test.go
@@ -1,0 +1,19 @@
+package disk
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBtrfsSubvolume_GetFSTabOptions(t *testing.T) {
+	subvol := BtrfsSubvolume{
+		Name:       "root",
+		Mountpoint: "/",
+		Compress:   "zstd:1",
+	}
+	actual := subvol.GetFSTabOptions()
+
+	assert.Equal(t, FSTabOptions{
+		MntOps: "subvol=root,compress=zstd:1",
+	}, actual)
+}

--- a/pkg/disk/btrfs_test.go
+++ b/pkg/disk/btrfs_test.go
@@ -1,8 +1,9 @@
 package disk
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBtrfsSubvolume_GetFSTabOptions(t *testing.T) {
@@ -19,4 +20,12 @@ func TestBtrfsSubvolume_GetFSTabOptions(t *testing.T) {
 
 		assert.Equal(t, FSTabOptions{MntOps: tc.expectedMntOpts}, actual)
 	}
+}
+
+func TestBtrfsSubvolume_GetFSTabOptionsPanics(t *testing.T) {
+	assert.PanicsWithError(t, `internal error: BtrfsSubvolume.GetFSTabOptions() for &{Name: Size:0 Mountpoint: GroupID:0 Compress: ReadOnly:false UUID:} called without a name`, func() {
+		subvol := &BtrfsSubvolume{}
+		subvol.GetFSTabOptions()
+	})
+
 }

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -21,8 +21,10 @@ import (
 	"io"
 	"math/rand"
 	"reflect"
+	"strings"
 
 	"github.com/google/uuid"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -151,6 +153,16 @@ type FSTabOptions struct {
 	Freq uint64
 	// The sixth field of fstab(5); fs_passno
 	PassNo uint64
+}
+
+// ReadOnly returns true is the filesystem is mounted read-only
+func (o FSTabOptions) ReadOnly() bool {
+	opts := strings.Split(o.MntOps, ",")
+
+	// filesystem is mounted read-only if:
+	// - there's ro (because rw is the default)
+	// - AND there's no rw (because rw overrides ro)
+	return slices.Contains(opts, "ro") && !slices.Contains(opts, "rw")
 }
 
 // uuid generator helpers

--- a/pkg/disk/disk_test.go
+++ b/pkg/disk/disk_test.go
@@ -1171,3 +1171,25 @@ func TestMinimumSizesWithRequiredSizes(t *testing.T) {
 		}
 	}
 }
+
+func TestFSTabOptionsReadOnly(t *testing.T) {
+	cases := []struct {
+		options string
+		ro      bool
+	}{
+		{"ro", true},
+		{"ro,relatime,seclabel,compress=zstd:1,ssd,discard=async,space_cache,subvolid=257,subvol=/root", true},
+
+		{"defaults", false},
+		{"rw", false},
+		{"rw,ro", false},
+		{"rw,relatime,seclabel,compress=zstd:1,ssd,discard=async,space_cache,subvolid=257,subvol=/root", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.options, func(t *testing.T) {
+			options := FSTabOptions{MntOps: c.options}
+			assert.Equal(t, c.ro, options.ReadOnly())
+		})
+	}
+}

--- a/pkg/disk/disk_test.go
+++ b/pkg/disk/disk_test.go
@@ -1174,8 +1174,8 @@ func TestMinimumSizesWithRequiredSizes(t *testing.T) {
 
 func TestFSTabOptionsReadOnly(t *testing.T) {
 	cases := []struct {
-		options string
-		ro      bool
+		options    string
+		expectedRO bool
 	}{
 		{"ro", true},
 		{"ro,relatime,seclabel,compress=zstd:1,ssd,discard=async,space_cache,subvolid=257,subvol=/root", true},
@@ -1189,7 +1189,7 @@ func TestFSTabOptionsReadOnly(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.options, func(t *testing.T) {
 			options := FSTabOptions{MntOps: c.options}
-			assert.Equal(t, c.ro, options.ReadOnly())
+			assert.Equal(t, c.expectedRO, options.ReadOnly())
 		})
 	}
 }

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -718,7 +718,7 @@ func (pt *PartitionTable) ensureBtrfs() error {
 				{
 					Name:       "root",
 					Mountpoint: "/",
-					Compress:   "zstd:1",
+					Compress:   DefaultBtrfsCompression,
 				},
 			},
 		}

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -53,8 +53,7 @@ func NewPartitionTable(basePT *PartitionTable, mountpoints []blueprint.Filesyste
 	// first pass: enlarge existing mountpoints and collect new ones
 	newMountpoints, _ := newPT.applyCustomization(mountpoints, false)
 
-	var ensureLVM bool
-	ensureBtrfs := false
+	var ensureLVM, ensureBtrfs bool
 	switch mode {
 	case LVMPartitioningMode:
 		ensureLVM = true

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -36,6 +36,9 @@ const (
 	// RawPartitioningMode always creates a raw layout.
 	RawPartitioningMode PartitioningMode = "raw"
 
+	// BtrfsPartitioningMode creates a btrfs layout.
+	BtfrsPartitioningMode PartitioningMode = "btrfs"
+
 	// DefaultPartitioningMode is AutoLVMPartitioningMode and is the empty state
 	DefaultPartitioningMode PartitioningMode = ""
 )
@@ -43,14 +46,15 @@ const (
 func NewPartitionTable(basePT *PartitionTable, mountpoints []blueprint.FilesystemCustomization, imageSize uint64, mode PartitioningMode, requiredSizes map[string]uint64, rng *rand.Rand) (*PartitionTable, error) {
 	newPT := basePT.Clone().(*PartitionTable)
 
-	if basePT.features().LVM && mode == RawPartitioningMode {
-		return nil, fmt.Errorf("raw partitioning mode set for a base partition table with LVM, this is unsupported")
+	if basePT.features().LVM && (mode == RawPartitioningMode || mode == BtfrsPartitioningMode) {
+		return nil, fmt.Errorf("%s partitioning mode set for a base partition table with LVM, this is unsupported", mode)
 	}
 
 	// first pass: enlarge existing mountpoints and collect new ones
 	newMountpoints, _ := newPT.applyCustomization(mountpoints, false)
 
 	var ensureLVM bool
+	ensureBtrfs := false
 	switch mode {
 	case LVMPartitioningMode:
 		ensureLVM = true
@@ -58,11 +62,18 @@ func NewPartitionTable(basePT *PartitionTable, mountpoints []blueprint.Filesyste
 		ensureLVM = false
 	case DefaultPartitioningMode, AutoLVMPartitioningMode:
 		ensureLVM = len(newMountpoints) > 0
+	case BtfrsPartitioningMode:
+		ensureBtrfs = true
 	default:
 		return nil, fmt.Errorf("unsupported partitioning mode %q", mode)
 	}
 	if ensureLVM {
 		err := newPT.ensureLVM()
+		if err != nil {
+			return nil, err
+		}
+	} else if ensureBtrfs {
+		err := newPT.ensureBtrfs()
 		if err != nil {
 			return nil, err
 		}
@@ -673,6 +684,59 @@ func (pt *PartitionTable) ensureLVM() error {
 
 	} else {
 		return fmt.Errorf("Unsupported parent for LVM")
+	}
+
+	return nil
+}
+
+// ensureBtrfs will ensure that the root partition is on a btrfs subvolume, i.e. if
+// it currently is not, it will wrap it in one
+func (pt *PartitionTable) ensureBtrfs() error {
+
+	rootPath := entityPath(pt, "/")
+	if rootPath == nil {
+		return fmt.Errorf("no root mountpoint for a partition table: %#v", pt)
+	}
+
+	// we need a /boot partition to boot btrfs, ensure one exists
+	bootPath := entityPath(pt, "/boot")
+	if bootPath == nil {
+		_, err := pt.CreateMountpoint("/boot", 512*common.MiB)
+		if err != nil {
+			return fmt.Errorf("cannot create /boot partition when ensuring btrfs: %w", err)
+		}
+	}
+
+	parent := rootPath[1] // NB: entityPath has reversed order
+
+	if _, ok := parent.(*Btrfs); ok {
+		return nil
+	} else if part, ok := parent.(*Partition); ok {
+		btrfs := &Btrfs{
+			Label: "root",
+			Subvolumes: []BtrfsSubvolume{
+				{
+					Name:       "root",
+					Mountpoint: "/",
+					Compress:   "zstd:1",
+				},
+			},
+		}
+
+		// replace the top-level partition payload with a new btrfs filesystem
+		part.Payload = btrfs
+
+		// reset the btrfs partition size - it will be grown later
+		part.Size = 0
+
+		if pt.Type == "gpt" {
+			part.Type = FilesystemDataGUID
+		} else {
+			part.Type = "83"
+		}
+
+	} else {
+		return fmt.Errorf("unsupported parent for btrfs: %T", parent)
 	}
 
 	return nil

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -704,6 +704,8 @@ func (pt *PartitionTable) ensureBtrfs() error {
 		if err != nil {
 			return fmt.Errorf("failed to create /boot partition when ensuring btrfs: %w", err)
 		}
+
+		rootPath = entityPath(pt, "/")
 	}
 
 	parent := rootPath[1] // NB: entityPath has reversed order

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -712,6 +712,11 @@ func (pt *PartitionTable) ensureBtrfs() error {
 	if _, ok := parent.(*Btrfs); ok {
 		return nil
 	} else if part, ok := parent.(*Partition); ok {
+		rootMountable, ok := rootPath[0].(Mountable)
+		if !ok {
+			return fmt.Errorf("root entity is not mountable: %T, this is a violation of entityPath() contract", rootPath[0])
+		}
+
 		btrfs := &Btrfs{
 			Label: "root",
 			Subvolumes: []BtrfsSubvolume{
@@ -719,6 +724,7 @@ func (pt *PartitionTable) ensureBtrfs() error {
 					Name:       "root",
 					Mountpoint: "/",
 					Compress:   DefaultBtrfsCompression,
+					ReadOnly:   rootMountable.GetFSTabOptions().ReadOnly(),
 				},
 			},
 		}

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -703,7 +703,7 @@ func (pt *PartitionTable) ensureBtrfs() error {
 	if bootPath == nil {
 		_, err := pt.CreateMountpoint("/boot", 512*common.MiB)
 		if err != nil {
-			return fmt.Errorf("cannot create /boot partition when ensuring btrfs: %w", err)
+			return fmt.Errorf("failed to create /boot partition when ensuring btrfs: %w", err)
 		}
 	}
 

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -1,11 +1,14 @@
 package disk_test
 
 import (
+	"math/rand"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/testdisk"
+	"github.com/osbuild/images/pkg/disk"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPartitionTable_GetMountpointSize(t *testing.T) {
@@ -23,4 +26,57 @@ func TestPartitionTable_GetMountpointSize(t *testing.T) {
 	_, err = pt.GetMountpointSize("/custom")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot find mountpoint /custom")
+}
+
+func TestPartitionTable_GenerateUUIDs(t *testing.T) {
+	pt := disk.PartitionTable{
+		Type: "gpt",
+		Partitions: []disk.Partition{
+			{
+				Size:     1 * common.MebiByte,
+				Bootable: true,
+				Type:     disk.BIOSBootPartitionGUID,
+				UUID:     disk.BIOSBootPartitionUUID,
+			},
+			{
+				Size: 2 * common.GibiByte,
+				Type: disk.FilesystemDataGUID,
+				Payload: &disk.Filesystem{
+					Type:         "xfs",
+					Label:        "root",
+					Mountpoint:   "/",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+			{
+				Size: 10 * common.GibiByte,
+				Payload: &disk.Btrfs{
+					Subvolumes: []disk.BtrfsSubvolume{
+						{
+							Mountpoint: "/var",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Static seed for testing
+	/* #nosec G404 */
+	rnd := rand.New(rand.NewSource(0))
+
+	pt.GenerateUUIDs(rnd)
+
+	// Check that GenUUID doesn't change already defined UUIDs
+	assert.Equal(t, disk.BIOSBootPartitionUUID, pt.Partitions[0].UUID)
+
+	// Check that GenUUID generates fresh UUIDs if not defined prior the call
+	assert.Equal(t, "a178892e-e285-4ce1-9114-55780875d64e", pt.Partitions[1].UUID)
+	assert.Equal(t, "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75", pt.Partitions[1].Payload.(*disk.Filesystem).UUID)
+
+	// Check that GenUUID generates the same UUID for BTRFS and its subvolumes
+	assert.Equal(t, "fb180daf-48a7-4ee0-b10d-394651850fd4", pt.Partitions[2].Payload.(*disk.Btrfs).UUID)
+	assert.Equal(t, "fb180daf-48a7-4ee0-b10d-394651850fd4", pt.Partitions[2].Payload.(*disk.Btrfs).Subvolumes[0].UUID)
 }

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -42,6 +42,7 @@ func TestPartitionTable_GenerateUUIDs(t *testing.T) {
 				Size: 2 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				Payload: &disk.Filesystem{
+					// create mixed xfs root filesystem and a btrfs /var partition
 					Type:         "xfs",
 					Label:        "root",
 					Mountpoint:   "/",

--- a/pkg/osbuild/bootupd_stage.go
+++ b/pkg/osbuild/bootupd_stage.go
@@ -99,6 +99,15 @@ func genMountsForBootupd(source string, pt *disk.PartitionTable) ([]Mount, error
 			}
 			mount.Partition = common.ToPtr(idx + 1)
 			mounts = append(mounts, *mount)
+		case *disk.Btrfs:
+			for _, subvol := range payload.Subvolumes {
+				mount, err := genOsbuildMount(source, &subvol)
+				if err != nil {
+					return nil, err
+				}
+				mount.Partition = common.ToPtr(idx + 1)
+				mounts = append(mounts, *mount)
+			}
 		default:
 			return nil, fmt.Errorf("type %T not supported by bootupd handling yet", part.Payload)
 		}

--- a/pkg/osbuild/bootupd_stage.go
+++ b/pkg/osbuild/bootupd_stage.go
@@ -100,8 +100,8 @@ func genMountsForBootupd(source string, pt *disk.PartitionTable) ([]Mount, error
 			mount.Partition = common.ToPtr(idx + 1)
 			mounts = append(mounts, *mount)
 		case *disk.Btrfs:
-			for _, subvol := range payload.Subvolumes {
-				mount, err := genOsbuildMount(source, &subvol)
+			for i := range payload.Subvolumes {
+				mount, err := genOsbuildMount(source, &payload.Subvolumes[i])
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/osbuild/bootupd_stage_test.go
+++ b/pkg/osbuild/bootupd_stage_test.go
@@ -290,8 +290,12 @@ func TestGenBootupdDevicesMountsHappy(t *testing.T) {
 
 func TestGenBootupdDevicesMountsHappyBtrfs(t *testing.T) {
 	filename := "fake-disk.img"
+	pf := &platform.X86{
+		BasePlatform: platform.BasePlatform{},
+		UEFIVendor:   "test",
+	}
 
-	devices, mounts, err := osbuild.GenBootupdDevicesMounts(filename, testdisk.MakeFakeBtrfsPartitionTable("/", "/home", "/boot/efi", "/boot"))
+	devices, mounts, err := osbuild.GenBootupdDevicesMounts(filename, testdisk.MakeFakeBtrfsPartitionTable("/", "/home", "/boot/efi", "/boot"), pf)
 	require.Nil(t, err)
 	assert.Equal(t, devices, map[string]osbuild.Device{
 		"disk": {

--- a/pkg/osbuild/btrfs_mount.go
+++ b/pkg/osbuild/btrfs_mount.go
@@ -1,10 +1,21 @@
 package osbuild
 
-func NewBtrfsMount(name, source, target string) *Mount {
+type BtrfsMountOptions struct {
+	Subvol   string `json:"subvol,omitempty"`
+	Compress string `json:"compress,omitempty"`
+}
+
+func (b BtrfsMountOptions) isMountOptions() {}
+
+func NewBtrfsMount(name, source, target, subvol, compress string) *Mount {
 	return &Mount{
 		Type:   "org.osbuild.btrfs",
 		Name:   name,
 		Source: source,
 		Target: target,
+		Options: BtrfsMountOptions{
+			Subvol:   subvol,
+			Compress: compress,
+		},
 	}
 }

--- a/pkg/osbuild/btrfs_subvol_stage.go
+++ b/pkg/osbuild/btrfs_subvol_stage.go
@@ -1,0 +1,73 @@
+package osbuild
+
+import (
+	"github.com/osbuild/images/pkg/disk"
+)
+
+type BtrfsSubVolOptions struct {
+	Subvolumes []BtrfsSubVol `json:"subvolumes"`
+}
+
+type BtrfsSubVol struct {
+	Name string `json:"name"`
+}
+
+func (BtrfsSubVolOptions) isStageOptions() {}
+
+func NewBtrfsSubVol(options *BtrfsSubVolOptions, devices *map[string]Device, mounts *[]Mount) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.btrfs.subvol",
+		Options: options,
+		Devices: *devices,
+		Mounts:  *mounts,
+	}
+}
+
+func GenBtrfsSubVolStage(filename string, pt *disk.PartitionTable) *Stage {
+	var subvolumes []BtrfsSubVol
+
+	genStage := func(mnt disk.Mountable, path []disk.Entity) error {
+		if mnt.GetFSType() != "btrfs" {
+			return nil
+		}
+
+		btrfs := mnt.(*disk.BtrfsSubvolume)
+		subvolumes = append(subvolumes, BtrfsSubVol{Name: "/" + btrfs.Name})
+
+		return nil
+	}
+
+	_ = pt.ForEachMountable(genStage)
+
+	if len(subvolumes) == 0 {
+		return nil
+	}
+
+	devices, mounts := genBtrfsMountDevices(filename, pt)
+
+	return NewBtrfsSubVol(&BtrfsSubVolOptions{subvolumes}, devices, mounts)
+}
+
+func genBtrfsMountDevices(filename string, pt *disk.PartitionTable) (*map[string]Device, *[]Mount) {
+	devices := make(map[string]Device, len(pt.Partitions))
+	mounts := make([]Mount, 0, len(pt.Partitions))
+	genMounts := func(ent disk.Entity, path []disk.Entity) error {
+		if _, isBtrfs := ent.(*disk.Btrfs); !isBtrfs {
+			return nil
+		}
+
+		stageDevices, name := getDevices(path, filename, false)
+
+		mounts = append(mounts, *NewBtrfsMount(name, name, "/"))
+
+		// update devices map with new elements from stageDevices
+		for devName := range stageDevices {
+			devices[devName] = stageDevices[devName]
+		}
+		return nil
+	}
+
+	_ = pt.ForEachEntity(genMounts)
+
+	return &devices, &mounts
+}

--- a/pkg/osbuild/btrfs_subvol_stage.go
+++ b/pkg/osbuild/btrfs_subvol_stage.go
@@ -58,7 +58,7 @@ func genBtrfsMountDevices(filename string, pt *disk.PartitionTable) (*map[string
 
 		stageDevices, name := getDevices(path, filename, false)
 
-		mounts = append(mounts, *NewBtrfsMount(name, name, "/"))
+		mounts = append(mounts, *NewBtrfsMount(name, name, "/", "", ""))
 
 		// update devices map with new elements from stageDevices
 		for devName := range stageDevices {

--- a/pkg/osbuild/copy_stage_test.go
+++ b/pkg/osbuild/copy_stage_test.go
@@ -27,7 +27,7 @@ func TestNewCopyStage(t *testing.T) {
 	}
 
 	mounts := []Mount{
-		*NewBtrfsMount("root", "root", "/"),
+		*NewBtrfsMount("root", "root", "/", "", ""),
 	}
 
 	treeInput := NewTreeInput("name:input-pipeline")

--- a/pkg/osbuild/device.go
+++ b/pkg/osbuild/device.go
@@ -257,7 +257,7 @@ func genOsbuildMount(source string, mnt disk.Mountable) (*Mount, error) {
 		return NewExt4Mount(name, source, mountpoint), nil
 	case "btrfs":
 		if subvol, isSubvol := mnt.(*disk.BtrfsSubvolume); isSubvol {
-			return NewBtrfsMount(name, source, mountpoint, subvol.Name, ""), nil
+			return NewBtrfsMount(name, source, mountpoint, subvol.Name, subvol.Compress), nil
 		} else {
 			return nil, fmt.Errorf("mounting bare btrfs partition is unsupported: %s", mountpoint)
 		}

--- a/pkg/osbuild/device.go
+++ b/pkg/osbuild/device.go
@@ -256,7 +256,11 @@ func genOsbuildMount(source string, mnt disk.Mountable) (*Mount, error) {
 	case "ext4":
 		return NewExt4Mount(name, source, mountpoint), nil
 	case "btrfs":
-		return NewBtrfsMount(name, source, mountpoint), nil
+		if subvol, isSubvol := mnt.(*disk.BtrfsSubvolume); isSubvol {
+			return NewBtrfsMount(name, source, mountpoint, subvol.Name, ""), nil
+		} else {
+			return nil, fmt.Errorf("mounting bare btrfs partition is unsupported: %s", mountpoint)
+		}
 	default:
 		return nil, fmt.Errorf("unknown fs type " + t)
 	}

--- a/pkg/osbuild/device.go
+++ b/pkg/osbuild/device.go
@@ -160,6 +160,8 @@ func deviceName(p disk.Entity) string {
 		return payload.Name
 	case *disk.LVMLogicalVolume:
 		return payload.Name
+	case *disk.Btrfs:
+		return "btrfs-" + payload.UUID[:4]
 	}
 	panic(fmt.Sprintf("unsupported device type in deviceName: '%T'", p))
 }

--- a/pkg/osbuild/device_test.go
+++ b/pkg/osbuild/device_test.go
@@ -221,3 +221,22 @@ func TestMountsDeviceFromPtHappy(t *testing.T) {
 		},
 	})
 }
+
+func Test_deviceName(t *testing.T) {
+	tests := []struct {
+		e    disk.Entity
+		name string
+	}{
+		{e: &disk.Filesystem{Mountpoint: "/toucan"}, name: "toucan"},
+		{e: &disk.BtrfsSubvolume{Mountpoint: "/ostrich"}, name: "ostrich"},
+		{e: &disk.LUKSContainer{UUID: "fb180daf-48a7-4ee0-b10d-394651850fd4"}, name: "luks-fb18"},
+		{e: &disk.LVMVolumeGroup{Name: "vg-main"}, name: "vg-main"},
+		{e: &disk.LVMLogicalVolume{Name: "lv-main"}, name: "lv-main"},
+		{e: &disk.Btrfs{UUID: "fb180daf-48a7-4ee0-b10d-394651850fd4"}, name: "btrfs-fb18"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.name, deviceName(tt.e))
+		})
+	}
+}

--- a/pkg/osbuild/device_test.go
+++ b/pkg/osbuild/device_test.go
@@ -254,19 +254,19 @@ func TestMountsDeviceFromBrfs(t *testing.T) {
 
 func Test_deviceName(t *testing.T) {
 	tests := []struct {
-		e    disk.Entity
-		name string
+		e            disk.Entity
+		expectedName string
 	}{
-		{e: &disk.Filesystem{Mountpoint: "/toucan"}, name: "toucan"},
-		{e: &disk.BtrfsSubvolume{Mountpoint: "/ostrich"}, name: "ostrich"},
-		{e: &disk.LUKSContainer{UUID: "fb180daf-48a7-4ee0-b10d-394651850fd4"}, name: "luks-fb18"},
-		{e: &disk.LVMVolumeGroup{Name: "vg-main"}, name: "vg-main"},
-		{e: &disk.LVMLogicalVolume{Name: "lv-main"}, name: "lv-main"},
-		{e: &disk.Btrfs{UUID: "fb180daf-48a7-4ee0-b10d-394651850fd4"}, name: "btrfs-fb18"},
+		{&disk.Filesystem{Mountpoint: "/toucan"}, "toucan"},
+		{&disk.BtrfsSubvolume{Mountpoint: "/ostrich"}, "ostrich"},
+		{&disk.LUKSContainer{UUID: "fb180daf-48a7-4ee0-b10d-394651850fd4"}, "luks-fb18"},
+		{&disk.LVMVolumeGroup{Name: "vg-main"}, "vg-main"},
+		{&disk.LVMLogicalVolume{Name: "lv-main"}, "lv-main"},
+		{&disk.Btrfs{UUID: "fb180daf-48a7-4ee0-b10d-394651850fd4"}, "btrfs-fb18"},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.name, deviceName(tt.e))
+		t.Run(tt.expectedName, func(t *testing.T) {
+			assert.Equal(t, tt.expectedName, deviceName(tt.e))
 		})
 	}
 }

--- a/pkg/osbuild/device_test.go
+++ b/pkg/osbuild/device_test.go
@@ -230,7 +230,7 @@ func TestMountsDeviceFromBrfs(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, "-", fsRootMntName)
 	assert.Equal(t, []Mount{
-		{Name: "-", Type: "org.osbuild.btrfs", Source: "btrfs-6264", Target: "/", Options: BtrfsMountOptions{Subvol: "root"}},
+		{Name: "-", Type: "org.osbuild.btrfs", Source: "btrfs-6264", Target: "/", Options: BtrfsMountOptions{Subvol: "root", Compress: "zstd:1"}},
 		{Name: "boot", Type: "org.osbuild.ext4", Source: "boot", Target: "/boot"},
 	}, mounts)
 	assert.Equal(t, map[string]Device{

--- a/pkg/osbuild/disk.go
+++ b/pkg/osbuild/disk.go
@@ -102,6 +102,11 @@ func GenImagePrepareStages(pt *disk.PartitionTable, filename string, partTool Pa
 	s = GenMkfsStages(pt, filename)
 	stages = append(stages, s...)
 
+	subvolStage := GenBtrfsSubVolStage(filename, pt)
+	if subvolStage != nil {
+		stages = append(stages, subvolStage)
+	}
+
 	return stages
 }
 

--- a/pkg/osbuild/disk.go
+++ b/pkg/osbuild/disk.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+
 	"github.com/osbuild/images/pkg/disk"
 )
 
@@ -122,6 +123,11 @@ func GenImageKernelOptions(pt *disk.PartitionTable) []string {
 		case *disk.LUKSContainer:
 			karg := "luks.uuid=" + ent.UUID
 			cmdline = append(cmdline, karg)
+		case *disk.BtrfsSubvolume:
+			if ent.Mountpoint == "/" {
+				karg := "rootflags=subvol=" + ent.Name
+				cmdline = append(cmdline, karg)
+			}
 		}
 		return nil
 	}

--- a/pkg/osbuild/disk_test.go
+++ b/pkg/osbuild/disk_test.go
@@ -49,6 +49,12 @@ func TestGenImageKernelOptionsBtrfs(t *testing.T) {
 	assert.Equal(t, []string{"rootflags=subvol=root"}, actual)
 }
 
+func TestGenImageKernelOptionsBtrfsNotRootCmdlineGenerated(t *testing.T) {
+	pt := testdisk.MakeFakeBtrfsPartitionTable("/var")
+	kopts := GenImageKernelOptions(pt)
+	assert.Equal(t, len(kopts), 0)
+}
+
 func TestGenImagePrepareStages(t *testing.T) {
 	pt := testdisk.MakeFakeBtrfsPartitionTable("/", "/boot")
 	filename := "image.raw"

--- a/pkg/osbuild/disk_test.go
+++ b/pkg/osbuild/disk_test.go
@@ -131,6 +131,7 @@ func TestGenImagePrepareStages(t *testing.T) {
 					Type:   "org.osbuild.btrfs",
 					Source: "btrfs-6264",
 					Target: "/",
+					Options: BtrfsMountOptions{},
 				},
 			},
 			Options: &BtrfsSubVolOptions{

--- a/pkg/osbuild/disk_test.go
+++ b/pkg/osbuild/disk_test.go
@@ -133,10 +133,10 @@ func TestGenImagePrepareStages(t *testing.T) {
 			},
 			Mounts: []Mount{
 				{
-					Name:   "btrfs-6264",
-					Type:   "org.osbuild.btrfs",
-					Source: "btrfs-6264",
-					Target: "/",
+					Name:    "btrfs-6264",
+					Type:    "org.osbuild.btrfs",
+					Source:  "btrfs-6264",
+					Target:  "/",
 					Options: BtrfsMountOptions{},
 				},
 			},

--- a/pkg/osbuild/disk_test.go
+++ b/pkg/osbuild/disk_test.go
@@ -43,6 +43,12 @@ func TestGenImageKernelOptions(t *testing.T) {
 	assert.Subset(cmdline, []string{"luks.uuid=" + uuid})
 }
 
+func TestGenImageKernelOptionsBtrfs(t *testing.T) {
+	pt := testdisk.MakeFakeBtrfsPartitionTable("/")
+	actual := GenImageKernelOptions(pt)
+	assert.Equal(t, []string{"rootflags=subvol=root"}, actual)
+}
+
 func TestGenImagePrepareStages(t *testing.T) {
 	pt := testdisk.MakeFakeBtrfsPartitionTable("/", "/boot")
 	filename := "image.raw"

--- a/pkg/osbuild/mount_test.go
+++ b/pkg/osbuild/mount_test.go
@@ -15,12 +15,13 @@ func TestNewMounts(t *testing.T) {
 	assert := assert.New(t)
 
 	{ // btrfs
-		actual := osbuild.NewBtrfsMount("btrfs", "/dev/sda1", "/mnt/btrfs")
+		actual := osbuild.NewBtrfsMount("btrfs", "/dev/sda1", "/mnt/btrfs", "", "")
 		expected := &osbuild.Mount{
-			Name:   "btrfs",
-			Type:   "org.osbuild.btrfs",
-			Source: "/dev/sda1",
-			Target: "/mnt/btrfs",
+			Name:    "btrfs",
+			Type:    "org.osbuild.btrfs",
+			Source:  "/dev/sda1",
+			Target:  "/mnt/btrfs",
+			Options: osbuild.BtrfsMountOptions{},
 		}
 		assert.Equal(expected, actual)
 	}


### PR DESCRIPTION
(This is a revived #422.)

This PR has basically three parts:

1) The first commits fix already existing btrfs code in the library (it was never used before). Just tiny fixes. I tried to add tests where they had been missing before.
2) The "middle section" adds missing parts for btrfs subvolume. The scaffolding was there, but the translation from an abstract partition table to osbuild stages was missing.
3) The final section is the actual addition of a btrfs partitioning mode. When this mode is used, a root partition from the base partition table is converted to a btrfs one with a subvolume. The code for adding more btrfs subvolumes based on blueprint mountpoints was already there.

Weird parts:

- When a btrfs partitioning mode is used, the compression is hard-coded to zstd:1. It would be great if this could be configured per an image type/distro/arch, but the partitioning code currently cannot do such specific things. In the end, this should be probably also user-configurable. However, I think that this default value is alright for the starters, we can always iterate on this.
- Setting min-size for extra mountpoints is a weird thing, because the extra mountpoints are translated to subvolumes... Maybe we should just error out if the min size is set with btrfs and depend just on the total size customization... Happy to discuss this!


TODO:
- [ ] more tests (especially for `ensureBtrfs`)