### PR TITLE
bootupd: Don't require /boot mount point

### DIFF
--- a/pkg/manifest/raw_bootc_test.go
+++ b/pkg/manifest/raw_bootc_test.go
@@ -88,7 +88,7 @@ func TestRawBootcImageSerializeMountsValidated(t *testing.T) {
 	// note that we create a partition table without /boot here
 	rawBootcPipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/missing-boot")
 	rawBootcPipeline.SerializeStart(nil, []container.Spec{{Source: "foo"}}, nil, nil)
-	assert.PanicsWithError(t, `required mounts for bootupd stage [/boot /boot/efi] missing`, func() {
+	assert.PanicsWithError(t, `required mounts for bootupd stage [/boot/efi] missing`, func() {
 		rawBootcPipeline.Serialize()
 	})
 }

--- a/pkg/osbuild/bootc_install_to_filesystem_stage_test.go
+++ b/pkg/osbuild/bootc_install_to_filesystem_stage_test.go
@@ -90,7 +90,7 @@ func TestBootcInstallToFilesystemStageMissingMounts(t *testing.T) {
 
 	stage, err := osbuild.NewBootcInstallToFilesystemStage(nil, inputs, devices, mounts, pf)
 	// XXX: rename error
-	assert.ErrorContains(t, err, "required mounts for bootupd stage [/boot /boot/efi] missing")
+	assert.ErrorContains(t, err, "required mounts for bootupd stage [/boot/efi] missing")
 	require.Nil(t, stage)
 }
 

--- a/pkg/osbuild/bootupd_stage.go
+++ b/pkg/osbuild/bootupd_stage.go
@@ -41,8 +41,7 @@ func (opts *BootupdStageOptions) validate(devices map[string]Device) error {
 // to find all the bootloader configs
 func validateBootupdMounts(mounts []Mount, pf platform.Platform) error {
 	requiredMounts := map[string]bool{
-		"/":     true,
-		"/boot": true,
+		"/": true,
 	}
 	if pf.GetUEFIVendor() != "" {
 		requiredMounts["/boot/efi"] = true

--- a/pkg/osbuild/bootupd_stage_test.go
+++ b/pkg/osbuild/bootupd_stage_test.go
@@ -70,7 +70,7 @@ func TestBootupdStageMissingMounts(t *testing.T) {
 	}
 
 	stage, err := osbuild.NewBootupdStage(opts, devices, mounts, pf)
-	assert.ErrorContains(t, err, "required mounts for bootupd stage [/boot /boot/efi] missing")
+	assert.ErrorContains(t, err, "required mounts for bootupd stage [/boot/efi] missing")
 	require.Nil(t, stage)
 }
 
@@ -171,7 +171,7 @@ func TestGenBootupdDevicesMountsMissingRoot(t *testing.T) {
 		UEFIVendor:   "test",
 	}
 	_, _, err := osbuild.GenBootupdDevicesMounts(filename, pt, pf)
-	assert.EqualError(t, err, "required mounts for bootupd stage [/ /boot /boot/efi] missing")
+	assert.EqualError(t, err, "required mounts for bootupd stage [/ /boot/efi] missing")
 }
 
 func TestGenBootupdDevicesMountsUnexpectedEntity(t *testing.T) {


### PR DESCRIPTION
I'd like to change bib to just drop the separate `/boot` partition by default because it isn't doing anything useful right now.

A separate `/boot` is only useful with things like LUKS or LVM, but since bib doesn't do those now and it's not in the near term roadmap clearly either, let's just not add the complexity of a separate `/boot` by default.