### PR TITLE
distro/rhel8: update RHUI client RPM for Azure SAP 8.10 images (COMPOSER-2254)

### DIFF
--- a/pkg/distro/rhel/rhel8/azure.go
+++ b/pkg/distro/rhel/rhel8/azure.go
@@ -256,10 +256,14 @@ func azureRhuiPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 // Includes the common azure package set, the common SAP packages, and
 // the azure rhui sap package.
 func azureSapPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
+	rhuiPkg := "rhui-azure-rhel8-sap-ha"
+	if t.Arch().Distro().OsVersion() == "8.10" {
+		rhuiPkg = "rhui-azure-rhel8-base-sap-ha"
+	}
 	return rpmmd.PackageSet{
 		Include: []string{
 			"firewalld",
-			"rhui-azure-rhel8-sap-ha",
+			rhuiPkg,
 		},
 	}.Append(azureCommonPackageSet(t)).Append(SapPackageSet(t))
 }

--- a/test/data/repositories/rhel-8.10.json
+++ b/test/data/repositories/rhel-8.10.json
@@ -63,8 +63,8 @@
       ]
     },
     {
-      "name": "sap-rhui-azure",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-sap-rhui-azure-20240515",
+      "name": "base-sap-rhui-azure",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-base-sap-rhui-azure-20240531",
       "image_type_tags": [
         "azure-sap-rhui"
       ],


### PR DESCRIPTION
Since 8.10 is the last minor release of RHEL8, and it's not E4S one / has unversioned repos, its RHUI client rpm name is different.

See COMPOSER-2254

---

While the [snapshot job](https://github.com/osbuild/rpmrepo/actions/runs/9317155443/job/25646887891) is still running, the repository we need for this is already done, so let's use it here and we'll update the rest of the repo snapshots later.
