### PR TITLE
rhel10: drop `ifcfg-eth0` sysconfig network-scripts file

### DIFF
--- a/pkg/distro/rhel/rhel10/ami.go
+++ b/pkg/distro/rhel/rhel10/ami.go
@@ -58,19 +58,6 @@ func baseEc2ImageConfig() *distro.ImageConfig {
 					Networking: true,
 					NoZeroConf: true,
 				},
-				NetworkScripts: &osbuild.NetworkScriptsOptions{
-					IfcfgFiles: map[string]osbuild.IfcfgFile{
-						"eth0": {
-							Device:    "eth0",
-							Bootproto: osbuild.IfcfgBootprotoDHCP,
-							OnBoot:    common.ToPtr(true),
-							Type:      osbuild.IfcfgTypeEthernet,
-							UserCtl:   common.ToPtr(true),
-							PeerDNS:   common.ToPtr(true),
-							IPv6Init:  common.ToPtr(false),
-						},
-					},
-				},
 			},
 		},
 		SystemdLogind: []*osbuild.SystemdLogindStageOptions{


### PR DESCRIPTION
The AMI for rhel9 and below writes a `ifcfg-eth0` sysconfig file that enables dhcp and disables ipv6. This commit drops this file because:
1. ipcfg-rh is deprecated
2. NetworkManager defaults to dhcp by default for wired ethernet (unless configured otherwise)
3. It seems we do not need to disable ipv6 in 2024 anymore

With the exception of (3) I'm pretty confident in this commit. Feedback welcome (especially on (3)). Fwiw, I did testbuild/ran the centos10 ami and it booted fine and network is available.

Thanks to @thozza and @ondrejbudai 