### PR TITLE
disk,otk-make-fstab-stage: make `GetFSTabOptions()` return an error and remove `recover()` 

### DIFF
--- a/cmd/otk-make-fstab-stage/main.go
+++ b/cmd/otk-make-fstab-stage/main.go
@@ -23,7 +23,11 @@ func makeFstabStages(inp Input) (stages *osbuild.Stage, err error) {
 	}()
 
 	pt := inp.Tree.Const.Internal.PartitionTable
-	fstabStage := osbuild.NewFSTabStage(osbuild.NewFSTabStageOptions(pt))
+	opts, err := osbuild.NewFSTabStageOptions(pt)
+	if err != nil {
+		return nil, err
+	}
+	fstabStage := osbuild.NewFSTabStage(opts)
 	return fstabStage, nil
 }
 

--- a/cmd/otk-make-fstab-stage/main.go
+++ b/cmd/otk-make-fstab-stage/main.go
@@ -15,32 +15,17 @@ type Input struct {
 	Tree otkdisk.Data `json:"tree"`
 }
 
-func makeFstabStages(inp Input) (stages *osbuild.Stage, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("cannot generate image prepare stages: %v", r)
-		}
-	}()
-
-	pt := inp.Tree.Const.Internal.PartitionTable
-	opts, err := osbuild.NewFSTabStageOptions(pt)
-	if err != nil {
-		return nil, err
-	}
-	fstabStage := osbuild.NewFSTabStage(opts)
-	return fstabStage, nil
-}
-
 func run(r io.Reader, w io.Writer) error {
 	var inp Input
 	if err := json.NewDecoder(r).Decode(&inp); err != nil {
 		return err
 	}
 
-	stage, err := makeFstabStages(inp)
+	opts, err := osbuild.NewFSTabStageOptions(inp.Tree.Const.Internal.PartitionTable)
 	if err != nil {
 		return fmt.Errorf("cannot make partition stages: %w", err)
 	}
+	stage := osbuild.NewFSTabStage(opts)
 
 	out := map[string]interface{}{
 		"tree": stage,

--- a/pkg/disk/btrfs.go
+++ b/pkg/disk/btrfs.go
@@ -177,13 +177,13 @@ func (bs *BtrfsSubvolume) GetFSSpec() FSSpec {
 	}
 }
 
-func (bs *BtrfsSubvolume) GetFSTabOptions() FSTabOptions {
+func (bs *BtrfsSubvolume) GetFSTabOptions() (FSTabOptions, error) {
 	if bs == nil {
-		return FSTabOptions{}
+		return FSTabOptions{}, nil
 	}
 
 	if bs.Name == "" {
-		panic(fmt.Errorf("internal error: BtrfsSubvolume.GetFSTabOptions() for %+v called without a name", bs))
+		return FSTabOptions{}, fmt.Errorf("internal error: BtrfsSubvolume.GetFSTabOptions() for %+v called without a name", bs)
 	}
 	ops := fmt.Sprintf("subvol=%s", bs.Name)
 	if bs.Compress != "" {
@@ -196,5 +196,5 @@ func (bs *BtrfsSubvolume) GetFSTabOptions() FSTabOptions {
 		MntOps: ops,
 		Freq:   0,
 		PassNo: 0,
-	}
+	}, nil
 }

--- a/pkg/disk/btrfs_test.go
+++ b/pkg/disk/btrfs_test.go
@@ -16,18 +16,17 @@ func TestBtrfsSubvolume_GetFSTabOptions(t *testing.T) {
 		{BtrfsSubvolume{Name: "root", Compress: "zstd:1", ReadOnly: true},
 			"subvol=root,compress=zstd:1,ro"},
 	} {
-		actual := tc.subvol.GetFSTabOptions()
+		actual, err := tc.subvol.GetFSTabOptions()
+		assert.NoError(t, err)
 
 		assert.Equal(t, FSTabOptions{MntOps: tc.expectedMntOpts}, actual)
 	}
 }
 
 func TestBtrfsSubvolume_GetFSTabOptionsPanics(t *testing.T) {
-	assert.PanicsWithError(t, `internal error: BtrfsSubvolume.GetFSTabOptions() for &{Name: Size:0 Mountpoint: GroupID:0 Compress: ReadOnly:false UUID:} called without a name`, func() {
-		subvol := &BtrfsSubvolume{}
-		subvol.GetFSTabOptions()
-	})
-
+	subvol := &BtrfsSubvolume{}
+	_, err := subvol.GetFSTabOptions()
+	assert.EqualError(t, err, `internal error: BtrfsSubvolume.GetFSTabOptions() for &{Name: Size:0 Mountpoint: GroupID:0 Compress: ReadOnly:false UUID:} called without a name`)
 }
 
 func TestImplementsInterfacesCompileTimeCheckBtrfs(t *testing.T) {

--- a/pkg/disk/btrfs_test.go
+++ b/pkg/disk/btrfs_test.go
@@ -29,3 +29,10 @@ func TestBtrfsSubvolume_GetFSTabOptionsPanics(t *testing.T) {
 	})
 
 }
+
+func TestImplementsInterfacesCompileTimeCheckBtrfs(t *testing.T) {
+	var _ = Container(&Btrfs{})
+	var _ = UniqueEntity(&Btrfs{})
+	var _ = Mountable(&BtrfsSubvolume{})
+	var _ = Sizeable(&BtrfsSubvolume{})
+}

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -114,7 +114,7 @@ type Mountable interface {
 	GetFSSpec() FSSpec
 
 	// GetFSTabOptions returns options for mounting the entity.
-	GetFSTabOptions() FSTabOptions
+	GetFSTabOptions() (FSTabOptions, error)
 }
 
 // A MountpointCreator is a container that is able to create new volumes.

--- a/pkg/disk/filesystem.go
+++ b/pkg/disk/filesystem.go
@@ -76,15 +76,15 @@ func (fs *Filesystem) GetFSSpec() FSSpec {
 	}
 }
 
-func (fs *Filesystem) GetFSTabOptions() FSTabOptions {
+func (fs *Filesystem) GetFSTabOptions() (FSTabOptions, error) {
 	if fs == nil {
-		return FSTabOptions{}
+		return FSTabOptions{}, nil
 	}
 	return FSTabOptions{
 		MntOps: fs.FSTabOptions,
 		Freq:   fs.FSTabFreq,
 		PassNo: fs.FSTabPassNo,
-	}
+	}, nil
 }
 
 func (fs *Filesystem) GenUUID(rng *rand.Rand) {

--- a/pkg/disk/filesystem_test.go
+++ b/pkg/disk/filesystem_test.go
@@ -1,0 +1,12 @@
+package disk_test
+
+import (
+	"testing"
+
+	"github.com/osbuild/images/pkg/disk"
+)
+
+func TestImplementsInterfacesCompileTimeCheckFilesystem(t *testing.T) {
+	var _ = disk.Mountable(&disk.Filesystem{})
+	var _ = disk.UniqueEntity(&disk.Filesystem{})
+}

--- a/pkg/disk/luks_test.go
+++ b/pkg/disk/luks_test.go
@@ -1,0 +1,11 @@
+package disk_test
+
+import (
+	"testing"
+
+	"github.com/osbuild/images/pkg/disk"
+)
+
+func TestImplementsInterfacesCompileTimeCheckLUKS(t *testing.T) {
+	var _ = disk.Container(&disk.LUKSContainer{})
+}

--- a/pkg/disk/lvm_test.go
+++ b/pkg/disk/lvm_test.go
@@ -38,3 +38,8 @@ func TestLVMVCreateMountpoint(t *testing.T) {
 	_, err = vg.CreateMountpoint("/home/test", 0)
 	assert.Error(err)
 }
+
+func TestImplementsInterfacesCompileTimeCheckLVM(t *testing.T) {
+	var _ = Container(&LVMVolumeGroup{})
+	var _ = Sizeable(&LVMLogicalVolume{})
+}

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -773,6 +773,10 @@ func (pt *PartitionTable) ensureBtrfs() error {
 			return fmt.Errorf("root entity is not mountable: %T, this is a violation of entityPath() contract", rootPath[0])
 		}
 
+		opts, err := rootMountable.GetFSTabOptions()
+		if err != nil {
+			return err
+		}
 		btrfs := &Btrfs{
 			Label: "root",
 			Subvolumes: []BtrfsSubvolume{
@@ -780,7 +784,7 @@ func (pt *PartitionTable) ensureBtrfs() error {
 					Name:       "root",
 					Mountpoint: "/",
 					Compress:   DefaultBtrfsCompression,
-					ReadOnly:   rootMountable.GetFSTabOptions().ReadOnly(),
+					ReadOnly:   opts.ReadOnly(),
 				},
 			},
 		}

--- a/pkg/disk/partition_test.go
+++ b/pkg/disk/partition_test.go
@@ -100,3 +100,8 @@ func TestAllPayloadEntityExported(t *testing.T) {
 	// payloadEntityMap so that the json marshaling will work
 	assert.Equal(t, len(entityNameImpl), len(disk.PayloadEntityMap), fmt.Sprintf("the EntityName() function is implemented by %q but only %v are registered in %v, was a new PayloadEntity added but not registered?", entityNameImpl, len(disk.PayloadEntityMap), disk.PayloadEntityMap))
 }
+
+func TestImplementsInterfacesCompileTimeCheckPartition(t *testing.T) {
+	var _ = disk.Container(&disk.Partition{})
+	var _ = disk.Sizeable(&disk.Partition{})
+}

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -678,7 +678,11 @@ func (p *OS) serialize() osbuild.Pipeline {
 			pipeline = prependKernelCmdlineStage(pipeline, strings.Join(kernelOptions, " "), pt)
 		}
 
-		pipeline.AddStage(osbuild.NewFSTabStage(osbuild.NewFSTabStageOptions(pt)))
+		opts, err := osbuild.NewFSTabStageOptions(pt)
+		if err != nil {
+			panic(err)
+		}
+		pipeline.AddStage(osbuild.NewFSTabStage(opts))
 
 		var bootloader *osbuild.Stage
 		switch p.platform.GetArch() {

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -330,7 +330,10 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 	configStage.MountOSTree(p.osName, ref, 0)
 	pipeline.AddStage(configStage)
 
-	fstabOptions := osbuild.NewFSTabStageOptions(p.PartitionTable)
+	fstabOptions, err := osbuild.NewFSTabStageOptions(p.PartitionTable)
+	if err != nil {
+		panic(err)
+	}
 	fstabStage := osbuild.NewFSTabStage(fstabOptions)
 	fstabStage.MountOSTree(p.osName, ref, 0)
 	pipeline.AddStage(fstabStage)

--- a/pkg/manifest/raw_bootc.go
+++ b/pkg/manifest/raw_bootc.go
@@ -166,7 +166,11 @@ func (p *RawBootcImage) serialize() osbuild.Pipeline {
 	mounts = append(mounts, *osbuild.NewBindMount("bind-ostree-deployment-to-tree", "mount://", "tree://"))
 
 	// we always include the fstab stage
-	fstabStage := osbuild.NewFSTabStage(osbuild.NewFSTabStageOptions(pt))
+	fstabOpts, err := osbuild.NewFSTabStageOptions(pt)
+	if err != nil {
+		panic(err)
+	}
+	fstabStage := osbuild.NewFSTabStage(fstabOpts)
 	fstabStage.Mounts = mounts
 	fstabStage.Devices = devices
 	pipeline.AddStage(fstabStage)


### PR DESCRIPTION
disk: add static checks that interfaces are implemented

This commit adds some static checks that ensure that the disk,
btrfs,filesystem and lvm types implement the expected interfaces.

This is important because when changing e.g. the Mountable
interface by adding an "error" to GetFSTabOptions() without
this change all non-updated types just silently drop implementing
the interface without any error or warning leading to unexpected
test failures.

---

disk: make `GetFSTabOptions()` return an error

The disk package is now used for the `otk` externals. This means
that the inputs we get are much less controlled and instead of
panicing we should return more user-friendly error messages.

This commit starts by making `GetFSTabOptions()` return an error
and then bubbling it up.

Followup to https://github.com/osbuild/images/pull/787/files#r1673752935

----

otk-make-fstab-stage: remove `recover()`

With the changes in the previous commit to return an error from
`osbuild.NewFSTabStageOptions` if something goes wrong there is
no need anymore for the `recover()` that was used before.

Note that it is currently not entirely easy to reason about this
because one needs to manually follow all possible code paths
into `osbuild` and `disk` to see what functions could `panic()`.
For this one it was realtivly small, for the `otk-make-partition-stages`
it is a lot more involved though.
