### PR TITLE
filesystem: fix Filesystem.GenUUID() for vfat partitions

### DIFF
--- a/pkg/disk/filesystem.go
+++ b/pkg/disk/filesystem.go
@@ -88,6 +88,11 @@ func (fs *Filesystem) GetFSTabOptions() FSTabOptions {
 }
 
 func (fs *Filesystem) GenUUID(rng *rand.Rand) {
+	if fs.Type == "vfat" && fs.UUID == "" {
+		// vfat has no uuids, it has "serial numbers" (volume IDs)
+		fs.UUID = NewVolIDFromRand(rng)
+		return
+	}
 	if fs.UUID == "" {
 		fs.UUID = uuid.Must(newRandomUUIDFromReader(rng)).String()
 	}

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -81,3 +81,27 @@ func TestPartitionTable_GenerateUUIDs(t *testing.T) {
 	assert.Equal(t, "fb180daf-48a7-4ee0-b10d-394651850fd4", pt.Partitions[2].Payload.(*disk.Btrfs).UUID)
 	assert.Equal(t, "fb180daf-48a7-4ee0-b10d-394651850fd4", pt.Partitions[2].Payload.(*disk.Btrfs).Subvolumes[0].UUID)
 }
+
+func TestPartitionTable_GenerateUUIDs_VFAT(t *testing.T) {
+	pt := disk.PartitionTable{
+		Type: "dos",
+		Partitions: []disk.Partition{
+			{
+				Size: 2 * common.GibiByte,
+				Type: disk.FilesystemDataGUID,
+				Payload: &disk.Filesystem{
+					Type:       "vfat",
+					Mountpoint: "/boot/efi",
+				},
+			},
+		},
+	}
+
+	// Static seed for testing
+	/* #nosec G404 */
+	rnd := rand.New(rand.NewSource(0))
+
+	pt.GenerateUUIDs(rnd)
+
+	assert.Equal(t, "6e4ff95f", pt.Partitions[0].Payload.(*disk.Filesystem).UUID)
+}


### PR DESCRIPTION
When generating UUIDs for filesystems we need to special case the vfat filesystem. It does not actually support UUIDs but instead uses a 32bit hex encoded serial number (volume id). So special case "vfat" and generate a volume-id in this case.