### PR TITLE
Test utility function for validating Partition Table sizes

### DIFF
--- a/pkg/disk/partition_table_internal_test.go
+++ b/pkg/disk/partition_table_internal_test.go
@@ -24,3 +24,49 @@ func TestPartitionTableFeatures(t *testing.T) {
 
 	}
 }
+
+// validatePTSize checks that each Partition is large enough to contain every
+// sizeable under it.
+func validatePTSize(pt *PartitionTable) error {
+	ptTotal := uint64(0)
+	for _, partition := range pt.Partitions {
+		if err := validateEntitySize(&partition, partition.GetSize()); err != nil {
+			return err
+		}
+		ptTotal += partition.GetSize()
+	}
+
+	if pt.GetSize() < ptTotal {
+		return fmt.Errorf("PartitionTable size %d is smaller than the sum of its partitions %d", pt.GetSize(), ptTotal)
+	}
+	return nil
+}
+
+// validateEntitySize checks that every sizeable under a given Entity can be
+// contained in the given size.
+func validateEntitySize(ent Entity, size uint64) error {
+	if ent.IsContainer() {
+		containerTotal := uint64(0)
+		cont := ent.(Container)
+		for idx := uint(0); idx < cont.GetItemCount(); idx++ {
+			child := cont.GetChild(idx)
+			var childSize uint64
+			if sizeable, convOk := child.(Sizeable); convOk {
+				childSize = sizeable.GetSize()
+				containerTotal += childSize
+			} else {
+				// child is not sizeable: use the parent size
+				childSize = size
+			}
+			if err := validateEntitySize(child, childSize); err != nil {
+				return err
+			}
+		}
+
+		if size < containerTotal {
+			return fmt.Errorf("Entity size %d is smaller than the sum of its children %d", size, containerTotal)
+		}
+	}
+	// non-containers need no checking
+	return nil
+}


### PR DESCRIPTION
There is currently a bug that occurs when converting a partition table to LVM with a root partition size that is larger than the original partition size (or larger than the partition table).  @croissanne discovered it and we investigated it together yesterday.  We both have ideas for how to fix it properly, but first I decided to write some tests to catch similar issues.

To keep things easier to follow and review, I decided to first introduce a utility function for validating partition table sizes.  Currently this is a test utility function.  If we discover that we need it outside of testing, we can move it to the `partition_table.go` file.