### PR TITLE
pkg/oscap: refactor & clean up

### DIFF
--- a/pkg/customizations/oscap/oscap_test.go
+++ b/pkg/customizations/oscap/oscap_test.go
@@ -11,11 +11,10 @@ import (
 
 func TestOscapConfigGeneration(t *testing.T) {
 	tests := []struct {
-		name                string
-		options             blueprint.OpenSCAPCustomization
-		expectedRemediation *RemediationConfig
-		expectedTailoring   *TailoringConfig
-		err                 error
+		name     string
+		options  blueprint.OpenSCAPCustomization
+		expected *RemediationConfig
+		err      error
 	}{
 		{
 			name:    "no-datastream",
@@ -59,20 +58,15 @@ func TestOscapConfigGeneration(t *testing.T) {
 					ProfileID: "some-tailored-id",
 				},
 			},
-			expectedRemediation: &RemediationConfig{
+			expected: &RemediationConfig{
 				Datastream:         "datastream",
-				ProfileID:          "some-tailored-id",
-				TailoringPath:      filepath.Join(DataDir, "tailoring.xml"),
+				ProfileID:          "some-profile-id",
 				CompressionEnabled: true,
-			},
-			expectedTailoring: &TailoringConfig{
-				RemediationConfig: RemediationConfig{
-					Datastream:    "datastream",
-					ProfileID:     "some-profile-id",
-					TailoringPath: filepath.Join(DataDir, "tailoring.xml"),
+				TailoringConfig: &TailoringConfig{
+					TailoringPath:     filepath.Join(DataDir, "tailoring.xml"),
+					JSONFilepath:      "/some/filepath.json",
+					TailoredProfileID: "some-tailored-id",
 				},
-				JSONFilepath:      "/some/filepath.json",
-				TailoredProfileID: "some-tailored-id",
 			},
 			err: nil,
 		},
@@ -86,37 +80,30 @@ func TestOscapConfigGeneration(t *testing.T) {
 					Unselected: []string{"two", "four"},
 				},
 			},
-			expectedRemediation: &RemediationConfig{
+			expected: &RemediationConfig{
 				Datastream:         "datastream",
-				ProfileID:          "some-profile-id_osbuild_tailoring",
-				TailoringPath:      filepath.Join(DataDir, "tailoring.xml"),
+				ProfileID:          "some-profile-id",
 				CompressionEnabled: true,
-			},
-			expectedTailoring: &TailoringConfig{
-				RemediationConfig: RemediationConfig{
-					Datastream:    "datastream",
-					ProfileID:     "some-profile-id",
-					TailoringPath: filepath.Join(DataDir, "tailoring.xml"),
+				TailoringConfig: &TailoringConfig{
+					TailoringPath:     filepath.Join(DataDir, "tailoring.xml"),
+					TailoredProfileID: "some-profile-id_osbuild_tailoring",
+					Selected:          []string{"one", "three"},
+					Unselected:        []string{"two", "four"},
 				},
-				TailoredProfileID: "some-profile-id_osbuild_tailoring",
-				Selected:          []string{"one", "three"},
-				Unselected:        []string{"two", "four"},
 			},
 			err: nil,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			remediationConfig, tailoringConfig, err := NewConfigs(tt.options, nil)
+			remediationConfig, err := NewConfigs(tt.options, nil)
 			if tt.err != nil {
 				assert.NotNil(t, err)
 				assert.EqualValues(t, tt.err, err)
 				assert.Nil(t, remediationConfig)
-				assert.Nil(t, tailoringConfig)
 			} else {
 				assert.NoError(t, err)
-				assert.EqualValues(t, tt.expectedRemediation, remediationConfig)
-				assert.EqualValues(t, tt.expectedTailoring, tailoringConfig)
+				assert.EqualValues(t, tt.expected, remediationConfig)
 			}
 		})
 	}

--- a/pkg/customizations/oscap/oscap_test.go
+++ b/pkg/customizations/oscap/oscap_test.go
@@ -1,0 +1,123 @@
+package oscap
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/osbuild/images/pkg/blueprint"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOscapConfigGeneration(t *testing.T) {
+	tests := []struct {
+		name                string
+		options             blueprint.OpenSCAPCustomization
+		expectedRemediation *RemediationConfig
+		expectedTailoring   *TailoringConfig
+		err                 error
+	}{
+		{
+			name:    "no-datastream",
+			options: blueprint.OpenSCAPCustomization{},
+			err:     fmt.Errorf("No OSCAP datastream specified and the distro does not have any default set"),
+		},
+		{
+			name: "multiple-tailoring-options",
+			options: blueprint.OpenSCAPCustomization{
+				DataStream:    "datastream",
+				Tailoring:     &blueprint.OpenSCAPTailoringCustomizations{},
+				JSONTailoring: &blueprint.OpenSCAPJSONTailoringCustomizations{},
+			},
+			err: fmt.Errorf("Multiple tailoring types set, only one type can be chosen (JSON/Override rules)"),
+		},
+		{
+			name: "no-json-filepath",
+			options: blueprint.OpenSCAPCustomization{
+				DataStream:    "datastream",
+				JSONTailoring: &blueprint.OpenSCAPJSONTailoringCustomizations{},
+			},
+			err: fmt.Errorf("Filepath to an JSON tailoring file is required"),
+		},
+		{
+			name: "no-json-tailoring-id",
+			options: blueprint.OpenSCAPCustomization{
+				DataStream: "datastream",
+				JSONTailoring: &blueprint.OpenSCAPJSONTailoringCustomizations{
+					Filepath: "/some/filepath.json",
+				},
+			},
+			err: fmt.Errorf("Tailoring profile ID is required for an JSON tailoring file"),
+		},
+		{
+			name: "valid-json-tailoring",
+			options: blueprint.OpenSCAPCustomization{
+				DataStream: "datastream",
+				ProfileID:  "some-profile-id",
+				JSONTailoring: &blueprint.OpenSCAPJSONTailoringCustomizations{
+					Filepath:  "/some/filepath.json",
+					ProfileID: "some-tailored-id",
+				},
+			},
+			expectedRemediation: &RemediationConfig{
+				Datastream:         "datastream",
+				ProfileID:          "some-tailored-id",
+				TailoringPath:      filepath.Join(DataDir, "tailoring.xml"),
+				CompressionEnabled: true,
+			},
+			expectedTailoring: &TailoringConfig{
+				RemediationConfig: RemediationConfig{
+					Datastream:    "datastream",
+					ProfileID:     "some-profile-id",
+					TailoringPath: filepath.Join(DataDir, "tailoring.xml"),
+				},
+				JSONFilepath:      "/some/filepath.json",
+				TailoredProfileID: "some-tailored-id",
+			},
+			err: nil,
+		},
+		{
+			name: "valid-tailoring",
+			options: blueprint.OpenSCAPCustomization{
+				DataStream: "datastream",
+				ProfileID:  "some-profile-id",
+				Tailoring: &blueprint.OpenSCAPTailoringCustomizations{
+					Selected:   []string{"one", "three"},
+					Unselected: []string{"two", "four"},
+				},
+			},
+			expectedRemediation: &RemediationConfig{
+				Datastream:         "datastream",
+				ProfileID:          "some-profile-id_osbuild_tailoring",
+				TailoringPath:      filepath.Join(DataDir, "tailoring.xml"),
+				CompressionEnabled: true,
+			},
+			expectedTailoring: &TailoringConfig{
+				RemediationConfig: RemediationConfig{
+					Datastream:    "datastream",
+					ProfileID:     "some-profile-id",
+					TailoringPath: filepath.Join(DataDir, "tailoring.xml"),
+				},
+				TailoredProfileID: "some-profile-id_osbuild_tailoring",
+				Selected:          []string{"one", "three"},
+				Unselected:        []string{"two", "four"},
+			},
+			err: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			remediationConfig, tailoringConfig, err := NewConfigs(tt.options, nil)
+			if tt.err != nil {
+				assert.NotNil(t, err)
+				assert.EqualValues(t, tt.err, err)
+				assert.Nil(t, remediationConfig)
+				assert.Nil(t, tailoringConfig)
+			} else {
+				assert.NoError(t, err)
+				assert.EqualValues(t, tt.expectedRemediation, remediationConfig)
+				assert.EqualValues(t, tt.expectedTailoring, tailoringConfig)
+			}
+		})
+	}
+}

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -189,12 +189,11 @@ func osCustomizations(
 		}
 		osc.Directories = append(osc.Directories, oscapDataNode)
 
-		remediationConfig, tailoringConfig, err := oscap.NewConfigs(*oscapConfig, imageConfig.DefaultOSCAPDatastream)
+		remediationConfig, err := oscap.NewConfigs(*oscapConfig, imageConfig.DefaultOSCAPDatastream)
 		if err != nil {
 			panic(fmt.Errorf("error creating OpenSCAP configs: %w", err))
 		}
 
-		osc.OpenSCAPTailorConfig = tailoringConfig
 		osc.OpenSCAPRemediationConfig = remediationConfig
 	}
 

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -210,12 +210,11 @@ func osCustomizations(
 		}
 		osc.Directories = append(osc.Directories, oscapDataNode)
 
-		remediationConfig, tailoringConfig, err := oscap.NewConfigs(*oscapConfig, imageConfig.DefaultOSCAPDatastream)
+		remediationConfig, err := oscap.NewConfigs(*oscapConfig, imageConfig.DefaultOSCAPDatastream)
 		if err != nil {
 			panic(fmt.Errorf("error creating OpenSCAP configs: %w", err))
 		}
 
-		osc.OpenSCAPTailorConfig = tailoringConfig
 		osc.OpenSCAPRemediationConfig = remediationConfig
 	}
 

--- a/pkg/osbuild/oscap_autotailor_stage.go
+++ b/pkg/osbuild/oscap_autotailor_stage.go
@@ -73,36 +73,41 @@ func NewOscapAutotailorStage(options *OscapAutotailorStageOptions) *Stage {
 	}
 }
 
-func NewOscapAutotailorStageOptions(options *oscap.TailoringConfig) *OscapAutotailorStageOptions {
+func NewOscapAutotailorStageOptions(options *oscap.RemediationConfig) *OscapAutotailorStageOptions {
 	if options == nil {
+		return nil
+	}
+
+	tailoringConfig := options.TailoringConfig
+	if tailoringConfig == nil {
 		return nil
 	}
 
 	// TODO: don't panic! unfortunately this would involve quite
 	// a big refactor and we still need to be a bit defensive here
-	if options.RemediationConfig.TailoringPath == "" {
+	if tailoringConfig.TailoringPath == "" {
 		panic(fmt.Errorf("The tailoring path for the OpenSCAP remediation config cannot be empty, this is a programming error"))
 	}
 
-	if options.JSONFilepath != "" {
+	if tailoringConfig.JSONFilepath != "" {
 		return &OscapAutotailorStageOptions{
-			Filepath: options.RemediationConfig.TailoringPath,
+			Filepath: tailoringConfig.TailoringPath,
 			Config: AutotailorJSONConfig{
-				TailoredProfileID: options.TailoredProfileID,
-				Datastream:        options.RemediationConfig.Datastream,
-				TailoringFile:     options.JSONFilepath,
+				Datastream:        options.Datastream,
+				TailoredProfileID: tailoringConfig.TailoredProfileID,
+				TailoringFile:     tailoringConfig.JSONFilepath,
 			},
 		}
 	}
 
 	return &OscapAutotailorStageOptions{
-		Filepath: options.RemediationConfig.TailoringPath,
+		Filepath: tailoringConfig.TailoringPath,
 		Config: AutotailorKeyValueConfig{
-			NewProfile: options.TailoredProfileID,
-			Datastream: options.RemediationConfig.Datastream,
-			ProfileID:  options.RemediationConfig.ProfileID,
-			Selected:   options.Selected,
-			Unselected: options.Unselected,
+			Datastream: options.Datastream,
+			ProfileID:  options.ProfileID,
+			NewProfile: tailoringConfig.TailoredProfileID,
+			Selected:   tailoringConfig.Selected,
+			Unselected: tailoringConfig.Unselected,
 		},
 	}
 }

--- a/pkg/osbuild/oscap_remediation_stage.go
+++ b/pkg/osbuild/oscap_remediation_stage.go
@@ -81,13 +81,19 @@ func NewOscapRemediationStageOptions(dataDir string, options *oscap.RemediationC
 		return nil
 	}
 
+	config := OscapConfig{
+		ProfileID:   options.ProfileID,
+		Datastream:  options.Datastream,
+		Compression: options.CompressionEnabled,
+	}
+
+	if tc := options.TailoringConfig; tc != nil {
+		config.ProfileID = tc.TailoredProfileID
+		config.Tailoring = tc.TailoringPath
+	}
+
 	return &OscapRemediationStageOptions{
 		DataDir: dataDir,
-		Config: OscapConfig{
-			ProfileID:   options.ProfileID,
-			Datastream:  options.Datastream,
-			Tailoring:   options.TailoringPath,
-			Compression: options.CompressionEnabled,
-		},
+		Config:  config,
 	}
 }


### PR DESCRIPTION
The oscap tailoring and remediation configs were too tightly coupled with the osbuild stage implementations. These configs can be refactored further by making the `TailoringConfig` a pointer on the
`RemediationConfig`, reversing the dependency of the configs.

These changes should reduce the complexity of the OpenSCAP stage options and hopefully reduce some of the confusion too.

Thanks to @thozza for the suggestion