### PR TITLE
disk: support json unmarshal for `Partition`

### DIFF
--- a/pkg/disk/btrfs.go
+++ b/pkg/disk/btrfs.go
@@ -3,10 +3,15 @@ package disk
 import (
 	"fmt"
 	"math/rand"
+	"reflect"
 	"strings"
 
 	"github.com/google/uuid"
 )
+
+func init() {
+	entityTypes = append(entityTypes, reflect.TypeOf(Btrfs{}))
+}
 
 type Btrfs struct {
 	UUID       string

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"io"
 	"math/rand"
+	"reflect"
 
 	"github.com/google/uuid"
 )
@@ -49,6 +50,10 @@ const (
 	// Extended Boot Loader Partition
 	XBootLDRPartitionGUID = "BC13C2FF-59E6-4262-A352-B275FD6F7172"
 )
+
+// entityTypes must contain all the types that implemnt "Entity"
+// in the package so that json unmarshal works transparently
+var entityTypes []reflect.Type
 
 // Entity is the base interface for all disk-related entities.
 type Entity interface {

--- a/pkg/disk/filesystem.go
+++ b/pkg/disk/filesystem.go
@@ -2,9 +2,14 @@ package disk
 
 import (
 	"math/rand"
+	"reflect"
 
 	"github.com/google/uuid"
 )
+
+func init() {
+	entityTypes = append(entityTypes, reflect.TypeOf(Filesystem{}))
+}
 
 // Filesystem related functions
 type Filesystem struct {

--- a/pkg/disk/luks.go
+++ b/pkg/disk/luks.go
@@ -3,6 +3,7 @@ package disk
 import (
 	"fmt"
 	"math/rand"
+	"reflect"
 
 	"github.com/google/uuid"
 
@@ -20,6 +21,11 @@ type ClevisBind struct {
 	Policy           string
 	RemovePassphrase bool
 }
+
+func init() {
+	entityTypes = append(entityTypes, reflect.TypeOf(LUKSContainer{}))
+}
+
 type LUKSContainer struct {
 	Passphrase string
 	UUID       string

--- a/pkg/disk/lvm.go
+++ b/pkg/disk/lvm.go
@@ -2,10 +2,15 @@ package disk
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/osbuild/images/internal/common"
 )
+
+func init() {
+	entityTypes = append(entityTypes, reflect.TypeOf(LVMVolumeGroup{}))
+}
 
 // Default physical extent size in bytes: logical volumes
 // created inside the VG will be aligned to this.

--- a/pkg/disk/partition.go
+++ b/pkg/disk/partition.go
@@ -1,7 +1,10 @@
 package disk
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"reflect"
 )
 
 type Partition struct {
@@ -84,4 +87,55 @@ func (p *Partition) IsPReP() bool {
 	}
 
 	return p.Type == "41" || p.Type == PRePartitionGUID
+}
+
+func (p *Partition) UnmarshalJSON(data []byte) error {
+	// golang make this complicated: "Payload" is an interface that
+	// can be either: "Filesystem", "LVMVolumeGroup", "Btrfs" or
+	// "LUKSContainer". So we use a type registry and try to dynamically
+	// detect the type
+	type partAlias Partition
+	var partWithoutPayload struct {
+		partAlias
+		Payload json.RawMessage
+	}
+	dec := json.NewDecoder(bytes.NewBuffer(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&partWithoutPayload); err != nil {
+		return fmt.Errorf("cannot build partition from %q: %w", data, err)
+	}
+	*p = Partition(partWithoutPayload.partAlias)
+	// check if payload is null first, that is valid for e.g. BIOS
+	// partitions and if it's null no need to decode further
+	var val interface{}
+	if err := json.Unmarshal(partWithoutPayload.Payload, &val); err != nil {
+		return fmt.Errorf("cannot decode payload: %w", err)
+	}
+	if val == nil {
+		return nil
+	}
+
+	// now resolve payload, it's an interface
+	for i := range entityTypes {
+		// entValP is of type reflect.Value and points to a
+		// struct that implements the Entity interface
+		entValP := reflect.New(entityTypes[i]).Elem().Addr()
+		// ent is the concrete type/value
+		// (e.g. *disk.Filesysem), it's required so that
+		// json.Decode() can introspect the fields
+		ent := entValP.Interface()
+
+		// try to decode, by disallowing unknown fields this
+		// will only work for matching types
+		dec := json.NewDecoder(bytes.NewBuffer(partWithoutPayload.Payload))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&ent); err != nil {
+			continue
+		}
+		// the right payload is found and needs to be assigned/converted now
+		p.Payload = entValP.Interface().(Entity)
+		return nil
+	}
+
+	return fmt.Errorf("cannot build partition from: %q", data)
 }

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -1,9 +1,11 @@
 package disk_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/osbuild/images/internal/testdisk"
+	"github.com/osbuild/images/pkg/disk"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,4 +24,55 @@ func TestPartitionTable_GetMountpointSize(t *testing.T) {
 	_, err = pt.GetMountpointSize("/custom")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot find mountpoint /custom")
+}
+
+func TestMarshalUnmarshalSimple(t *testing.T) {
+	fakePt := testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
+
+	js, err := json.Marshal(fakePt)
+	assert.NoError(t, err)
+
+	var ptFromJS disk.PartitionTable
+	err = json.Unmarshal(js, &ptFromJS)
+	assert.NoError(t, err)
+	assert.Equal(t, fakePt, &ptFromJS)
+}
+
+func TestMarshalUnmarshalSad(t *testing.T) {
+	var part disk.Partition
+	err := json.Unmarshal([]byte(`{"randon": "json"}`), &part)
+	assert.ErrorContains(t, err, `cannot build partition from "{`)
+}
+
+func TestMarshalUnmarshalPartitionHappy(t *testing.T) {
+	part := &disk.Partition{}
+
+	for _, ent := range []disk.Entity{
+		&disk.Filesystem{Type: "ext2"},
+		&disk.LUKSContainer{Passphrase: "secret"},
+		&disk.Btrfs{Label: "foo"},
+		&disk.LVMVolumeGroup{Name: "bar"},
+	} {
+		part.Payload = ent
+		js, err := json.Marshal(part)
+		assert.NoError(t, err)
+
+		var partFromJS disk.Partition
+		err = json.Unmarshal(js, &partFromJS)
+		assert.NoError(t, err)
+		assert.Equal(t, part, &partFromJS)
+	}
+}
+
+func TestUnmarshalNullPayload(t *testing.T) {
+	part := &disk.Partition{}
+	part.Payload = nil
+
+	js, err := json.Marshal(part)
+	assert.NoError(t, err)
+
+	var partFromJS disk.Partition
+	err = json.Unmarshal(js, &partFromJS)
+	assert.NoError(t, err)
+	assert.Equal(t, part, &partFromJS)
 }


### PR DESCRIPTION
The `disk.Partition` uses interfaces inside the data structure. To support json unmarshal we need a custom `UnmarshalJSON()` that peeks into the marshalled json and detects what concrete type to use.

This commit provides the `disk.Partition.UnmarshalJSON` implementation and a test.

Split out from https://github.com/osbuild/images/pull/732 with extra test.

Draft until I find a little bit more time to make the tests a bit more comprehensive and until the other payloads are supported.