### PR TITLE
manifest: wait for user input before rebooting when creating a bootc installer

### DIFF
--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -502,7 +502,7 @@ reqpart --add-boot
 part swap --fstype=swap --size=1024
 part / --fstype=ext4 --grow
 
-reboot --eject
+halt --eject
 `
 
 	// Workaround for lack of --target-imgref in Anaconda, xref https://github.com/osbuild/images/issues/380

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -508,6 +508,11 @@ halt --eject
 	// Workaround for lack of --target-imgref in Anaconda, xref https://github.com/osbuild/images/issues/380
 	hardcodedKickstartBits += fmt.Sprintf(`%%post
 bootc switch --mutate-in-place --transport %s %s
+
+# used during automatic image testing as finished marker
+if [ -c /dev/ttyS0 ]; then
+    echo "Install finished" > /dev/ttyS0
+fi
 %%end
 `, targetContainerTransport, p.containerSpec.LocalName)
 


### PR DESCRIPTION
In issue #230 it was raised that it is undesirable to automatically reboot when the install is finished. So instead halt the install and show a message to the user.

This is a draft because it changes the existing behavior so users who rely on the auto-reboot (like our tests) will fail [0] - but  if everyone is happy and we consider the old behavior a bug I will undraft it.


Closes: https://github.com/osbuild/bootc-image-builder/issues/230


[0] We can fix this via https://github.com/osbuild/bootc-image-builder/compare/main...mvo5:handle-halt-instead-of-reboot?expand=1