### PR TITLE
dnfjson: enable loading of optional metadata when needed

### DIFF
--- a/pkg/dnfjson/dnfjson.go
+++ b/pkg/dnfjson/dnfjson.go
@@ -640,6 +640,9 @@ type arguments struct {
 	// Load repository configurations, gpg keys, and vars from an os-root-like
 	// tree.
 	RootDir string `json:"root_dir"`
+
+	// Optional metadata to download for the repositories
+	OptionalMetadata []string `json:"optional-metadata,omitempty"`
 }
 
 type searchArgs struct {

--- a/pkg/dnfjson/dnfjson.go
+++ b/pkg/dnfjson/dnfjson.go
@@ -460,10 +460,12 @@ func (s *Solver) makeDepsolveRequest(pkgSets []rpmmd.PackageSet) (*Request, map[
 	if err != nil {
 		return nil, nil, err
 	}
+
 	args := arguments{
-		Repos:        dnfRepoMap,
-		RootDir:      s.rootDir,
-		Transactions: transactions,
+		Repos:            dnfRepoMap,
+		RootDir:          s.rootDir,
+		Transactions:     transactions,
+		OptionalMetadata: s.optionalMetadataForDistro(),
 	}
 
 	req := Request{
@@ -477,6 +479,20 @@ func (s *Solver) makeDepsolveRequest(pkgSets []rpmmd.PackageSet) (*Request, map[
 	}
 
 	return &req, rhsmMap, nil
+}
+
+func (s *Solver) optionalMetadataForDistro() []string {
+	// filelist repo metadata is required when using newer versions of libdnf
+	// with old repositories or packages that specify dependencies on files.
+	// EL10+ and Fedora 40+ packaging guidelines prohibit depending on
+	// filepaths so filelist downloads are disabled by default and are not
+	// required when depsolving for those distros. Explicitly enable the option
+	// for older distro versions in case we are using a newer libdnf.
+	switch s.modulePlatformID {
+	case "platform:f39", "platform:el7", "platform:el8", "platform:el9":
+		return []string{"filelists"}
+	}
+	return nil
 }
 
 // Helper function for creating a dump request payload


### PR DESCRIPTION
**dnfjson: add OptionalMetadata property to depsolve args**

New property on the arguments object that controls the types of metadata
to download for repositories and use when depsolving.

See https://github.com/osbuild/osbuild/pull/1775

---

**dnfjson: enable filelists for older distro versions**

Enable filelists in the optional metadata for EL7, EL8, EL9, and Fedora 39.

When running osbuild-depsolve-dnf with the libdnf version that's
included in these distro versions, this option will have no effect since
it is enabled by default.  However, when depsolving packages for these
distro versions with newer versions of libdnf, the filelists are
disabled and can cause issues with packages that declare dependencies on
filepaths.

The cutoff point is a little fuzzy for CentOS and Fedora.  Depsolving
all our test manifests for Fedora 39 and CentOS Stream 9 without
filelists works, but since the packaging guidelines of not depending on
filepaths went into effect in EL10 and Fedora 40, it's possible there
are packages in F39 and C9S that don't conform yet, so it's probably
safer to keep filelists enabled for these distro versions.

---

Requires https://github.com/osbuild/osbuild/pull/1775