### PR TITLE
manifest: Add awscli2 to RHEL 9 AMI (CLOUDX-913)

### DIFF
--- a/pkg/distro/rhel/rhel9/ami.go
+++ b/pkg/distro/rhel/rhel9/ami.go
@@ -240,6 +240,11 @@ func ec2CommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 		},
 	}.Append(distroSpecificPackageSet(t))
 
+	// Include awscli2 on RHEL 9.5+ (CLOUDX-913)
+	if common.VersionGreaterThanOrEqual(t.Arch().Distro().OsVersion(), "9.5") {
+		ps.Include = append(ps.Include, "awscli2")
+	}
+
 	return ps
 }
 


### PR DESCRIPTION
The awscli2 package is included in the upcoming RHEL 9.5.0 release and it would be helpful to include it in AWS AMIs by default.