### PR TITLE
OpenSCAP XML tailoring (HMS-4386)

### DIFF
--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -114,14 +114,20 @@ type ServicesCustomization struct {
 }
 
 type OpenSCAPCustomization struct {
-	DataStream string                           `json:"datastream,omitempty" toml:"datastream,omitempty"`
-	ProfileID  string                           `json:"profile_id,omitempty" toml:"profile_id,omitempty"`
-	Tailoring  *OpenSCAPTailoringCustomizations `json:"tailoring,omitempty" toml:"tailoring,omitempty"`
+	DataStream   string                              `json:"datastream,omitempty" toml:"datastream,omitempty"`
+	ProfileID    string                              `json:"profile_id,omitempty" toml:"profile_id,omitempty"`
+	Tailoring    *OpenSCAPTailoringCustomizations    `json:"tailoring,omitempty" toml:"tailoring,omitempty"`
+	XMLTailoring *OpenSCAPXMLTailoringCustomizations `json:"xml_tailoring,omitempty" toml:"xml_tailoring,omitempty"`
 }
 
 type OpenSCAPTailoringCustomizations struct {
 	Selected   []string `json:"selected,omitempty" toml:"selected,omitempty"`
 	Unselected []string `json:"unselected,omitempty" toml:"unselected,omitempty"`
+}
+
+type OpenSCAPXMLTailoringCustomizations struct {
+	ProfileID string `json:"profile_id,omitempty" toml:"profile_id,omitempty"`
+	Filepath  string `json:"filepath,omitempty" toml:"filepath,omitempty"`
 }
 
 // Configure the container storage separately from containers, since we most likely would

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -3,7 +3,6 @@ package fedora
 import (
 	"fmt"
 	"math/rand"
-	"path/filepath"
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/workload"
@@ -190,37 +189,13 @@ func osCustomizations(
 		}
 		osc.Directories = append(osc.Directories, oscapDataNode)
 
-		var datastream = oscapConfig.DataStream
-		if datastream == "" {
-			if imageConfig.DefaultOSCAPDatastream == nil {
-				return manifest.OSCustomizations{}, fmt.Errorf("No OSCAP datastream specified and the distro does not have any default set")
-			}
-			datastream = *imageConfig.DefaultOSCAPDatastream
-		}
-
-		remediationConfig := oscap.RemediationConfig{
-			Datastream:         datastream,
-			ProfileID:          oscapConfig.ProfileID,
-			CompressionEnabled: true,
-		}
-
-		var tailoringConfig *oscap.TailoringConfig
-		if oscapConfig.Tailoring != nil {
-			remediationConfig.TailoringPath = filepath.Join(oscap.DataDir, "tailoring.xml")
-			tailoringConfig = &oscap.TailoringConfig{
-				RemediationConfig: remediationConfig,
-				TailoredProfileID: fmt.Sprintf("%s_osbuild_tailoring", oscapConfig.ProfileID),
-				Selected:          oscapConfig.Tailoring.Selected,
-				Unselected:        oscapConfig.Tailoring.Unselected,
-			}
-			// we need to set this after the tailoring config
-			// since the tailoring config needs to know about both
-			// the base profile id and the tailored profile id
-			remediationConfig.ProfileID = tailoringConfig.TailoredProfileID
+		remediationConfig, tailoringConfig, err := oscap.NewConfigs(*oscapConfig, imageConfig.DefaultOSCAPDatastream)
+		if err != nil {
+			panic(fmt.Errorf("error creating OpenSCAP configs: %w", err))
 		}
 
 		osc.OpenSCAPTailorConfig = tailoringConfig
-		osc.OpenSCAPRemediationConfig = &remediationConfig
+		osc.OpenSCAPRemediationConfig = remediationConfig
 	}
 
 	osc.ShellInit = imageConfig.ShellInit

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -196,7 +196,23 @@
       "ami"
     ]
   },
+  "./configs/oscap-rhel8-with-xml-tailoring.json": {
+    "distros": [
+      "rhel-8.10"
+    ],
+    "image-types": [
+      "ami"
+    ]
+  },
   "./configs/oscap-rhel9.json": {
+    "distros": [
+      "rhel-9.4"
+    ],
+    "image-types": [
+      "ami"
+    ]
+  },
+  "./configs/oscap-rhel9-with-xml-tailoring.json": {
     "distros": [
       "rhel-9.4"
     ],

--- a/test/configs/oscap-rhel8-with-xml-tailoring.json
+++ b/test/configs/oscap-rhel8-with-xml-tailoring.json
@@ -1,0 +1,32 @@
+{
+  "name": "oscap-rhel8-with-xml-tailoring",
+  "blueprint": {
+    "packages": [
+      {
+        "name": "xmlstarlet"
+      },
+      {
+        "name": "openscap-utils"
+      },
+      {
+        "name": "jq"
+      }
+    ],
+    "customizations": {
+      "files": [
+        {
+          "path": "/oscap_data/tailoring.xml",
+          "data": "<?xml version='1.0' ?>\n<ns0:Tailoring xmlns:ns0='http://checklists.nist.gov/xccdf/1.2' id='xccdf_auto_tailoring_default'>\n\t<ns0:benchmark href='file:///usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml'/>\n\t<ns0:version time='2024-07-03T13:13:48.909893'>1</ns0:version>\n\t<ns0:Profile id='xccdf_org.ssgproject.content_profile_cis_osbuild_tailoring' extends='xccdf_org.ssgproject.content_profile_cis'>\n\t\t<ns0:title override='true'>cis_osbuild_tailoring</ns0:title>\n\t\t<ns0:select idref='xccdf_org.ssgproject.content_rule_grub2_password' selected='false'/>\n\t\t<ns0:select idref='xccdf_org.ssgproject.content_rule_grub2_uefi_password' selected='false'/>\n\t\t<ns0:select idref='xccdf_org.ssgproject.content_rule_partition_for_dev_shm' selected='false'/>\n\t\t<ns0:select idref='xccdf_org.ssgproject.content_rule_mount_option_dev_shm_nosuid' selected='false'/>\n\t\t<ns0:select idref='xccdf_org.ssgproject.content_rule_mount_option_dev_shm_noexec' selected='false'/>\n\t\t<ns0:select idref='xccdf_org.ssgproject.content_rule_mount_option_dev_shm_nodev' selected='false'/>\n\t</ns0:Profile>\n</ns0:Tailoring>"
+        }
+      ],
+      "openscap": {
+        "profile_id": "xccdf_org.ssgproject.content_profile_cis",
+        "datastream": "/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml",
+        "xml_tailoring": {
+          "profile_id": "xccdf_org.ssgproject.content_profile_cis_osbuild_tailoring",
+          "filepath": "/oscap_data/tailoring.xml"
+        }
+      }
+    }
+  }
+}

--- a/test/configs/oscap-rhel9-with-xml-tailoring.json
+++ b/test/configs/oscap-rhel9-with-xml-tailoring.json
@@ -1,0 +1,32 @@
+{
+  "name": "oscap-rhel9-with-xml-tailoring",
+  "blueprint": {
+    "packages": [
+      {
+        "name": "xmlstarlet"
+      },
+      {
+        "name": "openscap-utils"
+      },
+      {
+        "name": "jq"
+      }
+    ],
+    "customizations": {
+      "files": [
+        {
+          "path": "/oscap_data/tailoring.xml",
+          "data": "<?xml version='1.0' ?>\n<ns0:Tailoring xmlns:ns0='http://checklists.nist.gov/xccdf/1.2' id='xccdf_auto_tailoring_default'>\n\t<ns0:benchmark href='file:///usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml'/>\n\t<ns0:version time='2024-07-03T13:13:48.909893'>1</ns0:version>\n\t<ns0:Profile id='xccdf_org.ssgproject.content_profile_cis_osbuild_tailoring' extends='xccdf_org.ssgproject.content_profile_cis'>\n\t\t<ns0:title override='true'>cis_osbuild_tailoring</ns0:title>\n\t\t<ns0:select idref='xccdf_org.ssgproject.content_rule_grub2_password' selected='false'/>\n\t\t<ns0:select idref='xccdf_org.ssgproject.content_rule_grub2_uefi_password' selected='false'/>\n\t\t<ns0:select idref='xccdf_org.ssgproject.content_rule_partition_for_dev_shm' selected='false'/>\n\t\t<ns0:select idref='xccdf_org.ssgproject.content_rule_mount_option_dev_shm_nosuid' selected='false'/>\n\t\t<ns0:select idref='xccdf_org.ssgproject.content_rule_mount_option_dev_shm_noexec' selected='false'/>\n\t\t<ns0:select idref='xccdf_org.ssgproject.content_rule_mount_option_dev_shm_nodev' selected='false'/>\n\t</ns0:Profile>\n</ns0:Tailoring>"
+        }
+      ],
+      "openscap": {
+        "profile_id": "xccdf_org.ssgproject.content_profile_cis",
+        "datastream": "/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml",
+        "xml_tailoring": {
+          "profile_id": "xccdf_org.ssgproject.content_profile_cis_osbuild_tailoring",
+          "filepath": "/oscap_data/tailoring.xml"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
If the user supplies an xml tailoring file, we can skip the autotailor
stage - since the autotailor stage just generates the xml file. In this
case we can just set the tailoring config to `nil` and ensure that the
remediation configs have the correct values.