### PR TITLE
Fix kickstart path handling in AnacondaInstaller

### DIFF
--- a/pkg/image/installer_image_test.go
+++ b/pkg/image/installer_image_test.go
@@ -154,6 +154,12 @@ func TestTarInstallerUnsetKSPath(t *testing.T) {
 	// interactive-defaults.ks is used
 	assert.Contains(t, mfs, fmt.Sprintf(`"inst.stage2=hd:LABEL=%s"`, isolabel))
 	assert.Contains(t, mfs, fmt.Sprintf("%q", osbuild.KickstartPathInteractiveDefaults))
+
+	// enable unattended and retest
+	img.Kickstart.Unattended = true
+	mfs = instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
+	assert.Contains(t, mfs, fmt.Sprintf(`"inst.ks=hd:LABEL=%s:/osbuild.ks"`, isolabel))
+	assert.NotContains(t, mfs, osbuild.KickstartPathInteractiveDefaults)
 }
 
 func instantiateAndSerialize(t *testing.T, img image.ImageKind, packages map[string][]rpmmd.PackageSpec, containers map[string][]container.Spec, commits map[string][]ostree.CommitSpec) string {

--- a/pkg/image/installer_image_test.go
+++ b/pkg/image/installer_image_test.go
@@ -69,8 +69,18 @@ var testPlatform = &platform.X86{
 	UEFIVendor: "test",
 }
 
+const (
+	product   = "Fedora"
+	osversion = "40"
+	isolabel  = "Fedora-40-Workstation-x86_64"
+)
+
 func TestContainerInstallerUnsetKSOptions(t *testing.T) {
 	img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+	img.Product = product
+	img.OSVersion = osversion
+	img.ISOLabel = isolabel
+
 	assert.NotNil(t, img)
 	img.Platform = testPlatform
 	instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil)
@@ -78,6 +88,10 @@ func TestContainerInstallerUnsetKSOptions(t *testing.T) {
 
 func TestContainerInstallerUnsetKSPath(t *testing.T) {
 	img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+	img.Product = product
+	img.OSVersion = osversion
+	img.ISOLabel = isolabel
+
 	assert.NotNil(t, img)
 	img.Platform = testPlatform
 	// set empty kickstart options (no path)
@@ -88,6 +102,10 @@ func TestContainerInstallerUnsetKSPath(t *testing.T) {
 
 func TestOSTreeInstallerUnsetKSPath(t *testing.T) {
 	img := image.NewAnacondaOSTreeInstaller(ostree.SourceSpec{})
+	img.Product = product
+	img.OSVersion = osversion
+	img.ISOLabel = isolabel
+
 	assert.NotNil(t, img)
 	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{
@@ -100,6 +118,10 @@ func TestOSTreeInstallerUnsetKSPath(t *testing.T) {
 
 func TestTarInstallerUnsetKSOptions(t *testing.T) {
 	img := image.NewAnacondaTarInstaller()
+	img.Product = product
+	img.OSVersion = osversion
+	img.ISOLabel = isolabel
+
 	assert.NotNil(t, img)
 	img.Platform = testPlatform
 
@@ -108,6 +130,10 @@ func TestTarInstallerUnsetKSOptions(t *testing.T) {
 
 func TestTarInstallerUnsetKSPath(t *testing.T) {
 	img := image.NewAnacondaTarInstaller()
+	img.Product = product
+	img.OSVersion = osversion
+	img.ISOLabel = isolabel
+
 	assert.NotNil(t, img)
 	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{}

--- a/pkg/osbuild/grub_iso_stage.go
+++ b/pkg/osbuild/grub_iso_stage.go
@@ -1,5 +1,9 @@
 package osbuild
 
+import "fmt"
+
+const grubisoStageType = "org.osbuild.grub2.iso"
+
 type GrubISOStageOptions struct {
 	Product Product `json:"product"`
 
@@ -14,6 +18,30 @@ type GrubISOStageOptions struct {
 
 func (GrubISOStageOptions) isStageOptions() {}
 
+func (o GrubISOStageOptions) validate() error {
+	// The stage schema marks product.name, product.version, kernel.dir, and
+	// isolabel as required.  Empty values are technically valid according to
+	// the schema, but here we will consider them invalid.
+
+	if o.Product.Name == "" {
+		return fmt.Errorf("%s: product.name option is required", grubisoStageType)
+	}
+
+	if o.Product.Version == "" {
+		return fmt.Errorf("%s: product.version option is required", grubisoStageType)
+	}
+
+	if o.Kernel.Dir == "" {
+		return fmt.Errorf("%s: kernel.dir option is required", grubisoStageType)
+	}
+
+	if o.ISOLabel == "" {
+		return fmt.Errorf("%s: isolabel option is required", grubisoStageType)
+	}
+
+	return nil
+}
+
 type ISOKernel struct {
 	Dir string `json:"dir"`
 
@@ -23,8 +51,11 @@ type ISOKernel struct {
 
 // Assemble a file system tree for a bootable ISO
 func NewGrubISOStage(options *GrubISOStageOptions) *Stage {
+	if err := options.validate(); err != nil {
+		panic(err)
+	}
 	return &Stage{
-		Type:    "org.osbuild.grub2.iso",
+		Type:    grubisoStageType,
 		Options: options,
 	}
 }

--- a/pkg/osbuild/grub_iso_stage_test.go
+++ b/pkg/osbuild/grub_iso_stage_test.go
@@ -1,0 +1,92 @@
+package osbuild_test
+
+import (
+	"testing"
+
+	"github.com/osbuild/images/pkg/osbuild"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGrubIsoStageValidation(t *testing.T) {
+	type testCase struct {
+		options       osbuild.GrubISOStageOptions
+		expectedError string
+	}
+
+	testCases := map[string]testCase{
+		"happy": {
+			options: osbuild.GrubISOStageOptions{
+				Product: osbuild.Product{
+					Name:    "whatever",
+					Version: "42",
+				},
+				Kernel: osbuild.ISOKernel{
+					Dir: "/path",
+				},
+				ISOLabel: "whatever-42-workstation",
+			},
+		},
+		"no product name": {
+			options: osbuild.GrubISOStageOptions{
+				Product: osbuild.Product{
+					Version: "42",
+				},
+				Kernel: osbuild.ISOKernel{
+					Dir: "/path",
+				},
+				ISOLabel: "whatever-42-workstation",
+			},
+			expectedError: "org.osbuild.grub2.iso: product.name option is required",
+		},
+		"no product version": {
+			options: osbuild.GrubISOStageOptions{
+				Product: osbuild.Product{
+					Name: "whatever",
+				},
+				Kernel: osbuild.ISOKernel{
+					Dir: "/path",
+				},
+				ISOLabel: "whatever-42-workstation",
+			},
+			expectedError: "org.osbuild.grub2.iso: product.version option is required",
+		},
+		"no kernel dir": {
+			options: osbuild.GrubISOStageOptions{
+				Product: osbuild.Product{
+					Name:    "whatever",
+					Version: "13",
+				},
+				Kernel:   osbuild.ISOKernel{},
+				ISOLabel: "whatever-42-workstation",
+			},
+			expectedError: "org.osbuild.grub2.iso: kernel.dir option is required",
+		},
+		"no isolabel": {
+			options: osbuild.GrubISOStageOptions{
+				Product: osbuild.Product{
+					Name:    "whatever",
+					Version: "13",
+				},
+				Kernel: osbuild.ISOKernel{
+					Dir: "/doesnt/matter",
+				},
+			},
+			expectedError: "org.osbuild.grub2.iso: isolabel option is required",
+		},
+	}
+
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
+			if tc.expectedError == "" {
+				assert.NotPanics(t, func() { osbuild.NewGrubISOStage(&tc.options) })
+			} else {
+				assert.PanicsWithError(
+					t,
+					tc.expectedError,
+					func() { osbuild.NewGrubISOStage(&tc.options) },
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #764.

This PR mainly fixes the handling of the kickstart path in AnacondaInstaller.  The fallback logic for unset kickstart paths was a bit buggy, but we never noticed because we never really set the value to anything else.  Tests have now been added and the buggy logic has been fixed.

I also added validation to the grub2.iso stage options, which ensures that certain ISO values are not unset (Product, Version, ISOLabel).