### PR TITLE
Add BP customization for importing RPM GPG keys from the image tree (COMPOSER-2308)

### DIFF
--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -27,6 +27,7 @@ type Customizations struct {
 	FIPS               *bool                          `json:"fips,omitempty" toml:"fips,omitempty"`
 	ContainersStorage  *ContainerStorageCustomization `json:"containers-storage,omitempty" toml:"containers-storage,omitempty"`
 	Installer          *InstallerCustomization        `json:"installer,omitempty" toml:"installer,omitempty"`
+	RPM                *RPMCustomization              `json:"rpm,omitempty" toml:"rpm,omitempty"`
 }
 
 type IgnitionCustomization struct {
@@ -411,4 +412,11 @@ func (c *Customizations) GetInstaller() (*InstallerCustomization, error) {
 	}
 
 	return c.Installer, nil
+}
+
+func (c *Customizations) GetRPM() *RPMCustomization {
+	if c == nil {
+		return nil
+	}
+	return c.RPM
 }

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -376,3 +376,20 @@ func TestGetOpenSCAPConfig(t *testing.T) {
 
 	assert.EqualValues(t, expectedOscap, *retOpenSCAPCustomiztions)
 }
+
+func TestGetImportRPMGPGKey(t *testing.T) {
+	expectedRPM := RPMCustomization{
+		ImportKeys: &RPMImportKeys{
+			[]string{
+				"/etc/pki/rpm-gpg/RPM-GPG-KEY",
+			},
+		},
+	}
+
+	TestCustomizations := Customizations{
+		RPM: &expectedRPM,
+	}
+
+	retRPM := TestCustomizations.GetRPM()
+	assert.EqualValues(t, expectedRPM, *retRPM)
+}

--- a/pkg/blueprint/rpm_customizations.go
+++ b/pkg/blueprint/rpm_customizations.go
@@ -1,0 +1,10 @@
+package blueprint
+
+type RPMImportKeys struct {
+	// File paths in the image to import keys from
+	Files []string `json:"files,omitempty" toml:"files,omitempty"`
+}
+
+type RPMCustomization struct {
+	ImportKeys *RPMImportKeys `json:"import_keys,omitempty" toml:"import_keys,omitempty"`
+}

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -57,6 +57,10 @@ func osCustomizations(
 	osc.Containers = containers
 
 	osc.GPGKeyFiles = imageConfig.GPGKeyFiles
+	if rpm := c.GetRPM(); rpm != nil && rpm.ImportKeys != nil {
+		osc.GPGKeyFiles = append(osc.GPGKeyFiles, rpm.ImportKeys.Files...)
+	}
+
 	if imageConfig.ExcludeDocs != nil {
 		osc.ExcludeDocs = *imageConfig.ExcludeDocs
 	}

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -58,6 +58,10 @@ func osCustomizations(
 	osc.Containers = containers
 
 	osc.GPGKeyFiles = imageConfig.GPGKeyFiles
+	if rpm := c.GetRPM(); rpm != nil && rpm.ImportKeys != nil {
+		osc.GPGKeyFiles = append(osc.GPGKeyFiles, rpm.ImportKeys.Files...)
+	}
+
 	if imageConfig.ExcludeDocs != nil {
 		osc.ExcludeDocs = *imageConfig.ExcludeDocs
 	}

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -278,5 +278,22 @@
       "rhel-9.3",
       "rhel-9.4"
     ]
+  },
+  "./configs/import-rpm-gpg-keys-from-tree-rhel.json": {
+    "image-types": [
+      "qcow2"
+    ],
+    "distros": [
+      "rhel-8.10",
+      "rhel-9.5"
+    ]
+  },
+  "./configs/import-rpm-gpg-keys-from-tree-fedora.json": {
+    "image-types": [
+      "qcow2"
+    ],
+    "distros": [
+      "fedora*"
+    ]
   }
 }

--- a/test/configs/import-rpm-gpg-keys-from-tree-fedora.json
+++ b/test/configs/import-rpm-gpg-keys-from-tree-fedora.json
@@ -1,0 +1,14 @@
+{
+  "name": "import-rpm-gpg-keys-from-tree-fedora",
+  "blueprint": {
+    "customizations": {
+      "rpm": {
+        "import_keys": {
+          "files": [
+            "/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-18-primary"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/test/configs/import-rpm-gpg-keys-from-tree-rhel.json
+++ b/test/configs/import-rpm-gpg-keys-from-tree-rhel.json
@@ -1,0 +1,14 @@
+{
+  "name": "import-rpm-gpg-keys-from-tree-rhel",
+  "blueprint": {
+    "customizations": {
+      "rpm": {
+        "import_keys": {
+          "files": [
+            "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
As part of https://issues.redhat.com/browse/COMPOSER-2308, I'm moving RHUI client RPMs installation from the image definition to customizations. However, Azure RHUI images import by default RPM GPG keys from the image tree, which are installed by the RHUI client rpm. Which means that the image definition technically still has hard dependency on the RHUI client rpm. Therefore it makes sense to also move the RPM GPG key importing from tree also to the customizations.

Add a BP customization for specifying paths to RPM GPG keys installed in the image, which will be imported to the RPM database during image build.