### PR TITLE
test/data: update gce rpmrepo snapshots

### DIFF
--- a/test/data/repositories/centos-9.json
+++ b/test/data/repositories/centos-9.json
@@ -80,7 +80,7 @@
     },
     {
       "name": "google-compute-engine",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-compute-engine-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-compute-engine-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce"
@@ -88,7 +88,7 @@
     },
     {
       "name": "google-cloud-sdk",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-cloud-sdk-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-cloud-sdk-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce"

--- a/test/data/repositories/rhel-8.10.json
+++ b/test/data/repositories/rhel-8.10.json
@@ -119,7 +119,7 @@
     },
     {
       "name": "google-compute-engine",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-compute-engine-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-compute-engine-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",
@@ -128,7 +128,7 @@
     },
     {
       "name": "google-cloud-sdk",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-cloud-sdk-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-cloud-sdk-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",

--- a/test/data/repositories/rhel-8.4.json
+++ b/test/data/repositories/rhel-8.4.json
@@ -111,7 +111,7 @@
     },
     {
       "name": "google-compute-engine",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-compute-engine-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-compute-engine-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",
@@ -120,7 +120,7 @@
     },
     {
       "name": "google-cloud-sdk",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-cloud-sdk-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-cloud-sdk-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",

--- a/test/data/repositories/rhel-8.5.json
+++ b/test/data/repositories/rhel-8.5.json
@@ -63,7 +63,7 @@
     },
     {
       "name": "google-compute-engine",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-compute-engine-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-compute-engine-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",
@@ -72,7 +72,7 @@
     },
     {
       "name": "google-cloud-sdk",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-cloud-sdk-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-cloud-sdk-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",

--- a/test/data/repositories/rhel-8.6.json
+++ b/test/data/repositories/rhel-8.6.json
@@ -112,7 +112,7 @@
     },
     {
       "name": "google-compute-engine",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-compute-engine-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-compute-engine-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",
@@ -121,7 +121,7 @@
     },
     {
       "name": "google-cloud-sdk",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-cloud-sdk-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-cloud-sdk-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",

--- a/test/data/repositories/rhel-8.7.json
+++ b/test/data/repositories/rhel-8.7.json
@@ -111,7 +111,7 @@
     },
     {
       "name": "google-compute-engine",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-compute-engine-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-compute-engine-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",
@@ -120,7 +120,7 @@
     },
     {
       "name": "google-cloud-sdk",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-cloud-sdk-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-cloud-sdk-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",

--- a/test/data/repositories/rhel-8.8.json
+++ b/test/data/repositories/rhel-8.8.json
@@ -111,7 +111,7 @@
     },
     {
       "name": "google-compute-engine",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-compute-engine-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-compute-engine-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",
@@ -120,7 +120,7 @@
     },
     {
       "name": "google-cloud-sdk",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-cloud-sdk-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-cloud-sdk-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",

--- a/test/data/repositories/rhel-8.9.json
+++ b/test/data/repositories/rhel-8.9.json
@@ -119,7 +119,7 @@
     },
     {
       "name": "google-compute-engine",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-compute-engine-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-compute-engine-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",
@@ -128,7 +128,7 @@
     },
     {
       "name": "google-cloud-sdk",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-cloud-sdk-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-cloud-sdk-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",

--- a/test/data/repositories/rhel-9.0.json
+++ b/test/data/repositories/rhel-9.0.json
@@ -176,7 +176,7 @@
     },
     {
       "name": "google-compute-engine",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-compute-engine-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-compute-engine-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",
@@ -185,7 +185,7 @@
     },
     {
       "name": "google-cloud-sdk",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-cloud-sdk-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-cloud-sdk-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",

--- a/test/data/repositories/rhel-9.1.json
+++ b/test/data/repositories/rhel-9.1.json
@@ -189,7 +189,7 @@
     },
     {
       "name": "google-compute-engine",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-compute-engine-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-compute-engine-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",
@@ -198,7 +198,7 @@
     },
     {
       "name": "google-cloud-sdk",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-cloud-sdk-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-cloud-sdk-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",

--- a/test/data/repositories/rhel-9.2.json
+++ b/test/data/repositories/rhel-9.2.json
@@ -189,7 +189,7 @@
     },
     {
       "name": "google-compute-engine",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-compute-engine-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-compute-engine-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",
@@ -198,7 +198,7 @@
     },
     {
       "name": "google-cloud-sdk",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-cloud-sdk-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-cloud-sdk-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",

--- a/test/data/repositories/rhel-9.3.json
+++ b/test/data/repositories/rhel-9.3.json
@@ -189,7 +189,7 @@
     },
     {
       "name": "google-compute-engine",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-compute-engine-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-compute-engine-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",
@@ -198,7 +198,7 @@
     },
     {
       "name": "google-cloud-sdk",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-cloud-sdk-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-cloud-sdk-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",

--- a/test/data/repositories/rhel-9.4.json
+++ b/test/data/repositories/rhel-9.4.json
@@ -189,7 +189,7 @@
     },
     {
       "name": "google-compute-engine",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-compute-engine-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-compute-engine-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",
@@ -198,7 +198,7 @@
     },
     {
       "name": "google-cloud-sdk",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-cloud-sdk-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-cloud-sdk-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",

--- a/test/data/repositories/rhel-9.5.json
+++ b/test/data/repositories/rhel-9.5.json
@@ -189,7 +189,7 @@
     },
     {
       "name": "google-compute-engine",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-compute-engine-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-compute-engine-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",
@@ -198,7 +198,7 @@
     },
     {
       "name": "google-cloud-sdk",
-      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-cloud-sdk-20240515",
+      "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/el9-x86_64-google-cloud-sdk-20240522",
       "check_gpg": false,
       "image_type_tags": [
         "gce",


### PR DESCRIPTION
The snapshots for gce rpm repos started breaking as the repos could not be found. Update the snapshots. I just bumped it to the next avaiilable snapshot.