### PR TITLE
Set the chunk size for S3 upload to 64MB

### DIFF
--- a/pkg/cloud/awscloud/awscloud.go
+++ b/pkg/cloud/awscloud/awscloud.go
@@ -58,9 +58,11 @@ func newAwsFromCreds(creds *credentials.Credentials, region string) (*AWS, error
 	}
 
 	return &AWS{
-		uploader: s3manager.NewUploader(sess),
-		ec2:      ec2.New(sess),
-		s3:       s3.New(sess),
+		uploader: s3manager.NewUploader(sess, func(u *s3manager.Uploader) {
+			u.PartSize = 64 * 1024 * 1024 // 64MB per part
+		}),
+		ec2: ec2.New(sess),
+		s3:  s3.New(sess),
 	}, nil
 }
 


### PR DESCRIPTION
The default minimum chunk size of 5MB for s3 upload only allows for an upload of about 50Gi. It is not out of the question for a bootc image to get above this threshhold.

For now, this will increase the chunk size to 64MB making it possible to upload images up to ~640Gi. This could in the future become a dynamic value, but for now, this should at least give some head room.