### PR TITLE
pkg/osbuild: Skip EFI partition check for non UEFI platforms

### DIFF
--- a/pkg/manifest/raw_bootc.go
+++ b/pkg/manifest/raw_bootc.go
@@ -142,11 +142,11 @@ func (p *RawBootcImage) serialize() osbuild.Pipeline {
 	inputs := osbuild.ContainerDeployInputs{
 		Images: osbuild.NewContainersInputForSingleSource(p.containerSpecs[0]),
 	}
-	devices, mounts, err := osbuild.GenBootupdDevicesMounts(p.filename, p.PartitionTable)
+	devices, mounts, err := osbuild.GenBootupdDevicesMounts(p.filename, p.PartitionTable, p.platform)
 	if err != nil {
 		panic(err)
 	}
-	st, err := osbuild.NewBootcInstallToFilesystemStage(opts, inputs, devices, mounts)
+	st, err := osbuild.NewBootcInstallToFilesystemStage(opts, inputs, devices, mounts, p.platform)
 	if err != nil {
 		panic(err)
 	}
@@ -158,7 +158,7 @@ func (p *RawBootcImage) serialize() osbuild.Pipeline {
 
 	// all our customizations work directly on the mounted deployment
 	// root from the image so generate the devices/mounts for all
-	devices, mounts, err = osbuild.GenBootupdDevicesMounts(p.filename, p.PartitionTable)
+	devices, mounts, err = osbuild.GenBootupdDevicesMounts(p.filename, p.PartitionTable, p.platform)
 	if err != nil {
 		panic(fmt.Sprintf("gen devices stage failed %v", err))
 	}

--- a/pkg/manifest/raw_bootc_test.go
+++ b/pkg/manifest/raw_bootc_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/osbuild"
+	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/runner"
 )
 
@@ -50,8 +51,12 @@ func TestRawBootcImageSerialize(t *testing.T) {
 	mani := manifest.New()
 	runner := &runner.Linux{}
 	build := manifest.NewBuildFromContainer(&mani, runner, nil, nil)
+	pf := &platform.X86{
+		BasePlatform: platform.BasePlatform{},
+		UEFIVendor:   "test",
+	}
 
-	rawBootcPipeline := manifest.NewRawBootcImage(build, containers, nil)
+	rawBootcPipeline := manifest.NewRawBootcImage(build, containers, pf)
 	rawBootcPipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
 	rawBootcPipeline.Users = []users.User{{Name: "root", Key: common.ToPtr("some-ssh-key")}}
 	rawBootcPipeline.KernelOptionsAppend = []string{"karg1", "karg2"}
@@ -74,8 +79,12 @@ func TestRawBootcImageSerializeMountsValidated(t *testing.T) {
 	mani := manifest.New()
 	runner := &runner.Linux{}
 	build := manifest.NewBuildFromContainer(&mani, runner, nil, nil)
+	pf := &platform.X86{
+		BasePlatform: platform.BasePlatform{},
+		UEFIVendor:   "test",
+	}
 
-	rawBootcPipeline := manifest.NewRawBootcImage(build, nil, nil)
+	rawBootcPipeline := manifest.NewRawBootcImage(build, nil, pf)
 	// note that we create a partition table without /boot here
 	rawBootcPipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/missing-boot")
 	rawBootcPipeline.SerializeStart(nil, []container.Spec{{Source: "foo"}}, nil, nil)
@@ -96,8 +105,12 @@ func findMountIdx(mounts []osbuild.Mount, mntType string) int {
 func makeFakeRawBootcPipeline() *manifest.RawBootcImage {
 	mani := manifest.New()
 	runner := &runner.Linux{}
+	pf := &platform.X86{
+		BasePlatform: platform.BasePlatform{},
+		UEFIVendor:   "test",
+	}
 	build := manifest.NewBuildFromContainer(&mani, runner, nil, nil)
-	rawBootcPipeline := manifest.NewRawBootcImage(build, nil, nil)
+	rawBootcPipeline := manifest.NewRawBootcImage(build, nil, pf)
 	rawBootcPipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
 	rawBootcPipeline.SerializeStart(nil, []container.Spec{{Source: "foo"}}, nil, nil)
 

--- a/pkg/manifest/raw_ostree.go
+++ b/pkg/manifest/raw_ostree.go
@@ -122,7 +122,7 @@ func (p *RawOSTreeImage) serialize() osbuild.Pipeline {
 func (p *RawOSTreeImage) addBootupdStage(pipeline *osbuild.Pipeline) {
 	pt := p.treePipeline.PartitionTable
 
-	treeBootupdDevices, treeBootupdMounts, err := osbuild.GenBootupdDevicesMounts(p.Filename(), pt)
+	treeBootupdDevices, treeBootupdMounts, err := osbuild.GenBootupdDevicesMounts(p.Filename(), pt, p.platform)
 	if err != nil {
 		panic(err)
 	}
@@ -138,7 +138,7 @@ func (p *RawOSTreeImage) addBootupdStage(pipeline *osbuild.Pipeline) {
 			Device: "disk",
 		}
 	}
-	bootupd, err := osbuild.NewBootupdStage(opts, treeBootupdDevices, treeBootupdMounts)
+	bootupd, err := osbuild.NewBootupdStage(opts, treeBootupdDevices, treeBootupdMounts, p.platform)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/osbuild/bootc_install_to_filesystem_stage.go
+++ b/pkg/osbuild/bootc_install_to_filesystem_stage.go
@@ -2,6 +2,8 @@ package osbuild
 
 import (
 	"fmt"
+
+	"github.com/osbuild/images/pkg/platform"
 )
 
 type BootcInstallToFilesystemOptions struct {
@@ -24,8 +26,8 @@ func (BootcInstallToFilesystemOptions) isStageOptions() {}
 // bootc/bootupd find and install all required bootloader bits.
 //
 // The mounts input should be generated with GenBootupdDevicesMounts.
-func NewBootcInstallToFilesystemStage(options *BootcInstallToFilesystemOptions, inputs ContainerDeployInputs, devices map[string]Device, mounts []Mount) (*Stage, error) {
-	if err := validateBootupdMounts(mounts); err != nil {
+func NewBootcInstallToFilesystemStage(options *BootcInstallToFilesystemOptions, inputs ContainerDeployInputs, devices map[string]Device, mounts []Mount, pltf platform.Platform) (*Stage, error) {
+	if err := validateBootupdMounts(mounts, pltf); err != nil {
 		return nil, err
 	}
 

--- a/pkg/osbuild/bootc_install_to_filesystem_stage_test.go
+++ b/pkg/osbuild/bootc_install_to_filesystem_stage_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/osbuild"
+	"github.com/osbuild/images/pkg/platform"
 )
 
 func makeFakeContainerInputs() osbuild.ContainerDeployInputs {
@@ -28,6 +29,10 @@ func TestBootcInstallToFilesystemStageNewHappy(t *testing.T) {
 	devices := makeOsbuildDevices("dev-for-/", "dev-for-/boot", "dev-for-/boot/efi")
 	mounts := makeOsbuildMounts("/", "/boot", "/boot/efi")
 	inputs := makeFakeContainerInputs()
+	pf := &platform.X86{
+		BasePlatform: platform.BasePlatform{},
+		UEFIVendor:   "test",
+	}
 
 	expectedStage := &osbuild.Stage{
 		Type:    "org.osbuild.bootc.install-to-filesystem",
@@ -36,7 +41,7 @@ func TestBootcInstallToFilesystemStageNewHappy(t *testing.T) {
 		Devices: devices,
 		Mounts:  mounts,
 	}
-	stage, err := osbuild.NewBootcInstallToFilesystemStage(nil, inputs, devices, mounts)
+	stage, err := osbuild.NewBootcInstallToFilesystemStage(nil, inputs, devices, mounts, pf)
 	require.Nil(t, err)
 	assert.Equal(t, stage, expectedStage)
 }
@@ -45,8 +50,12 @@ func TestBootcInstallToFilesystemStageNewNoContainers(t *testing.T) {
 	devices := makeOsbuildDevices("dev-for-/", "dev-for-/boot", "dev-for-/boot/efi")
 	mounts := makeOsbuildMounts("/", "/boot", "/boot/efi")
 	inputs := osbuild.ContainerDeployInputs{}
+	pf := &platform.X86{
+		BasePlatform: platform.BasePlatform{},
+		UEFIVendor:   "test",
+	}
 
-	_, err := osbuild.NewBootcInstallToFilesystemStage(nil, inputs, devices, mounts)
+	_, err := osbuild.NewBootcInstallToFilesystemStage(nil, inputs, devices, mounts, pf)
 	assert.EqualError(t, err, "expected exactly one container input but got: 0 (map[])")
 }
 
@@ -61,8 +70,12 @@ func TestBootcInstallToFilesystemStageNewTwoContainers(t *testing.T) {
 			},
 		},
 	}
+	pf := &platform.X86{
+		BasePlatform: platform.BasePlatform{},
+		UEFIVendor:   "test",
+	}
 
-	_, err := osbuild.NewBootcInstallToFilesystemStage(nil, inputs, devices, mounts)
+	_, err := osbuild.NewBootcInstallToFilesystemStage(nil, inputs, devices, mounts, pf)
 	assert.EqualError(t, err, "expected exactly one container input but got: 2 (map[1:{} 2:{}])")
 }
 
@@ -70,8 +83,12 @@ func TestBootcInstallToFilesystemStageMissingMounts(t *testing.T) {
 	devices := makeOsbuildDevices("dev-for-/")
 	mounts := makeOsbuildMounts("/")
 	inputs := makeFakeContainerInputs()
+	pf := &platform.X86{
+		BasePlatform: platform.BasePlatform{},
+		UEFIVendor:   "test",
+	}
 
-	stage, err := osbuild.NewBootcInstallToFilesystemStage(nil, inputs, devices, mounts)
+	stage, err := osbuild.NewBootcInstallToFilesystemStage(nil, inputs, devices, mounts, pf)
 	// XXX: rename error
 	assert.ErrorContains(t, err, "required mounts for bootupd stage [/boot /boot/efi] missing")
 	require.Nil(t, stage)
@@ -81,11 +98,15 @@ func TestBootcInstallToFilesystemStageJsonHappy(t *testing.T) {
 	devices := makeOsbuildDevices("disk", "dev-for-/", "dev-for-/boot", "dev-for-/boot/efi")
 	mounts := makeOsbuildMounts("/", "/boot", "/boot/efi")
 	inputs := makeFakeContainerInputs()
+	pf := &platform.X86{
+		BasePlatform: platform.BasePlatform{},
+		UEFIVendor:   "test",
+	}
 
 	opts := &osbuild.BootcInstallToFilesystemOptions{
 		TargetImgref: "quay.io/centos-bootc/centos-bootc-dev:stream9",
 	}
-	stage, err := osbuild.NewBootcInstallToFilesystemStage(opts, inputs, devices, mounts)
+	stage, err := osbuild.NewBootcInstallToFilesystemStage(opts, inputs, devices, mounts, pf)
 	require.Nil(t, err)
 	stageJson, err := json.MarshalIndent(stage, "", "  ")
 	require.Nil(t, err)


### PR DESCRIPTION
Currently, validateBootupdMounts always ensures that `/boot/efi` exists. This requirement is not necessary on non-UEFI platforms such as s390x.

This patch skips the check for `/boot/efi` when UEFIVendor is not set.

This change is required for this issue: https://github.com/osbuild/bootc-image-builder/issues/460
