### PR TITLE
Schutzfile: update osbuild dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,43 +136,6 @@ jobs:
       - name: Run depsolver tests with force-dnf to make sure it's not skipped for any reason
         run: go test -v -race ./pkg/dnfjson/... -force-dnf
 
-  unit-tests-c8s:
-    name: "🛃 Unit tests (CentOS Stream 8)"
-    runs-on: ubuntu-latest
-    container:
-      image: quay.io/centos/centos:stream8
-    env:
-      GOFLAGS: "-tags=exclude_graphdriver_btrfs"
-
-    steps:
-      - name: Install dnf plugins
-        run: dnf -y install dnf-plugins-core
-
-      - name: Enable powertools repo
-        run: dnf config-manager --set-enabled powertools
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Set up repository for pinned osbuild commit
-        run: |
-          dnf -y install python3
-          ./test/scripts/setup-osbuild-repo
-
-      - name: Install build and test dependencies
-        run: dnf -y install krb5-devel gcc git-core go gpgme-devel osbuild-depsolve-dnf device-mapper-devel
-
-      - name: Mark the working directory as safe for git
-        run: git config --global --add safe.directory "$(pwd)"
-
-      - name: Run unit tests
-        run: go test -v -race  ./...
-
-      - name: Run depsolver tests with force-dnf to make sure it's not skipped for any reason
-        run: go test -v -race ./pkg/dnfjson/... -force-dnf
-
   lint:
     name: "⌨ Lint"
     runs-on: ubuntu-latest

--- a/Schutzfile
+++ b/Schutzfile
@@ -8,21 +8,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "4dbf8e2d593b769bf4797a18a9c6462696990af3"
+        "commit": "484130b678d586cab8fba75381de77437bd4a663"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "4dbf8e2d593b769bf4797a18a9c6462696990af3"
+        "commit": "484130b678d586cab8fba75381de77437bd4a663"
       }
     }
   },
   "fedora-39": {
     "dependencies": {
       "osbuild": {
-        "commit": "4dbf8e2d593b769bf4797a18a9c6462696990af3"
+        "commit": "484130b678d586cab8fba75381de77437bd4a663"
       }
     },
     "repos": [
@@ -65,7 +65,7 @@
   "fedora-40": {
     "dependencies": {
       "osbuild": {
-        "commit": "4dbf8e2d593b769bf4797a18a9c6462696990af3"
+        "commit": "484130b678d586cab8fba75381de77437bd4a663"
       }
     }
   }

--- a/test/scripts/generate-ostree-build-config
+++ b/test/scripts/generate-ostree-build-config
@@ -165,7 +165,8 @@ def gen_image_manifests(config_map, configs, distro, arch, outputdir):
 def default_ref(distro, arch):
     name, version = distro.split("-")
     if name == "rhel":
-        version = version[0]  # this will break on RHEL 10
+        # we use dots in our RHEL versions now
+        version, *_ = version.split(".")
         product = "edge"
     elif name == "fedora":
         product = "iot"

--- a/test/scripts/generate-ostree-build-config
+++ b/test/scripts/generate-ostree-build-config
@@ -171,6 +171,8 @@ def default_ref(distro, arch):
         product = "iot"
     elif name == "centos":
         product = "edge"
+    else:
+        raise ValueError(f"unknown distro name {name}")
 
     return f"{name}/{version}/{arch}/{product}"
 


### PR DESCRIPTION
Some strange failures started happening last week in our CI.  The ostree containers that we use to build ostree-based images appear to be randomly failing to start, or return `403 Forbidden` when queried.  This makes our CI pipeline flaky which is blocking any PR from being merged through the merge queue (see for example the failures here https://gitlab.com/redhat/services/products/image-builder/ci/images/-/pipelines/1314481981).

I suspect this might be related to PR #716, which changes the CI configurations to all run on Fedora 40.  In that PR, all ostree containers were rebuilt on F40 and now all subsequent runs (that don't need to update the image) use these new containers.  I'm hoping the issue is related to our Fedora 40 runners being quite old (pre GA), and some already-solved bug is causing this.

I need to look into this further and figure out if (and why) this is happening, but in the meantime, let's try to unblock PRs by rebuilding everything on Fedora 39 again.

This PR updates the osbuild commit ID, which will trigger a rebuild of all image types.