### PR TITLE
rhel10: drop `net.ifnames=0` from rhel10/centos10

### DIFF
--- a/pkg/distro/rhel/rhel10/ami.go
+++ b/pkg/distro/rhel/rhel10/ami.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TODO: move these to the EC2 environment
-const amiKernelOptions = "console=tty0 console=ttyS0,115200n8 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295"
+const amiKernelOptions = "console=tty0 console=ttyS0,115200n8 rd.blacklist=nouveau nvme_core.io_timeout=4294967295"
 
 // default EC2 images config (common for all architectures)
 func baseEc2ImageConfig() *distro.ImageConfig {
@@ -262,7 +262,7 @@ func mkAMIImgTypeAarch64() *rhel.ImageType {
 		[]string{"image"},
 	)
 
-	it.KernelOptions = "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0"
+	it.KernelOptions = "console=ttyS0,115200n8 console=tty0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0"
 	it.Bootable = true
 	it.DefaultSize = 10 * common.GibiByte
 	it.DefaultImageConfig = defaultAMIImageConfig()

--- a/pkg/distro/rhel/rhel10/distro_test.go
+++ b/pkg/distro/rhel/rhel10/distro_test.go
@@ -398,7 +398,7 @@ func TestRhel10_KernelOption(t *testing.T) {
 }
 
 func TestDistro_CustomFileSystemManifestError(t *testing.T) {
-	r9distro := rhelFamilyDistros[0].distro
+	r10distro := rhelFamilyDistros[0].distro
 	bp := blueprint.Blueprint{
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
@@ -409,8 +409,8 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 			},
 		},
 	}
-	for _, archName := range r9distro.ListArches() {
-		arch, _ := r9distro.GetArch(archName)
+	for _, archName := range r10distro.ListArches() {
+		arch, _ := r10distro.GetArch(archName)
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
@@ -420,7 +420,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 }
 
 func TestDistro_TestRootMountPoint(t *testing.T) {
-	r9distro := rhelFamilyDistros[0].distro
+	r10distro := rhelFamilyDistros[0].distro
 	bp := blueprint.Blueprint{
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
@@ -431,8 +431,8 @@ func TestDistro_TestRootMountPoint(t *testing.T) {
 			},
 		},
 	}
-	for _, archName := range r9distro.ListArches() {
-		arch, _ := r9distro.GetArch(archName)
+	for _, archName := range r10distro.ListArches() {
+		arch, _ := r10distro.GetArch(archName)
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
@@ -442,7 +442,7 @@ func TestDistro_TestRootMountPoint(t *testing.T) {
 }
 
 func TestDistro_CustomFileSystemSubDirectories(t *testing.T) {
-	r9distro := rhelFamilyDistros[0].distro
+	r10distro := rhelFamilyDistros[0].distro
 	bp := blueprint.Blueprint{
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
@@ -457,8 +457,8 @@ func TestDistro_CustomFileSystemSubDirectories(t *testing.T) {
 			},
 		},
 	}
-	for _, archName := range r9distro.ListArches() {
-		arch, _ := r9distro.GetArch(archName)
+	for _, archName := range r10distro.ListArches() {
+		arch, _ := r10distro.GetArch(archName)
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
@@ -472,7 +472,7 @@ func TestDistro_CustomFileSystemSubDirectories(t *testing.T) {
 }
 
 func TestDistro_MountpointsWithArbitraryDepthAllowed(t *testing.T) {
-	r9distro := rhelFamilyDistros[0].distro
+	r10distro := rhelFamilyDistros[0].distro
 	bp := blueprint.Blueprint{
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
@@ -495,8 +495,8 @@ func TestDistro_MountpointsWithArbitraryDepthAllowed(t *testing.T) {
 			},
 		},
 	}
-	for _, archName := range r9distro.ListArches() {
-		arch, _ := r9distro.GetArch(archName)
+	for _, archName := range r10distro.ListArches() {
+		arch, _ := r10distro.GetArch(archName)
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
@@ -510,7 +510,7 @@ func TestDistro_MountpointsWithArbitraryDepthAllowed(t *testing.T) {
 }
 
 func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
-	r9distro := rhelFamilyDistros[0].distro
+	r10distro := rhelFamilyDistros[0].distro
 	bp := blueprint.Blueprint{
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
@@ -529,8 +529,8 @@ func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 			},
 		},
 	}
-	for _, archName := range r9distro.ListArches() {
-		arch, _ := r9distro.GetArch(archName)
+	for _, archName := range r10distro.ListArches() {
+		arch, _ := r10distro.GetArch(archName)
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
@@ -540,7 +540,7 @@ func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 }
 
 func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
-	r9distro := rhelFamilyDistros[0].distro
+	r10distro := rhelFamilyDistros[0].distro
 	bp := blueprint.Blueprint{
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
@@ -551,8 +551,8 @@ func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 			},
 		},
 	}
-	for _, archName := range r9distro.ListArches() {
-		arch, _ := r9distro.GetArch(archName)
+	for _, archName := range r10distro.ListArches() {
+		arch, _ := r10distro.GetArch(archName)
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)

--- a/pkg/distro/rhel/rhel10/distro_test.go
+++ b/pkg/distro/rhel/rhel10/distro_test.go
@@ -338,12 +338,12 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 	}
 }
 
-func TestRhel9_ListArches(t *testing.T) {
+func TestRhel10_ListArches(t *testing.T) {
 	arches := rhelFamilyDistros[0].distro.ListArches()
 	assert.Equal(t, []string{"aarch64", "ppc64le", "s390x", "x86_64"}, arches)
 }
 
-func TestRhel9_GetArch(t *testing.T) {
+func TestRhel10_GetArch(t *testing.T) {
 	arches := []struct {
 		name                  string
 		errorExpected         bool
@@ -383,17 +383,17 @@ func TestRhel9_GetArch(t *testing.T) {
 	}
 }
 
-func TestRhel9_Name(t *testing.T) {
+func TestRhel10_Name(t *testing.T) {
 	distro := rhelFamilyDistros[0].distro
 	assert.Equal(t, "rhel-10.0", distro.Name())
 }
 
-func TestRhel9_ModulePlatformID(t *testing.T) {
+func TestRhel10_ModulePlatformID(t *testing.T) {
 	distro := rhelFamilyDistros[0].distro
 	assert.Equal(t, "platform:el10", distro.ModulePlatformID())
 }
 
-func TestRhel9_KernelOption(t *testing.T) {
+func TestRhel10_KernelOption(t *testing.T) {
 	distro_test_common.TestDistro_KernelOption(t, rhelFamilyDistros[0].distro)
 }
 

--- a/pkg/distro/rhel/rhel10/distro_test.go
+++ b/pkg/distro/rhel/rhel10/distro_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/distro_test_common"
+	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/distro/rhel/rhel10"
 )
 
@@ -395,6 +396,21 @@ func TestRhel10_ModulePlatformID(t *testing.T) {
 
 func TestRhel10_KernelOption(t *testing.T) {
 	distro_test_common.TestDistro_KernelOption(t, rhelFamilyDistros[0].distro)
+}
+
+func TestRhel10_KernelOption_NoIfnames(t *testing.T) {
+	for _, distroName := range []string{"rhel-10.0", "centos-10"} {
+		distro := rhel10.DistroFactory(distroName)
+		for _, archName := range distro.ListArches() {
+			arch, err := distro.GetArch(archName)
+			assert.NoError(t, err)
+			for _, imgTypeName := range arch.ListImageTypes() {
+				imgType, err := arch.GetImageType(imgTypeName)
+				assert.NoError(t, err)
+				assert.NotContains(t, imgType.(*rhel.ImageType).KernelOptions, "net.ifnames=0", "type %s contains unwanted net.ifnames=0", imgType.Name())
+			}
+		}
+	}
 }
 
 func TestDistro_CustomFileSystemManifestError(t *testing.T) {

--- a/pkg/distro/rhel/rhel10/qcow2.go
+++ b/pkg/distro/rhel/rhel10/qcow2.go
@@ -24,7 +24,7 @@ func mkQcow2ImgType(d *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = qcowImageConfig(d)
-	it.KernelOptions = "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+	it.KernelOptions = "console=tty0 console=ttyS0,115200n8 no_timer_check"
 	it.DefaultSize = 10 * common.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -47,7 +47,7 @@ func mkOCIImgType(d *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = qcowImageConfig(d)
-	it.KernelOptions = "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+	it.KernelOptions = "console=tty0 console=ttyS0,115200n8 no_timer_check"
 	it.DefaultSize = 10 * common.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -72,7 +72,7 @@ func mkOpenstackImgType() *rhel.ImageType {
 	it.DefaultImageConfig = &distro.ImageConfig{
 		Locale: common.ToPtr("en_US.UTF-8"),
 	}
-	it.KernelOptions = "ro net.ifnames=0"
+	it.KernelOptions = "ro"
 	it.DefaultSize = 4 * common.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables

--- a/pkg/distro/rhel/rhel10/vmdk.go
+++ b/pkg/distro/rhel/rhel10/vmdk.go
@@ -7,7 +7,7 @@ import (
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-const vmdkKernelOptions = "ro net.ifnames=0"
+const vmdkKernelOptions = "ro"
 
 func mkVMDKImgType() *rhel.ImageType {
 	it := rhel.NewImageType(


### PR DESCRIPTION
Drop net.ifnames=0 from RHEL 10 and Centos10 disk images and add test.

Fixes: COMPOSER-2289
Fixes: COMPOSER-2323

