### PR TITLE
rhel10: drop hardcoded UUIDs from {centos,rhel}-10, fedora

### DIFF
--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -9,22 +9,18 @@ import (
 
 var defaultBasePartitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_X86_64.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
 				Size:     1 * common.MebiByte,
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
-				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
 				Size: 200 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
 					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
 					Mountpoint:   "/boot/efi",
 					Label:        "EFI-SYSTEM",
 					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
@@ -35,7 +31,6 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 			{
 				Size: 500 * common.MebiByte,
 				Type: disk.FilesystemDataGUID,
-				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
@@ -48,7 +43,6 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 			{
 				Size: 2 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Label:        "root",
@@ -61,16 +55,13 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		},
 	},
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
 				Size: 200 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
 					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
 					Mountpoint:   "/boot/efi",
 					Label:        "EFI-SYSTEM",
 					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
@@ -81,7 +72,6 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 			{
 				Size: 500 * common.MebiByte,
 				Type: disk.FilesystemDataGUID,
-				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
@@ -94,7 +84,6 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 			{
 				Size: 2 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Label:        "root",
@@ -107,7 +96,6 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		},
 	},
 	arch.ARCH_PPC64LE.String(): disk.PartitionTable{
-		UUID: "0x14fc63d2",
 		Type: "dos",
 		Partitions: []disk.Partition{
 			{
@@ -140,7 +128,6 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 	},
 
 	arch.ARCH_S390X.String(): disk.PartitionTable{
-		UUID: "0x14fc63d2",
 		Type: "dos",
 		Partitions: []disk.Partition{
 			{
@@ -171,17 +158,14 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 
 var minimalrawPartitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_X86_64.String(): disk.PartitionTable{
-		UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type:        "gpt",
 		StartOffset: 8 * common.MebiByte,
 		Partitions: []disk.Partition{
 			{
 				Size: 200 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
 					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
 					Mountpoint:   "/boot/efi",
 					Label:        "EFI-SYSTEM",
 					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
@@ -192,7 +176,6 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 			{
 				Size: 1 * common.GibiByte,
 				Type: disk.XBootLDRPartitionGUID,
-				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
@@ -205,7 +188,6 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 			{
 				Size: 2 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Label:        "root",
@@ -218,7 +200,6 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 		},
 	},
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
-		UUID:        "0xc1748067",
 		Type:        "dos",
 		StartOffset: 8 * common.MebiByte,
 		Partitions: []disk.Partition{
@@ -228,7 +209,6 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 				Bootable: true,
 				Payload: &disk.Filesystem{
 					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
 					Mountpoint:   "/boot/efi",
 					Label:        "EFI-SYSTEM",
 					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
@@ -266,17 +246,14 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 
 var iotBasePartitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_X86_64.String(): disk.PartitionTable{
-		UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type:        "gpt",
 		StartOffset: 8 * common.MebiByte,
 		Partitions: []disk.Partition{
 			{
 				Size: 501 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
 					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
 					Mountpoint:   "/boot/efi",
 					Label:        "EFI-SYSTEM",
 					FSTabOptions: "umask=0077,shortname=winnt",
@@ -287,7 +264,6 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 			{
 				Size: 1 * common.GibiByte,
 				Type: disk.FilesystemDataGUID,
-				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
@@ -300,7 +276,6 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 			{
 				Size: 2569 * common.MebiByte,
 				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Label:        "root",
@@ -313,7 +288,6 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 		},
 	},
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
-		UUID:        "0xc1748067",
 		Type:        "dos",
 		StartOffset: 8 * common.MebiByte,
 		Partitions: []disk.Partition{
@@ -323,7 +297,6 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 				Bootable: true,
 				Payload: &disk.Filesystem{
 					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
 					Mountpoint:   "/boot/efi",
 					Label:        "EFI-SYSTEM",
 					FSTabOptions: "umask=0077,shortname=winnt",
@@ -361,16 +334,13 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 
 var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_X86_64.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
 				Size: 501 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
 					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
 					Mountpoint:   "/boot/efi",
 					Label:        "EFI-SYSTEM",
 					FSTabOptions: "umask=0077,shortname=winnt",
@@ -381,7 +351,6 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 			{
 				Size: 1 * common.GibiByte,
 				Type: disk.XBootLDRPartitionGUID,
-				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
@@ -393,7 +362,6 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 			},
 			{
 				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
 				Payload: &disk.LUKSContainer{
 					Label:      "crypt_root",
 					Cipher:     "cipher_null",
@@ -431,16 +399,13 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 		},
 	},
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
 				Size: 501 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
 					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
 					Mountpoint:   "/boot/efi",
 					Label:        "EFI-SYSTEM",
 					FSTabOptions: "umask=0077,shortname=winnt",
@@ -451,7 +416,6 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 			{
 				Size: 1 * common.GibiByte,
 				Type: disk.XBootLDRPartitionGUID,
-				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
@@ -463,7 +427,6 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 			},
 			{
 				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
 				Payload: &disk.LUKSContainer{
 					Label:      "crypt_root",
 					Cipher:     "cipher_null",

--- a/pkg/distro/rhel/rhel10/partition_tables.go
+++ b/pkg/distro/rhel/rhel10/partition_tables.go
@@ -11,22 +11,18 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	switch t.Arch().Name() {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
 					Size:     1 * common.MebiByte,
 					Bootable: true,
 					Type:     disk.BIOSBootPartitionGUID,
-					UUID:     disk.BIOSBootPartitionUUID,
 				},
 				{
 					Size: 200 * common.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
-					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
 						Type:         "vfat",
-						UUID:         disk.EFIFilesystemUUID,
 						Mountpoint:   "/boot/efi",
 						Label:        "EFI-SYSTEM",
 						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
@@ -37,7 +33,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 				{
 					Size: 2 * common.GibiByte,
 					Type: disk.FilesystemDataGUID,
-					UUID: disk.RootPartitionUUID,
 					Payload: &disk.Filesystem{
 						Type:         "xfs",
 						Label:        "root",
@@ -51,16 +46,13 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 		}, true
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
 					Size: 200 * common.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
-					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
 						Type:         "vfat",
-						UUID:         disk.EFIFilesystemUUID,
 						Mountpoint:   "/boot/efi",
 						Label:        "EFI-SYSTEM",
 						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
@@ -71,7 +63,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 				{
 					Size: 2 * common.GibiByte,
 					Type: disk.FilesystemDataGUID,
-					UUID: disk.RootPartitionUUID,
 					Payload: &disk.Filesystem{
 						Type:         "xfs",
 						Label:        "root",
@@ -85,7 +76,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 		}, true
 	case arch.ARCH_PPC64LE.String():
 		return disk.PartitionTable{
-			UUID: "0x14fc63d2",
 			Type: "dos",
 			Partitions: []disk.Partition{
 				{
@@ -108,7 +98,6 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 
 	case arch.ARCH_S390X.String():
 		return disk.PartitionTable{
-			UUID: "0x14fc63d2",
 			Type: "dos",
 			Partitions: []disk.Partition{
 				{


### PR DESCRIPTION
rhel10: drop hardcoded UUIDs from {centos,rhel}-10

Historically the rhel/centos image defintion hardcoded the partition
table, partition and filesystem UUIDs. The exact reasons for this
is unclear and it seems it was done mostly for comaptibility with
the previous generation of image build tools.

However given that a UUIDs is meant to be (practically) unique
from rhel10 on we stop hardcoding them. The images library will
then create a random one for each image build. For the cases
where this is undesirable the `OSBUILD_TESTING_RNG_SEED` env
can be used to control the RNG.

----

fedora: drop hardcoded UUIDs for partitions/filesystems

Similar to the change in the previous commit for centos10/rhel10
the hardcoding of the UUIDs is also dropped on fedora.


This is the result of the discussion in https://github.com/osbuild/images/pull/816 