### PR TITLE
manifest: remove redundant error check

### DIFF
--- a/pkg/manifest/raw_bootc.go
+++ b/pkg/manifest/raw_bootc.go
@@ -174,9 +174,6 @@ func (p *RawBootcImage) serialize() osbuild.Pipeline {
 	// customize the image
 	if len(p.Groups) > 0 {
 		groupsStage := osbuild.GenGroupsStage(p.Groups)
-		if err != nil {
-			panic(fmt.Sprintf("group stage failed %v", err))
-		}
 		groupsStage.Mounts = mounts
 		groupsStage.Devices = devices
 		pipeline.AddStage(groupsStage)


### PR DESCRIPTION
The group stage block was checking for an error after the osbuild.GenGroupStage() call, which doesn't return an error.