### PR TITLE
github: disable the cron scheduled updates of the BIB ref (COMPOSER-2245)

### DIFF
--- a/.github/workflows/update-bootc-image-builder.yml
+++ b/.github/workflows/update-bootc-image-builder.yml
@@ -4,9 +4,10 @@ name: "Update bootc-image-builder ref"
 
 on:
   workflow_dispatch:
-  schedule:
-    # Every Sunday at 12:00
-    - cron: "0 12 * * 0"
+  # temporarily disabled until we fix the compatibility between bib and our bootc containers
+  # schedule:
+  #   # Every Sunday at 12:00
+  #   - cron: "0 12 * * 0"
 
 jobs:
   update-and-push:


### PR DESCRIPTION
Our bootc containers are incompatible with newer versions of the bootc-image-builder tool because the tool sets options that require composefs, which our images don't support yet.

Temporarily disable the update cronjob until we fix this.