### PR TITLE
dnfjson: allow (optional) field `solver` in the dnfjson output

### DIFF
--- a/pkg/dnfjson/dnfjson.go
+++ b/pkg/dnfjson/dnfjson.go
@@ -690,6 +690,9 @@ type packageSpecs []PackageSpec
 type depsolveResult struct {
 	Packages packageSpecs          `json:"packages"`
 	Repos    map[string]repoConfig `json:"repos"`
+
+	// (optional) contains the solver used, e.g. "dnf5"
+	Solver string `json:"solver"`
 }
 
 // Package specification


### PR DESCRIPTION
With the new "dnf5" solver is seems useful to allow the dnfjson code return what solver was actually used in the transaction.

This commit allows an (optional) "solver" field in the json that is returned from the dnfjson helper. It does not do more yet but we should (probably) make it avaialble for the higher layers too so that it can be e.g. logged.

See also https://github.com/osbuild/osbuild/pull/1776