### PR TITLE
RHEL 8.10: change RHUI client package and remove version lock (COMPOSER-2252)

### DIFF
--- a/pkg/distro/rhel/rhel8/ami.go
+++ b/pkg/distro/rhel/rhel8/ami.go
@@ -417,9 +417,14 @@ func rhelEc2HaPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 // Includes the common ec2 package set, the common SAP packages, and
 // the amazon rhui sap package
 func rhelEc2SapPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
+	rhuiPkg := "rh-amazon-rhui-client-sap-bundle-e4s"
+	if t.Arch().Distro().OsVersion() == "8.10" {
+		rhuiPkg = "rh-amazon-rhui-client-sap-bundle"
+	}
+
 	return rpmmd.PackageSet{
 		Include: []string{
-			"rh-amazon-rhui-client-sap-bundle-e4s",
+			rhuiPkg,
 		},
 	}.Append(rhelEc2CommonPackageSet(t)).Append(SapPackageSet(t))
 }

--- a/pkg/distro/rhel/rhel8/sap.go
+++ b/pkg/distro/rhel/rhel8/sap.go
@@ -10,7 +10,7 @@ import (
 
 // sapImageConfig returns the SAP specific ImageConfig data
 func sapImageConfig(rd distro.Distro) *distro.ImageConfig {
-	return &distro.ImageConfig{
+	ic := &distro.ImageConfig{
 		SELinuxConfig: &osbuild.SELinuxConfigStageOptions{
 			State: osbuild.SELinuxStatePermissive,
 		},
@@ -105,8 +105,11 @@ func sapImageConfig(rd distro.Distro) *distro.ImageConfig {
 				},
 			),
 		},
+	}
+
+	if common.VersionLessThan(rd.OsVersion(), "8.10") {
 		// E4S/EUS
-		DNFConfig: []*osbuild.DNFConfigStageOptions{
+		ic.DNFConfig = []*osbuild.DNFConfigStageOptions{
 			osbuild.NewDNFConfigStageOptions(
 				[]osbuild.DNFVariable{
 					{
@@ -116,8 +119,10 @@ func sapImageConfig(rd distro.Distro) *distro.ImageConfig {
 				},
 				nil,
 			),
-		},
+		}
 	}
+
+	return ic
 }
 
 func SapPackageSet(t *rhel.ImageType) rpmmd.PackageSet {


### PR DESCRIPTION
**distro/rhel8: rh-amazon-rhui-client-sap-bundle for RHEL 8 "unversioned"**

For RHEL 8.10 SAP, e4s isn't planned, but SAP is supported with the
unversioned RHUI client.

See RHUIOPS-276

---

**distro/rhel8: remove version lock on 8.10 for SAP**

Version lock should not exist on 8.10 for SAP.  It's the last RHEL
release in the 8.* stream.

See COMPOSER-2252

---
