### PR TITLE
Fix the disk relayout function to resize all sizeable containers to fit their contents

### DIFF
--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -384,7 +384,7 @@ func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
 			Filename: "disk.img",
 			Internal: otkdisk.Internal{
 				PartitionTable: &disk.PartitionTable{
-					Size: 15890120704,
+					Size: 15893266432,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
 					Type: "dos",
 					Partitions: []disk.Partition{
@@ -399,7 +399,7 @@ func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
 						},
 						{
 							Start: 2148532224,
-							Size:  13741588480,
+							Size:  13744734208,
 							Type:  "8e",
 							Payload: &disk.LVMVolumeGroup{
 								Name:        "rootvg",

--- a/pkg/disk/btrfs.go
+++ b/pkg/disk/btrfs.go
@@ -96,6 +96,20 @@ func (b *Btrfs) MetadataSize() uint64 {
 	return 0
 }
 
+func (b *Btrfs) minSize(size uint64) uint64 {
+	var subvolsum uint64
+	for _, sv := range b.Subvolumes {
+		subvolsum += sv.Size
+	}
+	minSize := subvolsum + b.MetadataSize()
+
+	if minSize > size {
+		size = minSize
+	}
+
+	return b.AlignUp(size)
+}
+
 type BtrfsSubvolume struct {
 	Name       string
 	Size       uint64

--- a/pkg/disk/btrfs.go
+++ b/pkg/disk/btrfs.go
@@ -92,6 +92,10 @@ func (b *Btrfs) GenUUID(rng *rand.Rand) {
 	}
 }
 
+func (b *Btrfs) MetadataSize() uint64 {
+	return 0
+}
+
 type BtrfsSubvolume struct {
 	Name       string
 	Size       uint64

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -138,6 +138,16 @@ type VolumeContainer interface {
 	// bytes), i.e. the storage space that needs to be reserved for
 	// the container itself, in contrast to the data it contains.
 	MetadataSize() uint64
+
+	// minSize returns the size for the VolumeContainer that is either the
+	// provided desired size value or the sum of all children if that is
+	// larger. It will also add any space required for metadata. The returned
+	// value should, at minimum, be large enough to fit all the children, their
+	// metadata, and the VolumeContainer's metadata. In other words, the
+	// VolumeContainer's size, or its parent size, will be able to hold the
+	// VolumeContainer if it is created with the exact size returned by the
+	// function.
+	minSize(size uint64) uint64
 }
 
 // FSSpec for a filesystem (UUID and Label); the first field of fstab(5)

--- a/pkg/disk/luks.go
+++ b/pkg/disk/luks.go
@@ -109,3 +109,16 @@ func (lc *LUKSContainer) MetadataSize() uint64 {
 	// 16 MiB is the default size for the LUKS2 header
 	return 16 * common.MiB
 }
+
+func (lc *LUKSContainer) minSize(size uint64) uint64 {
+	// since a LUKS container can contain pretty much any payload, but we only
+	// care about the ones that have a size, or contain children with sizes
+	minSize := lc.MetadataSize()
+	switch payload := lc.Payload.(type) {
+	case VolumeContainer:
+		minSize += payload.minSize(size)
+	case Sizeable:
+		minSize += payload.GetSize()
+	}
+	return minSize
+}

--- a/pkg/disk/lvm.go
+++ b/pkg/disk/lvm.go
@@ -150,6 +150,20 @@ func (vg *LVMVolumeGroup) MetadataSize() uint64 {
 	return 1 * common.MiB
 }
 
+func (vg *LVMVolumeGroup) minSize(size uint64) uint64 {
+	var lvsum uint64
+	for _, lv := range vg.LogicalVolumes {
+		lvsum += lv.Size
+	}
+	minSize := lvsum + vg.MetadataSize()
+
+	if minSize > size {
+		size = minSize
+	}
+
+	return vg.AlignUp(size)
+}
+
 type LVMLogicalVolume struct {
 	Name    string
 	Size    uint64

--- a/pkg/disk/partition.go
+++ b/pkg/disk/partition.go
@@ -59,6 +59,19 @@ func (p *Partition) GetChild(n uint) Entity {
 	return p.Payload
 }
 
+// fitTo resizes a partition to be either the given the size or the size of its
+// payload if that is larger. The payload can be larger if it is a container
+// with sized children.
+func (p *Partition) fitTo(size uint64) {
+	payload, isVC := p.Payload.(VolumeContainer)
+	if isVC {
+		if payloadMinSize := payload.minSize(size); payloadMinSize > size {
+			size = payloadMinSize
+		}
+	}
+	p.Size = size
+}
+
 func (p *Partition) GetSize() uint64 {
 	return p.Size
 }

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -423,6 +423,7 @@ func (pt *PartitionTable) relayout(size uint64) uint64 {
 			continue
 		}
 		partition.Start = start
+		partition.fitTo(partition.Size)
 		partition.Size = pt.AlignUp(partition.Size)
 		start += partition.Size
 	}
@@ -433,6 +434,7 @@ func (pt *PartitionTable) relayout(size uint64) uint64 {
 
 	root := &pt.Partitions[rootIdx]
 	root.Start = start
+	root.fitTo(root.Size)
 
 	// add the extra padding specified in the partition table
 	footer += pt.ExtraPadding

--- a/pkg/disk/partition_table_internal_test.go
+++ b/pkg/disk/partition_table_internal_test.go
@@ -321,6 +321,48 @@ func TestRelayout(t *testing.T) {
 				},
 			},
 		},
+		"simple-gpt-root-first": {
+			pt: &PartitionTable{
+				Type: "gpt",
+				Size: 100 * MiB,
+				Partitions: []Partition{
+					{
+						Size: 10 * MiB,
+						Payload: &Filesystem{
+							Mountpoint: "/",
+						},
+					},
+					{
+						Size: 20 * MiB,
+					},
+					{
+						Size: 30 * MiB,
+					},
+				},
+			},
+			size: 100 * MiB,
+			expected: &PartitionTable{
+				Type: "gpt",
+				Size: 100 * MiB,
+				Partitions: []Partition{
+					{
+						Start: 51 * MiB,                                   // root gets moved to last position
+						Size:  49*MiB - (DefaultSectorSize + (128 * 128)), // Grows to fill the space, but gpt adds a footer the same size as the header (unaligned)
+						Payload: &Filesystem{
+							Mountpoint: "/",
+						},
+					},
+					{
+						Start: 1 * MiB, // header (1 sector + 128 B * 128 partitions) aligned up to the default grain (1 MiB)
+						Size:  20 * MiB,
+					},
+					{
+						Start: 21 * MiB, // header (1 sector + 128 B * 128 partitions) aligned up to the default grain (1 MiB)
+						Size:  30 * MiB,
+					},
+				},
+			},
+		},
 	}
 
 	for name := range testCases {

--- a/pkg/disk/partition_table_internal_test.go
+++ b/pkg/disk/partition_table_internal_test.go
@@ -459,6 +459,62 @@ func TestRelayout(t *testing.T) {
 				},
 			},
 		},
+		"lvm-gpt-multilv": {
+			pt: &PartitionTable{
+				Type: "gpt",
+				Size: 100 * MiB,
+				Partitions: []Partition{
+					{
+						Size: 20 * MiB,
+					},
+					{
+						Size: 30 * MiB,
+						Payload: &LVMVolumeGroup{
+							LogicalVolumes: []LVMLogicalVolume{
+								{
+									Size: 20 * MiB,
+								},
+								{
+									Payload: &Filesystem{
+										Mountpoint: "/",
+									},
+									// TODO: fix bug where the VG partition is not resized to fit the sum of LVs
+									Size: 10 * MiB,
+								},
+							},
+						},
+					},
+				},
+			},
+			size: 100 * MiB,
+			expected: &PartitionTable{
+				Type: "gpt",
+				Size: 100 * MiB,
+				Partitions: []Partition{
+					{
+						Start: 1 * MiB, // 1 sector header aligned up to the default grain (1 MiB)
+						Size:  20 * MiB,
+					},
+					{
+						Start: 21 * MiB,
+						Size:  79*MiB - (DefaultSectorSize + (128 * 128)), // Grows to fill the space, but gpt adds a footer the same size as the header (unaligned)
+						Payload: &LVMVolumeGroup{
+							LogicalVolumes: []LVMLogicalVolume{
+								{
+									Size: 20 * MiB,
+								},
+								{
+									Payload: &Filesystem{
+										Mountpoint: "/",
+									},
+									Size: 10 * MiB, // We don't automatically grow the root LV
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name := range testCases {


### PR DESCRIPTION
This PR is primarily concerned with fixing a bug where partitions that contain sized sub-volumes would not be resized to be able to contain their children.  The bulk of this PR however adds tests for all kinds of partition table resizing scenarios, using the `PartitionTable.relayout()` method.

## The bug

@croissanne discovered a bug in the `PartitionTable.relayout()` method that would not grow a Partition to fit the sum of the LogicalVolume sizes in an LVM VolumeGroup.  The following example describes a scenario where the bug manifests:
1. Starting with a Partition Table with size `10 GiB` which only has a root partition `9 GiB`.
2. The user adds a `/boot` with size `1 GiB` and sets `/` to `15 GiB`.
3. First, the root partition is grown to `15 GiB`.  This also grows the Partition Table size to fit.
4. The addition of `/boot` triggers the LVM converstion of the partition table (though this might also be something we want to reconsider).
5. The LVM conversion creates a VolumeGroup and a LogicalVolume with size `15 GiB` for `/` and a `/boot` partition.  The `/boot` partition size is set to `500 MiB` (the default) and the one for the LVM VolumeGroup is set to `0`.  This is intentional as the sizes are meant to be calculated later.
6. The `/boot` partition is resized to `1 GiB` to match the user's request.
7. The `PT.relayout()` method is called to adjust the start positions and sizes of the partitions.  **The VolumeGroup partition is grown to fill the remaining space in the Partition Table.**

The last step is where things go wrong: The size of the Partition Table is the result of the resizing of `/`, but the later changes are not taken into account.  The size of the VolumeGroup partition is set by simply growing the partition to fit the space in the Partition Table, which will always fall short due to the LVM VG metadata that are not accounted for.

This bug also occurs when the partitioning mode option is used to "force" conversion to LVM without adding another LogicalVolume, which is essentially what the addition of `/boot` does.
When a second LogicalVolume is added, an extra step is added between steps 5 and 6 which introduces the new LV and **forces a resize of the VolumeGroup Partition and the Partition Table to fit**.

So, in summary, this bug is caused when a Partition Table is converted to LVM without a recalculation of the VG Partition table size to properly fit all LVs + metadata.

## The fix

The bug is fixed by adding functionality to the `PT.relayout()` function that recalculates the size for all VolumeContainer types to ensure that they are large enough to fit the sum of their children and any metadata.
This means that we have a few places where we duplicate size calculations: when we introduce new partitions or LogicalVolumes and when we relayout the PT.  While this is fine, functionally, it might make it hard to reason about the PT size calculations.  We might want to simplify some things later.

## General principles

While investigating this bug and the fix with @croissanne, I remembered some decisions that were made when we were first writing this whole package that were never written down explicitly.  I'm including them here but I plan to also document them in other places for future reference:
1. Desired sizes for partitions, partition tables, volumes, etc, are **always** treated as minimum sizes.
    - This means that when a user wants a `/` partition to be `10 GiB`, we will always make it at least `10 GiB` and grow any container to fit.
    - It also means that very often the full disk image size is larger than the size of the sum of the partitions due to metadata.  We consider that the size of volumes have higher priority than the size of the disk.
2. The `/` partition (or volume container that contains `/`) is always last.
3. When the `/` partition is raw, it is grown to fill any leftover space on the Partition Table.
4. LogicalVolumes do not need to fill the space in the VolumeGroup since it is trivial to grow LVs.

The first principle has some interesting user experience implications.  If a user wants a disk image to be, for example, exactly `5 GiB`, and they specify it in their build request (the `composer-cli compose start` call), but they also include a list of partitions that sum up to `5 GiB` exactly, they will get a disk that is larger than `5 GiB` due to the header, footer, and metadata.  To get a disk size that is exactly `5 GiB`, the user will have to define partitions that sum up to slightly less and also specify the disk size in the compose call, which will create a disk that is exactly `5 GiB`, with all the desired volumes at their defined size, and a VolumeGroup partition that fills the space.