### PR TITLE
cmd/otk-*: fix all otk external to be wrapped in a "tree" json

### DIFF
--- a/cmd/otk-make-fstab-stage/main.go
+++ b/cmd/otk-make-fstab-stage/main.go
@@ -11,7 +11,9 @@ import (
 	"github.com/osbuild/images/internal/otkdisk"
 )
 
-type Input = otkdisk.Data
+type Input struct {
+	Tree otkdisk.Data `json:"tree"`
+}
 
 func makeFstabStages(inp Input) (stages *osbuild.Stage, err error) {
 	defer func() {
@@ -20,7 +22,7 @@ func makeFstabStages(inp Input) (stages *osbuild.Stage, err error) {
 		}
 	}()
 
-	pt := inp.Const.Internal.PartitionTable
+	pt := inp.Tree.Const.Internal.PartitionTable
 	fstabStage := osbuild.NewFSTabStage(osbuild.NewFSTabStageOptions(pt))
 	return fstabStage, nil
 }
@@ -36,7 +38,10 @@ func run(r io.Reader, w io.Writer) error {
 		return fmt.Errorf("cannot make partition stages: %w", err)
 	}
 
-	outputJson, err := json.MarshalIndent(stage, "", "  ")
+	out := map[string]interface{}{
+		"tree": stage,
+	}
+	outputJson, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		return fmt.Errorf("cannot marshal response: %w", err)
 	}

--- a/cmd/otk-make-fstab-stage/main_test.go
+++ b/cmd/otk-make-fstab-stage/main_test.go
@@ -17,35 +17,39 @@ import (
 // disk.PartitionTable so encoding it in json here will not add
 // a benefit for the test
 var minimalInputBase = makefstab.Input{
-	Const: otkdisk.Const{
-		Internal: otkdisk.Internal{
-			PartitionTable: testdisk.MakeFakePartitionTable("/", "/var"),
+	Tree: otkdisk.Data{
+		Const: otkdisk.Const{
+			Internal: otkdisk.Internal{
+				PartitionTable: testdisk.MakeFakePartitionTable("/", "/var"),
+			},
 		},
 	},
 }
 
 var minimalExpectedStages = `{
-  "type": "org.osbuild.fstab",
-  "options": {
-    "filesystems": [
-      {
-        "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
-        "vfs_type": "ext4",
-        "path": "/"
-      },
-      {
-        "uuid": "CB07C243-BC44-4717-853E-28852021225B",
-        "vfs_type": "ext4",
-        "path": "/var"
-      }
-    ]
+  "tree": {
+    "type": "org.osbuild.fstab",
+    "options": {
+      "filesystems": [
+        {
+          "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
+          "vfs_type": "ext4",
+          "path": "/"
+        },
+        {
+          "uuid": "CB07C243-BC44-4717-853E-28852021225B",
+          "vfs_type": "ext4",
+          "path": "/var"
+        }
+      ]
+    }
   }
 }
 `
 
 func TestIntegration(t *testing.T) {
 	minimalInput := minimalInputBase
-	minimalInput.Const.Filename = "disk.img"
+	minimalInput.Tree.Const.Filename = "disk.img"
 	expectedStages := minimalExpectedStages
 
 	inpJSON, err := json.Marshal(&minimalInput)

--- a/cmd/otk-make-partition-mounts-devices/main.go
+++ b/cmd/otk-make-partition-mounts-devices/main.go
@@ -10,7 +10,9 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
-type Input = otkdisk.Data
+type Input struct {
+	Tree otkdisk.Data `json:"tree"`
+}
 
 type Output struct {
 	RootMountName string                    `json:"root_mount_name"`
@@ -24,15 +26,17 @@ func run(r io.Reader, w io.Writer) error {
 		return err
 	}
 
-	rootMntName, mounts, devices, err := osbuild.GenMountsDevicesFromPT(inp.Const.Filename, inp.Const.Internal.PartitionTable)
+	rootMntName, mounts, devices, err := osbuild.GenMountsDevicesFromPT(inp.Tree.Const.Filename, inp.Tree.Const.Internal.PartitionTable)
 	if err != nil {
 		return err
 	}
 
-	out := Output{
-		RootMountName: rootMntName,
-		Mounts:        mounts,
-		Devices:       devices,
+	out := map[string]interface{}{
+		"tree": Output{
+			RootMountName: rootMntName,
+			Mounts:        mounts,
+			Devices:       devices,
+		},
 	}
 	outputJson, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {

--- a/cmd/otk-make-partition-mounts-devices/main_test.go
+++ b/cmd/otk-make-partition-mounts-devices/main_test.go
@@ -12,47 +12,49 @@ import (
 )
 
 const expectedOutput = `{
-  "root_mount_name": "-",
-  "mounts": [
-    {
-      "name": "-",
-      "type": "org.osbuild.ext4",
-      "source": "-",
-      "target": "/"
-    },
-    {
-      "name": "boot",
-      "type": "org.osbuild.ext4",
-      "source": "boot",
-      "target": "/boot"
-    },
-    {
-      "name": "boot-efi",
-      "type": "org.osbuild.fat",
-      "source": "boot-efi",
-      "target": "/boot/efi"
-    }
-  ],
-  "devices": {
-    "-": {
-      "type": "org.osbuild.loopback",
-      "options": {
-        "filename": "test.disk",
-        "size": 1615872
+  "tree": {
+    "root_mount_name": "-",
+    "mounts": [
+      {
+        "name": "-",
+        "type": "org.osbuild.ext4",
+        "source": "-",
+        "target": "/"
+      },
+      {
+        "name": "boot",
+        "type": "org.osbuild.ext4",
+        "source": "boot",
+        "target": "/boot"
+      },
+      {
+        "name": "boot-efi",
+        "type": "org.osbuild.fat",
+        "source": "boot-efi",
+        "target": "/boot/efi"
       }
-    },
-    "boot": {
-      "type": "org.osbuild.loopback",
-      "options": {
-        "filename": "test.disk",
-        "size": 1615872
-      }
-    },
-    "boot-efi": {
-      "type": "org.osbuild.loopback",
-      "options": {
-        "filename": "test.disk",
-        "size": 1615872
+    ],
+    "devices": {
+      "-": {
+        "type": "org.osbuild.loopback",
+        "options": {
+          "filename": "test.disk",
+          "size": 1615872
+        }
+      },
+      "boot": {
+        "type": "org.osbuild.loopback",
+        "options": {
+          "filename": "test.disk",
+          "size": 1615872
+        }
+      },
+      "boot-efi": {
+        "type": "org.osbuild.loopback",
+        "options": {
+          "filename": "test.disk",
+          "size": 1615872
+        }
       }
     }
   }
@@ -62,10 +64,12 @@ const expectedOutput = `{
 func TestIntegration(t *testing.T) {
 	pt := testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
 	input := mkdevmnt.Input{
-		Const: otkdisk.Const{
-			Filename: "test.disk",
-			Internal: otkdisk.Internal{
-				PartitionTable: pt,
+		Tree: otkdisk.Data{
+			Const: otkdisk.Const{
+				Filename: "test.disk",
+				Internal: otkdisk.Internal{
+					PartitionTable: pt,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
When otk calls externals it expects them to be wrapped inside a "tree" json key for both the inputs and the outputs. This is important to make the schema extensible. However the existing otk externals in this repo do not respect that.

This commit fixes it and updates the tests.