### PR TITLE
disk: support json unmarshal for Partition

### DIFF
--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -3,8 +3,9 @@ package disk_test
 import (
 	"testing"
 
-	"github.com/osbuild/images/internal/testdisk"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/internal/testdisk"
 )
 
 func TestPartitionTable_GetMountpointSize(t *testing.T) {

--- a/pkg/disk/partition_test.go
+++ b/pkg/disk/partition_test.go
@@ -1,0 +1,62 @@
+package disk_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/internal/testdisk"
+	"github.com/osbuild/images/pkg/disk"
+)
+
+func TestMarshalUnmarshalSimple(t *testing.T) {
+	fakePt := testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
+
+	js, err := json.Marshal(fakePt)
+	assert.NoError(t, err)
+
+	var ptFromJS disk.PartitionTable
+	err = json.Unmarshal(js, &ptFromJS)
+	assert.NoError(t, err)
+	assert.Equal(t, fakePt, &ptFromJS)
+}
+
+func TestMarshalUnmarshalSad(t *testing.T) {
+	var part disk.Partition
+	err := json.Unmarshal([]byte(`{"randon": "json"}`), &part)
+	assert.ErrorContains(t, err, `cannot build partition from "{`)
+}
+
+func TestMarshalUnmarshalPartitionHappy(t *testing.T) {
+	part := &disk.Partition{}
+
+	for _, ent := range []disk.Entity{
+		&disk.Filesystem{Type: "ext2"},
+		&disk.LUKSContainer{Passphrase: "secret"},
+		&disk.Btrfs{Label: "foo"},
+		&disk.LVMVolumeGroup{Name: "bar"},
+	} {
+		part.Payload = ent
+		js, err := json.Marshal(part)
+		assert.NoError(t, err)
+
+		var partFromJS disk.Partition
+		err = json.Unmarshal(js, &partFromJS)
+		assert.NoError(t, err)
+		assert.Equal(t, part, &partFromJS)
+	}
+}
+
+func TestUnmarshalNullPayload(t *testing.T) {
+	part := &disk.Partition{}
+	part.Payload = nil
+
+	js, err := json.Marshal(part)
+	assert.NoError(t, err)
+
+	var partFromJS disk.Partition
+	err = json.Unmarshal(js, &partFromJS)
+	assert.NoError(t, err)
+	assert.Equal(t, part, &partFromJS)
+}


### PR DESCRIPTION
The `disk.Partition` uses interfaces inside the data structure. To support json unmarshal we need a custom `{Unm,M}arshalJSON()` that peeks into the marshalled json and detects what concrete type to use.

This commit provides the `disk.Partition.{Unm,M}arshalJSON` implementation and matching tests.

Another alternative version for https://github.com/osbuild/images/pull/737

Split out from https://github.com/osbuild/images/pull/732 with extra test.

Draft until I find a little bit more time to make the tests a bit more comprehensive and until the other payloads are supported.