### PR TITLE
github: remove skip-gpg-cache from go lint job

### DIFF
--- a/.github/workflows/test-osbuild-composer-intergation.yml
+++ b/.github/workflows/test-osbuild-composer-intergation.yml
@@ -97,5 +97,3 @@ jobs:
           version: v1.54.2
           working-directory: osbuild-composer
           args: --verbose --timeout 5m0s
-          # Needed due to https://github.com/golangci/golangci-lint-action/issues/135
-          skip-pkg-cache: true


### PR DESCRIPTION
We've been ignoring the osbuild-composer integration test failures because we assumed they were due to unresolved incompatibilities but after opening https://github.com/osbuild/osbuild-composer/pull/4198 I realised that the compatibility is fine.  It was actually failing because an option we were using had been removed:
```
Warning: Unexpected input(s) 'skip-pkg-cache', valid inputs are ['version', 'install-mode', 'working-directory', 'github-token', 'only-new-issues', 'skip-cache', 'skip-save-cache', 'problem-matchers', 'args', 'cache-invalidation-interval']
```

The option is no longer needed (see previously linked issue) and has been removed.