### PR TITLE
Revert "manifest: Add awscli2 to RHEL 9 AMI (CLOUDX-913)"

### DIFF
--- a/pkg/distro/rhel/rhel9/ami.go
+++ b/pkg/distro/rhel/rhel9/ami.go
@@ -240,11 +240,6 @@ func ec2CommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 		},
 	}.Append(distroSpecificPackageSet(t))
 
-	// Include awscli2 on RHEL 9.5+ (CLOUDX-913)
-	if common.VersionGreaterThanOrEqual(t.Arch().Distro().OsVersion(), "9.5") {
-		ps.Include = append(ps.Include, "awscli2")
-	}
-
 	return ps
 }
 


### PR DESCRIPTION
This reverts commit c46dc3b59953fabc945ec5c0891aee933b00bc8e.

We need a bit more discussion before we consider adding this to all AMI images. 🤔