### PR TITLE
New github action that regularly updates osbuild commit ID

### DIFF
--- a/.github/workflows/update-osbuild.yml
+++ b/.github/workflows/update-osbuild.yml
@@ -1,0 +1,51 @@
+# This action updates the osbuild ref in the Schutzfile
+---
+name: "Update osbuild commit ID"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every Sunday at 12:00
+    - cron: "0 12 * * 0"
+
+jobs:
+  update-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apt update
+        run: sudo apt update
+
+      - name: Check out main
+        uses: actions/checkout@v4
+        with:
+          path: images
+          ref: main
+
+      - name: Update Schutzfile
+        working-directory: ./images
+        env:
+          GITHUB_TOKEN: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+        run: |
+          ./test/scripts/update-schutzfile-osbuild
+
+      - name: Open PR
+        working-directory: ./images
+        env:
+          GITHUB_TOKEN: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+        run: |
+          if git diff --exit-code; then echo "No changes"; exit 0; fi
+          git config --unset-all http.https://github.com/.extraheader
+          git config user.name "schutzbot"
+          git config user.email "schutzbot@gmail.com"
+          branch="schutzfile-osbuild-$(date -I)"
+          git checkout -b "${branch}"
+          git add Schutzfile
+          git commit -m "schutzfile: Update osbuild dependency commit ID"
+          git push -f https://"$GITHUB_TOKEN"@github.com/schutzbot/images.git
+          echo "Updating osbuild dependency commit IDs to current `main`" > body
+          gh pr create \
+            -t "Update osbuild dependency commit ID to latest" \
+            -F "body" \
+            --repo "osbuild/images" \
+            --base "main" \
+            --head "schutzbot:${branch}"

--- a/test/scripts/update-schutzfile-osbuild
+++ b/test/scripts/update-schutzfile-osbuild
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+import urllib.request
+
+import imgtestlib as testlib
+
+
+def osbuild_main_commit_id():
+    token = os.environ.get("GITHUB_TOKEN")
+    req = urllib.request.Request("https://api.github.com/repos/osbuild/osbuild/commits/main")
+    req.add_header("Accept", "application/vnd.github+json")
+    if token:
+        # this API request doesn't necessarily require a token, but let's use it if we have one
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = resp.read()
+    except urllib.error.HTTPError as http_error:
+        print(http_error)
+        sys.exit(1)
+
+    data = json.loads(body)
+    return data["sha"]
+
+
+def update_osbuild_commit_ids(new):
+    with open(testlib.SCHUTZFILE, encoding="utf-8") as schutzfile:
+        data = json.load(schutzfile)
+
+    for distro in data.keys():
+        if data[distro].get("dependencies", {}).get("osbuild", {}).get("commit", {}):
+            data[distro]["dependencies"]["osbuild"]["commit"] = new
+
+    with open(testlib.SCHUTZFILE, encoding="utf-8", mode="w") as schutzfile:
+        json.dump(data, schutzfile, indent="  ")
+
+
+def main():
+    main_id = osbuild_main_commit_id()
+    print(f"osbuild/osbuild main commit ID: {main_id}")
+    print("Updating Schutzfile")
+    update_osbuild_commit_ids(main_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
New job that runs weekly (or on-demand) that updates the osbuild commit ID in the Schutzfile to the latest main commit.  This is used to install the osbuild dependency in gitlab CI to build images.  While we often update this manually when needed, this job will make sure we don't miss any updates when no new features required us to update manually.

The job runs on Sundays at noon (UTC).  When the osbuild commit ID changes, our gitlab CI jobs always rebuild every test image configuration, which can take up to three hours so it is good to do it on a Sunday, when there are much fewer CI jobs running.