### PR TITLE
[RFC] internal: add new `bool3` package to help with tristate values

### DIFF
--- a/internal/bool3/bool3.go
+++ b/internal/bool3/bool3.go
@@ -1,0 +1,105 @@
+package bool3
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type Bool3 int
+
+const (
+	Unset Bool3 = iota
+	True
+	False
+)
+
+func New(v bool) Bool3 {
+	if v {
+		return True
+	}
+	return False
+}
+
+func (b Bool3) String() string {
+	switch b {
+	case True:
+		return "true"
+	case False:
+		return "false"
+	default:
+		return "unset"
+	}
+}
+
+func parseBool3(v interface{}) (Bool3, error) {
+	switch val := v.(type) {
+	case nil:
+		return Unset, nil
+	case bool:
+		switch val {
+		case true:
+			return True, nil
+		case false:
+			return False, nil
+		}
+	case string:
+		switch val {
+		case "true":
+			return True, nil
+		case "false":
+			return False, nil
+		case "unset":
+			return Unset, nil
+		default:
+			return Unset, fmt.Errorf("cannot parse %q as Bool3", val)
+		}
+	}
+	return Unset, fmt.Errorf("cannot unmarshal %T to Bool3", v)
+}
+
+func (b Bool3) MarshalJSON() ([]byte, error) {
+	switch b {
+	case True, False:
+		return json.Marshal(b.String())
+	}
+	// XXX: or should we just remove this special case and use "unset"?
+	return []byte("null"), nil
+}
+
+func (b *Bool3) UnmarshalJSON(data []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	bb, err := parseBool3(v)
+	*b = bb
+	return err
+}
+
+func (b Bool3) MarshalTOML() ([]byte, error) {
+	// TODO: return "null" here for unset too?
+	return []byte(fmt.Sprintf("\"%s\"", b.String())), nil
+}
+
+func (b *Bool3) UnmarshalTOML(v interface{}) error {
+	bb, err := parseBool3(v)
+	*b = bb
+	return err
+}
+
+func (b Bool3) MarshalYAML() (interface{}, error) {
+	// TODO: return null here for unset too?
+	return b.String(), nil
+}
+
+func (b *Bool3) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var v interface{}
+	if err := unmarshal(&v); err != nil {
+		return err
+	}
+
+	bb, err := parseBool3(v)
+	*b = bb
+	return err
+}

--- a/internal/bool3/bool3_test.go
+++ b/internal/bool3/bool3_test.go
@@ -1,0 +1,59 @@
+package bool3_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/internal/bool3"
+)
+
+func TestBasic(t *testing.T) {
+	var b3 bool3.Bool3
+	assert.Equal(t, b3, bool3.Unset)
+
+	b3 = bool3.New(true)
+	assert.Equal(t, b3, bool3.True)
+
+	b3 = bool3.New(false)
+	assert.Equal(t, b3, bool3.False)
+}
+
+func TestUnmarshal(t *testing.T) {
+	var b3 bool3.Bool3
+
+	err := json.Unmarshal([]byte(`true`), &b3)
+	assert.NoError(t, err)
+	assert.Equal(t, b3, bool3.True)
+
+	err = json.Unmarshal([]byte(`false`), &b3)
+	assert.NoError(t, err)
+	assert.Equal(t, b3, bool3.False)
+}
+
+func TestMarshalUnmarshal(t *testing.T) {
+	type b3struct struct {
+		B bool3.Bool3 `json:"B"`
+	}
+
+	var t1 b3struct
+	jsonOutput, err := json.Marshal(&t1)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"B":null}`, string(jsonOutput))
+
+	var t2 b3struct
+	err = json.Unmarshal(jsonOutput, &t2)
+	assert.NoError(t, err)
+	assert.Equal(t, t2.B, bool3.Unset)
+}
+
+func TestUnmarshalBad(t *testing.T) {
+	var b3 bool3.Bool3
+
+	err := json.Unmarshal([]byte(`"foo"`), &b3)
+	assert.EqualError(t, err, `cannot parse "foo" as Bool3`)
+
+	err = json.Unmarshal([]byte(`3`), &b3)
+	assert.EqualError(t, err, `cannot unmarshal float64 to Bool3`)
+}


### PR DESCRIPTION
It seems we are currently using `*bool` a lot to distinguish between `{unset,true,false}`. This commit contains an alternative idea to introduce a new `Bool3` data-type that serves the same purpose but does not require the extra care that pointers require as it's all values.

[draft and only half done (i.e. tests missing and some more elegance in the usnet handling) but want early feedback so that I can stop if this is silly :)]