### PR TITLE
Refactor OpenSCAP stage config (HMS-3826)

### DIFF
--- a/pkg/customizations/oscap/oscap.go
+++ b/pkg/customizations/oscap/oscap.go
@@ -43,8 +43,9 @@ const (
 	defaultRHEL8Datastream   string = "/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml"
 	defaultRHEL9Datastream   string = "/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml"
 
-	// tailoring directory path
-	tailoringDirPath string = "/usr/share/xml/osbuild-openscap-data"
+	// oscap related directories
+	DataDir          string = "/oscap_data"
+	TailoringDirPath string = "/usr/share/xml/osbuild-openscap-data"
 )
 
 func DefaultFedoraDatastream() string {
@@ -83,9 +84,9 @@ func IsProfileAllowed(profile string, allowlist []Profile) bool {
 
 func GetTailoringFile(profile string) (string, string, *fsnode.Directory, error) {
 	newProfile := fmt.Sprintf("%s_osbuild_tailoring", profile)
-	path := filepath.Join(tailoringDirPath, "tailoring.xml")
+	path := filepath.Join(TailoringDirPath, "tailoring.xml")
 
-	tailoringDir, err := fsnode.NewDirectory(tailoringDirPath, nil, nil, nil, true)
+	tailoringDir, err := fsnode.NewDirectory(TailoringDirPath, nil, nil, nil, true)
 	if err != nil {
 		return "", "", nil, err
 	}

--- a/pkg/customizations/oscap/oscap.go
+++ b/pkg/customizations/oscap/oscap.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-
-	"github.com/osbuild/images/pkg/customizations/fsnode"
 )
 
 type Profile string
@@ -82,14 +80,8 @@ func IsProfileAllowed(profile string, allowlist []Profile) bool {
 	return false
 }
 
-func GetTailoringFile(profile string) (string, string, *fsnode.Directory, error) {
+func GetTailoringFile(profile string) (string, string) {
 	newProfile := fmt.Sprintf("%s_osbuild_tailoring", profile)
 	path := filepath.Join(TailoringDirPath, "tailoring.xml")
-
-	tailoringDir, err := fsnode.NewDirectory(TailoringDirPath, nil, nil, nil, true)
-	if err != nil {
-		return "", "", nil, err
-	}
-
-	return newProfile, path, tailoringDir, nil
+	return newProfile, path
 }

--- a/pkg/customizations/oscap/oscap.go
+++ b/pkg/customizations/oscap/oscap.go
@@ -1,8 +1,6 @@
 package oscap
 
 import (
-	"fmt"
-	"path/filepath"
 	"strings"
 )
 
@@ -42,8 +40,7 @@ const (
 	defaultRHEL9Datastream   string = "/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml"
 
 	// oscap related directories
-	DataDir          string = "/oscap_data"
-	TailoringDirPath string = "/usr/share/xml/osbuild-openscap-data"
+	DataDir string = "/oscap_data"
 )
 
 func DefaultFedoraDatastream() string {
@@ -78,10 +75,4 @@ func IsProfileAllowed(profile string, allowlist []Profile) bool {
 	}
 
 	return false
-}
-
-func GetTailoringFile(profile string) (string, string) {
-	newProfile := fmt.Sprintf("%s_osbuild_tailoring", profile)
-	path := filepath.Join(TailoringDirPath, "tailoring.xml")
-	return newProfile, path
 }

--- a/pkg/customizations/oscap/oscap.go
+++ b/pkg/customizations/oscap/oscap.go
@@ -43,6 +43,20 @@ const (
 	DataDir string = "/oscap_data"
 )
 
+type RemediationConfig struct {
+	Datastream         string
+	ProfileID          string
+	TailoringPath      string
+	CompressionEnabled bool
+}
+
+type TailoringConfig struct {
+	RemediationConfig
+	TailoredProfileID string
+	Selected          []string
+	Unselected        []string
+}
+
 func DefaultFedoraDatastream() string {
 	return defaultFedoraDatastream
 }

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -41,9 +41,6 @@ const (
 
 	// Added kernel command line options for iot-raw-image and iot-qcow2-image types
 	ostreeDeploymentKernelOptions = "modprobe.blacklist=vc4 rw coreos.no_persist_ip"
-
-	// location for saving openscap remediation data
-	oscapDataDir = "/oscap_data"
 )
 
 var (

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -219,8 +219,8 @@ func osCustomizations(
 			remediationConfig.ProfileID = tailoringConfig.TailoredProfileID
 		}
 
-		osc.OpenSCAPTailorConfig = osbuild.NewOscapAutotailorStageOptions(tailoringConfig)
-		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscap.DataDir, &remediationConfig)
+		osc.OpenSCAPTailorConfig = tailoringConfig
+		osc.OpenSCAPRemediationConfig = &remediationConfig
 	}
 
 	osc.ShellInit = imageConfig.ShellInit

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -3,6 +3,7 @@ package fedora
 import (
 	"fmt"
 	"math/rand"
+	"path/filepath"
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/workload"
@@ -183,7 +184,11 @@ func osCustomizations(
 			panic("unexpected oscap options for ostree image type")
 		}
 
-		directoriesToCreate := []string{oscap.DataDir}
+		oscapDataNode, err := fsnode.NewDirectory(oscap.DataDir, nil, nil, nil, true)
+		if err != nil {
+			panic(fmt.Sprintf("unexpected error creating required OpenSCAP directory: %s", oscap.DataDir))
+		}
+		osc.Directories = append(osc.Directories, oscapDataNode)
 
 		var datastream = oscapConfig.DataStream
 		if datastream == "" {
@@ -200,9 +205,8 @@ func osCustomizations(
 		}
 
 		if oscapConfig.Tailoring != nil {
-			directoriesToCreate = append(directoriesToCreate, oscap.TailoringDirPath)
-
-			newProfile, tailoringFilepath := oscap.GetTailoringFile(oscapConfig.ProfileID)
+			tailoringFilepath := filepath.Join(oscap.DataDir, "tailoring.xml")
+			newProfile := fmt.Sprintf("%s_osbuild_tailoring", oscapConfig.ProfileID)
 
 			tailoringOptions := osbuild.OscapAutotailorConfig{
 				NewProfile: newProfile,
@@ -220,14 +224,6 @@ func osCustomizations(
 			// overwrite the profile id with the new tailoring id
 			oscapStageOptions.ProfileID = newProfile
 			oscapStageOptions.Tailoring = tailoringFilepath
-		}
-
-		for _, directory := range directoriesToCreate {
-			directoryNode, err := fsnode.NewDirectory(directory, nil, nil, nil, true)
-			if err != nil {
-				panic(fmt.Sprintf("unexpected error creating required OpenSCAP directory: %s", directory))
-			}
-			osc.Directories = append(osc.Directories, directoryNode)
 		}
 
 		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscap.DataDir, oscapStageOptions)

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -185,7 +185,7 @@ func osCustomizations(
 
 		// although the osbuild stage will create this directory,
 		// it's probably better to ensure that it is created here
-		dataDirNode, err := fsnode.NewDirectory(oscapDataDir, nil, nil, nil, true)
+		dataDirNode, err := fsnode.NewDirectory(oscap.DataDir, nil, nil, nil, true)
 		if err != nil {
 			panic("unexpected error creating OpenSCAP data directory")
 		}
@@ -233,7 +233,7 @@ func osCustomizations(
 			osc.Directories = append(osc.Directories, tailoringDir)
 		}
 
-		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscapDataDir, oscapStageOptions)
+		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscap.DataDir, oscapStageOptions)
 	}
 
 	osc.ShellInit = imageConfig.ShellInit

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -204,28 +204,22 @@ func osCustomizations(
 			CompressionEnabled: true,
 		}
 
+		var tailoringConfig *oscap.TailoringConfig
 		if oscapConfig.Tailoring != nil {
-			tailoringFilepath := filepath.Join(oscap.DataDir, "tailoring.xml")
-			newProfile := fmt.Sprintf("%s_osbuild_tailoring", oscapConfig.ProfileID)
-
-			tailoringOptions := osbuild.OscapAutotailorConfig{
-				NewProfile: newProfile,
-				Datastream: datastream,
-				ProfileID:  oscapConfig.ProfileID,
-				Selected:   oscapConfig.Tailoring.Selected,
-				Unselected: oscapConfig.Tailoring.Unselected,
+			remediationConfig.TailoringPath = filepath.Join(oscap.DataDir, "tailoring.xml")
+			tailoringConfig = &oscap.TailoringConfig{
+				RemediationConfig: remediationConfig,
+				TailoredProfileID: fmt.Sprintf("%s_osbuild_tailoring", oscapConfig.ProfileID),
+				Selected:          oscapConfig.Tailoring.Selected,
+				Unselected:        oscapConfig.Tailoring.Unselected,
 			}
-
-			osc.OpenSCAPTailorConfig = osbuild.NewOscapAutotailorStageOptions(
-				tailoringFilepath,
-				tailoringOptions,
-			)
-
-			// overwrite the profile id with the new tailoring id
-			remediationConfig.ProfileID = newProfile
-			remediationConfig.TailoringPath = tailoringFilepath
+			// we need to set this after the tailoring config
+			// since the tailoring config needs to know about both
+			// the base profile id and the tailored profile id
+			remediationConfig.ProfileID = tailoringConfig.TailoredProfileID
 		}
 
+		osc.OpenSCAPTailorConfig = osbuild.NewOscapAutotailorStageOptions(tailoringConfig)
 		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscap.DataDir, &remediationConfig)
 	}
 

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -198,10 +198,10 @@ func osCustomizations(
 			datastream = *imageConfig.DefaultOSCAPDatastream
 		}
 
-		oscapStageOptions := osbuild.OscapConfig{
-			Datastream:  datastream,
-			ProfileID:   oscapConfig.ProfileID,
-			Compression: true,
+		remediationConfig := oscap.RemediationConfig{
+			Datastream:         datastream,
+			ProfileID:          oscapConfig.ProfileID,
+			CompressionEnabled: true,
 		}
 
 		if oscapConfig.Tailoring != nil {
@@ -222,11 +222,11 @@ func osCustomizations(
 			)
 
 			// overwrite the profile id with the new tailoring id
-			oscapStageOptions.ProfileID = newProfile
-			oscapStageOptions.Tailoring = tailoringFilepath
+			remediationConfig.ProfileID = newProfile
+			remediationConfig.TailoringPath = tailoringFilepath
 		}
 
-		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscap.DataDir, oscapStageOptions)
+		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscap.DataDir, &remediationConfig)
 	}
 
 	osc.ShellInit = imageConfig.ShellInit

--- a/pkg/distro/rhel/defaults.go
+++ b/pkg/distro/rhel/defaults.go
@@ -1,8 +1,5 @@
 package rhel
 
 const (
-	// location for saving openscap remediation data
-	oscapDataDir = "/oscap_data"
-
 	UEFIVendor = "redhat"
 )

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -240,8 +240,8 @@ func osCustomizations(
 			remediationConfig.ProfileID = tailoringConfig.TailoredProfileID
 		}
 
-		osc.OpenSCAPTailorConfig = osbuild.NewOscapAutotailorStageOptions(tailoringConfig)
-		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscap.DataDir, &remediationConfig)
+		osc.OpenSCAPTailorConfig = tailoringConfig
+		osc.OpenSCAPRemediationConfig = &remediationConfig
 	}
 
 	osc.ShellInit = imageConfig.ShellInit

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -225,28 +225,22 @@ func osCustomizations(
 			CompressionEnabled: true,
 		}
 
+		var tailoringConfig *oscap.TailoringConfig
 		if oscapConfig.Tailoring != nil {
-			tailoringFilepath := filepath.Join(oscap.DataDir, "tailoring.xml")
-			newProfile := fmt.Sprintf("%s_osbuild_tailoring", oscapConfig.ProfileID)
-
-			tailoringOptions := osbuild.OscapAutotailorConfig{
-				NewProfile: newProfile,
-				Datastream: datastream,
-				ProfileID:  oscapConfig.ProfileID,
-				Selected:   oscapConfig.Tailoring.Selected,
-				Unselected: oscapConfig.Tailoring.Unselected,
+			remediationConfig.TailoringPath = filepath.Join(oscap.DataDir, "tailoring.xml")
+			tailoringConfig = &oscap.TailoringConfig{
+				RemediationConfig: remediationConfig,
+				TailoredProfileID: fmt.Sprintf("%s_osbuild_tailoring", oscapConfig.ProfileID),
+				Selected:          oscapConfig.Tailoring.Selected,
+				Unselected:        oscapConfig.Tailoring.Unselected,
 			}
-
-			osc.OpenSCAPTailorConfig = osbuild.NewOscapAutotailorStageOptions(
-				tailoringFilepath,
-				tailoringOptions,
-			)
-
-			// overwrite the profile id with the new tailoring id
-			remediationConfig.ProfileID = newProfile
-			remediationConfig.TailoringPath = tailoringFilepath
+			// we need to set this after the tailoring config
+			// since the tailoring config needs to know about both
+			// the base profile id and the tailored profile id
+			remediationConfig.ProfileID = tailoringConfig.TailoredProfileID
 		}
 
+		osc.OpenSCAPTailorConfig = osbuild.NewOscapAutotailorStageOptions(tailoringConfig)
 		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscap.DataDir, &remediationConfig)
 	}
 

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -219,10 +219,10 @@ func osCustomizations(
 			datastream = *imageConfig.DefaultOSCAPDatastream
 		}
 
-		oscapStageOptions := osbuild.OscapConfig{
-			Datastream:  datastream,
-			ProfileID:   oscapConfig.ProfileID,
-			Compression: true,
+		remediationConfig := oscap.RemediationConfig{
+			Datastream:         datastream,
+			ProfileID:          oscapConfig.ProfileID,
+			CompressionEnabled: true,
 		}
 
 		if oscapConfig.Tailoring != nil {
@@ -243,11 +243,11 @@ func osCustomizations(
 			)
 
 			// overwrite the profile id with the new tailoring id
-			oscapStageOptions.ProfileID = newProfile
-			oscapStageOptions.Tailoring = tailoringFilepath
+			remediationConfig.ProfileID = newProfile
+			remediationConfig.TailoringPath = tailoringFilepath
 		}
 
-		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscap.DataDir, oscapStageOptions)
+		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscap.DataDir, &remediationConfig)
 	}
 
 	osc.ShellInit = imageConfig.ShellInit

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -204,14 +204,7 @@ func osCustomizations(
 			panic("unexpected oscap options for ostree image type")
 		}
 
-		// although the osbuild stage will create this directory,
-		// it's probably better to ensure that it is created here
-		dataDirNode, err := fsnode.NewDirectory(oscap.DataDir, nil, nil, nil, true)
-		if err != nil {
-			panic("unexpected error creating OpenSCAP data directory")
-		}
-
-		osc.Directories = append(osc.Directories, dataDirNode)
+		directoriesToCreate := []string{oscap.DataDir}
 
 		var datastream = oscapConfig.DataStream
 		if datastream == "" {
@@ -228,10 +221,9 @@ func osCustomizations(
 		}
 
 		if oscapConfig.Tailoring != nil {
-			newProfile, tailoringFilepath, tailoringDir, err := oscap.GetTailoringFile(oscapConfig.ProfileID)
-			if err != nil {
-				panic(fmt.Sprintf("unexpected error creating tailoring file options: %v", err))
-			}
+			directoriesToCreate = append(directoriesToCreate, oscap.TailoringDirPath)
+
+			newProfile, tailoringFilepath := oscap.GetTailoringFile(oscapConfig.ProfileID)
 
 			tailoringOptions := osbuild.OscapAutotailorConfig{
 				NewProfile: newProfile,
@@ -249,9 +241,14 @@ func osCustomizations(
 			// overwrite the profile id with the new tailoring id
 			oscapStageOptions.ProfileID = newProfile
 			oscapStageOptions.Tailoring = tailoringFilepath
+		}
 
-			// add the parent directory for the tailoring file
-			osc.Directories = append(osc.Directories, tailoringDir)
+		for _, directory := range directoriesToCreate {
+			directoryNode, err := fsnode.NewDirectory(directory, nil, nil, nil, true)
+			if err != nil {
+				panic(fmt.Sprintf("unexpected error creating required OpenSCAP directory: %s", directory))
+			}
+			osc.Directories = append(osc.Directories, directoryNode)
 		}
 
 		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscap.DataDir, oscapStageOptions)

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -206,7 +206,7 @@ func osCustomizations(
 
 		// although the osbuild stage will create this directory,
 		// it's probably better to ensure that it is created here
-		dataDirNode, err := fsnode.NewDirectory(oscapDataDir, nil, nil, nil, true)
+		dataDirNode, err := fsnode.NewDirectory(oscap.DataDir, nil, nil, nil, true)
 		if err != nil {
 			panic("unexpected error creating OpenSCAP data directory")
 		}
@@ -254,7 +254,7 @@ func osCustomizations(
 			osc.Directories = append(osc.Directories, tailoringDir)
 		}
 
-		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscapDataDir, oscapStageOptions)
+		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(oscap.DataDir, oscapStageOptions)
 	}
 
 	osc.ShellInit = imageConfig.ShellInit

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -12,6 +12,7 @@ import (
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/bootc"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
+	"github.com/osbuild/images/pkg/customizations/oscap"
 	"github.com/osbuild/images/pkg/customizations/shell"
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/disk"
@@ -96,38 +97,40 @@ type OSCustomizations struct {
 	ShellInit []shell.InitFile
 
 	// TODO: drop osbuild types from the API
-	Firewall             *osbuild.FirewallStageOptions
-	Grub2Config          *osbuild.GRUB2Config
-	Sysconfig            []*osbuild.SysconfigStageOptions
-	SystemdLogind        []*osbuild.SystemdLogindStageOptions
-	CloudInit            []*osbuild.CloudInitStageOptions
-	Modprobe             []*osbuild.ModprobeStageOptions
-	DracutConf           []*osbuild.DracutConfStageOptions
-	SystemdUnit          []*osbuild.SystemdUnitStageOptions
-	Authselect           *osbuild.AuthselectStageOptions
-	SELinuxConfig        *osbuild.SELinuxConfigStageOptions
-	Tuned                *osbuild.TunedStageOptions
-	Tmpfilesd            []*osbuild.TmpfilesdStageOptions
-	PamLimitsConf        []*osbuild.PamLimitsConfStageOptions
-	Sysctld              []*osbuild.SysctldStageOptions
-	DNFConfig            []*osbuild.DNFConfigStageOptions
-	DNFAutomaticConfig   *osbuild.DNFAutomaticConfigStageOptions
-	YUMConfig            *osbuild.YumConfigStageOptions
-	YUMRepos             []*osbuild.YumReposStageOptions
-	SshdConfig           *osbuild.SshdConfigStageOptions
-	GCPGuestAgentConfig  *osbuild.GcpGuestAgentConfigOptions
-	AuthConfig           *osbuild.AuthconfigStageOptions
-	PwQuality            *osbuild.PwqualityConfStageOptions
-	OpenSCAPTailorConfig *osbuild.OscapAutotailorStageOptions
-	OpenSCAPConfig       *osbuild.OscapRemediationStageOptions
-	NTPServers           []osbuild.ChronyConfigServer
-	WAAgentConfig        *osbuild.WAAgentConfStageOptions
-	UdevRules            *osbuild.UdevRulesStageOptions
-	WSLConfig            *osbuild.WSLConfStageOptions
-	LeapSecTZ            *string
-	FactAPIType          *facts.APIType
-	Presets              []osbuild.Preset
-	ContainersStorage    *string
+	Firewall            *osbuild.FirewallStageOptions
+	Grub2Config         *osbuild.GRUB2Config
+	Sysconfig           []*osbuild.SysconfigStageOptions
+	SystemdLogind       []*osbuild.SystemdLogindStageOptions
+	CloudInit           []*osbuild.CloudInitStageOptions
+	Modprobe            []*osbuild.ModprobeStageOptions
+	DracutConf          []*osbuild.DracutConfStageOptions
+	SystemdUnit         []*osbuild.SystemdUnitStageOptions
+	Authselect          *osbuild.AuthselectStageOptions
+	SELinuxConfig       *osbuild.SELinuxConfigStageOptions
+	Tuned               *osbuild.TunedStageOptions
+	Tmpfilesd           []*osbuild.TmpfilesdStageOptions
+	PamLimitsConf       []*osbuild.PamLimitsConfStageOptions
+	Sysctld             []*osbuild.SysctldStageOptions
+	DNFConfig           []*osbuild.DNFConfigStageOptions
+	DNFAutomaticConfig  *osbuild.DNFAutomaticConfigStageOptions
+	YUMConfig           *osbuild.YumConfigStageOptions
+	YUMRepos            []*osbuild.YumReposStageOptions
+	SshdConfig          *osbuild.SshdConfigStageOptions
+	GCPGuestAgentConfig *osbuild.GcpGuestAgentConfigOptions
+	AuthConfig          *osbuild.AuthconfigStageOptions
+	PwQuality           *osbuild.PwqualityConfStageOptions
+	NTPServers          []osbuild.ChronyConfigServer
+	WAAgentConfig       *osbuild.WAAgentConfStageOptions
+	UdevRules           *osbuild.UdevRulesStageOptions
+	WSLConfig           *osbuild.WSLConfStageOptions
+	LeapSecTZ           *string
+	FactAPIType         *facts.APIType
+	Presets             []osbuild.Preset
+	ContainersStorage   *string
+
+	// OpenSCAP config
+	OpenSCAPTailorConfig      *oscap.TailoringConfig
+	OpenSCAPRemediationConfig *oscap.RemediationConfig
 
 	Subscription *subscription.ImageOptions
 	RHSMConfig   map[subscription.RHSMStatus]*osbuild.RHSMStageOptions
@@ -230,7 +233,7 @@ func (p *OS) getPackageSetChain(Distro) []rpmmd.PackageSet {
 		packages = append(packages, fmt.Sprintf("selinux-policy-%s", p.SElinux))
 	}
 
-	if p.OpenSCAPConfig != nil {
+	if p.OpenSCAPRemediationConfig != nil {
 		packages = append(packages, "openscap-scanner", "scap-security-guide", "xz")
 	}
 
@@ -805,19 +808,22 @@ func (p *OS) serialize() osbuild.Pipeline {
 	}
 
 	if p.OpenSCAPTailorConfig != nil {
-		if p.OpenSCAPConfig == nil {
+		if p.OpenSCAPRemediationConfig == nil {
 			// This is a programming error, since it doesn't make sense
 			// to have tailoring configs without openscap config.
 			panic(fmt.Errorf("OpenSCAP autotailoring cannot be set if no OpenSCAP config has been provided"))
 		}
-		pipeline.AddStage(osbuild.NewOscapAutotailorStage(p.OpenSCAPTailorConfig))
+
+		tailoringStageOpts := osbuild.NewOscapAutotailorStageOptions(p.OpenSCAPTailorConfig)
+		pipeline.AddStage(osbuild.NewOscapAutotailorStage(tailoringStageOpts))
 	}
 
 	// NOTE: We need to run the OpenSCAP stages as the last stage before SELinux
 	// since the remediation may change file permissions and other aspects of the
 	// hardened image
-	if p.OpenSCAPConfig != nil {
-		pipeline.AddStage(osbuild.NewOscapRemediationStage(p.OpenSCAPConfig))
+	if p.OpenSCAPRemediationConfig != nil {
+		remediationStageOpts := osbuild.NewOscapRemediationStageOptions(oscap.DataDir, p.OpenSCAPRemediationConfig)
+		pipeline.AddStage(osbuild.NewOscapRemediationStage(remediationStageOpts))
 	}
 
 	if len(p.Presets) != 0 {

--- a/pkg/osbuild/oscap_autotailor_stage.go
+++ b/pkg/osbuild/oscap_autotailor_stage.go
@@ -9,8 +9,8 @@ type OscapAutotailorStageOptions struct {
 
 type OscapAutotailorConfig struct {
 	NewProfile string   `json:"new_profile"`
-	Datastream string   `json:"datastream" toml:"datastream"`
-	ProfileID  string   `json:"profile_id" toml:"profile_id"`
+	Datastream string   `json:"datastream"`
+	ProfileID  string   `json:"profile_id"`
 	Selected   []string `json:"selected,omitempty"`
 	Unselected []string `json:"unselected,omitempty"`
 }

--- a/pkg/osbuild/oscap_autotailor_stage.go
+++ b/pkg/osbuild/oscap_autotailor_stage.go
@@ -1,6 +1,10 @@
 package osbuild
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/osbuild/images/pkg/customizations/oscap"
+)
 
 type OscapAutotailorStageOptions struct {
 	Filepath string                `json:"filepath"`
@@ -8,11 +12,11 @@ type OscapAutotailorStageOptions struct {
 }
 
 type OscapAutotailorConfig struct {
-	NewProfile string   `json:"new_profile"`
-	Datastream string   `json:"datastream"`
-	ProfileID  string   `json:"profile_id"`
-	Selected   []string `json:"selected,omitempty"`
-	Unselected []string `json:"unselected,omitempty"`
+	TailoredProfileID string   `json:"new_profile"`
+	Datastream        string   `json:"datastream"`
+	ProfileID         string   `json:"profile_id"`
+	Selected          []string `json:"selected,omitempty"`
+	Unselected        []string `json:"unselected,omitempty"`
 }
 
 func (OscapAutotailorStageOptions) isStageOptions() {}
@@ -24,7 +28,7 @@ func (c OscapAutotailorConfig) validate() error {
 	if c.ProfileID == "" {
 		return fmt.Errorf("'profile_id' must be specified")
 	}
-	if c.NewProfile == "" {
+	if c.TailoredProfileID == "" {
 		return fmt.Errorf("'new_profile' must be specified")
 	}
 	return nil
@@ -41,15 +45,19 @@ func NewOscapAutotailorStage(options *OscapAutotailorStageOptions) *Stage {
 	}
 }
 
-func NewOscapAutotailorStageOptions(filepath string, autotailorOptions OscapAutotailorConfig) *OscapAutotailorStageOptions {
+func NewOscapAutotailorStageOptions(options *oscap.TailoringConfig) *OscapAutotailorStageOptions {
+	if options == nil {
+		return nil
+	}
+
 	return &OscapAutotailorStageOptions{
-		Filepath: filepath,
+		Filepath: options.RemediationConfig.TailoringPath,
 		Config: OscapAutotailorConfig{
-			NewProfile: autotailorOptions.NewProfile,
-			Datastream: autotailorOptions.Datastream,
-			ProfileID:  autotailorOptions.ProfileID,
-			Selected:   autotailorOptions.Selected,
-			Unselected: autotailorOptions.Unselected,
+			TailoredProfileID: options.TailoredProfileID,
+			Datastream:        options.RemediationConfig.Datastream,
+			ProfileID:         options.RemediationConfig.ProfileID,
+			Selected:          options.Selected,
+			Unselected:        options.Unselected,
 		},
 	}
 }

--- a/pkg/osbuild/oscap_autotailor_stage.go
+++ b/pkg/osbuild/oscap_autotailor_stage.go
@@ -50,6 +50,12 @@ func NewOscapAutotailorStageOptions(options *oscap.TailoringConfig) *OscapAutota
 		return nil
 	}
 
+	// TODO: don't panic! unfortunately this would involve quite
+	// a big refactor and we still need to be a bit defensive here
+	if options.RemediationConfig.TailoringPath == "" {
+		panic(fmt.Errorf("The tailoring path for the OpenSCAP remediation config cannot be empty, this is a programming error"))
+	}
+
 	return &OscapAutotailorStageOptions{
 		Filepath: options.RemediationConfig.TailoringPath,
 		Config: OscapAutotailorConfig{

--- a/pkg/osbuild/oscap_autotailor_stage_test.go
+++ b/pkg/osbuild/oscap_autotailor_stage_test.go
@@ -10,11 +10,11 @@ func TestNewOscapAutotailorStage(t *testing.T) {
 	stageOptions := &OscapAutotailorStageOptions{
 		Filepath: "tailoring.xml",
 		Config: OscapAutotailorConfig{
-			Datastream: "test_stream",
-			ProfileID:  "test_profile",
-			NewProfile: "test_profile_osbuild_profile",
-			Selected:   []string{"fast_rule"},
-			Unselected: []string{"slow_rule"},
+			Datastream:        "test_stream",
+			ProfileID:         "test_profile",
+			TailoredProfileID: "test_profile_osbuild_profile",
+			Selected:          []string{"fast_rule"},
+			Unselected:        []string{"slow_rule"},
 		},
 	}
 
@@ -69,9 +69,9 @@ func TestOscapAutotailorStageOptionsValidate(t *testing.T) {
 			name: "valid-data",
 			options: OscapAutotailorStageOptions{
 				Config: OscapAutotailorConfig{
-					ProfileID:  "test-profile",
-					Datastream: "test-datastream",
-					NewProfile: "test-profile-osbuild-profile",
+					ProfileID:         "test-profile",
+					Datastream:        "test-datastream",
+					TailoredProfileID: "test-profile-osbuild-profile",
 				},
 			},
 			err: false,

--- a/pkg/osbuild/oscap_remediation_stage.go
+++ b/pkg/osbuild/oscap_remediation_stage.go
@@ -1,6 +1,10 @@
 package osbuild
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/osbuild/images/pkg/customizations/oscap"
+)
 
 type OscapVerbosityLevel string
 
@@ -72,21 +76,18 @@ func NewOscapRemediationStage(options *OscapRemediationStageOptions) *Stage {
 	}
 }
 
-func NewOscapRemediationStageOptions(dataDir string, options OscapConfig) *OscapRemediationStageOptions {
+func NewOscapRemediationStageOptions(dataDir string, options *oscap.RemediationConfig) *OscapRemediationStageOptions {
+	if options == nil {
+		return nil
+	}
+
 	return &OscapRemediationStageOptions{
 		DataDir: dataDir,
 		Config: OscapConfig{
-			ProfileID:    options.ProfileID,
-			Datastream:   options.Datastream,
-			DatastreamID: options.DatastreamID,
-			Tailoring:    options.Tailoring,
-			XCCDFID:      options.XCCDFID,
-			BenchmarkID:  options.BenchmarkID,
-			ArfResult:    options.ArfResult,
-			HtmlReport:   options.HtmlReport,
-			VerboseLog:   options.VerboseLog,
-			VerboseLevel: options.VerboseLevel,
-			Compression:  options.Compression,
+			ProfileID:   options.ProfileID,
+			Datastream:  options.Datastream,
+			Tailoring:   options.TailoringPath,
+			Compression: options.CompressionEnabled,
 		},
 	}
 }

--- a/test/scripts/base-host-check.sh
+++ b/test/scripts/base-host-check.sh
@@ -43,7 +43,7 @@ get_oscap_score() {
     sudo oscap xccdf eval \
         --results results.xml \
         --profile "${profile}_osbuild_tailoring" \
-        --tailoring-file "/usr/share/xml/osbuild-openscap-data/tailoring.xml" \
+        --tailoring-file "/oscap_data/tailoring.xml" \
         "${datastream}" || true # oscap returns exit code 2 for any failed rules
 
     echo "📄 Saving results"


### PR DESCRIPTION
This PR is in preparation for a follow up PRs to simplify tailoring to accept an `xml` file.
It's an attempt to simplify the stage creation options using an internal abstraction to create
the options.

This splits up #708, drops the `json` tailoring and the tailoring `overrides`.