### PR TITLE
image: make the RHEL lorax template selection configurable

### DIFF
--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -41,6 +41,8 @@ type AnacondaContainerInstaller struct {
 	FIPS                      bool
 
 	Kickstart *kickstart.Options
+
+	UseRHELLoraxTemplates bool
 }
 
 func NewAnacondaContainerInstaller(container container.SourceSpec, ref string) *AnacondaContainerInstaller {
@@ -69,8 +71,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 		img.Preview,
 	)
 
-	// This is only built with ELN for now
-	anacondaPipeline.UseRHELLoraxTemplates = true
+	anacondaPipeline.UseRHELLoraxTemplates = img.UseRHELLoraxTemplates
 
 	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include
 	anacondaPipeline.ExcludePackages = img.ExtraBasePackages.Exclude


### PR DESCRIPTION
Make the use of RHEL lorax templates configurable from the top level image definition so that we can control it in BIB based on the distro being built.

See https://github.com/osbuild/bootc-image-builder/issues/421