### PR TITLE
distro/fedora: drop oscap-anaconda-addon from anacondaPackageSet

### DIFF
--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -428,7 +428,6 @@ func anacondaPackageSet(t *imageType) rpmmd.PackageSet {
 			"nss-tools",
 			"openssh-clients",
 			"openssh-server",
-			"oscap-anaconda-addon",
 			"ostree",
 			"pciutils",
 			"perl-interpreter",


### PR DESCRIPTION
Drop `oscap-anaconda-addon` from `anacondaPackageSet` in Fedora. It's currently breaking the [Fedora IoT Rawhide compose](https://koji.fedoraproject.org/koji/taskinfo?taskID=119644972), and not included in other Fedora ISO's. 