### PR TITLE
blueprint: fix filesystem minsize toml key

### DIFF
--- a/pkg/blueprint/filesystem_customizations.go
+++ b/pkg/blueprint/filesystem_customizations.go
@@ -10,7 +10,7 @@ import (
 
 type FilesystemCustomization struct {
 	Mountpoint string `json:"mountpoint,omitempty" toml:"mountpoint,omitempty"`
-	MinSize    uint64 `json:"minsize,omitempty" toml:"size,omitempty"`
+	MinSize    uint64 `json:"minsize,omitempty" toml:"minsize,omitempty"`
 }
 
 func (fsc *FilesystemCustomization) UnmarshalTOML(data interface{}) error {


### PR DESCRIPTION
The toml tag for customizations.filesystem.minsize was incorrectly set to size.  In osbuild-composer this was already changed to minsize [1]. The blueprint implementation in this repo is used directly in bootc-image-builder, so the tags affect how the config is parsed by that tool.

Our blueprint reference for bootc-image-builder also uses `minsize` [2]. Let's finally unify the config everywhere.

[1] https://github.com/osbuild/osbuild-composer/pull/3783
[2] https://osbuild.org/docs/user-guide/blueprint-reference/#filesystems