### PR TITLE
Make sure the default kickstart path is used when the option is unset

### DIFF
--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -102,11 +102,14 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	bootTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
 	bootTreePipeline.ISOLabel = img.ISOLabel
 
-	ksPath := osbuild.KickstartPathOSBuild
-	if img.Kickstart != nil && img.Kickstart.Path != "" {
-		ksPath = img.Kickstart.Path
+	if img.Kickstart == nil {
+		img.Kickstart = &kickstart.Options{}
 	}
-	bootTreePipeline.KernelOpts = []string{fmt.Sprintf("inst.stage2=hd:LABEL=%s", img.ISOLabel), fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", img.ISOLabel, ksPath)}
+	if img.Kickstart.Path == "" {
+		img.Kickstart.Path = osbuild.KickstartPathOSBuild
+	}
+
+	bootTreePipeline.KernelOpts = []string{fmt.Sprintf("inst.stage2=hd:LABEL=%s", img.ISOLabel), fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", img.ISOLabel, img.Kickstart.Path)}
 	if img.FIPS {
 		bootTreePipeline.KernelOpts = append(bootTreePipeline.KernelOpts, "fips=1")
 	}

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -76,11 +76,6 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include
 	anacondaPipeline.ExcludePackages = img.ExtraBasePackages.Exclude
 	anacondaPipeline.ExtraRepos = img.ExtraBasePackages.Repositories
-	anacondaPipeline.InteractiveDefaultsKickstart = &kickstart.Options{
-		Users:  img.Kickstart.Users,
-		Groups: img.Kickstart.Groups,
-		Path:   osbuild.KickstartPathOSBuild,
-	}
 	anacondaPipeline.Variant = img.Variant
 	anacondaPipeline.Biosdevname = (img.Platform.GetArch() == arch.ARCH_X86_64)
 	anacondaPipeline.Checkpoint()

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -96,11 +96,13 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	bootTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
 	bootTreePipeline.ISOLabel = img.ISOLabel
 
-	ksPath := osbuild.KickstartPathOSBuild
-	if img.Kickstart != nil && img.Kickstart.Path != "" {
-		ksPath = img.Kickstart.Path
+	if img.Kickstart == nil || img.Kickstart.OSTree == nil {
+		return nil, fmt.Errorf("kickstart options not set for ostree installer")
 	}
-	bootTreePipeline.KernelOpts = []string{fmt.Sprintf("inst.stage2=hd:LABEL=%s", img.ISOLabel), fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", img.ISOLabel, ksPath)}
+	if img.Kickstart.Path == "" {
+		img.Kickstart.Path = osbuild.KickstartPathOSBuild
+	}
+	bootTreePipeline.KernelOpts = []string{fmt.Sprintf("inst.stage2=hd:LABEL=%s", img.ISOLabel), fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", img.ISOLabel, img.Kickstart.Path)}
 	if img.FIPS {
 		bootTreePipeline.KernelOpts = append(bootTreePipeline.KernelOpts, "fips=1")
 	}

--- a/pkg/image/installer_image_test.go
+++ b/pkg/image/installer_image_test.go
@@ -1,0 +1,130 @@
+package image_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/customizations/kickstart"
+	"github.com/osbuild/images/pkg/image"
+	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/ostree"
+	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/rpmmd"
+	"github.com/osbuild/images/pkg/runner"
+	"github.com/stretchr/testify/assert"
+)
+
+func mockPackageSets() map[string][]rpmmd.PackageSpec {
+	return map[string][]rpmmd.PackageSpec{
+		"build": {
+			{
+				Name:     "coreutils",
+				Checksum: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+			},
+		},
+		"os": {
+			{
+				Name:     "kernel",
+				Checksum: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			},
+		},
+		"anaconda-tree": {
+			{
+				Name:     "kernel",
+				Checksum: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			},
+		},
+	}
+}
+
+func mockContainerSpecs() map[string][]container.Spec {
+	return map[string][]container.Spec{
+		"bootiso-tree": {
+			{
+				Source:  "repo.example.com/container",
+				Digest:  "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				ImageID: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+		},
+	}
+}
+
+func mockOSTreeCommitSpecs() map[string][]ostree.CommitSpec {
+	return map[string][]ostree.CommitSpec{
+		"bootiso-tree": {
+			{
+				Ref: "test/ostree/3",
+				URL: "http://localhost:8080/repo",
+			},
+		},
+	}
+}
+
+var testPlatform = &platform.X86{
+	BasePlatform: platform.BasePlatform{
+		ImageFormat: platform.FORMAT_ISO,
+	},
+	BIOS:       true,
+	UEFIVendor: "test",
+}
+
+func TestContainerInstallerUnsetKSOptions(t *testing.T) {
+	img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+	assert.NotNil(t, img)
+	img.Platform = testPlatform
+	instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil)
+}
+
+func TestContainerInstallerUnsetKSPath(t *testing.T) {
+	img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+	assert.NotNil(t, img)
+	img.Platform = testPlatform
+	// set empty kickstart options (no path)
+	img.Kickstart = &kickstart.Options{}
+
+	instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil)
+}
+
+func TestOSTreeInstallerUnsetKSPath(t *testing.T) {
+	img := image.NewAnacondaOSTreeInstaller(ostree.SourceSpec{})
+	assert.NotNil(t, img)
+	img.Platform = testPlatform
+	img.Kickstart = &kickstart.Options{
+		// the ostree options must be non-nil
+		OSTree: &kickstart.OSTree{},
+	}
+
+	instantiateAndSerialize(t, img, mockPackageSets(), nil, mockOSTreeCommitSpecs())
+}
+
+func TestTarInstallerUnsetKSOptions(t *testing.T) {
+	img := image.NewAnacondaTarInstaller()
+	assert.NotNil(t, img)
+	img.Platform = testPlatform
+
+	instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
+}
+
+func TestTarInstallerUnsetKSPath(t *testing.T) {
+	img := image.NewAnacondaTarInstaller()
+	assert.NotNil(t, img)
+	img.Platform = testPlatform
+	img.Kickstart = &kickstart.Options{}
+
+	instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
+}
+
+func instantiateAndSerialize(t *testing.T, img image.ImageKind, packages map[string][]rpmmd.PackageSpec, containers map[string][]container.Spec, commits map[string][]ostree.CommitSpec) {
+	source := rand.NewSource(int64(0))
+	// math/rand is good enough in this case
+	/* #nosec G404 */
+	rng := rand.New(source)
+
+	mf := manifest.New()
+	_, err := img.InstantiateManifest(&mf, nil, &runner.CentOS{Version: 9}, rng)
+	assert.NoError(t, err)
+
+	_, err = mf.Serialize(packages, containers, commits, nil)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
**image: allow unset kickstart options where possible**

For the AnacondaContainerInstaller, having empty kickstart options when
creating the ImageKind should be possible.  The only option that's
required is the Kickstart.Path, which has a default value we can set.

For the AnacondaOSTreeInstaller, at least the OSTree options are
required, so return an error when they're not set, but also set the
Kickstart.Path to the default when it's not already set from the caller.

---

**image: drop InteractiveDefaultKickstart in AnacondaContainerInstaller**

This isn't used and can cause unnecessary errors when 'img.Kickstart' is
not set.

---

**test: instantiate and serialize anaconda manifests without ks options**

Test that anaconda manifests can be generated without error when
kickstart options are not set (or when only the required ones are set).
This ensures that no errors or panics occur when the kickstart options
are nil or when the kickstart path is empty.

---


Fixes #763