### PR TITLE
Add Anaconda Module customizations to Blueprint (RHEL-49499)

### DIFF
--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -3,6 +3,7 @@ package blueprint
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 )
 
@@ -409,6 +410,14 @@ func (c *Customizations) GetInstaller() (*InstallerCustomization, error) {
 		if len(c.Installer.SudoNopasswd) > 0 {
 			return nil, fmt.Errorf("installer.sudo-nopasswd is not allowed when adding custom kickstart contents")
 		}
+	}
+
+	// Disabling the user module isn't supported when users or groups are
+	// defined
+	if c.Installer.Modules != nil &&
+		slices.Contains(c.Installer.Modules.Disable, "org.fedoraproject.Anaconda.Modules.Users") &&
+		len(c.User)+len(c.Group) > 0 {
+		return nil, fmt.Errorf("blueprint contains user or group customizations but disables the required Users Anaconda module")
 	}
 
 	return c.Installer, nil

--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+
+	"github.com/osbuild/images/pkg/customizations/anaconda"
 )
 
 type Customizations struct {
@@ -415,7 +417,7 @@ func (c *Customizations) GetInstaller() (*InstallerCustomization, error) {
 	// Disabling the user module isn't supported when users or groups are
 	// defined
 	if c.Installer.Modules != nil &&
-		slices.Contains(c.Installer.Modules.Disable, "org.fedoraproject.Anaconda.Modules.Users") &&
+		slices.Contains(c.Installer.Modules.Disable, anaconda.ModuleUsers) &&
 		len(c.User)+len(c.Group) > 0 {
 		return nil, fmt.Errorf("blueprint contains user or group customizations but disables the required Users Anaconda module")
 	}

--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -407,10 +407,10 @@ func (c *Customizations) GetInstaller() (*InstallerCustomization, error) {
 	// when the user adds their own kickstart content
 	if c.Installer.Kickstart != nil && len(c.Installer.Kickstart.Contents) > 0 {
 		if c.Installer.Unattended {
-			return nil, fmt.Errorf("installer.unattended is not allowed when adding custom kickstart contents")
+			return nil, fmt.Errorf("installer.unattended is not supported when adding custom kickstart contents")
 		}
 		if len(c.Installer.SudoNopasswd) > 0 {
-			return nil, fmt.Errorf("installer.sudo-nopasswd is not allowed when adding custom kickstart contents")
+			return nil, fmt.Errorf("installer.sudo-nopasswd is not supported when adding custom kickstart contents")
 		}
 	}
 

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -429,7 +429,7 @@ func TestGetInstallerErrors(t *testing.T) {
 					},
 				},
 			},
-			expected: "installer.unattended is not allowed when adding custom kickstart contents",
+			expected: "installer.unattended is not supported when adding custom kickstart contents",
 		},
 		"sudo+custom": {
 			customizations: Customizations{
@@ -445,7 +445,7 @@ func TestGetInstallerErrors(t *testing.T) {
 					},
 				},
 			},
-			expected: "installer.sudo-nopasswd is not allowed when adding custom kickstart contents",
+			expected: "installer.sudo-nopasswd is not supported when adding custom kickstart contents",
 		},
 		"users-disabled": {
 			customizations: Customizations{

--- a/pkg/blueprint/installer_customizations.go
+++ b/pkg/blueprint/installer_customizations.go
@@ -1,11 +1,17 @@
 package blueprint
 
 type InstallerCustomization struct {
-	Unattended   bool       `json:"unattended,omitempty" toml:"unattended,omitempty"`
-	SudoNopasswd []string   `json:"sudo-nopasswd,omitempty" toml:"sudo-nopasswd,omitempty"`
-	Kickstart    *Kickstart `json:"kickstart,omitempty" toml:"kickstart,omitempty"`
+	Unattended   bool             `json:"unattended,omitempty" toml:"unattended,omitempty"`
+	SudoNopasswd []string         `json:"sudo-nopasswd,omitempty" toml:"sudo-nopasswd,omitempty"`
+	Kickstart    *Kickstart       `json:"kickstart,omitempty" toml:"kickstart,omitempty"`
+	Modules      *AnacondaModules `json:"modules,omitempty" toml:"modules,omitempty"`
 }
 
 type Kickstart struct {
 	Contents string `json:"contents" toml:"contents"`
+}
+
+type AnacondaModules struct {
+	Enable  []string `json:"enable,omitempty" toml:"enable,omitempty"`
+	Disable []string `json:"disable,omitempty" toml:"disable,omitempty"`
 }

--- a/pkg/customizations/anaconda/anaconda.go
+++ b/pkg/customizations/anaconda/anaconda.go
@@ -1,0 +1,14 @@
+package anaconda
+
+const (
+	ModuleLocalization = "org.fedoraproject.Anaconda.Modules.Localization"
+	ModuleNetwork      = "org.fedoraproject.Anaconda.Modules.Network"
+	ModulePayloads     = "org.fedoraproject.Anaconda.Modules.Payloads"
+	ModuleRuntime      = "org.fedoraproject.Anaconda.Modules.Runtime"
+	ModuleSecurity     = "org.fedoraproject.Anaconda.Modules.Security"
+	ModuleServices     = "org.fedoraproject.Anaconda.Modules.Services"
+	ModuleStorage      = "org.fedoraproject.Anaconda.Modules.Storage"
+	ModuleSubscription = "org.fedoraproject.Anaconda.Modules.Subscription"
+	ModuleTimezone     = "org.fedoraproject.Anaconda.Modules.Timezone"
+	ModuleUsers        = "org.fedoraproject.Anaconda.Modules.Users"
+)

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osbuild/images/internal/workload"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/customizations/bootc"
 	"github.com/osbuild/images/pkg/customizations/fdo"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
@@ -629,9 +630,9 @@ func iotInstallerImage(workload workload.Workload,
 	img.Kickstart.Timezone, _ = customizations.GetTimezoneSettings()
 
 	img.AdditionalAnacondaModules = []string{
-		"org.fedoraproject.Anaconda.Modules.Timezone",
-		"org.fedoraproject.Anaconda.Modules.Localization",
-		"org.fedoraproject.Anaconda.Modules.Users",
+		anaconda.ModuleTimezone,
+		anaconda.ModuleLocalization,
+		anaconda.ModuleUsers,
 	}
 
 	img.SquashfsCompression = "lz4"

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -430,6 +430,15 @@ func imageInstallerImage(workload workload.Workload,
 		img.AdditionalKernelOpts = []string{"inst.text", "inst.noninteractive"}
 	}
 
+	instCust, err := customizations.GetInstaller()
+	if err != nil {
+		return nil, err
+	}
+	if instCust != nil && instCust.Modules != nil {
+		img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, instCust.Modules.Enable...)
+		img.DisabledAnacondaModules = append(img.DisabledAnacondaModules, instCust.Modules.Disable...)
+	}
+
 	img.Platform = t.platform
 	img.Workload = workload
 
@@ -629,11 +638,20 @@ func iotInstallerImage(workload workload.Workload,
 	// kickstart though kickstart does support setting them
 	img.Kickstart.Timezone, _ = customizations.GetTimezoneSettings()
 
-	img.AdditionalAnacondaModules = []string{
+	instCust, err := customizations.GetInstaller()
+	if err != nil {
+		return nil, err
+	}
+	if instCust != nil && instCust.Modules != nil {
+		img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, instCust.Modules.Enable...)
+		img.DisabledAnacondaModules = append(img.DisabledAnacondaModules, instCust.Modules.Disable...)
+	}
+
+	img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, []string{
 		anaconda.ModuleTimezone,
 		anaconda.ModuleLocalization,
 		anaconda.ModuleUsers,
-	}
+	}...)
 
 	img.SquashfsCompression = "lz4"
 

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -7,6 +7,7 @@ import (
 	"github.com/osbuild/images/internal/workload"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/customizations/fdo"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/ignition"
@@ -482,7 +483,7 @@ func EdgeInstallerImage(workload workload.Workload,
 
 	if len(img.Kickstart.Users)+len(img.Kickstart.Groups) > 0 {
 		// only enable the users module if needed
-		img.AdditionalAnacondaModules = []string{"org.fedoraproject.Anaconda.Modules.Users"}
+		img.AdditionalAnacondaModules = []string{anaconda.ModuleUsers}
 	}
 
 	img.ISOLabel, err = t.ISOLabel()
@@ -662,7 +663,7 @@ func ImageInstallerImage(workload workload.Workload,
 		img.AdditionalDrivers = installerConfig.AdditionalDrivers
 	}
 
-	img.AdditionalAnacondaModules = []string{"org.fedoraproject.Anaconda.Modules.Users"}
+	img.AdditionalAnacondaModules = []string{anaconda.ModuleUsers}
 
 	img.SquashfsCompression = "xz"
 

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -481,9 +481,18 @@ func EdgeInstallerImage(workload workload.Workload,
 		img.AdditionalDrivers = installerConfig.AdditionalDrivers
 	}
 
+	instCust, err := customizations.GetInstaller()
+	if err != nil {
+		return nil, err
+	}
+	if instCust != nil && instCust.Modules != nil {
+		img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, instCust.Modules.Enable...)
+		img.DisabledAnacondaModules = append(img.DisabledAnacondaModules, instCust.Modules.Disable...)
+	}
+
 	if len(img.Kickstart.Users)+len(img.Kickstart.Groups) > 0 {
 		// only enable the users module if needed
-		img.AdditionalAnacondaModules = []string{anaconda.ModuleUsers}
+		img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, anaconda.ModuleUsers)
 	}
 
 	img.ISOLabel, err = t.ISOLabel()
@@ -663,7 +672,15 @@ func ImageInstallerImage(workload workload.Workload,
 		img.AdditionalDrivers = installerConfig.AdditionalDrivers
 	}
 
-	img.AdditionalAnacondaModules = []string{anaconda.ModuleUsers}
+	instCust, err := customizations.GetInstaller()
+	if err != nil {
+		return nil, err
+	}
+	if instCust != nil && instCust.Modules != nil {
+		img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, instCust.Modules.Enable...)
+		img.DisabledAnacondaModules = append(img.DisabledAnacondaModules, instCust.Modules.Disable...)
+	}
+	img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, anaconda.ModuleUsers)
 
 	img.SquashfsCompression = "xz"
 

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/artifact"
 	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -86,7 +87,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	if img.FIPS {
 		anacondaPipeline.AdditionalAnacondaModules = append(
 			anacondaPipeline.AdditionalAnacondaModules,
-			"org.fedoraproject.Anaconda.Modules.Security",
+			anaconda.ModuleSecurity,
 		)
 	}
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -37,6 +37,7 @@ type AnacondaContainerInstaller struct {
 
 	AdditionalDracutModules   []string
 	AdditionalAnacondaModules []string
+	DisabledAnacondaModules   []string
 	AdditionalDrivers         []string
 	FIPS                      bool
 
@@ -81,6 +82,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline.Checkpoint()
 	anacondaPipeline.AdditionalDracutModules = img.AdditionalDracutModules
 	anacondaPipeline.AdditionalAnacondaModules = img.AdditionalAnacondaModules
+	anacondaPipeline.DisabledAnacondaModules = img.DisabledAnacondaModules
 	if img.FIPS {
 		anacondaPipeline.AdditionalAnacondaModules = append(
 			anacondaPipeline.AdditionalAnacondaModules,

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/artifact"
+	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -84,7 +85,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	if img.FIPS {
 		anacondaPipeline.AdditionalAnacondaModules = append(
 			anacondaPipeline.AdditionalAnacondaModules,
-			"org.fedoraproject.Anaconda.Modules.Security",
+			anaconda.ModuleSecurity,
 		)
 	}
 	anacondaPipeline.DisabledAnacondaModules = img.DisabledAnacondaModules

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -38,6 +38,7 @@ type AnacondaOSTreeInstaller struct {
 
 	AdditionalDracutModules   []string
 	AdditionalAnacondaModules []string
+	DisabledAnacondaModules   []string
 	AdditionalDrivers         []string
 	FIPS                      bool
 }
@@ -86,6 +87,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 			"org.fedoraproject.Anaconda.Modules.Security",
 		)
 	}
+	anacondaPipeline.DisabledAnacondaModules = img.DisabledAnacondaModules
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers
 
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -68,6 +68,7 @@ type AnacondaTarInstaller struct {
 
 	AdditionalKernelOpts      []string
 	AdditionalAnacondaModules []string
+	DisabledAnacondaModules   []string
 	AdditionalDracutModules   []string
 	AdditionalDrivers         []string
 }
@@ -132,6 +133,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 			"org.fedoraproject.Anaconda.Modules.Security",
 		)
 	}
+	anacondaPipeline.DisabledAnacondaModules = img.DisabledAnacondaModules
 	anacondaPipeline.AdditionalDracutModules = img.AdditionalDracutModules
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers
 

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osbuild/images/internal/workload"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/artifact"
+	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/manifest"
@@ -130,7 +131,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	if img.OSCustomizations.FIPS {
 		anacondaPipeline.AdditionalAnacondaModules = append(
 			anacondaPipeline.AdditionalAnacondaModules,
-			"org.fedoraproject.Anaconda.Modules.Security",
+			anaconda.ModuleSecurity,
 		)
 	}
 	anacondaPipeline.DisabledAnacondaModules = img.DisabledAnacondaModules

--- a/pkg/image/installer_image_test.go
+++ b/pkg/image/installer_image_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
 	"github.com/osbuild/images/pkg/image"
 	"github.com/osbuild/images/pkg/manifest"
@@ -312,54 +313,54 @@ type testCase struct {
 var moduleTestCases = map[string]testCase{
 	"empty-args": {
 		expected: []string{
-			"org.fedoraproject.Anaconda.Modules.Payloads",
-			"org.fedoraproject.Anaconda.Modules.Network",
-			"org.fedoraproject.Anaconda.Modules.Storage",
+			anaconda.ModulePayloads,
+			anaconda.ModuleNetwork,
+			anaconda.ModuleStorage,
 		},
 	},
 	"no-op": {
 		enable: []string{
-			"org.fedoraproject.Anaconda.Modules.Payloads",
-			"org.fedoraproject.Anaconda.Modules.Network",
-			"org.fedoraproject.Anaconda.Modules.Storage",
+			anaconda.ModulePayloads,
+			anaconda.ModuleNetwork,
+			anaconda.ModuleStorage,
 		},
 		expected: []string{
-			"org.fedoraproject.Anaconda.Modules.Payloads",
-			"org.fedoraproject.Anaconda.Modules.Network",
-			"org.fedoraproject.Anaconda.Modules.Storage",
+			anaconda.ModulePayloads,
+			anaconda.ModuleNetwork,
+			anaconda.ModuleStorage,
 		},
 	},
 	"enable-users": {
 		enable: []string{
-			"org.fedoraproject.Anaconda.Modules.Users",
+			anaconda.ModuleUsers,
 		},
 		expected: []string{
-			"org.fedoraproject.Anaconda.Modules.Payloads",
-			"org.fedoraproject.Anaconda.Modules.Network",
-			"org.fedoraproject.Anaconda.Modules.Storage",
-			"org.fedoraproject.Anaconda.Modules.Users",
+			anaconda.ModulePayloads,
+			anaconda.ModuleNetwork,
+			anaconda.ModuleStorage,
+			anaconda.ModuleUsers,
 		},
 	},
 	"disable-storage": {
 		disable: []string{
-			"org.fedoraproject.Anaconda.Modules.Storage",
+			anaconda.ModuleStorage,
 		},
 		expected: []string{
-			"org.fedoraproject.Anaconda.Modules.Payloads",
-			"org.fedoraproject.Anaconda.Modules.Network",
+			anaconda.ModulePayloads,
+			anaconda.ModuleNetwork,
 		},
 	},
 	"enable-users-disable-storage": {
 		enable: []string{
-			"org.fedoraproject.Anaconda.Modules.Users",
+			anaconda.ModuleUsers,
 		},
 		disable: []string{
-			"org.fedoraproject.Anaconda.Modules.Storage",
+			anaconda.ModuleStorage,
 		},
 		expected: []string{
-			"org.fedoraproject.Anaconda.Modules.Payloads",
-			"org.fedoraproject.Anaconda.Modules.Network",
-			"org.fedoraproject.Anaconda.Modules.Users",
+			anaconda.ModulePayloads,
+			anaconda.ModuleNetwork,
+			anaconda.ModuleUsers,
 		},
 	},
 }

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -269,7 +269,7 @@ func (p *AnacondaInstaller) payloadStages() []*osbuild.Stage {
 		LoraxPath = "99-generic/runtime-postinstall.tmpl"
 	}
 
-	stages = append(stages, osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptions(p.AdditionalAnacondaModules)))
+	stages = append(stages, osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptions(p.AdditionalAnacondaModules, nil)))
 	stages = append(stages, osbuild.NewLoraxScriptStage(&osbuild.LoraxScriptStageOptions{
 		Path:     LoraxPath,
 		BaseArch: p.platform.GetArch().String(),

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -69,6 +69,8 @@ type AnacondaInstaller struct {
 
 	// Additional anaconda modules to enable
 	AdditionalAnacondaModules []string
+	// Anaconda modules to explicitly disable
+	DisabledAnacondaModules []string
 
 	// Additional dracut modules and drivers to enable
 	AdditionalDracutModules []string
@@ -269,7 +271,7 @@ func (p *AnacondaInstaller) payloadStages() []*osbuild.Stage {
 		LoraxPath = "99-generic/runtime-postinstall.tmpl"
 	}
 
-	stages = append(stages, osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptions(p.AdditionalAnacondaModules, nil)))
+	stages = append(stages, osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptions(p.AdditionalAnacondaModules, p.DisabledAnacondaModules)))
 	stages = append(stages, osbuild.NewLoraxScriptStage(&osbuild.LoraxScriptStageOptions{
 		Path:     LoraxPath,
 		BaseArch: p.platform.GetArch().String(),

--- a/pkg/manifest/anaconda_installer_test.go
+++ b/pkg/manifest/anaconda_installer_test.go
@@ -1,0 +1,121 @@
+package manifest
+
+import (
+	"testing"
+
+	"github.com/osbuild/images/pkg/osbuild"
+	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/rpmmd"
+	"github.com/osbuild/images/pkg/runner"
+	"github.com/stretchr/testify/require"
+)
+
+func newAnacondaInstaller() *AnacondaInstaller {
+	m := &Manifest{}
+	runner := &runner.Linux{}
+	build := NewBuild(m, runner, nil, nil)
+
+	x86plat := &platform.X86{}
+
+	product := ""
+	osversion := ""
+
+	preview := false
+
+	installer := NewAnacondaInstaller(AnacondaInstallerTypePayload, build, x86plat, nil, "kernel", product, osversion, preview)
+	return installer
+}
+
+func TestAnacondaInstallerModules(t *testing.T) {
+	pkgs := []rpmmd.PackageSpec{
+		{
+			Name:     "kernel",
+			Checksum: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+		},
+	}
+	type testCase struct {
+		enable   []string
+		disable  []string
+		expected []string
+	}
+
+	testCases := map[string]testCase{
+		"empty-args": {
+			expected: []string{
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+				"org.fedoraproject.Anaconda.Modules.Storage",
+			},
+		},
+		"no-op": {
+			enable: []string{
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+				"org.fedoraproject.Anaconda.Modules.Storage",
+			},
+			expected: []string{
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+				"org.fedoraproject.Anaconda.Modules.Storage",
+			},
+		},
+		"enable-users": {
+			enable: []string{
+				"org.fedoraproject.Anaconda.Modules.Users",
+			},
+			expected: []string{
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+				"org.fedoraproject.Anaconda.Modules.Storage",
+				"org.fedoraproject.Anaconda.Modules.Users",
+			},
+		},
+		"disable-storage": {
+			disable: []string{
+				"org.fedoraproject.Anaconda.Modules.Storage",
+			},
+			expected: []string{
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+			},
+		},
+		"enable-users-disable-storage": {
+			enable: []string{
+				"org.fedoraproject.Anaconda.Modules.Users",
+			},
+			disable: []string{
+				"org.fedoraproject.Anaconda.Modules.Storage",
+			},
+			expected: []string{
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+				"org.fedoraproject.Anaconda.Modules.Users",
+			},
+		},
+	}
+
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
+			installerPipeline := newAnacondaInstaller()
+			installerPipeline.AdditionalAnacondaModules = tc.enable
+			installerPipeline.DisabledAnacondaModules = tc.disable
+			installerPipeline.serializeStart(pkgs, nil, nil, nil)
+			pipeline := installerPipeline.serialize()
+
+			require := require.New(t)
+			require.NotNil(pipeline)
+			require.NotNil(pipeline.Stages)
+
+			var anacondaStageOptions *osbuild.AnacondaStageOptions
+			for _, stage := range pipeline.Stages {
+				if stage.Type == "org.osbuild.anaconda" {
+					anacondaStageOptions = stage.Options.(*osbuild.AnacondaStageOptions)
+				}
+			}
+
+			require.NotNil(anacondaStageOptions, "serialized anaconda pipeline does not contain an org.osbuild.anaconda stage")
+			require.ElementsMatch(anacondaStageOptions.KickstartModules, tc.expected)
+		})
+	}
+}

--- a/pkg/manifest/anaconda_installer_test.go
+++ b/pkg/manifest/anaconda_installer_test.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"testing"
 
+	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -42,54 +43,54 @@ func TestAnacondaInstallerModules(t *testing.T) {
 	testCases := map[string]testCase{
 		"empty-args": {
 			expected: []string{
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
-				"org.fedoraproject.Anaconda.Modules.Storage",
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
+				anaconda.ModuleStorage,
 			},
 		},
 		"no-op": {
 			enable: []string{
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
-				"org.fedoraproject.Anaconda.Modules.Storage",
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
+				anaconda.ModuleStorage,
 			},
 			expected: []string{
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
-				"org.fedoraproject.Anaconda.Modules.Storage",
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
+				anaconda.ModuleStorage,
 			},
 		},
 		"enable-users": {
 			enable: []string{
-				"org.fedoraproject.Anaconda.Modules.Users",
+				anaconda.ModuleUsers,
 			},
 			expected: []string{
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
-				"org.fedoraproject.Anaconda.Modules.Storage",
-				"org.fedoraproject.Anaconda.Modules.Users",
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
+				anaconda.ModuleStorage,
+				anaconda.ModuleUsers,
 			},
 		},
 		"disable-storage": {
 			disable: []string{
-				"org.fedoraproject.Anaconda.Modules.Storage",
+				anaconda.ModuleStorage,
 			},
 			expected: []string{
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
 			},
 		},
 		"enable-users-disable-storage": {
 			enable: []string{
-				"org.fedoraproject.Anaconda.Modules.Users",
+				anaconda.ModuleUsers,
 			},
 			disable: []string{
-				"org.fedoraproject.Anaconda.Modules.Storage",
+				anaconda.ModuleStorage,
 			},
 			expected: []string{
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
-				"org.fedoraproject.Anaconda.Modules.Users",
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
+				anaconda.ModuleUsers,
 			},
 		},
 	}

--- a/pkg/osbuild/anaconda_stage.go
+++ b/pkg/osbuild/anaconda_stage.go
@@ -1,5 +1,7 @@
 package osbuild
 
+import "github.com/osbuild/images/pkg/customizations/anaconda"
+
 type AnacondaStageOptions struct {
 	// Kickstart modules to enable
 	KickstartModules []string `json:"kickstart-modules"`
@@ -17,16 +19,16 @@ func NewAnacondaStage(options *AnacondaStageOptions) *Stage {
 
 func defaultModuleStates() map[string]bool {
 	return map[string]bool{
-		"org.fedoraproject.Anaconda.Modules.Localization": false,
-		"org.fedoraproject.Anaconda.Modules.Network":      true,
-		"org.fedoraproject.Anaconda.Modules.Payloads":     true,
-		"org.fedoraproject.Anaconda.Modules.Runtime":      false,
-		"org.fedoraproject.Anaconda.Modules.Security":     false,
-		"org.fedoraproject.Anaconda.Modules.Services":     false,
-		"org.fedoraproject.Anaconda.Modules.Storage":      true,
-		"org.fedoraproject.Anaconda.Modules.Subscription": false,
-		"org.fedoraproject.Anaconda.Modules.Timezone":     false,
-		"org.fedoraproject.Anaconda.Modules.Users":        false,
+		anaconda.ModuleLocalization: false,
+		anaconda.ModuleNetwork:      true,
+		anaconda.ModulePayloads:     true,
+		anaconda.ModuleRuntime:      false,
+		anaconda.ModuleSecurity:     false,
+		anaconda.ModuleServices:     false,
+		anaconda.ModuleStorage:      true,
+		anaconda.ModuleSubscription: false,
+		anaconda.ModuleTimezone:     false,
+		anaconda.ModuleUsers:        false,
 	}
 }
 

--- a/pkg/osbuild/anaconda_stage.go
+++ b/pkg/osbuild/anaconda_stage.go
@@ -1,6 +1,9 @@
 package osbuild
 
-import "github.com/osbuild/images/pkg/customizations/anaconda"
+import (
+	"github.com/osbuild/images/pkg/customizations/anaconda"
+	"golang.org/x/exp/slices"
+)
 
 type AnacondaStageOptions struct {
 	// Kickstart modules to enable
@@ -48,6 +51,8 @@ func filterEnabledModules(moduleStates map[string]bool) []string {
 			enabled = append(enabled, modname)
 		}
 	}
+	// sort the list to guarantee stable manifests
+	slices.Sort(enabled)
 	return enabled
 }
 

--- a/pkg/osbuild/anaconda_stage.go
+++ b/pkg/osbuild/anaconda_stage.go
@@ -15,18 +15,42 @@ func NewAnacondaStage(options *AnacondaStageOptions) *Stage {
 	}
 }
 
-func NewAnacondaStageOptions(additionalModules []string) *AnacondaStageOptions {
-	modules := []string{
-		"org.fedoraproject.Anaconda.Modules.Network",
-		"org.fedoraproject.Anaconda.Modules.Payloads",
-		"org.fedoraproject.Anaconda.Modules.Storage",
+func defaultModuleStates() map[string]bool {
+	return map[string]bool{
+		"org.fedoraproject.Anaconda.Modules.Localization": false,
+		"org.fedoraproject.Anaconda.Modules.Network":      true,
+		"org.fedoraproject.Anaconda.Modules.Payloads":     true,
+		"org.fedoraproject.Anaconda.Modules.Runtime":      false,
+		"org.fedoraproject.Anaconda.Modules.Security":     false,
+		"org.fedoraproject.Anaconda.Modules.Services":     false,
+		"org.fedoraproject.Anaconda.Modules.Storage":      true,
+		"org.fedoraproject.Anaconda.Modules.Subscription": false,
+		"org.fedoraproject.Anaconda.Modules.Timezone":     false,
+		"org.fedoraproject.Anaconda.Modules.Users":        false,
 	}
+}
 
-	if len(additionalModules) > 0 {
-		modules = append(modules, additionalModules...)
+func enableModules(states map[string]bool, additional []string) {
+	for _, modname := range additional {
+		states[modname] = true
 	}
+}
+
+func filterEnabledModules(moduleStates map[string]bool) []string {
+	enabled := make([]string, 0, len(moduleStates))
+	for modname, state := range moduleStates {
+		if state {
+			enabled = append(enabled, modname)
+		}
+	}
+	return enabled
+}
+
+func NewAnacondaStageOptions(additionalModules []string) *AnacondaStageOptions {
+	states := defaultModuleStates()
+	enableModules(states, additionalModules)
 
 	return &AnacondaStageOptions{
-		KickstartModules: modules,
+		KickstartModules: filterEnabledModules(states),
 	}
 }

--- a/pkg/osbuild/anaconda_stage.go
+++ b/pkg/osbuild/anaconda_stage.go
@@ -30,9 +30,12 @@ func defaultModuleStates() map[string]bool {
 	}
 }
 
-func enableModules(states map[string]bool, additional []string) {
-	for _, modname := range additional {
+func setModuleStates(states map[string]bool, enable, disable []string) {
+	for _, modname := range enable {
 		states[modname] = true
+	}
+	for _, modname := range disable {
+		states[modname] = false
 	}
 }
 
@@ -46,9 +49,9 @@ func filterEnabledModules(moduleStates map[string]bool) []string {
 	return enabled
 }
 
-func NewAnacondaStageOptions(additionalModules []string) *AnacondaStageOptions {
+func NewAnacondaStageOptions(enableModules, disableModules []string) *AnacondaStageOptions {
 	states := defaultModuleStates()
-	enableModules(states, additionalModules)
+	setModuleStates(states, enableModules, disableModules)
 
 	return &AnacondaStageOptions{
 		KickstartModules: filterEnabledModules(states),

--- a/pkg/osbuild/anaconda_stage_test.go
+++ b/pkg/osbuild/anaconda_stage_test.go
@@ -63,7 +63,7 @@ func TestAnacondaStageOptions(t *testing.T) {
 		tc := testCases[name]
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
-			options := osbuild.NewAnacondaStageOptions(tc.additional)
+			options := osbuild.NewAnacondaStageOptions(tc.additional, nil)
 
 			require.NotNil(options)
 			require.ElementsMatch(options.KickstartModules, tc.expected)

--- a/pkg/osbuild/anaconda_stage_test.go
+++ b/pkg/osbuild/anaconda_stage_test.go
@@ -3,6 +3,7 @@ package osbuild_test
 import (
 	"testing"
 
+	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/stretchr/testify/require"
 )
@@ -18,47 +19,47 @@ func TestAnacondaStageOptions(t *testing.T) {
 	testCases := map[string]testCase{
 		"empty-args": {
 			expected: []string{
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
-				"org.fedoraproject.Anaconda.Modules.Storage",
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
+				anaconda.ModuleStorage,
 			},
 		},
 		"no-op": {
 			enable: []string{
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
-				"org.fedoraproject.Anaconda.Modules.Storage",
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
+				anaconda.ModuleStorage,
 			},
 			expected: []string{
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
-				"org.fedoraproject.Anaconda.Modules.Storage",
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
+				anaconda.ModuleStorage,
 			},
 		},
 		"add-users": {
 			enable: []string{
-				"org.fedoraproject.Anaconda.Modules.Users",
+				anaconda.ModuleUsers,
 			},
 			expected: []string{
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
-				"org.fedoraproject.Anaconda.Modules.Storage",
-				"org.fedoraproject.Anaconda.Modules.Users",
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
+				anaconda.ModuleStorage,
+				anaconda.ModuleUsers,
 			},
 		},
 		"add-multi": {
 			enable: []string{
-				"org.fedoraproject.Anaconda.Modules.Subscription",
-				"org.fedoraproject.Anaconda.Modules.Timezone",
-				"org.fedoraproject.Anaconda.Modules.Users",
+				anaconda.ModuleSubscription,
+				anaconda.ModuleTimezone,
+				anaconda.ModuleUsers,
 			},
 			expected: []string{
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
-				"org.fedoraproject.Anaconda.Modules.Storage",
-				"org.fedoraproject.Anaconda.Modules.Subscription",
-				"org.fedoraproject.Anaconda.Modules.Timezone",
-				"org.fedoraproject.Anaconda.Modules.Users",
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
+				anaconda.ModuleStorage,
+				anaconda.ModuleSubscription,
+				anaconda.ModuleTimezone,
+				anaconda.ModuleUsers,
 			},
 		},
 		"add-nonsense": {
@@ -66,50 +67,50 @@ func TestAnacondaStageOptions(t *testing.T) {
 				"org.osbuild.not.anaconda.module",
 			},
 			expected: []string{
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
-				"org.fedoraproject.Anaconda.Modules.Storage",
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
+				anaconda.ModuleStorage,
 				"org.osbuild.not.anaconda.module",
 			},
 		},
 		"no-op-disable": {
 			disable: []string{
-				"org.fedoraproject.Anaconda.Modules.Users",
+				anaconda.ModuleUsers,
 			},
 			expected: []string{
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
-				"org.fedoraproject.Anaconda.Modules.Storage",
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
+				anaconda.ModuleStorage,
 			},
 		},
 		"disable-all": {
 			disable: []string{
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
-				"org.fedoraproject.Anaconda.Modules.Storage",
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
+				anaconda.ModuleStorage,
 			},
 			expected: nil,
 		},
 		"disable-one": {
 			disable: []string{
-				"org.fedoraproject.Anaconda.Modules.Storage",
+				anaconda.ModuleStorage,
 			},
 			expected: []string{
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
 			},
 		},
 		"enable-then-disable": {
 			enable: []string{
-				"org.fedoraproject.Anaconda.Modules.Services",
+				anaconda.ModuleServices,
 			},
 			disable: []string{
-				"org.fedoraproject.Anaconda.Modules.Services",
+				anaconda.ModuleServices,
 			},
 			expected: []string{
-				"org.fedoraproject.Anaconda.Modules.Storage",
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
+				anaconda.ModuleStorage,
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
 			},
 		},
 		"enable-then-disable-nonsense": {
@@ -120,26 +121,26 @@ func TestAnacondaStageOptions(t *testing.T) {
 				"org.osbuild.not.anaconda.module.2",
 			},
 			expected: []string{
-				"org.fedoraproject.Anaconda.Modules.Storage",
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
+				anaconda.ModuleStorage,
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
 			},
 		},
 		"enable-then-disable-multi": {
 			enable: []string{
-				"org.fedoraproject.Anaconda.Modules.Subscription",
-				"org.fedoraproject.Anaconda.Modules.Timezone",
-				"org.fedoraproject.Anaconda.Modules.Users",
+				anaconda.ModuleSubscription,
+				anaconda.ModuleTimezone,
+				anaconda.ModuleUsers,
 			},
 			disable: []string{
-				"org.fedoraproject.Anaconda.Modules.Subscription",
-				"org.fedoraproject.Anaconda.Modules.Timezone",
-				"org.fedoraproject.Anaconda.Modules.Users",
+				anaconda.ModuleSubscription,
+				anaconda.ModuleTimezone,
+				anaconda.ModuleUsers,
 			},
 			expected: []string{
-				"org.fedoraproject.Anaconda.Modules.Storage",
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
+				anaconda.ModuleStorage,
+				anaconda.ModulePayloads,
+				anaconda.ModuleNetwork,
 			},
 		},
 	}

--- a/pkg/osbuild/anaconda_stage_test.go
+++ b/pkg/osbuild/anaconda_stage_test.go
@@ -23,16 +23,13 @@ func TestAnacondaStageOptions(t *testing.T) {
 				"org.fedoraproject.Anaconda.Modules.Storage",
 			},
 		},
-		"duplicate": {
+		"no-op": {
 			additional: []string{
 				"org.fedoraproject.Anaconda.Modules.Payloads",
 				"org.fedoraproject.Anaconda.Modules.Network",
 				"org.fedoraproject.Anaconda.Modules.Storage",
 			},
 			expected: []string{
-				"org.fedoraproject.Anaconda.Modules.Payloads",
-				"org.fedoraproject.Anaconda.Modules.Network",
-				"org.fedoraproject.Anaconda.Modules.Storage",
 				"org.fedoraproject.Anaconda.Modules.Payloads",
 				"org.fedoraproject.Anaconda.Modules.Network",
 				"org.fedoraproject.Anaconda.Modules.Storage",

--- a/pkg/osbuild/anaconda_stage_test.go
+++ b/pkg/osbuild/anaconda_stage_test.go
@@ -1,0 +1,76 @@
+package osbuild_test
+
+import (
+	"testing"
+
+	"github.com/osbuild/images/pkg/osbuild"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnacondaStageOptions(t *testing.T) {
+
+	type testCase struct {
+		additional []string
+		expected   []string
+	}
+
+	testCases := map[string]testCase{
+		"zero-add": {
+			additional: []string{},
+			expected: []string{
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+				"org.fedoraproject.Anaconda.Modules.Storage",
+			},
+		},
+		"duplicate": {
+			additional: []string{
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+				"org.fedoraproject.Anaconda.Modules.Storage",
+			},
+			expected: []string{
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+				"org.fedoraproject.Anaconda.Modules.Storage",
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+				"org.fedoraproject.Anaconda.Modules.Storage",
+			},
+		},
+		"add-users": {
+			additional: []string{
+				"org.fedoraproject.Anaconda.Modules.Users",
+			},
+			expected: []string{
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+				"org.fedoraproject.Anaconda.Modules.Storage",
+				"org.fedoraproject.Anaconda.Modules.Users",
+			},
+		},
+		"add-nonsense": {
+			additional: []string{
+				"org.osbuild.not.anaconda.module",
+			},
+			expected: []string{
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+				"org.fedoraproject.Anaconda.Modules.Storage",
+				"org.osbuild.not.anaconda.module",
+			},
+		},
+	}
+
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			options := osbuild.NewAnacondaStageOptions(tc.additional)
+
+			require.NotNil(options)
+			require.ElementsMatch(options.KickstartModules, tc.expected)
+		})
+	}
+
+}

--- a/pkg/osbuild/anaconda_stage_test.go
+++ b/pkg/osbuild/anaconda_stage_test.go
@@ -10,13 +10,13 @@ import (
 func TestAnacondaStageOptions(t *testing.T) {
 
 	type testCase struct {
-		additional []string
-		expected   []string
+		enable   []string
+		disable  []string
+		expected []string
 	}
 
 	testCases := map[string]testCase{
-		"zero-add": {
-			additional: []string{},
+		"empty-args": {
 			expected: []string{
 				"org.fedoraproject.Anaconda.Modules.Payloads",
 				"org.fedoraproject.Anaconda.Modules.Network",
@@ -24,7 +24,7 @@ func TestAnacondaStageOptions(t *testing.T) {
 			},
 		},
 		"no-op": {
-			additional: []string{
+			enable: []string{
 				"org.fedoraproject.Anaconda.Modules.Payloads",
 				"org.fedoraproject.Anaconda.Modules.Network",
 				"org.fedoraproject.Anaconda.Modules.Storage",
@@ -36,7 +36,7 @@ func TestAnacondaStageOptions(t *testing.T) {
 			},
 		},
 		"add-users": {
-			additional: []string{
+			enable: []string{
 				"org.fedoraproject.Anaconda.Modules.Users",
 			},
 			expected: []string{
@@ -46,8 +46,23 @@ func TestAnacondaStageOptions(t *testing.T) {
 				"org.fedoraproject.Anaconda.Modules.Users",
 			},
 		},
+		"add-multi": {
+			enable: []string{
+				"org.fedoraproject.Anaconda.Modules.Subscription",
+				"org.fedoraproject.Anaconda.Modules.Timezone",
+				"org.fedoraproject.Anaconda.Modules.Users",
+			},
+			expected: []string{
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+				"org.fedoraproject.Anaconda.Modules.Storage",
+				"org.fedoraproject.Anaconda.Modules.Subscription",
+				"org.fedoraproject.Anaconda.Modules.Timezone",
+				"org.fedoraproject.Anaconda.Modules.Users",
+			},
+		},
 		"add-nonsense": {
-			additional: []string{
+			enable: []string{
 				"org.osbuild.not.anaconda.module",
 			},
 			expected: []string{
@@ -55,6 +70,76 @@ func TestAnacondaStageOptions(t *testing.T) {
 				"org.fedoraproject.Anaconda.Modules.Network",
 				"org.fedoraproject.Anaconda.Modules.Storage",
 				"org.osbuild.not.anaconda.module",
+			},
+		},
+		"no-op-disable": {
+			disable: []string{
+				"org.fedoraproject.Anaconda.Modules.Users",
+			},
+			expected: []string{
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+				"org.fedoraproject.Anaconda.Modules.Storage",
+			},
+		},
+		"disable-all": {
+			disable: []string{
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+				"org.fedoraproject.Anaconda.Modules.Storage",
+			},
+			expected: nil,
+		},
+		"disable-one": {
+			disable: []string{
+				"org.fedoraproject.Anaconda.Modules.Storage",
+			},
+			expected: []string{
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+			},
+		},
+		"enable-then-disable": {
+			enable: []string{
+				"org.fedoraproject.Anaconda.Modules.Services",
+			},
+			disable: []string{
+				"org.fedoraproject.Anaconda.Modules.Services",
+			},
+			expected: []string{
+				"org.fedoraproject.Anaconda.Modules.Storage",
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+			},
+		},
+		"enable-then-disable-nonsense": {
+			enable: []string{
+				"org.osbuild.not.anaconda.module.2",
+			},
+			disable: []string{
+				"org.osbuild.not.anaconda.module.2",
+			},
+			expected: []string{
+				"org.fedoraproject.Anaconda.Modules.Storage",
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
+			},
+		},
+		"enable-then-disable-multi": {
+			enable: []string{
+				"org.fedoraproject.Anaconda.Modules.Subscription",
+				"org.fedoraproject.Anaconda.Modules.Timezone",
+				"org.fedoraproject.Anaconda.Modules.Users",
+			},
+			disable: []string{
+				"org.fedoraproject.Anaconda.Modules.Subscription",
+				"org.fedoraproject.Anaconda.Modules.Timezone",
+				"org.fedoraproject.Anaconda.Modules.Users",
+			},
+			expected: []string{
+				"org.fedoraproject.Anaconda.Modules.Storage",
+				"org.fedoraproject.Anaconda.Modules.Payloads",
+				"org.fedoraproject.Anaconda.Modules.Network",
 			},
 		},
 	}
@@ -63,7 +148,7 @@ func TestAnacondaStageOptions(t *testing.T) {
 		tc := testCases[name]
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
-			options := osbuild.NewAnacondaStageOptions(tc.additional, nil)
+			options := osbuild.NewAnacondaStageOptions(tc.enable, tc.disable)
 
 			require.NotNil(options)
 			require.ElementsMatch(options.KickstartModules, tc.expected)

--- a/test/configs/unattended-iso.json
+++ b/test/configs/unattended-iso.json
@@ -25,7 +25,15 @@
         "sudo-nopasswd": [
           "%wheel",
           "%sudo"
-        ]
+        ],
+        "modules": {
+          "enable": [
+            "org.fedoraproject.Anaconda.Modules.Users",
+            "org.fedoraproject.Anaconda.Modules.Localization",
+            "org.fedoraproject.Anaconda.Modules.Network",
+            "org.fedoraproject.Anaconda.Modules.Services"
+          ]
+        }
       }
     }
   }


### PR DESCRIPTION
This PR generalises the solution to the problem we had in BIB (osbuild/bootc-image-builder#547) 
 where Anaconda Modules were not enabled for custom kickstarts, making it impossible to use certain kickstart features.  For example, in most Anaconda ISO builds, we only enable the Users module if a user is specified in the blueprint.  A custom kickstart with a user creation command would therefore have no effect, since the Users module would be disabled.  The same is true for many other kickstart commands.

However, enabling certain modules unconditionally is also not desirable.  For example, in the case of ostree payloads, enabling the user module can prevent automated/unattended installation, since Anaconda will block and prompt for an admin user to be created.  Users may not want to create a user account during installation if one is already included in the OS payload (ostree commit or container).

This PR makes it possible to specify a list of Anaconda modules to enable or explicitly disable using blueprint customizations.