### PR TITLE
test/upload-results: run aws command with --no-progress

### DIFF
--- a/test/scripts/upload-results
+++ b/test/scripts/upload-results
@@ -44,7 +44,7 @@ def main():
     s3url = testlib.gen_build_info_s3(distro, arch, manifest_id)
 
     print(f"⬆️ Uploading {build_dir} to {s3url}")
-    testlib.runcmd_nc(["aws", "s3", "cp", "--acl=private", "--recursive", build_dir+"/", s3url])
+    testlib.runcmd_nc(["aws", "s3", "cp", "--no-progress", "--acl=private", "--recursive", build_dir+"/", s3url])
     print("✅ DONE!!")
 
 


### PR DESCRIPTION
The progress output gets very spammy in the CI logs.

See for example https://gitlab.com/redhat/services/products/image-builder/ci/images/-/jobs/6990565006/viewer