### PR TITLE
[RFC] distro: drop hardcoded partiton table UUIDs

### DIFF
--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -9,7 +9,6 @@ import (
 
 var defaultBasePartitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_X86_64.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
@@ -61,7 +60,6 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		},
 	},
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
@@ -107,7 +105,6 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		},
 	},
 	arch.ARCH_PPC64LE.String(): disk.PartitionTable{
-		UUID: "0x14fc63d2",
 		Type: "dos",
 		Partitions: []disk.Partition{
 			{
@@ -140,7 +137,6 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 	},
 
 	arch.ARCH_S390X.String(): disk.PartitionTable{
-		UUID: "0x14fc63d2",
 		Type: "dos",
 		Partitions: []disk.Partition{
 			{
@@ -171,7 +167,6 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 
 var minimalrawPartitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_X86_64.String(): disk.PartitionTable{
-		UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type:        "gpt",
 		StartOffset: 8 * common.MebiByte,
 		Partitions: []disk.Partition{
@@ -218,7 +213,6 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 		},
 	},
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
-		UUID:        "0xc1748067",
 		Type:        "dos",
 		StartOffset: 8 * common.MebiByte,
 		Partitions: []disk.Partition{
@@ -266,7 +260,6 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 
 var iotBasePartitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_X86_64.String(): disk.PartitionTable{
-		UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type:        "gpt",
 		StartOffset: 8 * common.MebiByte,
 		Partitions: []disk.Partition{
@@ -313,7 +306,6 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 		},
 	},
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
-		UUID:        "0xc1748067",
 		Type:        "dos",
 		StartOffset: 8 * common.MebiByte,
 		Partitions: []disk.Partition{
@@ -361,7 +353,6 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 
 var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_X86_64.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
@@ -431,7 +422,6 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 		},
 	},
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{

--- a/pkg/distro/rhel/rhel10/partition_tables.go
+++ b/pkg/distro/rhel/rhel10/partition_tables.go
@@ -11,7 +11,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	switch t.Arch().Name() {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
@@ -64,7 +63,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 		}, true
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
@@ -111,7 +109,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 		}, true
 	case arch.ARCH_PPC64LE.String():
 		return disk.PartitionTable{
-			UUID: "0x14fc63d2",
 			Type: "dos",
 			Partitions: []disk.Partition{
 				{
@@ -145,7 +142,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 
 	case arch.ARCH_S390X.String():
 		return disk.PartitionTable{
-			UUID: "0x14fc63d2",
 			Type: "dos",
 			Partitions: []disk.Partition{
 				{

--- a/pkg/distro/rhel/rhel7/ami.go
+++ b/pkg/distro/rhel/rhel7/ami.go
@@ -257,7 +257,6 @@ func ec2PartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	switch t.Arch().Name() {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Size: 10 * common.GibiByte,
 			Partitions: []disk.Partition{

--- a/pkg/distro/rhel/rhel7/azure.go
+++ b/pkg/distro/rhel/rhel7/azure.go
@@ -284,7 +284,6 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 	switch t.Arch().Name() {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Size: 64 * common.GibiByte,
 			Partitions: []disk.Partition{

--- a/pkg/distro/rhel/rhel7/partition_tables.go
+++ b/pkg/distro/rhel/rhel7/partition_tables.go
@@ -11,7 +11,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	switch t.Arch().Name() {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{

--- a/pkg/distro/rhel/rhel8/azure.go
+++ b/pkg/distro/rhel/rhel8/azure.go
@@ -285,7 +285,6 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 	switch t.Arch().Name() {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Size: 64 * common.GibiByte,
 			Partitions: []disk.Partition{
@@ -395,7 +394,6 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Size: 64 * common.GibiByte,
 			Partitions: []disk.Partition{

--- a/pkg/distro/rhel/rhel8/partition_tables.go
+++ b/pkg/distro/rhel/rhel8/partition_tables.go
@@ -11,7 +11,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	switch t.Arch().Name() {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
@@ -51,7 +50,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
@@ -85,7 +83,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 
 	case arch.ARCH_PPC64LE.String():
 		return disk.PartitionTable{
-			UUID: "0x14fc63d2",
 			Type: "dos",
 			Partitions: []disk.Partition{
 				{
@@ -108,7 +105,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 
 	case arch.ARCH_S390X.String():
 		return disk.PartitionTable{
-			UUID: "0x14fc63d2",
 			Type: "dos",
 			Partitions: []disk.Partition{
 				{
@@ -134,7 +130,6 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	switch t.Arch().Name() {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
@@ -203,7 +198,6 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
@@ -281,7 +275,6 @@ func ec2PartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	}
 
 	x86PartitionTable := disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
@@ -321,7 +314,6 @@ func ec2PartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	// RHEL EC2 x86_64 images prior to 8.9 support only BIOS boot
 	if common.VersionLessThan(t.Arch().Distro().OsVersion(), "8.9") && t.IsRHEL() {
 		x86PartitionTable = disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
@@ -353,7 +345,6 @@ func ec2PartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{

--- a/pkg/distro/rhel/rhel9/azure.go
+++ b/pkg/distro/rhel/rhel9/azure.go
@@ -233,7 +233,6 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 	switch t.Arch().Name() {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Size: 64 * common.GibiByte,
 			Partitions: []disk.Partition{
@@ -342,7 +341,6 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 		}, true
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Size: 64 * common.GibiByte,
 			Partitions: []disk.Partition{

--- a/pkg/distro/rhel/rhel9/edge.go
+++ b/pkg/distro/rhel/rhel9/edge.go
@@ -371,7 +371,6 @@ func minimalrawPartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	switch t.Arch().Name() {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
-			UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type:        "gpt",
 			StartOffset: 8 * common.MebiByte,
 			Partitions: []disk.Partition{
@@ -419,7 +418,6 @@ func minimalrawPartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 		}, true
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
-			UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type:        "gpt",
 			StartOffset: 8 * common.MebiByte,
 			Partitions: []disk.Partition{
@@ -474,7 +472,6 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	switch t.Arch().Name() {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
@@ -551,7 +548,6 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 		}, true
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{

--- a/pkg/distro/rhel/rhel9/partition_tables.go
+++ b/pkg/distro/rhel/rhel9/partition_tables.go
@@ -24,7 +24,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	switch t.Arch().Name() {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
@@ -77,7 +76,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 		}, true
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
@@ -124,7 +122,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 		}, true
 	case arch.ARCH_PPC64LE.String():
 		return disk.PartitionTable{
-			UUID: "0x14fc63d2",
 			Type: "dos",
 			Partitions: []disk.Partition{
 				{
@@ -158,7 +155,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 
 	case arch.ARCH_S390X.String():
 		return disk.PartitionTable{
-			UUID: "0x14fc63d2",
 			Type: "dos",
 			Partitions: []disk.Partition{
 				{


### PR DESCRIPTION
The current distro partition tables contain hardcoded UUIDs for various elements like the partition table, the partition and the filesystem UUIDs. Hardcoding these seems slightly unusual, given that a UUID is supposed to be (practically) unique and that the images library will DTRT if no UUID is set.

This commit removes the hardcoded PartitionTable UUID as a starting point to spark a discussion. I have only a limited understanding of the history of this and while I did do a bit of git archeology I could not find a commit with a rational why the UUIDs are hardcoded [0] so I'm asking for a review from some of the people who are around for a long time. I would love to understand if there is a reason to have these hardcoded UUIDs and i'm happy to do a PR that adds comments etc that will explain this reason. If however we do not need/want the hardcoded UUIDs i will continue and remove them from the partition and filesystems too. If we go down this path I'm sure this is a risky change because some people probably rely by now on the fact that the UUID is actually quite predictable (also https://xkcd.com/1172) and because this behavior is here since day 1 (or so it seems). Also @achilleas-k mentioned "Chestertons fence" to me so I'm trying to be extra cautious. Help is greatly appreciated to help me understand this better!

C.f. https://github.com/osbuild/bootc-image-builder/pull/568

[0] I found 
https://github.com/osbuild/osbuild-composer/commit/22254637f810f1cabc95fb616b46d92049135e99#diff-de240f0bca8f03daafeb653ff429aafa12f43b5e0dc8ba327c56108a6ff864f3R115 and https://github.com/osbuild/osbuild-composer/commit/0dd17ae3f707ab9e89f4a289ed461ee0d28fd203