### PR TITLE
cmd: add `otk-make-fstab-stage` helper

### DIFF
--- a/cmd/otk-make-fstab-stage/export_test.go
+++ b/cmd/otk-make-fstab-stage/export_test.go
@@ -1,0 +1,3 @@
+package main
+
+var Run = run

--- a/cmd/otk-make-fstab-stage/main.go
+++ b/cmd/otk-make-fstab-stage/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/osbuild/images/pkg/osbuild"
+
+	"github.com/osbuild/images/internal/otkdisk"
+)
+
+type Input = otkdisk.Data
+
+func makeFstabStages(inp Input) (stages *osbuild.Stage, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("cannot generate image prepare stages: %v", r)
+		}
+	}()
+
+	pt := inp.Const.Internal.PartitionTable
+	fstabStage := osbuild.NewFSTabStage(osbuild.NewFSTabStageOptions(pt))
+	return fstabStage, nil
+}
+
+func run(r io.Reader, w io.Writer) error {
+	var inp Input
+	if err := json.NewDecoder(r).Decode(&inp); err != nil {
+		return err
+	}
+
+	stage, err := makeFstabStages(inp)
+	if err != nil {
+		return fmt.Errorf("cannot make partition stages: %w", err)
+	}
+
+	outputJson, err := json.MarshalIndent(stage, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cannot marshal response: %w", err)
+	}
+	fmt.Fprintf(w, "%s\n", outputJson)
+	return nil
+}
+
+func main() {
+	if err := run(os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v", err.Error())
+		os.Exit(1)
+	}
+}

--- a/cmd/otk-make-fstab-stage/main_test.go
+++ b/cmd/otk-make-fstab-stage/main_test.go
@@ -1,0 +1,60 @@
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	makefstab "github.com/osbuild/images/cmd/otk-make-fstab-stage"
+	"github.com/osbuild/images/internal/otkdisk"
+	"github.com/osbuild/images/internal/testdisk"
+)
+
+// this is not symetrical to the output, this is sad but also
+// okay because the input is really just a dump of the internal
+// disk.PartitionTable so encoding it in json here will not add
+// a benefit for the test
+var minimalInputBase = makefstab.Input{
+	Const: otkdisk.Const{
+		Internal: otkdisk.Internal{
+			PartitionTable: testdisk.MakeFakePartitionTable("/", "/var"),
+		},
+	},
+}
+
+var minimalExpectedStages = `{
+  "type": "org.osbuild.fstab",
+  "options": {
+    "filesystems": [
+      {
+        "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
+        "vfs_type": "ext4",
+        "path": "/"
+      },
+      {
+        "uuid": "CB07C243-BC44-4717-853E-28852021225B",
+        "vfs_type": "ext4",
+        "path": "/var"
+      }
+    ]
+  }
+}
+`
+
+func TestIntegration(t *testing.T) {
+	minimalInput := minimalInputBase
+	minimalInput.Const.Filename = "disk.img"
+	expectedStages := minimalExpectedStages
+
+	inpJSON, err := json.Marshal(&minimalInput)
+	assert.NoError(t, err)
+	fakeStdin := bytes.NewBuffer(inpJSON)
+	fakeStdout := bytes.NewBuffer(nil)
+
+	err = makefstab.Run(fakeStdin, fakeStdout)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedStages, fakeStdout.String())
+}


### PR DESCRIPTION
This helper is similar to the `otk-make-partition-stages` but for
the `fstab` generation. It consumes the variables generated by
`otk-gen-partition-table` and produces a fragment to generate
the `org.osbuild.fstab` stage.

The expected usage is something like:
```yaml
otk.define:
 filesystem:
   otk.external.gen_partition_table:
     modifications: ${modifications.filesystem}
     properties: ...
     partitions: ...

stages:
 ...
 otk.external.make_fstab_stage:
   internal: ${filesystem.internal}
```

Build on top of https://github.com/osbuild/images/pull/732 only the last commit is relevant.