### PR TITLE
generate-ostree-build-config: pylint is wrong about used-before-assignment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -220,4 +220,5 @@ jobs:
 
       - name: Analysing the code with pylint
         run: |
+          python3 -m pylint --version
           python3 -m pylint $(grep -l "/usr/bin/env python3" -r test/scripts) test/scripts/*.py

--- a/test/scripts/generate-ostree-build-config
+++ b/test/scripts/generate-ostree-build-config
@@ -175,7 +175,7 @@ def default_ref(distro, arch):
     else:
         raise ValueError(f"unknown distro name {name}")
 
-    return f"{name}/{version}/{arch}/{product}"
+    return f"{name}/{version}/{arch}/{product}"     #pylint: disable=possibly-used-before-assignment
 
 
 @contextmanager


### PR DESCRIPTION

Also output the version of pylint being used by the github workflow.