### PR TITLE
Schutzfile: move to latest osbuild with curl --parallel support

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -24,43 +24,7 @@
       "osbuild": {
         "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
-    },
-    "repos": [
-      {
-        "file": "/etc/yum.repos.d/fedora.repo",
-        "x86_64": [
-          {
-            "title": "fedora",
-            "name": "fedora",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-fedora-20231109"
-          }
-        ],
-        "aarch64": [
-          {
-            "title": "fedora",
-            "name": "fedora",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-fedora-20231109"
-          }
-        ]
-      },
-      {
-        "file": "/etc/yum.repos.d/fedora-updates.repo",
-        "x86_64": [
-          {
-            "title": "updates",
-            "name": "updates",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-updates-released-20240515"
-          }
-        ],
-        "aarch64": [
-          {
-            "title": "updates",
-            "name": "updates",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-updates-released-20240515"
-          }
-        ]
-      }
-    ]
+    }
   },
   "fedora-40": {
     "dependencies": {
@@ -92,14 +56,14 @@
           {
             "title": "updates",
             "name": "updates",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-x86_64-updates-released-20240515"
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-x86_64-updates-released-20240626"
           }
         ],
         "aarch64": [
           {
             "title": "updates",
             "name": "updates",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-aarch64-updates-released-20240515"
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-aarch64-updates-released-20240626"
           }
         ]
       }

--- a/Schutzfile
+++ b/Schutzfile
@@ -8,21 +8,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "ab711cb63070ec34fbd4051440b86f6a3ed95b0d"
+        "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "ab711cb63070ec34fbd4051440b86f6a3ed95b0d"
+        "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
     }
   },
   "fedora-39": {
     "dependencies": {
       "osbuild": {
-        "commit": "ab711cb63070ec34fbd4051440b86f6a3ed95b0d"
+        "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
     },
     "repos": [
@@ -65,7 +65,7 @@
   "fedora-40": {
     "dependencies": {
       "osbuild": {
-        "commit": "ab711cb63070ec34fbd4051440b86f6a3ed95b0d"
+        "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
     },
     "repos": [


### PR DESCRIPTION
This commit updates osbuild so that we benefit from osbuild PR#1573 to enable curl --parallel. This should speed up downloading especially on fast connections as less time is spend with the connection setup/handshake etc.

Similar to https://github.com/osbuild/osbuild-composer/pull/4247