### PR TITLE
Partition Table, Stages, Mounts, and Devices generator commands for otk

### DIFF
--- a/cmd/otk-gen-partition-table/export_test.go
+++ b/cmd/otk-gen-partition-table/export_test.go
@@ -1,3 +1,6 @@
 package main
 
-var Run = run
+var (
+	Run               = run
+	GenPartitionTable = genPartitionTable
+)

--- a/cmd/otk-gen-partition-table/export_test.go
+++ b/cmd/otk-gen-partition-table/export_test.go
@@ -1,0 +1,3 @@
+package main
+
+var Run = run

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -55,6 +55,7 @@ type InputModifications struct {
 	PartitionMode disk.PartitioningMode               `json:"partition_mode"`
 	Filesystems   []blueprint.FilesystemCustomization `json:"filesystems"`
 	MinDiskSize   string                              `json:"min_disk_size"`
+	Filename      string                              `json:"filename"`
 }
 
 type Output = otkdisk.Data
@@ -181,6 +182,10 @@ func genPartitionTable(genPartInput *Input, rng *rand.Rand) (*Output, error) {
 	if err != nil {
 		return nil, err
 	}
+	fname := "disk.img"
+	if genPartInput.Modifications.Filename != "" {
+		fname = genPartInput.Modifications.Filename
+	}
 
 	kernelOptions := osbuild.GenImageKernelOptions(pt)
 	otkPart := &Output{
@@ -190,6 +195,7 @@ func genPartitionTable(genPartInput *Input, rng *rand.Rand) (*Output, error) {
 			},
 			KernelOptsList: kernelOptions,
 			PartitionMap:   makePartMap(pt),
+			Filename:       fname,
 		},
 	}
 

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osbuild/images/internal/buildconfig"
 	"github.com/osbuild/images/internal/cmdutil"
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/otk"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -75,9 +76,7 @@ type OutputPartition struct {
 	UUID string `json:"uuid"`
 }
 
-type OutputInternal struct {
-	PartitionTable *disk.PartitionTable `json:"partition-table"`
-}
+type OutputInternal = otk.PartitionInternal
 
 func makePartMap(pt *disk.PartitionTable) map[string]OutputPartition {
 	pm := make(map[string]OutputPartition, len(pt.Partitions))

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -24,11 +24,11 @@ type Input struct {
 }
 
 type InputProperties struct {
-	UEFI        InputUEFI `json:"uefi"`
-	BIOS        bool      `json:"bios"`
-	Type        string    `json:"type"`
-	DefaultSize string    `json:"default_size"`
-	UUID        string    `json:"uuid"`
+	UEFI        InputUEFI        `json:"uefi"`
+	BIOS        bool             `json:"bios"`
+	Type        otkdisk.PartType `json:"type"`
+	DefaultSize string           `json:"default_size"`
+	UUID        string           `json:"uuid"`
 
 	SectorSize uint64 `json:"sector_size"`
 }
@@ -84,10 +84,22 @@ func makePartMap(pt *disk.PartitionTable) map[string]otkdisk.Partition {
 	return pm
 }
 
+func validateInput(input *Input) error {
+	// TODO: validate more
+	if err := input.Properties.Type.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) {
+	if err := validateInput(input); err != nil {
+		return nil, fmt.Errorf("cannot validate inputs: %w", err)
+	}
+
 	pt := &disk.PartitionTable{
 		UUID:       input.Properties.UUID,
-		Type:       input.Properties.Type,
+		Type:       string(input.Properties.Type),
 		SectorSize: input.Properties.SectorSize,
 	}
 	if input.Properties.BIOS {

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -104,7 +104,7 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 	}
 	if input.Properties.BIOS {
 		if len(pt.Partitions) > 0 {
-			panic("internal error: bios partition *must* go first")
+			return nil, fmt.Errorf("internal error: bios partition *must* go first")
 		}
 		pt.Partitions = append(pt.Partitions, disk.Partition{
 			Size:     1 * common.MebiByte,

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -48,7 +48,8 @@ type InputPartition struct {
 	Label      string `json:"label"`
 	Size       string `json:"size"`
 	Type       string `json:"type"`
-	UUID       string `json:"uuid"`
+	PartUUID   string `json:"part_uuid"`
+	FsUUID     string `json:"fs_uuid"`
 	FSMntOps   string `json:"fs_mntops"`
 	FSFreq     uint64 `json:"fs_freq"`
 	FSPassNo   uint64 `json:"fs_passno"`
@@ -152,12 +153,13 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 		}
 		pt.Partitions = append(pt.Partitions, disk.Partition{
 			Size: uintSize,
+			UUID: part.PartUUID,
 			// XXX: support lvm,luks here
 			Payload: &disk.Filesystem{
 				Label:        part.Label,
 				Type:         part.Type,
-				UUID:         part.UUID,
 				Mountpoint:   part.Mountpoint,
+				UUID:         part.FsUUID,
 				FSTabOptions: part.FSMntOps,
 				FSTabFreq:    part.FSFreq,
 				FSTabPassNo:  part.FSPassNo,

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+
+	"github.com/osbuild/images/internal/buildconfig"
+	"github.com/osbuild/images/internal/cmdutil"
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+type OtkGenPartitionInput struct {
+	Options    *OtkPartOptions `json:"options"`
+	Partitions []*OtkPartition `json:"partitions"`
+}
+
+type OtkPartOptions struct {
+	UEFI *OtkPartUEFI `json:"uefi"`
+	BIOS bool         `json:"bios"`
+	Type string       `json:"type"`
+	Size string       `json:"size"`
+	UUID string       `json:"uuid"`
+
+	SectorSize uint64 `json:"sector_size"`
+}
+
+type OtkPartUEFI struct {
+	Size string `json:"size"`
+}
+
+type OtkPartition struct {
+	Name       string `json:"name"`
+	Mountpoint string `json:"mountpoint"`
+	Label      string `json:"label"`
+	Size       string `json:"size"`
+	Type       string `json:"type"`
+	UUID       string `json:"uuid"`
+	FSMntOps   string `json:"fs_mntops"`
+	FSFreq     uint64 `json:"fs_freq"`
+	FSPassNo   uint64 `json:"fs_passno"`
+
+	// TODO: add sectorlvm,luks, see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
+}
+
+// XXX: review all struct names and make them consistent (OtkOutput*?)
+type OtkGenPartitionsOutput struct {
+	Const OtkGenPartConstOutput `json:"const"`
+}
+
+type OtkGenPartitionsInternal struct {
+	PartitionTable *disk.PartitionTable `json:"partition-table"`
+}
+
+// "exported" view of partitions, this is an API so only add things here
+// that are really needed and unlikely to change
+type OtkPublicPartition struct {
+	// not a UUID type because fat UUIDs are not compliant
+	UUID string `json:"uuid"`
+}
+
+type OtkGenPartConstOutput struct {
+	KernelOptsList []string `json:"kernel_opts_list"`
+	// we generate this for convenience for otk users, so that they
+	// can write, e.g. "filesystem.partition_map.boot.uuid"
+	PartitionMap map[string]OtkPublicPartition `json:"partition_map"`
+	Internal     OtkGenPartitionsInternal      `json:"internal"`
+}
+
+func makePartMap(pt *disk.PartitionTable) map[string]OtkPublicPartition {
+	pm := make(map[string]OtkPublicPartition, len(pt.Partitions))
+	// TODO: think about exposing more partitions, if we do, what labels
+	// would we use? OtkPartition.Name? what about clashes with
+	// "{r,b}oot" then?
+	for _, part := range pt.Partitions {
+		switch pl := part.Payload.(type) {
+		case *disk.Filesystem:
+			switch pl.Mountpoint {
+			case "/":
+				pm["root"] = OtkPublicPartition{
+					UUID: pl.UUID,
+				}
+			case "/boot":
+				pm["boot"] = OtkPublicPartition{
+					UUID: pl.UUID,
+				}
+			}
+		}
+	}
+
+	return pm
+}
+
+func makePartitionTableFromOtkInput(input *OtkGenPartitionInput) (*disk.PartitionTable, error) {
+	pt := &disk.PartitionTable{
+		UUID:       input.Options.UUID,
+		Type:       input.Options.Type,
+		SectorSize: input.Options.SectorSize,
+	}
+	if input.Options.BIOS {
+		if len(pt.Partitions) > 0 {
+			panic("internal error: bios partition *must* go first")
+		}
+		pt.Partitions = append(pt.Partitions, disk.Partition{
+			Size:     1 * common.MebiByte,
+			Bootable: true,
+			Type:     disk.BIOSBootPartitionGUID,
+			UUID:     disk.BIOSBootPartitionUUID,
+		})
+	}
+	if input.Options.UEFI.Size != "" {
+		uintSize, err := common.DataSizeToUint64(input.Options.UEFI.Size)
+		if err != nil {
+			return nil, err
+		}
+		if uintSize > 0 {
+			pt.Partitions = append(pt.Partitions, disk.Partition{
+				Size: uintSize,
+				Type: disk.EFISystemPartitionGUID,
+				UUID: disk.EFISystemPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "vfat",
+					UUID:         disk.EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					Label:        "EFI-SYSTEM",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			})
+		}
+	}
+
+	for _, part := range input.Partitions {
+		uintSize, err := common.DataSizeToUint64(part.Size)
+		if err != nil {
+			return nil, err
+		}
+		pt.Partitions = append(pt.Partitions, disk.Partition{
+			Size: uintSize,
+			// XXX: support lvm,luks here
+			Payload: &disk.Filesystem{
+				Label:        part.Label,
+				Type:         part.Type,
+				UUID:         part.UUID,
+				Mountpoint:   part.Mountpoint,
+				FSTabOptions: part.FSMntOps,
+				FSTabFreq:    part.FSFreq,
+				FSTabPassNo:  part.FSPassNo,
+			},
+		})
+	}
+
+	return pt, nil
+}
+
+// Missing:
+// 1. customizations^Wmodifications, e.g. extra partiton tables
+// 2. refactor, make this nicer, it sucks a bit right now
+func run(r io.Reader, rng *rand.Rand) (*OtkGenPartitionsOutput, error) {
+	var genPartInput OtkGenPartitionInput
+	if err := json.NewDecoder(r).Decode(&genPartInput); err != nil {
+		return nil, err
+	}
+
+	basePt, err := makePartitionTableFromOtkInput(&genPartInput)
+	if err != nil {
+		return nil, err
+	}
+
+	pt, err := disk.NewPartitionTable(basePt, nil, 0, disk.DefaultPartitioningMode, nil, rng)
+	if err != nil {
+		return nil, err
+	}
+
+	kernelOptions := osbuild.GenImageKernelOptions(pt)
+	otkPart := &OtkGenPartitionsOutput{
+		Const: OtkGenPartConstOutput{
+			Internal: OtkGenPartitionsInternal{
+				PartitionTable: pt,
+			},
+			KernelOptsList: kernelOptions,
+			PartitionMap:   makePartMap(pt),
+		},
+	}
+
+	return otkPart, nil
+}
+
+func main() {
+	rngSeed, err := cmdutil.SeedArgFor(&buildconfig.BuildConfig{}, "", "", "")
+	if err != nil {
+		// XXX: FIXME! helper
+		panic(err)
+	}
+	source := rand.NewSource(rngSeed)
+	// math/rand is good enough in this case
+	/* #nosec G404 */
+	rng := rand.New(source)
+
+	output, err := run(os.Stdin, rng)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v", err.Error())
+		os.Exit(1)
+	}
+
+	outputJson, err := json.Marshal(output)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v", err.Error())
+		os.Exit(1)
+	}
+	fmt.Print(string(outputJson))
+}

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -16,6 +16,8 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
+// Input represents the user provided inputs that will be used
+// to generate the partition table
 type Input struct {
 	Properties InputProperties   `json:"properties"`
 	Partitions []*InputPartition `json:"partitions"`
@@ -23,6 +25,7 @@ type Input struct {
 	Modifications InputModifications `json:"modifications"`
 }
 
+// InputProperties contains global properties of the partition table
 type InputProperties struct {
 	UEFI        InputUEFI        `json:"uefi"`
 	BIOS        bool             `json:"bios"`
@@ -33,10 +36,12 @@ type InputProperties struct {
 	SectorSize uint64 `json:"sector_size"`
 }
 
+// InputUEFI contains the uefi specific bits of the partition input
 type InputUEFI struct {
 	Size string `json:"size"`
 }
 
+// InputPartition represents a single user provided partition input
 type InputPartition struct {
 	Name       string `json:"name"`
 	Mountpoint string `json:"mountpoint"`
@@ -51,6 +56,8 @@ type InputPartition struct {
 	// TODO: add sectorlvm,luks, see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
 }
 
+// InputModifications allow modifiying the partition generation to e.g.
+// increase the default disk size
 type InputModifications struct {
 	PartitionMode disk.PartitioningMode               `json:"partition_mode"`
 	Filesystems   []blueprint.FilesystemCustomization `json:"filesystems"`
@@ -58,6 +65,8 @@ type InputModifications struct {
 	Filename      string                              `json:"filename"`
 }
 
+// Output contains a full description of a disk, this can be consumed
+// by other tools like otk-make-*
 type Output = otkdisk.Data
 
 func makePartMap(pt *disk.PartitionTable) map[string]otkdisk.Partition {

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -650,3 +650,13 @@ func TestGenPartitionTableModificationFilename(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOutput, output)
 }
+
+func TestGenPartitionTableValidates(t *testing.T) {
+	inp := &genpart.Input{
+		Properties: genpart.InputProperties{
+			Type: "invalid-type",
+		},
+	}
+	_, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	assert.EqualError(t, err, `cannot validate inputs: unsupported partition type "invalid-type"`)
+}

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -3,7 +3,6 @@ package main_test
 import (
 	"bytes"
 	"encoding/json"
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -147,6 +146,92 @@ var simplePartOptions = `
 }
 `
 
+// XXX: anything under "internal" we don't actually need to test
+// as we do not make any gurantees to the outside
+var expectedSimplePartOutput = `{
+  "const": {
+    "kernel_opts_list": [],
+    "partition_map": {
+      "root": {
+        "uuid": "9851898e-0b30-437d-8fad-51ec16c3697f"
+      }
+    },
+    "internal": {
+      "partition-table": {
+        "Size": 10740563968,
+        "UUID": "dbd21911-1c4e-4107-8a9f-14fe6e751358",
+        "Type": "gpt",
+        "Partitions": [
+          {
+            "Start": 1048576,
+            "Size": 1048576,
+            "Type": "21686148-6449-6E6F-744E-656564454649",
+            "Bootable": true,
+            "UUID": "FAC7F1FB-3E8D-4137-A512-961DE09A5549",
+            "Payload": null,
+            "PayloadType": "no-payload"
+          },
+          {
+            "Start": 2097152,
+            "Size": 1073741824,
+            "Type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+            "Bootable": false,
+            "UUID": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33",
+            "Payload": {
+              "Type": "vfat",
+              "UUID": "7B77-95E7",
+              "Label": "EFI-SYSTEM",
+              "Mountpoint": "/boot/efi",
+              "FSTabOptions": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+              "FSTabFreq": 0,
+              "FSTabPassNo": 2
+            },
+            "PayloadType": "filesystem"
+          },
+          {
+            "Start": 3223322624,
+            "Size": 7517224448,
+            "Type": "",
+            "Bootable": false,
+            "UUID": "ed130be6-c822-49af-83bb-4ea648bb2264",
+            "Payload": {
+              "Type": "ext4",
+              "UUID": "9851898e-0b30-437d-8fad-51ec16c3697f",
+              "Label": "root",
+              "Mountpoint": "/",
+              "FSTabOptions": "",
+              "FSTabFreq": 0,
+              "FSTabPassNo": 0
+            },
+            "PayloadType": "filesystem"
+          },
+          {
+            "Start": 1075838976,
+            "Size": 2147483648,
+            "Type": "",
+            "Bootable": false,
+            "UUID": "9f6173fd-edc9-4dbe-9313-632af556c607",
+            "Payload": {
+              "Type": "ext4",
+              "UUID": "d8bb61b8-81cf-4c85-937b-69439a23dc5e",
+              "Label": "home",
+              "Mountpoint": "/home",
+              "FSTabOptions": "",
+              "FSTabFreq": 0,
+              "FSTabPassNo": 0
+            },
+            "PayloadType": "filesystem"
+          }
+        ],
+        "SectorSize": 0,
+        "ExtraPadding": 0,
+        "StartOffset": 0
+      }
+    }
+  }
+}
+`
+
 var expectedOutput = &genpart.OtkGenPartitionsOutput{
 	Const: genpart.OtkGenPartConstOutput{
 		KernelOptsList: []string{},
@@ -210,10 +295,11 @@ var expectedOutput = &genpart.OtkGenPartitionsOutput{
 }
 
 func TestIntegration(t *testing.T) {
-	rng := rand.New(rand.NewSource(0))
+	t.Setenv("OSBUILD_TESTING_RNG_SEED", "0")
 
-	buf := bytes.NewBufferString(simplePartOptions)
-	otkOutputs, err := genpart.Run(buf, rng)
+	inp := bytes.NewBufferString(simplePartOptions)
+	outp := bytes.NewBuffer(nil)
+	err := genpart.Run(inp, outp)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedOutput, otkOutputs)
+	assert.Equal(t, expectedSimplePartOutput, outp.String())
 }

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -342,7 +342,7 @@ func TestGenPartitionTableMinimal(t *testing.T) {
 			},
 		},
 	}
-	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0))) /* #nosec G404 */
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOutput, output)
 }
@@ -434,7 +434,7 @@ func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
 		},
 	}
 	// default partition mode is "auto-lvm" so LVM is created by default
-	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0))) /* #nosec G404 */
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOutput, output)
 }
@@ -501,7 +501,7 @@ func TestGenPartitionTableCustomizationExtraMpPlusModificationPartitionMode(t *t
 			},
 		},
 	}
-	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0))) /* #nosec G404 */
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOutput, output)
 }
@@ -549,7 +549,7 @@ func TestGenPartitionTablePropertiesDefaultSize(t *testing.T) {
 			},
 		},
 	}
-	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0))) /* #nosec G404 */
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOutput, output)
 }
@@ -600,7 +600,7 @@ func TestGenPartitionTableModificationMinDiskSize(t *testing.T) {
 			},
 		},
 	}
-	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0))) /* #nosec G404 */
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOutput, output)
 }
@@ -650,7 +650,7 @@ func TestGenPartitionTableModificationFilename(t *testing.T) {
 			},
 		},
 	}
-	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0))) /* #nosec G404 */
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOutput, output)
 }
@@ -661,6 +661,6 @@ func TestGenPartitionTableValidates(t *testing.T) {
 			Type: "invalid-type",
 		},
 	}
-	_, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	_, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0))) /* #nosec G404 */
 	assert.EqualError(t, err, `cannot validate inputs: unsupported partition type "invalid-type"`)
 }

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -10,6 +10,7 @@ import (
 
 	genpart "github.com/osbuild/images/cmd/otk-gen-partition-table"
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/otkdisk"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/disk"
 )
@@ -94,15 +95,15 @@ func TestUnmarshalInput(t *testing.T) {
 }
 
 func TestUnmarshalOutput(t *testing.T) {
-	fakeOtkOutput := &genpart.Output{
-		Const: genpart.OutputConst{
+	fakeOtkOutput := &otkdisk.Data{
+		Const: otkdisk.Const{
 			KernelOptsList: []string{"root=UUID=1234"},
-			PartitionMap: map[string]genpart.OutputPartition{
+			PartitionMap: map[string]otkdisk.Partition{
 				"root": {
 					UUID: "12345",
 				},
 			},
-			Internal: genpart.OutputInternal{
+			Internal: otkdisk.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 911,
 					Partitions: []disk.Partition{
@@ -305,15 +306,15 @@ func TestGenPartitionTableMinimal(t *testing.T) {
 			},
 		},
 	}
-	expectedOutput := &genpart.Output{
-		Const: genpart.OutputConst{
+	expectedOutput := &otkdisk.Data{
+		Const: otkdisk.Const{
 			KernelOptsList: []string{},
-			PartitionMap: map[string]genpart.OutputPartition{
+			PartitionMap: map[string]otkdisk.Partition{
 				"root": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
-			Internal: genpart.OutputInternal{
+			Internal: otkdisk.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 10738466816,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
@@ -364,15 +365,15 @@ func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
 			},
 		},
 	}
-	expectedOutput := &genpart.Output{
-		Const: genpart.OutputConst{
+	expectedOutput := &otkdisk.Data{
+		Const: otkdisk.Const{
 			KernelOptsList: []string{},
-			PartitionMap: map[string]genpart.OutputPartition{
+			PartitionMap: map[string]otkdisk.Partition{
 				"boot": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
-			Internal: genpart.OutputInternal{
+			Internal: otkdisk.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 15890120704,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
@@ -452,15 +453,15 @@ func TestGenPartitionTableCustomizationExtraMpPlusModificationPartitionMode(t *t
 			},
 		},
 	}
-	expectedOutput := &genpart.Output{
-		Const: genpart.OutputConst{
+	expectedOutput := &otkdisk.Data{
+		Const: otkdisk.Const{
 			KernelOptsList: []string{},
-			PartitionMap: map[string]genpart.OutputPartition{
+			PartitionMap: map[string]otkdisk.Partition{
 				"root": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
-			Internal: genpart.OutputInternal{
+			Internal: otkdisk.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 13739491328,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
@@ -509,15 +510,15 @@ func TestGenPartitionTablePropertiesDefaultSize(t *testing.T) {
 			},
 		},
 	}
-	expectedOutput := &genpart.Output{
-		Const: genpart.OutputConst{
+	expectedOutput := &otkdisk.Data{
+		Const: otkdisk.Const{
 			KernelOptsList: []string{},
-			PartitionMap: map[string]genpart.OutputPartition{
+			PartitionMap: map[string]otkdisk.Partition{
 				"root": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
-			Internal: genpart.OutputInternal{
+			Internal: otkdisk.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 16106127360,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
@@ -559,15 +560,15 @@ func TestGenPartitionTableModificationMinDiskSize(t *testing.T) {
 			MinDiskSize: "20 GiB",
 		},
 	}
-	expectedOutput := &genpart.Output{
-		Const: genpart.OutputConst{
+	expectedOutput := &otkdisk.Data{
+		Const: otkdisk.Const{
 			KernelOptsList: []string{},
-			PartitionMap: map[string]genpart.OutputPartition{
+			PartitionMap: map[string]otkdisk.Partition{
 				"root": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
-			Internal: genpart.OutputInternal{
+			Internal: otkdisk.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 21474836480,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -103,6 +103,7 @@ func TestUnmarshalOutput(t *testing.T) {
 					UUID: "12345",
 				},
 			},
+			Filename: "disk.img",
 			Internal: otkdisk.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 911,
@@ -158,7 +159,8 @@ func TestUnmarshalOutput(t *testing.T) {
         "ExtraPadding": 0,
         "StartOffset": 0
       }
-    }
+    },
+    "filename": "disk.img"
   }
 }`
 	output, err := json.MarshalIndent(fakeOtkOutput, "", "  ")
@@ -275,7 +277,8 @@ var expectedSimplePartOutput = `{
         "ExtraPadding": 0,
         "StartOffset": 0
       }
-    }
+    },
+    "filename": "disk.img"
   }
 }
 `
@@ -314,6 +317,7 @@ func TestGenPartitionTableMinimal(t *testing.T) {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
+			Filename: "disk.img",
 			Internal: otkdisk.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 10738466816,
@@ -373,6 +377,7 @@ func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
+			Filename: "disk.img",
 			Internal: otkdisk.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 15890120704,
@@ -461,6 +466,7 @@ func TestGenPartitionTableCustomizationExtraMpPlusModificationPartitionMode(t *t
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
+			Filename: "disk.img",
 			Internal: otkdisk.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 13739491328,
@@ -518,6 +524,7 @@ func TestGenPartitionTablePropertiesDefaultSize(t *testing.T) {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
+			Filename: "disk.img",
 			Internal: otkdisk.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 16106127360,
@@ -568,6 +575,7 @@ func TestGenPartitionTableModificationMinDiskSize(t *testing.T) {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
+			Filename: "disk.img",
 			Internal: otkdisk.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 21474836480,
@@ -577,6 +585,56 @@ func TestGenPartitionTableModificationMinDiskSize(t *testing.T) {
 						{
 							Start: 1048576,
 							Size:  21473787904,
+							Payload: &disk.Filesystem{
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+								Mountpoint: "/",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, output)
+}
+
+func TestGenPartitionTableModificationFilename(t *testing.T) {
+	inp := &genpart.Input{
+		Properties: genpart.InputProperties{
+			Type: "dos",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Mountpoint: "/",
+				Size:       "10 GiB",
+				Type:       "ext4",
+			},
+		},
+		Modifications: genpart.InputModifications{
+			Filename: "custom-disk.img",
+		},
+	}
+	expectedOutput := &otkdisk.Data{
+		Const: otkdisk.Const{
+			KernelOptsList: []string{},
+			PartitionMap: map[string]otkdisk.Partition{
+				"root": {
+					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+				},
+			},
+			Filename: "custom-disk.img",
+			Internal: otkdisk.Internal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 10738466816,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start: 1048576,
+							Size:  10737418240,
 							Payload: &disk.Filesystem{
 								Type:       "ext4",
 								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -1,0 +1,219 @@
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	genpart "github.com/osbuild/images/cmd/otk-gen-partition-table"
+	"github.com/osbuild/images/pkg/disk"
+)
+
+var expectedInput = &genpart.OtkGenPartitionInput{
+	Options: &genpart.OtkPartOptions{
+		UEFI: &genpart.OtkPartUEFI{
+			Size: "1 GiB",
+		},
+		BIOS: true,
+		Type: "gpt",
+		Size: "10 GiB",
+	},
+	Partitions: []*genpart.OtkPartition{
+		{
+			Name:       "root",
+			Mountpoint: "/",
+			Label:      "root",
+			Size:       "7 GiB",
+			Type:       "ext4",
+		}, {
+			Name:       "home",
+			Mountpoint: "/home",
+			Label:      "home",
+			Size:       "2 GiB",
+			Type:       "ext4",
+		},
+	},
+}
+
+func TestUnmarshalInput(t *testing.T) {
+	var otkInput genpart.OtkGenPartitionInput
+	err := json.Unmarshal([]byte(simplePartOptions), &otkInput)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedInput, &otkInput)
+}
+
+func TestUnmarshalOutput(t *testing.T) {
+	fakeOtkOutput := &genpart.OtkGenPartitionsOutput{
+		Const: genpart.OtkGenPartConstOutput{
+			KernelOptsList: []string{"root=UUID=1234"},
+			PartitionMap: map[string]genpart.OtkPublicPartition{
+				"root": {
+					UUID: "12345",
+				},
+			},
+			Internal: genpart.OtkGenPartitionsInternal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 911,
+					Partitions: []disk.Partition{
+						{
+							UUID: "911911",
+							Payload: &disk.Filesystem{
+								Type: "ext4",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	// XXX: anything under "internal" we don't actually need to test
+	// as we do not make any gurantees to the outside
+	expectedOutput := `{
+  "const": {
+    "kernel_opts_list": [
+      "root=UUID=1234"
+    ],
+    "partition_map": {
+      "root": {
+        "uuid": "12345"
+      }
+    },
+    "internal": {
+      "partition-table": {
+        "Size": 911,
+        "UUID": "",
+        "Type": "",
+        "Partitions": [
+          {
+            "Start": 0,
+            "Size": 0,
+            "Type": "",
+            "Bootable": false,
+            "UUID": "911911",
+            "Payload": {
+              "Type": "ext4",
+              "UUID": "",
+              "Label": "",
+              "Mountpoint": "",
+              "FSTabOptions": "",
+              "FSTabFreq": 0,
+              "FSTabPassNo": 0
+            },
+            "PayloadType": "filesystem"
+          }
+        ],
+        "SectorSize": 0,
+        "ExtraPadding": 0,
+        "StartOffset": 0
+      }
+    }
+  }
+}`
+	output, err := json.MarshalIndent(fakeOtkOutput, "", "  ")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, string(output))
+}
+
+// see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
+var simplePartOptions = `
+{
+  "options": {
+    "uefi": {
+      "size": "1 GiB"
+    },
+    "bios": true,
+    "type": "gpt",
+    "size": "10 GiB"
+  },
+  "partitions": [
+    {
+      "name": "root",
+      "mountpoint": "/",
+      "label": "root",
+      "size": "7 GiB",
+      "type": "ext4"
+    },
+    {
+      "name": "home",
+      "mountpoint": "/home",
+      "label": "home",
+      "size": "2 GiB",
+      "type": "ext4"
+    }
+  ]
+}
+`
+
+var expectedOutput = &genpart.OtkGenPartitionsOutput{
+	Const: genpart.OtkGenPartConstOutput{
+		KernelOptsList: []string{},
+		PartitionMap: map[string]genpart.OtkPublicPartition{
+			"root": {
+				UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+			},
+		},
+		Internal: genpart.OtkGenPartitionsInternal{
+			PartitionTable: &disk.PartitionTable{
+				Size: 10740563968,
+				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type: "gpt",
+				Partitions: []disk.Partition{
+					{
+						Start:    1048576,
+						Size:     1048576,
+						Type:     "21686148-6449-6E6F-744E-656564454649",
+						Bootable: true,
+						UUID:     "FAC7F1FB-3E8D-4137-A512-961DE09A5549",
+					}, {
+						Start:    2097152,
+						Size:     1073741824,
+						Type:     "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+						Bootable: false,
+						UUID:     "68B2905B-DF3E-4FB3-80FA-49D1E773AA33",
+						Payload: &disk.Filesystem{
+							Type:         "vfat",
+							UUID:         "7B77-95E7",
+							Label:        "EFI-SYSTEM",
+							Mountpoint:   "/boot/efi",
+							FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+							FSTabFreq:    0,
+							FSTabPassNo:  2,
+						},
+					}, {
+						Start: 3223322624,
+						Size:  7517224448,
+						UUID:  "a178892e-e285-4ce1-9114-55780875d64e",
+						Payload: &disk.Filesystem{
+							Type:       "ext4",
+							UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+							Label:      "root",
+							Mountpoint: "/",
+						},
+					}, {
+						Start: 1075838976,
+						Size:  2147483648,
+						UUID:  "e2d3d0d0-de6b-48f9-b44c-e85ff044c6b1",
+						Payload: &disk.Filesystem{
+							Type:       "ext4",
+							UUID:       "fb180daf-48a7-4ee0-b10d-394651850fd4",
+							Label:      "home",
+							Mountpoint: "/home",
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+func TestIntegration(t *testing.T) {
+	rng := rand.New(rand.NewSource(0))
+
+	buf := bytes.NewBufferString(simplePartOptions)
+	otkOutputs, err := genpart.Run(buf, rng)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, otkOutputs)
+}

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -11,16 +11,16 @@ import (
 	"github.com/osbuild/images/pkg/disk"
 )
 
-var expectedInput = &genpart.OtkGenPartitionInput{
-	Options: &genpart.OtkPartOptions{
-		UEFI: &genpart.OtkPartUEFI{
+var expectedInput = &genpart.Input{
+	Options: &genpart.InputOptions{
+		UEFI: &genpart.InputUEFI{
 			Size: "1 GiB",
 		},
 		BIOS: true,
 		Type: "gpt",
 		Size: "10 GiB",
 	},
-	Partitions: []*genpart.OtkPartition{
+	Partitions: []*genpart.InputPartition{
 		{
 			Name:       "root",
 			Mountpoint: "/",
@@ -38,22 +38,22 @@ var expectedInput = &genpart.OtkGenPartitionInput{
 }
 
 func TestUnmarshalInput(t *testing.T) {
-	var otkInput genpart.OtkGenPartitionInput
+	var otkInput genpart.Input
 	err := json.Unmarshal([]byte(simplePartOptions), &otkInput)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedInput, &otkInput)
 }
 
 func TestUnmarshalOutput(t *testing.T) {
-	fakeOtkOutput := &genpart.OtkGenPartitionsOutput{
-		Const: genpart.OtkGenPartConstOutput{
+	fakeOtkOutput := &genpart.Output{
+		Const: genpart.OutputConst{
 			KernelOptsList: []string{"root=UUID=1234"},
-			PartitionMap: map[string]genpart.OtkPublicPartition{
+			PartitionMap: map[string]genpart.OutputPartition{
 				"root": {
 					UUID: "12345",
 				},
 			},
-			Internal: genpart.OtkGenPartitionsInternal{
+			Internal: genpart.OutputInternal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 911,
 					Partitions: []disk.Partition{
@@ -231,68 +231,6 @@ var expectedSimplePartOutput = `{
   }
 }
 `
-
-var expectedOutput = &genpart.OtkGenPartitionsOutput{
-	Const: genpart.OtkGenPartConstOutput{
-		KernelOptsList: []string{},
-		PartitionMap: map[string]genpart.OtkPublicPartition{
-			"root": {
-				UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-			},
-		},
-		Internal: genpart.OtkGenPartitionsInternal{
-			PartitionTable: &disk.PartitionTable{
-				Size: 10740563968,
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-				Type: "gpt",
-				Partitions: []disk.Partition{
-					{
-						Start:    1048576,
-						Size:     1048576,
-						Type:     "21686148-6449-6E6F-744E-656564454649",
-						Bootable: true,
-						UUID:     "FAC7F1FB-3E8D-4137-A512-961DE09A5549",
-					}, {
-						Start:    2097152,
-						Size:     1073741824,
-						Type:     "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-						Bootable: false,
-						UUID:     "68B2905B-DF3E-4FB3-80FA-49D1E773AA33",
-						Payload: &disk.Filesystem{
-							Type:         "vfat",
-							UUID:         "7B77-95E7",
-							Label:        "EFI-SYSTEM",
-							Mountpoint:   "/boot/efi",
-							FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-							FSTabFreq:    0,
-							FSTabPassNo:  2,
-						},
-					}, {
-						Start: 3223322624,
-						Size:  7517224448,
-						UUID:  "a178892e-e285-4ce1-9114-55780875d64e",
-						Payload: &disk.Filesystem{
-							Type:       "ext4",
-							UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-							Label:      "root",
-							Mountpoint: "/",
-						},
-					}, {
-						Start: 1075838976,
-						Size:  2147483648,
-						UUID:  "e2d3d0d0-de6b-48f9-b44c-e85ff044c6b1",
-						Payload: &disk.Filesystem{
-							Type:       "ext4",
-							UUID:       "fb180daf-48a7-4ee0-b10d-394651850fd4",
-							Label:      "home",
-							Mountpoint: "/home",
-						},
-					},
-				},
-			},
-		},
-	},
-}
 
 func TestIntegration(t *testing.T) {
 	t.Setenv("OSBUILD_TESTING_RNG_SEED", "0")

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -42,6 +42,7 @@ var partInputsComplete = `
     }
   ],
   "modifications": {
+    "min_disk_size": "20 GiB",
     "partition_mode": "auto-lvm",
     "filesystems": [
       {"mountpoint": "/var/log", "minsize": 10241024}
@@ -74,6 +75,7 @@ var expectedInput = &genpart.Input{
 		},
 	},
 	Modifications: genpart.InputModifications{
+		MinDiskSize:   "20 GiB",
 		PartitionMode: disk.AutoLVMPartitioningMode,
 		Filesystems: []blueprint.FilesystemCustomization{
 			{
@@ -481,6 +483,103 @@ func TestGenPartitionTableCustomizationExtraMpPlusModificationPartitionMode(t *t
 								Type:         "xfs",
 								UUID:         "fb180daf-48a7-4ee0-b10d-394651850fd4",
 								FSTabOptions: "defaults",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, output)
+}
+
+func TestGenPartitionTablePropertiesDefaultSize(t *testing.T) {
+	inp := &genpart.Input{
+		Properties: genpart.InputProperties{
+			Type:        "dos",
+			DefaultSize: "15 GiB",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Mountpoint: "/",
+				Size:       "10 GiB",
+				Type:       "ext4",
+			},
+		},
+	}
+	expectedOutput := &genpart.Output{
+		Const: genpart.OutputConst{
+			KernelOptsList: []string{},
+			PartitionMap: map[string]genpart.OutputPartition{
+				"root": {
+					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+				},
+			},
+			Internal: genpart.OutputInternal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 16106127360,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start: 1048576,
+							Size:  16105078784,
+							Payload: &disk.Filesystem{
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+								Mountpoint: "/",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, output)
+}
+
+func TestGenPartitionTableModificationMinDiskSize(t *testing.T) {
+	inp := &genpart.Input{
+		Properties: genpart.InputProperties{
+			Type:        "dos",
+			DefaultSize: "15 GiB",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Mountpoint: "/",
+				Size:       "10 GiB",
+				Type:       "ext4",
+			},
+		},
+		Modifications: genpart.InputModifications{
+			MinDiskSize: "20 GiB",
+		},
+	}
+	expectedOutput := &genpart.Output{
+		Const: genpart.OutputConst{
+			KernelOptsList: []string{},
+			PartitionMap: map[string]genpart.OutputPartition{
+				"root": {
+					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+				},
+			},
+			Internal: genpart.OutputInternal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 21474836480,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start: 1048576,
+							Size:  21473787904,
+							Payload: &disk.Filesystem{
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+								Mountpoint: "/",
 							},
 						},
 					},

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -19,8 +19,10 @@ import (
 var partInputsComplete = `
 {
   "properties": {
-    "uefi": {
-      "size": "1 GiB"
+    "create": {
+      "bios_boot_partition": true,
+      "esp_partition": true,
+      "esp_partition_size": "2 GiB"
     },
     "bios": true,
     "type": "gpt",
@@ -53,10 +55,11 @@ var partInputsComplete = `
 
 var expectedInput = &genpart.Input{
 	Properties: genpart.InputProperties{
-		UEFI: genpart.InputUEFI{
-			Size: "1 GiB",
+		Create: genpart.InputCreate{
+			BIOSBootPartition: true,
+			EspPartition:      true,
+			EspPartitionSize:  "2 GiB",
 		},
-		BIOS:        true,
 		Type:        "gpt",
 		DefaultSize: "10 GiB",
 	},
@@ -171,10 +174,11 @@ func TestUnmarshalOutput(t *testing.T) {
 var partInputsSimple = `
 {
   "properties": {
-    "uefi": {
-      "size": "1 GiB"
+    "create": {
+      "bios_boot_partition": true,
+      "esp_partition": true,
+      "esp_partition_size": "2 GiB"
     },
-    "bios": true,
     "type": "gpt",
     "default_size": "10 GiB"
   },
@@ -208,7 +212,7 @@ var expectedSimplePartOutput = `{
     },
     "internal": {
       "partition-table": {
-        "Size": 10740563968,
+        "Size": 11814305792,
         "UUID": "dbd21911-1c4e-4107-8a9f-14fe6e751358",
         "Type": "gpt",
         "Partitions": [
@@ -223,7 +227,7 @@ var expectedSimplePartOutput = `{
           },
           {
             "Start": 2097152,
-            "Size": 1073741824,
+            "Size": 2147483648,
             "Type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
             "Bootable": false,
             "UUID": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33",
@@ -239,7 +243,7 @@ var expectedSimplePartOutput = `{
             "PayloadType": "filesystem"
           },
           {
-            "Start": 3223322624,
+            "Start": 4297064448,
             "Size": 7517224448,
             "Type": "",
             "Bootable": false,
@@ -256,7 +260,7 @@ var expectedSimplePartOutput = `{
             "PayloadType": "filesystem"
           },
           {
-            "Start": 1075838976,
+            "Start": 2149580800,
             "Size": 2147483648,
             "Type": "",
             "Bootable": false,

--- a/cmd/otk-make-partition-mounts-devices/export_test.go
+++ b/cmd/otk-make-partition-mounts-devices/export_test.go
@@ -1,0 +1,3 @@
+package main
+
+var Run = run

--- a/cmd/otk-make-partition-mounts-devices/main.go
+++ b/cmd/otk-make-partition-mounts-devices/main.go
@@ -10,12 +10,7 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
-type Input struct {
-	otkdisk.Data
-
-	// XXX: move filename into gen-part-stages
-	Filename string `json:"filename"`
-}
+type Input = otkdisk.Data
 
 type Output struct {
 	RootMountName string                    `json:"root_mount_name"`
@@ -29,7 +24,7 @@ func run(r io.Reader, w io.Writer) error {
 		return err
 	}
 
-	rootMntName, mounts, devices, err := osbuild.GenMountsDevicesFromPT(inp.Filename, inp.Data.Const.Internal.PartitionTable)
+	rootMntName, mounts, devices, err := osbuild.GenMountsDevicesFromPT(inp.Const.Filename, inp.Const.Internal.PartitionTable)
 	if err != nil {
 		return err
 	}

--- a/cmd/otk-make-partition-mounts-devices/main.go
+++ b/cmd/otk-make-partition-mounts-devices/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/osbuild/images/internal/otk"
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+type Input struct {
+	Filename string                `json:"filename"`
+	Internal otk.PartitionInternal `json:"internal"`
+}
+
+type Output struct {
+	RootMountName string                    `json:"root_mount_name"`
+	Mounts        []osbuild.Mount           `json:"mounts"`
+	Devices       map[string]osbuild.Device `json:"devices"`
+}
+
+func run(r io.Reader, w io.Writer) error {
+	var inp Input
+	if err := json.NewDecoder(r).Decode(&inp); err != nil {
+		return err
+	}
+
+	rootMntName, mounts, devices, err := osbuild.GenMountsDevicesFromPT(inp.Filename, inp.Internal.PartitionTable)
+	if err != nil {
+		return err
+	}
+
+	out := Output{
+		RootMountName: rootMntName,
+		Mounts:        mounts,
+		Devices:       devices,
+	}
+	outputJson, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cannot marshal response: %w", err)
+	}
+	fmt.Fprintf(w, "%s\n", outputJson)
+	return nil
+}
+
+func main() {
+	if err := run(os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v", err.Error())
+		os.Exit(1)
+	}
+}

--- a/cmd/otk-make-partition-mounts-devices/main.go
+++ b/cmd/otk-make-partition-mounts-devices/main.go
@@ -6,13 +6,15 @@ import (
 	"io"
 	"os"
 
-	"github.com/osbuild/images/internal/otk"
+	"github.com/osbuild/images/internal/otkdisk"
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
 type Input struct {
-	Filename string                `json:"filename"`
-	Internal otk.PartitionInternal `json:"internal"`
+	otkdisk.Data
+
+	// XXX: move filename into gen-part-stages
+	Filename string `json:"filename"`
 }
 
 type Output struct {
@@ -27,7 +29,7 @@ func run(r io.Reader, w io.Writer) error {
 		return err
 	}
 
-	rootMntName, mounts, devices, err := osbuild.GenMountsDevicesFromPT(inp.Filename, inp.Internal.PartitionTable)
+	rootMntName, mounts, devices, err := osbuild.GenMountsDevicesFromPT(inp.Filename, inp.Data.Const.Internal.PartitionTable)
 	if err != nil {
 		return err
 	}

--- a/cmd/otk-make-partition-mounts-devices/main_test.go
+++ b/cmd/otk-make-partition-mounts-devices/main_test.go
@@ -62,12 +62,10 @@ const expectedOutput = `{
 func TestIntegration(t *testing.T) {
 	pt := testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
 	input := mkdevmnt.Input{
-		Filename: "test.disk",
-		Data: otkdisk.Data{
-			Const: otkdisk.Const{
-				Internal: otkdisk.Internal{
-					PartitionTable: pt,
-				},
+		Const: otkdisk.Const{
+			Filename: "test.disk",
+			Internal: otkdisk.Internal{
+				PartitionTable: pt,
 			},
 		},
 	}

--- a/cmd/otk-make-partition-mounts-devices/main_test.go
+++ b/cmd/otk-make-partition-mounts-devices/main_test.go
@@ -1,0 +1,77 @@
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	mkdevmnt "github.com/osbuild/images/cmd/otk-make-partition-mounts-devices"
+	"github.com/osbuild/images/internal/otk"
+	"github.com/osbuild/images/internal/testdisk"
+	"github.com/stretchr/testify/assert"
+)
+
+const expectedOutput = `{
+  "root_mount_name": "-",
+  "mounts": [
+    {
+      "name": "-",
+      "type": "org.osbuild.ext4",
+      "source": "-",
+      "target": "/"
+    },
+    {
+      "name": "boot",
+      "type": "org.osbuild.ext4",
+      "source": "boot",
+      "target": "/boot"
+    },
+    {
+      "name": "boot-efi",
+      "type": "org.osbuild.fat",
+      "source": "boot-efi",
+      "target": "/boot/efi"
+    }
+  ],
+  "devices": {
+    "-": {
+      "type": "org.osbuild.loopback",
+      "options": {
+        "filename": "test.disk",
+        "size": 1615872
+      }
+    },
+    "boot": {
+      "type": "org.osbuild.loopback",
+      "options": {
+        "filename": "test.disk",
+        "size": 1615872
+      }
+    },
+    "boot-efi": {
+      "type": "org.osbuild.loopback",
+      "options": {
+        "filename": "test.disk",
+        "size": 1615872
+      }
+    }
+  }
+}
+`
+
+func TestIntegration(t *testing.T) {
+	pt := testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
+	input := mkdevmnt.Input{
+		Filename: "test.disk",
+		Internal: otk.PartitionInternal{
+			PartitionTable: pt,
+		},
+	}
+	inpJSON, err := json.Marshal(&input)
+	assert.NoError(t, err)
+	fakeStdin := bytes.NewBuffer(inpJSON)
+	fakeStdout := bytes.NewBuffer(nil)
+	err = mkdevmnt.Run(fakeStdin, fakeStdout)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, fakeStdout.String())
+}

--- a/cmd/otk-make-partition-mounts-devices/main_test.go
+++ b/cmd/otk-make-partition-mounts-devices/main_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	mkdevmnt "github.com/osbuild/images/cmd/otk-make-partition-mounts-devices"
-	"github.com/osbuild/images/internal/otk"
+	"github.com/osbuild/images/internal/otkdisk"
 	"github.com/osbuild/images/internal/testdisk"
 	"github.com/stretchr/testify/assert"
 )
@@ -63,8 +63,12 @@ func TestIntegration(t *testing.T) {
 	pt := testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
 	input := mkdevmnt.Input{
 		Filename: "test.disk",
-		Internal: otk.PartitionInternal{
-			PartitionTable: pt,
+		Data: otkdisk.Data{
+			Const: otkdisk.Const{
+				Internal: otkdisk.Internal{
+					PartitionTable: pt,
+				},
+			},
 		},
 	}
 	inpJSON, err := json.Marshal(&input)

--- a/cmd/otk-make-partition-stages/export_test.go
+++ b/cmd/otk-make-partition-stages/export_test.go
@@ -1,0 +1,3 @@
+package main
+
+var Run = run

--- a/cmd/otk-make-partition-stages/main.go
+++ b/cmd/otk-make-partition-stages/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/osbuild/images/pkg/osbuild"
+
+	"github.com/osbuild/images/internal/otk"
+)
+
+type Input struct {
+	Internal      InputInternal      `json:"internal"`
+	Modifications InputModifications `json:"modifications"`
+}
+
+type InputInternal = otk.PartitionInternal
+
+type InputModifications struct {
+	Filename string `json:"filename"`
+}
+
+func makeImagePrepareStages(inp Input, filename string) (stages []*osbuild.Stage, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("cannot generate image prepare stages: %v", r)
+		}
+	}()
+
+	// rhel7 uses PTSgdisk, if we ever need to support this, make this
+	// configurable
+	partTool := osbuild.PTSfdisk
+	stages = osbuild.GenImagePrepareStages(inp.Internal.PartitionTable, filename, partTool)
+	return stages, nil
+}
+
+func run(r io.Reader, w io.Writer) error {
+	var inp Input
+	if err := json.NewDecoder(r).Decode(&inp); err != nil {
+		return err
+	}
+
+	fname := "disk.img"
+	if inp.Modifications.Filename != "" {
+		fname = inp.Modifications.Filename
+	}
+	stages, err := makeImagePrepareStages(inp, fname)
+	if err != nil {
+		return fmt.Errorf("cannot make partition stages: %w", err)
+	}
+
+	outputJson, err := json.MarshalIndent(stages, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cannot marshal response: %w", err)
+	}
+	fmt.Fprintf(w, "%s\n", outputJson)
+	return nil
+}
+
+func main() {
+	if err := run(os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v", err.Error())
+		os.Exit(1)
+	}
+}

--- a/cmd/otk-make-partition-stages/main.go
+++ b/cmd/otk-make-partition-stages/main.go
@@ -8,15 +8,15 @@ import (
 
 	"github.com/osbuild/images/pkg/osbuild"
 
-	"github.com/osbuild/images/internal/otk"
+	"github.com/osbuild/images/internal/otkdisk"
 )
 
 type Input struct {
-	Internal      InputInternal      `json:"internal"`
+	otkdisk.Data
+
+	// XXX: move filename into gen-part-stages
 	Modifications InputModifications `json:"modifications"`
 }
-
-type InputInternal = otk.PartitionInternal
 
 type InputModifications struct {
 	Filename string `json:"filename"`
@@ -32,7 +32,7 @@ func makeImagePrepareStages(inp Input, filename string) (stages []*osbuild.Stage
 	// rhel7 uses PTSgdisk, if we ever need to support this, make this
 	// configurable
 	partTool := osbuild.PTSfdisk
-	stages = osbuild.GenImagePrepareStages(inp.Internal.PartitionTable, filename, partTool)
+	stages = osbuild.GenImagePrepareStages(inp.Data.Const.Internal.PartitionTable, filename, partTool)
 	return stages, nil
 }
 

--- a/cmd/otk-make-partition-stages/main.go
+++ b/cmd/otk-make-partition-stages/main.go
@@ -11,16 +11,7 @@ import (
 	"github.com/osbuild/images/internal/otkdisk"
 )
 
-type Input struct {
-	otkdisk.Data
-
-	// XXX: move filename into gen-part-stages
-	Modifications InputModifications `json:"modifications"`
-}
-
-type InputModifications struct {
-	Filename string `json:"filename"`
-}
+type Input = otkdisk.Data
 
 func makeImagePrepareStages(inp Input, filename string) (stages []*osbuild.Stage, err error) {
 	defer func() {
@@ -32,7 +23,7 @@ func makeImagePrepareStages(inp Input, filename string) (stages []*osbuild.Stage
 	// rhel7 uses PTSgdisk, if we ever need to support this, make this
 	// configurable
 	partTool := osbuild.PTSfdisk
-	stages = osbuild.GenImagePrepareStages(inp.Data.Const.Internal.PartitionTable, filename, partTool)
+	stages = osbuild.GenImagePrepareStages(inp.Const.Internal.PartitionTable, inp.Const.Filename, partTool)
 	return stages, nil
 }
 
@@ -42,11 +33,7 @@ func run(r io.Reader, w io.Writer) error {
 		return err
 	}
 
-	fname := "disk.img"
-	if inp.Modifications.Filename != "" {
-		fname = inp.Modifications.Filename
-	}
-	stages, err := makeImagePrepareStages(inp, fname)
+	stages, err := makeImagePrepareStages(inp, inp.Const.Filename)
 	if err != nil {
 		return fmt.Errorf("cannot make partition stages: %w", err)
 	}

--- a/cmd/otk-make-partition-stages/main_test.go
+++ b/cmd/otk-make-partition-stages/main_test.go
@@ -1,0 +1,119 @@
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	makestages "github.com/osbuild/images/cmd/otk-make-partition-stages"
+	"github.com/osbuild/images/pkg/disk"
+)
+
+// this is not symetrical to the output, this is sad but also
+// okay because the input is really just a dump of the internal
+// disk.PartitionTable so encoding it in json here will not add
+// a benefit for the test
+var minimalInputBase = makestages.Input{
+	Internal: makestages.InputInternal{
+		PartitionTable: &disk.PartitionTable{
+			Size: 10738466816,
+			UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+			Type: "dos",
+			Partitions: []disk.Partition{
+				{
+					Start: 1048576,
+					Size:  10737418240,
+					Payload: &disk.Filesystem{
+						Type:       "ext4",
+						UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+						Mountpoint: "/",
+					},
+				},
+			},
+		},
+	},
+}
+
+var minimalExpectedStages = `[
+  {
+    "type": "org.osbuild.truncate",
+    "options": {
+      "filename": "disk.img",
+      "size": "10738466816"
+    }
+  },
+  {
+    "type": "org.osbuild.sfdisk",
+    "options": {
+      "label": "dos",
+      "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+      "partitions": [
+        {
+          "size": 20971520,
+          "start": 2048
+        }
+      ]
+    },
+    "devices": {
+      "device": {
+        "type": "org.osbuild.loopback",
+        "options": {
+          "filename": "disk.img",
+          "lock": true
+        }
+      }
+    }
+  },
+  {
+    "type": "org.osbuild.mkfs.ext4",
+    "options": {
+      "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+    },
+    "devices": {
+      "device": {
+        "type": "org.osbuild.loopback",
+        "options": {
+          "filename": "disk.img",
+          "start": 2048,
+          "size": 20971520,
+          "lock": true
+        }
+      }
+    }
+  }
+]
+`
+
+func TestIntegration(t *testing.T) {
+	minimalInput := minimalInputBase
+	expectedStages := minimalExpectedStages
+
+	inpJSON, err := json.Marshal(&minimalInput)
+	assert.NoError(t, err)
+	fakeStdin := bytes.NewBuffer(inpJSON)
+	fakeStdout := bytes.NewBuffer(nil)
+
+	err = makestages.Run(fakeStdin, fakeStdout)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedStages, fakeStdout.String())
+}
+
+func TestModificationFname(t *testing.T) {
+	input := minimalInputBase
+	input.Modifications.Filename = "mydisk.img2"
+	expectedStages := strings.Replace(minimalExpectedStages, `"disk.img"`, `"mydisk.img2"`, -1)
+
+	inpJSON, err := json.Marshal(&input)
+	assert.NoError(t, err)
+	fakeStdin := bytes.NewBuffer(inpJSON)
+	fakeStdout := bytes.NewBuffer(nil)
+
+	err = makestages.Run(fakeStdin, fakeStdout)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedStages, fakeStdout.String())
+}

--- a/cmd/otk-make-partition-stages/main_test.go
+++ b/cmd/otk-make-partition-stages/main_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	makestages "github.com/osbuild/images/cmd/otk-make-partition-stages"
+	"github.com/osbuild/images/internal/otkdisk"
 	"github.com/osbuild/images/pkg/disk"
 )
 
@@ -17,19 +18,23 @@ import (
 // disk.PartitionTable so encoding it in json here will not add
 // a benefit for the test
 var minimalInputBase = makestages.Input{
-	Internal: makestages.InputInternal{
-		PartitionTable: &disk.PartitionTable{
-			Size: 10738466816,
-			UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-			Type: "dos",
-			Partitions: []disk.Partition{
-				{
-					Start: 1048576,
-					Size:  10737418240,
-					Payload: &disk.Filesystem{
-						Type:       "ext4",
-						UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-						Mountpoint: "/",
+	Data: otkdisk.Data{
+		Const: otkdisk.Const{
+			Internal: otkdisk.Internal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 10738466816,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start: 1048576,
+							Size:  10737418240,
+							Payload: &disk.Filesystem{
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+								Mountpoint: "/",
+							},
+						},
 					},
 				},
 			},

--- a/cmd/otk-make-partition-stages/main_test.go
+++ b/cmd/otk-make-partition-stages/main_test.go
@@ -18,22 +18,20 @@ import (
 // disk.PartitionTable so encoding it in json here will not add
 // a benefit for the test
 var minimalInputBase = makestages.Input{
-	Data: otkdisk.Data{
-		Const: otkdisk.Const{
-			Internal: otkdisk.Internal{
-				PartitionTable: &disk.PartitionTable{
-					Size: 10738466816,
-					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-					Type: "dos",
-					Partitions: []disk.Partition{
-						{
-							Start: 1048576,
-							Size:  10737418240,
-							Payload: &disk.Filesystem{
-								Type:       "ext4",
-								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-								Mountpoint: "/",
-							},
+	Const: otkdisk.Const{
+		Internal: otkdisk.Internal{
+			PartitionTable: &disk.PartitionTable{
+				Size: 10738466816,
+				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type: "dos",
+				Partitions: []disk.Partition{
+					{
+						Start: 1048576,
+						Size:  10737418240,
+						Payload: &disk.Filesystem{
+							Type:       "ext4",
+							UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+							Mountpoint: "/",
 						},
 					},
 				},
@@ -94,6 +92,7 @@ var minimalExpectedStages = `[
 
 func TestIntegration(t *testing.T) {
 	minimalInput := minimalInputBase
+	minimalInput.Const.Filename = "disk.img"
 	expectedStages := minimalExpectedStages
 
 	inpJSON, err := json.Marshal(&minimalInput)
@@ -109,7 +108,7 @@ func TestIntegration(t *testing.T) {
 
 func TestModificationFname(t *testing.T) {
 	input := minimalInputBase
-	input.Modifications.Filename = "mydisk.img2"
+	input.Const.Filename = "mydisk.img2"
 	expectedStages := strings.Replace(minimalExpectedStages, `"disk.img"`, `"mydisk.img2"`, -1)
 
 	inpJSON, err := json.Marshal(&input)

--- a/internal/otk/partition.go
+++ b/internal/otk/partition.go
@@ -1,9 +1,0 @@
-package otk
-
-import (
-	"github.com/osbuild/images/pkg/disk"
-)
-
-type PartitionInternal struct {
-	PartitionTable *disk.PartitionTable `json:"partition-table"`
-}

--- a/internal/otk/partition.go
+++ b/internal/otk/partition.go
@@ -1,0 +1,9 @@
+package otk
+
+import (
+	"github.com/osbuild/images/pkg/disk"
+)
+
+type PartitionInternal struct {
+	PartitionTable *disk.PartitionTable `json:"partition-table"`
+}

--- a/internal/otkdisk/partition.go
+++ b/internal/otkdisk/partition.go
@@ -1,0 +1,39 @@
+package otkdisk
+
+import (
+	"github.com/osbuild/images/pkg/disk"
+)
+
+// Data contains the full description of the partition table as well as extra
+// options and a PartitionMap for easier access. The data under Const should
+// not be modified by a consumer of this data structure.
+type Data struct {
+	Const Const `json:"const"`
+}
+
+type Const struct {
+	KernelOptsList []string `json:"kernel_opts_list"`
+
+	// PartitionMap is generated for convenient indexing of certain partitions
+	// with predictable names in otk, such as
+	// "filesystem.partition_map.boot.uuid"
+	PartitionMap map[string]Partition `json:"partition_map"`
+
+	// Internal representation of the full partition table. The representation
+	// is internal to the partition tools and should not be used by otk
+	// directly. It makes noo external API guarantees about the content or
+	// structure.
+	Internal Internal `json:"internal"`
+}
+
+// Partition represents an exported view of a partition. This is an API so only
+// add things here that are necessary for convenient external access and
+// unlikely to change.
+type Partition struct {
+	// NOTE: Not a UUID type because fat UUIDs are not compliant
+	UUID string `json:"uuid"`
+}
+
+type Internal struct {
+	PartitionTable *disk.PartitionTable `json:"partition-table"`
+}

--- a/internal/otkdisk/partition.go
+++ b/internal/otkdisk/partition.go
@@ -15,6 +15,9 @@ type Data struct {
 	Const Const `json:"const"`
 }
 
+// Const contains partition table data that is considered "constant",
+// i.e.  that should not be modified by the consumer as there may be
+// inter-dependencies between the values
 type Const struct {
 	KernelOptsList []string `json:"kernel_opts_list"`
 
@@ -25,7 +28,7 @@ type Const struct {
 
 	// Internal representation of the full partition table. The representation
 	// is internal to the partition tools and should not be used by otk
-	// directly. It makes noo external API guarantees about the content or
+	// directly. It makes no external API guarantees about the content or
 	// structure.
 	Internal Internal `json:"internal"`
 
@@ -41,6 +44,10 @@ type Partition struct {
 	UUID string `json:"uuid"`
 }
 
+// Interal contains partition table data that is stricly internal and
+// may change in non-backward compatible ways. No "otk" manifest
+// should ever use this directly, it's strictly meant for the
+// "otk-{gen,make}-*" tools for their data exchange.
 type Internal struct {
 	PartitionTable *disk.PartitionTable `json:"partition-table"`
 }
@@ -54,6 +61,7 @@ const (
 	PartTypeDOS   PartType = "dos"
 )
 
+// Validate validates that the given PartType is valid
 func (p PartType) Validate() error {
 	if !slices.Contains([]PartType{PartTypeGPT, PartTypeDOS}, p) {
 		return fmt.Errorf("unsupported partition type %q", p)

--- a/internal/otkdisk/partition.go
+++ b/internal/otkdisk/partition.go
@@ -1,6 +1,10 @@
 package otkdisk
 
 import (
+	"fmt"
+
+	"golang.org/x/exp/slices"
+
 	"github.com/osbuild/images/pkg/disk"
 )
 
@@ -39,4 +43,20 @@ type Partition struct {
 
 type Internal struct {
 	PartitionTable *disk.PartitionTable `json:"partition-table"`
+}
+
+// PartType represents a partition type
+type PartType string
+
+const (
+	PartTypeUnset PartType = ""
+	PartTypeGPT   PartType = "gpt"
+	PartTypeDOS   PartType = "dos"
+)
+
+func (p PartType) Validate() error {
+	if !slices.Contains([]PartType{PartTypeGPT, PartTypeDOS}, p) {
+		return fmt.Errorf("unsupported partition type %q", p)
+	}
+	return nil
 }

--- a/internal/otkdisk/partition.go
+++ b/internal/otkdisk/partition.go
@@ -24,6 +24,9 @@ type Const struct {
 	// directly. It makes noo external API guarantees about the content or
 	// structure.
 	Internal Internal `json:"internal"`
+
+	// Filename for the disk image.
+	Filename string `json:"filename"`
 }
 
 // Partition represents an exported view of a partition. This is an API so only

--- a/internal/otkdisk/partition_test.go
+++ b/internal/otkdisk/partition_test.go
@@ -1,0 +1,19 @@
+package otkdisk_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/internal/otkdisk"
+)
+
+func TestPartTypeValidationHappy(t *testing.T) {
+	assert.NoError(t, otkdisk.PartTypeDOS.Validate())
+	assert.NoError(t, otkdisk.PartTypeGPT.Validate())
+}
+
+func TestPartTypeValidationSad(t *testing.T) {
+	assert.EqualError(t, otkdisk.PartTypeUnset.Validate(), `unsupported partition type ""`)
+	assert.EqualError(t, otkdisk.PartType("foo").Validate(), `unsupported partition type "foo"`)
+}

--- a/pkg/osbuild/copy_stage.go
+++ b/pkg/osbuild/copy_stage.go
@@ -61,7 +61,7 @@ func GenCopyFSTreeOptions(inputName, inputPipeline, filename string, pt *disk.Pa
 	[]Mount,
 ) {
 
-	fsRootMntName, mounts, devices, err := genMountsDevicesFromPt(filename, pt)
+	fsRootMntName, mounts, devices, err := GenMountsDevicesFromPT(filename, pt)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/osbuild/device.go
+++ b/pkg/osbuild/device.go
@@ -266,7 +266,7 @@ func genOsbuildMount(source string, mnt disk.Mountable) (*Mount, error) {
 	}
 }
 
-// genMountsDevicesFromPt generates osbuild mounts and devices from a disk.PartitionTable
+// GenMountsDevicesFromPT generates osbuild mounts and devices from a disk.PartitionTable
 // filename is the name of the underlying image file (which will get loop-mounted).
 //
 // Returned values:
@@ -274,7 +274,7 @@ func genOsbuildMount(source string, mnt disk.Mountable) (*Mount, error) {
 // 2) generated mounts
 // 3) generated devices
 // 4) error if any
-func genMountsDevicesFromPt(filename string, pt *disk.PartitionTable) (string, []Mount, map[string]Device, error) {
+func GenMountsDevicesFromPT(filename string, pt *disk.PartitionTable) (string, []Mount, map[string]Device, error) {
 	devices := make(map[string]Device, len(pt.Partitions))
 	mounts := make([]Mount, 0, len(pt.Partitions))
 	var fsRootMntName string

--- a/pkg/osbuild/device_test.go
+++ b/pkg/osbuild/device_test.go
@@ -173,7 +173,7 @@ func TestPathEscape(t *testing.T) {
 func TestMountsDeviceFromPtEmptyErrors(t *testing.T) {
 	filename := "fake-disk.img"
 	fakePt := testdisk.MakeFakePartitionTable()
-	fsRootMntName, mounts, devices, err := genMountsDevicesFromPt(filename, fakePt)
+	fsRootMntName, mounts, devices, err := GenMountsDevicesFromPT(filename, fakePt)
 	assert.ErrorContains(t, err, "no mount found for the filesystem root")
 	assert.Equal(t, fsRootMntName, "")
 	require.Nil(t, mounts)
@@ -183,14 +183,14 @@ func TestMountsDeviceFromPtEmptyErrors(t *testing.T) {
 func TestMountsDeviceFromPtNoRootErrors(t *testing.T) {
 	filename := "fake-disk.img"
 	fakePt := testdisk.MakeFakePartitionTable("/not-root")
-	_, _, _, err := genMountsDevicesFromPt(filename, fakePt)
+	_, _, _, err := GenMountsDevicesFromPT(filename, fakePt)
 	assert.ErrorContains(t, err, "no mount found for the filesystem root")
 }
 
 func TestMountsDeviceFromPtHappy(t *testing.T) {
 	filename := "fake-disk.img"
 	fakePt := testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
-	fsRootMntName, mounts, devices, err := genMountsDevicesFromPt(filename, fakePt)
+	fsRootMntName, mounts, devices, err := GenMountsDevicesFromPT(filename, fakePt)
 	require.Nil(t, err)
 	assert.Equal(t, fsRootMntName, "-")
 	assert.Equal(t, mounts, []Mount{

--- a/pkg/osbuild/device_test.go
+++ b/pkg/osbuild/device_test.go
@@ -226,7 +226,7 @@ func TestMountsDeviceFromPtHappy(t *testing.T) {
 func TestMountsDeviceFromBrfs(t *testing.T) {
 	filename := "fake-disk.img"
 	fakePt := testdisk.MakeFakeBtrfsPartitionTable("/", "/boot")
-	fsRootMntName, mounts, devices, err := genMountsDevicesFromPt(filename, fakePt)
+	fsRootMntName, mounts, devices, err := GenMountsDevicesFromPT(filename, fakePt)
 	require.Nil(t, err)
 	assert.Equal(t, "-", fsRootMntName)
 	assert.Equal(t, []Mount{


### PR DESCRIPTION
This is a joint PR by @mvo5 and me that adds three new commands:
- otk-gen-partition-table: generates a fully resolved partition table from a base description and modifications.  It's an externalised version of the `disk.NewPartitionTable()` function.
- otk-make-partition-stages: generates stages that can be added to a manifest to create a disk image from a fully resolved partition table.  It's an externalised version of the `osbuild.GenImagePrepareStages()` function.
- otk-make-partition-mounts-devices: generates mounts and devices that can be attached to osbuild stages that need to operate on a partitioned image file.  It's an externalised version of the `osbuild.GenMountsDevicesFromPT()` function.

Some tests can still be added and it might be good to test these with otk directly before merging, but they're mostly functionally complete.