### PR TITLE
blueprint: use go-optional to avoid points for unset 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/go-version v1.7.0
 	github.com/kolo/xmlrpc v0.0.0-20201022064351-38db28db192b
+	github.com/moznion/go-optional v0.12.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/oracle/oci-go-sdk/v54 v54.0.0

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/moznion/go-optional v0.12.0 h1:gM9YSR7kusSQHiaq2IDHU7WoJNGETT1NbuB15XU4ebA=
+github.com/moznion/go-optional v0.12.0/go.mod h1:UP85Bc+uliSDFDzN7Zw8D6gBO1bdPChKFpNu1DJfCqE=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/pkg/blueprint/blueprint.go
+++ b/pkg/blueprint/blueprint.go
@@ -1,6 +1,10 @@
 // Package blueprint contains primitives for representing weldr blueprints
 package blueprint
 
+import (
+	"github.com/moznion/go-optional"
+)
+
 // A Blueprint is a high-level description of an image.
 type Blueprint struct {
 	Name           string          `json:"name" toml:"name"`
@@ -32,8 +36,8 @@ type Container struct {
 	Source string `json:"source" toml:"source"`
 	Name   string `json:"name,omitempty" toml:"name,omitempty"`
 
-	TLSVerify    *bool `json:"tls-verify,omitempty" toml:"tls-verify,omitempty"`
-	LocalStorage bool  `json:"local-storage,omitempty" toml:"local-storage,omitempty"`
+	TLSVerify    optional.Option[bool] `json:"tls-verify,omitempty" toml:"tls-verify,omitempty"`
+	LocalStorage bool                  `json:"local-storage,omitempty" toml:"local-storage,omitempty"`
 }
 
 // packages, modules, and groups all resolve to rpm packages right now. This

--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -6,11 +6,13 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/moznion/go-optional"
+
 	"github.com/osbuild/images/pkg/customizations/anaconda"
 )
 
 type Customizations struct {
-	Hostname           *string                        `json:"hostname,omitempty" toml:"hostname,omitempty"`
+	Hostname           optional.Option[string]        `json:"hostname,omitempty" toml:"hostname,omitempty"`
 	Kernel             *KernelCustomization           `json:"kernel,omitempty" toml:"kernel,omitempty"`
 	SSHKey             []SSHKeyCustomization          `json:"sshkey,omitempty" toml:"sshkey,omitempty"`
 	User               []UserCustomization            `json:"user,omitempty" toml:"user,omitempty"`
@@ -27,7 +29,7 @@ type Customizations struct {
 	Directories        []DirectoryCustomization       `json:"directories,omitempty" toml:"directories,omitempty"`
 	Files              []FileCustomization            `json:"files,omitempty" toml:"files,omitempty"`
 	Repositories       []RepositoryCustomization      `json:"repositories,omitempty" toml:"repositories,omitempty"`
-	FIPS               *bool                          `json:"fips,omitempty" toml:"fips,omitempty"`
+	FIPS               optional.Option[bool]          `json:"fips,omitempty" toml:"fips,omitempty"`
 	ContainersStorage  *ContainerStorageCustomization `json:"containers-storage,omitempty" toml:"containers-storage,omitempty"`
 	Installer          *InstallerCustomization        `json:"installer,omitempty" toml:"installer,omitempty"`
 	RPM                *RPMCustomization              `json:"rpm,omitempty" toml:"rpm,omitempty"`
@@ -196,9 +198,9 @@ func (c *Customizations) CheckAllowed(allowed ...string) error {
 	return nil
 }
 
-func (c *Customizations) GetHostname() *string {
+func (c *Customizations) GetHostname() optional.Option[string] {
 	if c == nil {
-		return nil
+		return optional.None[string]()
 	}
 	return c.Hostname
 }
@@ -382,10 +384,10 @@ func (c *Customizations) GetRepositories() ([]RepositoryCustomization, error) {
 }
 
 func (c *Customizations) GetFIPS() bool {
-	if c == nil || c.FIPS == nil {
+	if c == nil {
 		return false
 	}
-	return *c.FIPS
+	return c.FIPS.Unwrap()
 }
 
 func (c *Customizations) GetContainerStorage() *ContainerStorageCustomization {

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -3,8 +3,10 @@ package blueprint
 import (
 	"testing"
 
-	"github.com/osbuild/images/pkg/customizations/anaconda"
+	"github.com/moznion/go-optional"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/customizations/anaconda"
 )
 
 func TestCheckAllowed(t *testing.T) {
@@ -33,9 +35,9 @@ func TestCheckAllowed(t *testing.T) {
 		},
 	}
 
-	expectedHostname := "Hostname"
+	expectedHostname := optional.Some("Hostname")
 
-	x := Customizations{Hostname: &expectedHostname, User: expectedUsers}
+	x := Customizations{Hostname: expectedHostname, User: expectedUsers}
 
 	err := x.CheckAllowed("Hostname", "User")
 	assert.NoError(t, err)
@@ -50,14 +52,14 @@ func TestCheckAllowed(t *testing.T) {
 }
 
 func TestGetHostname(t *testing.T) {
-	expectedHostname := "Hostname"
+	expectedHostname := optional.Some("Hostname")
 
 	TestCustomizations := Customizations{
-		Hostname: &expectedHostname,
+		Hostname: expectedHostname,
 	}
 
 	retHostname := TestCustomizations.GetHostname()
-	assert.Equal(t, &expectedHostname, retHostname)
+	assert.Equal(t, expectedHostname, retHostname)
 }
 
 func TestGetKernel(t *testing.T) {

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -26,11 +26,11 @@ import (
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
+	"github.com/moznion/go-optional"
 	"github.com/opencontainers/go-digest"
 
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 )
 
@@ -222,31 +222,31 @@ func (cl *Client) SetDockerCertPath(path string) {
 
 // SetSkipTLSVerify controls if TLS verification happens when
 // making requests. If nil is passed it falls back to the default.
-func (cl *Client) SetTLSVerify(verify *bool) {
-	if verify == nil {
+func (cl *Client) SetTLSVerify(verify optional.Option[bool]) {
+	if verify.IsNone() {
 		cl.sysCtx.DockerInsecureSkipTLSVerify = types.OptionalBoolUndefined
 	} else {
-		cl.sysCtx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!*verify)
+		cl.sysCtx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(verify.Unwrap())
 	}
 }
 
 // GetSkipTLSVerify returns current TLS verification state.
-func (cl *Client) GetTLSVerify() *bool {
+func (cl *Client) GetTLSVerify() optional.Option[bool] {
 
 	skip := cl.sysCtx.DockerInsecureSkipTLSVerify
 
 	if skip == types.OptionalBoolUndefined {
-		return nil
+		return optional.None[bool]()
 	}
 
 	// NB: we invert the state, i.e. verify == (skip == false)
-	return common.ToPtr(skip == types.OptionalBoolFalse)
+	return optional.Some(skip == types.OptionalBoolFalse)
 }
 
 // SkipTLSVerify is a convenience helper that internally calls
 // SetTLSVerify with false
 func (cl *Client) SkipTLSVerify() {
-	cl.SetTLSVerify(common.ToPtr(false))
+	cl.SetTLSVerify(optional.Some(false))
 }
 
 func parseImageName(name string) (types.ImageReference, error) {

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/manifest"
+	"github.com/moznion/go-optional"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/container"
 )
@@ -376,7 +376,7 @@ func (reg *Registry) Resolve(target string, imgArch arch.Arch) (container.Spec, 
 		Digest:     checksum,
 		ImageID:    mf.ConfigDescriptor.Digest.String(),
 		LocalName:  target,
-		TLSVerify:  common.ToPtr(false),
+		TLSVerify:  optional.Some(false),
 		ListDigest: listDigest,
 		Arch:       imgArch,
 	}, nil

--- a/pkg/container/resolver.go
+++ b/pkg/container/resolver.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/moznion/go-optional"
 )
 
 type resolveResult struct {
@@ -28,7 +30,7 @@ type SourceSpec struct {
 	Source    string
 	Name      string
 	Digest    *string
-	TLSVerify *bool
+	TLSVerify optional.Option[bool]
 	Local     bool
 }
 

--- a/pkg/container/resolver_test.go
+++ b/pkg/container/resolver_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/images/internal/common"
@@ -49,7 +50,7 @@ func TestResolver(t *testing.T) {
 			Source:    r,
 			Name:      "",
 			Digest:    common.ToPtr(""),
-			TLSVerify: common.ToPtr(false),
+			TLSVerify: optional.Some(false),
 			Local:     false,
 		})
 	}
@@ -77,7 +78,7 @@ func TestResolverFail(t *testing.T) {
 		Source:    "invalid-reference@${IMAGE_DIGEST}",
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: optional.Some(false),
 		Local:     false,
 	})
 	specs, err := resolver.Finish()
@@ -91,7 +92,7 @@ func TestResolverFail(t *testing.T) {
 		Source:    registry.GetRef("repo"),
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: optional.Some(false),
 		Local:     false,
 	})
 	specs, err = resolver.Finish()
@@ -102,7 +103,7 @@ func TestResolverFail(t *testing.T) {
 		Source:    registry.GetRef("repo"),
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: optional.Some(false),
 		Local:     false,
 	})
 	specs, err = resolver.Finish()
@@ -113,7 +114,7 @@ func TestResolverFail(t *testing.T) {
 		Source:    registry.GetRef("repo"),
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: optional.Some(false),
 		Local:     false,
 	})
 	specs, err = resolver.Finish()
@@ -178,7 +179,7 @@ func TestResolverLocalManifest(t *testing.T) {
 		Source:    "localhost/multi-arch",
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: optional.Some(false),
 		Local:     true,
 	})
 	specs, err := resolver.Finish()
@@ -196,7 +197,7 @@ func TestResolverLocalManifest(t *testing.T) {
 		Source:    "localhost/multi-arch",
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: optional.Some(false),
 		Local:     true,
 	})
 	specs, err = resolver.Finish()

--- a/pkg/container/spec.go
+++ b/pkg/container/spec.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/moznion/go-optional"
 	"github.com/opencontainers/go-digest"
 
 	"github.com/osbuild/images/pkg/arch"
@@ -13,12 +14,12 @@ import (
 // at the Source via Digest and ImageID. The latter one
 // should remain the same in the target image as well.
 type Spec struct {
-	Source       string // does not include the manifest digest
-	Digest       string // digest of the manifest at the Source
-	TLSVerify    *bool  // controls TLS verification
-	ImageID      string // container image identifier
-	LocalName    string // name to use inside the image
-	ListDigest   string // digest of the list manifest at the Source (optional)
+	Source       string                // does not include the manifest digest
+	Digest       string                // digest of the manifest at the Source
+	TLSVerify    optional.Option[bool] // controls TLS verification
+	ImageID      string                // container image identifier
+	LocalName    string                // name to use inside the image
+	ListDigest   string                // digest of the list manifest at the Source (optional)
 	LocalStorage bool
 
 	Arch arch.Arch // the architecture of the image
@@ -27,7 +28,7 @@ type Spec struct {
 // NewSpec creates a new Spec from the essential information.
 // It also converts is the transition point from container
 // specific types (digest.Digest) to generic types (string).
-func NewSpec(source reference.Named, digest, imageID digest.Digest, tlsVerify *bool, listDigest string, localName string, localStorage bool) Spec {
+func NewSpec(source reference.Named, digest, imageID digest.Digest, tlsVerify optional.Option[bool], listDigest string, localName string, localStorage bool) Spec {
 	if localName == "" {
 		localName = source.String()
 	}

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -7,6 +7,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/moznion/go-optional"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
@@ -15,9 +20,6 @@ import (
 	"github.com/osbuild/images/pkg/distrofactory"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/rpmmd"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 // Ensure that all package sets defined in the package set chains are defined for the image type
@@ -596,7 +598,7 @@ func TestDistro_ManifestFIPSWarning(t *testing.T) {
 			for _, imgTypeName := range arch.ListImageTypes() {
 				bp := blueprint.Blueprint{
 					Customizations: &blueprint.Customizations{
-						FIPS: &fips_enabled,
+						FIPS: optional.Some(fips_enabled),
 					},
 				}
 				imgType, _ := arch.GetImageType(imgTypeName)

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -104,11 +104,7 @@ func osCustomizations(
 		osc.Keyboard = &imageConfig.Keyboard.Keymap
 	}
 
-	if hostname := c.GetHostname(); hostname != nil {
-		osc.Hostname = *hostname
-	} else {
-		osc.Hostname = "localhost.localdomain"
-	}
+	osc.Hostname = c.GetHostname().TakeOr("localhost.localdomain")
 
 	timezone, ntpServers := c.GetTimezoneSettings()
 	if timezone != nil {

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -117,9 +117,7 @@ func osCustomizations(
 		}
 	}
 
-	if hostname := c.GetHostname(); hostname != nil {
-		osc.Hostname = *hostname
-	}
+	osc.Hostname = c.GetHostname().Unwrap()
 
 	timezone, ntpServers := c.GetTimezoneSettings()
 	if timezone != nil {

--- a/pkg/osbuild/skopeo_index_source.go
+++ b/pkg/osbuild/skopeo_index_source.go
@@ -2,6 +2,8 @@ package osbuild
 
 import (
 	"fmt"
+
+	"github.com/moznion/go-optional"
 )
 
 type SkopeoIndexSource struct {
@@ -11,8 +13,8 @@ type SkopeoIndexSource struct {
 func (SkopeoIndexSource) isSource() {}
 
 type SkopeoIndexSourceImage struct {
-	Name      string `json:"name"`
-	TLSVerify *bool  `json:"tls-verify,omitempty"`
+	Name      string                `json:"name"`
+	TLSVerify optional.Option[bool] `json:"tls-verify,omitempty"`
 }
 
 type SkopeoIndexSourceItem struct {
@@ -37,7 +39,7 @@ func NewSkopeoIndexSource() *SkopeoIndexSource {
 
 // AddItem adds a source item to the source; will panic
 // if any of the supplied options are invalid or missing
-func (source *SkopeoIndexSource) AddItem(name, image string, tlsVerify *bool) {
+func (source *SkopeoIndexSource) AddItem(name, image string, tlsVerify optional.Option[bool]) {
 	item := SkopeoIndexSourceItem{
 		Image: SkopeoIndexSourceImage{
 			Name:      name,

--- a/pkg/osbuild/skopeo_source.go
+++ b/pkg/osbuild/skopeo_source.go
@@ -3,6 +3,8 @@ package osbuild
 import (
 	"fmt"
 	"regexp"
+
+	"github.com/moznion/go-optional"
 )
 
 var skopeoDigestPattern = regexp.MustCompile(`sha256:[0-9a-f]{64}`)
@@ -17,9 +19,9 @@ type SkopeoSource struct {
 func (SkopeoSource) isSource() {}
 
 type SkopeopSourceImage struct {
-	Name      string `json:"name,omitempty"`
-	Digest    string `json:"digest,omitempty"`
-	TLSVerify *bool  `json:"tls-verify,omitempty"`
+	Name      string                `json:"name,omitempty"`
+	Digest    string                `json:"digest,omitempty"`
+	TLSVerify optional.Option[bool] `json:"tls-verify,omitempty"`
 }
 
 type SkopeoSourceItem struct {
@@ -27,7 +29,7 @@ type SkopeoSourceItem struct {
 }
 
 // NewSkopeoSourceItem creates a new source item for name and digest
-func NewSkopeoSourceItem(name, digest string, tlsVerify *bool) SkopeoSourceItem {
+func NewSkopeoSourceItem(name, digest string, tlsVerify optional.Option[bool]) SkopeoSourceItem {
 	item := SkopeoSourceItem{
 		Image: SkopeopSourceImage{
 			Name:      name,
@@ -62,7 +64,7 @@ func NewSkopeoSource() *SkopeoSource {
 
 // AddItem adds a source item to the source; will panic
 // if any of the supplied options are invalid or missing
-func (source *SkopeoSource) AddItem(name, digest, image string, tlsVerify *bool) {
+func (source *SkopeoSource) AddItem(name, digest, image string, tlsVerify optional.Option[bool]) {
 	item := NewSkopeoSourceItem(name, digest, tlsVerify)
 	if !skopeoDigestPattern.MatchString(image) {
 		panic(fmt.Errorf("item %#v has invalid image id", image))

--- a/pkg/osbuild/skopeo_source_test.go
+++ b/pkg/osbuild/skopeo_source_test.go
@@ -4,10 +4,10 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/moznion/go-optional"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/images/internal/assertx"
-	"github.com/osbuild/images/internal/common"
 )
 
 func TestNewSkopeoSource(t *testing.T) {
@@ -16,14 +16,14 @@ func TestNewSkopeoSource(t *testing.T) {
 
 	source := NewSkopeoSource()
 
-	source.AddItem("name", testDigest, imageID, common.ToPtr(false))
+	source.AddItem("name", testDigest, imageID, optional.Some(false))
 	assert.Len(t, source.Items, 1)
 
 	item, ok := source.Items[imageID]
 	assert.True(t, ok)
 	assert.Equal(t, item.Image.Name, "name")
 	assert.Equal(t, item.Image.Digest, testDigest)
-	assert.Equal(t, item.Image.TLSVerify, common.ToPtr(false), false)
+	assert.Equal(t, item.Image.TLSVerify, optional.Some(false), false)
 
 	testDigest = "sha256:d49eebefb6c7ce5505594bef652bd4adc36f413861bd44209d9b9486310b1264"
 	imageID = "sha256:d2ab8fea7f08a22f03b30c13c6ea443121f25e87202a7496e93736efa6fe345a"

--- a/vendor/github.com/moznion/go-optional/.gitignore
+++ b/vendor/github.com/moznion/go-optional/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/coverage.txt

--- a/vendor/github.com/moznion/go-optional/LICENSE
+++ b/vendor/github.com/moznion/go-optional/LICENSE
@@ -1,0 +1,8 @@
+Copyright 2021 Taiki Kawakami (a.k.a. moznion) https://moznion.net
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/vendor/github.com/moznion/go-optional/Makefile
+++ b/vendor/github.com/moznion/go-optional/Makefile
@@ -1,0 +1,19 @@
+.PHONY: check ci-check test fmt fmt-check lint
+
+check: fmt-check lint test
+ci-check: fmt-check test
+
+test:
+	go test ./... -race -v -coverprofile="coverage.txt" -covermode=atomic
+
+fmt:
+	gofmt -w -s *.go && goimports -w *.go
+
+fmt-check:
+	goimports -l *.go | grep [^*][.]go$$; \
+		EXIT_CODE=$$?; \
+		if [ $$EXIT_CODE -eq 0 ]; then exit 1; fi \
+
+lint:
+	golangci-lint run ./...
+

--- a/vendor/github.com/moznion/go-optional/README.md
+++ b/vendor/github.com/moznion/go-optional/README.md
@@ -1,0 +1,213 @@
+# go-optional [![.github/workflows/check.yml](https://github.com/moznion/go-optional/actions/workflows/check.yml/badge.svg)](https://github.com/moznion/go-optional/actions/workflows/check.yml) [![codecov](https://codecov.io/gh/moznion/go-optional/branch/main/graph/badge.svg?token=0HCVy6COy4)](https://codecov.io/gh/moznion/go-optional) [![GoDoc](https://godoc.org/github.com/moznion/go-optional?status.svg)](https://godoc.org/github.com/moznion/go-optional)
+
+A library that provides [Go Generics](https://go.dev/blog/generics-proposal) friendly "optional" features.
+
+## Synopsis
+
+```go
+some := optional.Some[int](123)
+fmt.Printf("%v\n", some.IsSome()) // => true
+fmt.Printf("%v\n", some.IsNone()) // => false
+
+v, err := some.Take()
+fmt.Printf("err is nil: %v\n", err == nil) // => err is nil: true
+fmt.Printf("%d\n", v) // => 123
+
+mapped := optional.Map(some, func (v int) int {
+    return v * 2
+})
+fmt.Printf("%v\n", mapped.IsSome()) // => true
+
+mappedValue, _ := some.Take()
+fmt.Printf("%d\n", mappedValue) // => 246
+```
+
+```go
+none := optional.None[int]()
+fmt.Printf("%v\n", none.IsSome()) // => false
+fmt.Printf("%v\n", none.IsNone()) // => true
+
+_, err := none.Take()
+fmt.Printf("err is nil: %v\n", err == nil) // => err is nil: false
+// the error must be `ErrNoneValueTaken`
+
+mapped := optional.Map(none, func (v int) int {
+    return v * 2
+})
+fmt.Printf("%v\n", mapped.IsNone()) // => true
+```
+
+and more detailed examples are here: [./examples_test.go](./examples_test.go).
+
+## Docs
+
+[![GoDoc](https://godoc.org/github.com/moznion/go-optional?status.svg)](https://godoc.org/github.com/moznion/go-optional)
+
+### Supported Operations
+
+#### Value Factory Methods
+
+- [Some[T]\() Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#Some)
+- [None[T]\() Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#None)
+- [FromNillable[T]\() Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#FromNillable)
+- [PtrFromNillable[T]\() Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#PtrFromNillable)
+
+#### Option value handler methods
+
+- [Option[T]#IsNone() bool](https://pkg.go.dev/github.com/moznion/go-optional#Option.IsNone)
+- [Option[T]#IsSome() bool](https://pkg.go.dev/github.com/moznion/go-optional#Option.IsSome)
+- [Option[T]#Unwrap() T](https://pkg.go.dev/github.com/moznion/go-optional#Option.Unwrap)
+- [Option[T]#UnwrapAsPtr() \*T](https://pkg.go.dev/github.com/moznion/go-optional#Option.UnwrapAsPtr)
+- [Option[T]#Take() (T, error)](https://pkg.go.dev/github.com/moznion/go-optional#Option.Take)
+- [Option[T]#TakeOr(fallbackValue T) T](https://pkg.go.dev/github.com/moznion/go-optional#Option.TakeOr)
+- [Option[T]#TakeOrElse(fallbackFunc func() T) T](https://pkg.go.dev/github.com/moznion/go-optional#Option.TakeOrElse)
+- [Option[T]#Or(fallbackOptionValue Option[T]) Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#Option.Or)
+- [Option[T]#OrElse(fallbackOptionFunc func() Option[T]) Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#Option.OrElse)
+- [Option[T]#Filter(predicate func(v T) bool) Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#Option.Filter)
+- [Option[T]#IfSome(f func(v T))](https://pkg.go.dev/github.com/moznion/go-optional#Option.IfSome)
+- [Option[T]#IfSomeWithError(f func(v T) error) error](https://pkg.go.dev/github.com/moznion/go-optional#Option.IfSomeWithError)
+- [Option[T]#IfNone(f func())](https://pkg.go.dev/github.com/moznion/go-optional#Option.IfNone)
+- [Option[T]#IfNoneWithError(f func() error) error](https://pkg.go.dev/github.com/moznion/go-optional#Option.IfNoneWithError)
+- [Option.Map[T, U any](option Option[T], mapper func(v T) U) Option[U]](https://pkg.go.dev/github.com/moznion/go-optional#Map)
+- [Option.MapOr[T, U any](option Option[T], fallbackValue U, mapper func(v T) U) U](https://pkg.go.dev/github.com/moznion/go-optional#MapOr)
+- [Option.MapWithError[T, U any](option Option[T], mapper func(v T) (U, error)) (Option[U], error)](https://pkg.go.dev/github.com/moznion/go-optional#MapWithError)
+- [Option.MapOrWithError[T, U any](option Option[T], fallbackValue U, mapper func(v T) (U, error)) (U, error)](https://pkg.go.dev/github.com/moznion/go-optional#MapOrWithError)
+- [Option.FlatMap[T, U any](option Option[T], mapper func(v T) Option[U]) Option[U]](https://pkg.go.dev/github.com/moznion/go-optional#FlatMap)
+- [Option.FlatMapOr[T, U any](option Option[T], fallbackValue U, mapper func(v T) Option[U]) U](https://pkg.go.dev/github.com/moznion/go-optional#FlatMapOr)
+- [Option.FlatMapWithError[T, U any](option Option[T], mapper func(v T) (Option[U], error)) (Option[U], error)](https://pkg.go.dev/github.com/moznion/go-optional#FlatMapWithError)
+- [Option.FlatMapOrWithError[T, U any](option Option[T], fallbackValue U, mapper func(v T) (Option[U], error)) (U, error)](https://pkg.go.dev/github.com/moznion/go-optional#FlatMapOrWithError)
+- [Option.Zip[T, U any](opt1 Option[T], opt2 Option[U]) Option[Pair[T, U]]](https://pkg.go.dev/github.com/moznion/go-optional#Zip)
+- [Option.ZipWith[T, U, V any](opt1 Option[T], opt2 Option[U], zipper func(opt1 T, opt2 U) V) Option[V]](https://pkg.go.dev/github.com/moznion/go-optional#ZipWith)
+- [Option.Unzip[T, U any](zipped Option[Pair[T, U]]) (Option[T], Option[U])](https://pkg.go.dev/github.com/moznion/go-optional#Unzip)
+- [Option.UnzipWith[T, U, V any](zipped Option[V], unzipper func(zipped V) (T, U)) (Option[T], Option[U])](https://pkg.go.dev/github.com/moznion/go-optional#UnzipWith)
+
+### nil == None[T]
+
+This library deals with `nil` as same as `None[T]`. So it works with like the following example:
+
+```go
+var nilValue Option[int] = nil
+fmt.Printf("%v\n", nilValue.IsNone()) // => true
+fmt.Printf("%v\n", nilValue.IsSome()) // => false
+```
+
+### JSON marshal/unmarshal support
+
+This `Option[T]` type supports JSON marshal and unmarshal.
+
+If the value wanted to marshal is `Some[T]` then it marshals that value into the JSON bytes simply, and in unmarshaling, if the given JSON string/bytes has the actual value on corresponded property, it unmarshals that value into `Some[T]` value.
+
+example:
+
+```go
+type JSONStruct struct {
+	Val Option[int] `json:"val"`
+}
+
+some := Some[int](123)
+jsonStruct := &JSONStruct{Val: some}
+
+marshal, err := json.Marshal(jsonStruct)
+if err != nil {
+	return err
+}
+fmt.Printf("%s\n", marshal) // => {"val":123}
+
+var unmarshalJSONStruct JSONStruct
+err = json.Unmarshal(marshal, &unmarshalJSONStruct)
+if err != nil {
+	return err
+}
+// unmarshalJSONStruct.Val == Some[int](123)
+```
+
+Elsewise, when the value is `None[T]`, the marshaller serializes that value as `null`. And if the unmarshaller gets the JSON `null` value on a property corresponding to the `Optional[T]` value, or the value of a property is missing, that deserializes that value as `None[T]`.
+
+example:
+
+```go
+type JSONStruct struct {
+	Val Option[int] `json:"val"`
+}
+
+none := None[int]()
+jsonStruct := &JSONStruct{Val: none}
+
+marshal, err := json.Marshal(jsonStruct)
+if err != nil {
+	return err
+}
+fmt.Printf("%s\n", marshal) // => {"val":null}
+
+var unmarshalJSONStruct JSONStruct
+err = json.Unmarshal(marshal, &unmarshalJSONStruct)
+if err != nil {
+	return err
+}
+// unmarshalJSONStruct.Val == None[int]()
+```
+
+And this also supports `omitempty` option for JSON unmarshaling. If the value of the property is `None[T]` and that property has `omitempty` option, it omits that property.
+
+ref:
+
+> The "omitempty" option specifies that the field should be omitted from the encoding if the field has an empty value, defined as false, 0, a nil pointer, a nil interface value, and any empty array, slice, map, or string.
+> https://pkg.go.dev/encoding/json#Marshal
+
+example:
+
+```go
+type JSONStruct struct {
+	OmitemptyVal Option[string] `json:"omitemptyVal,omitempty"` // this should be omitted
+}
+
+jsonStruct := &JSONStruct{OmitemptyVal: None[string]()}
+marshal, err := json.Marshal(jsonStruct)
+if err != nil {
+	return err
+}
+fmt.Printf("%s\n", marshal) // => {}
+```
+
+### SQL Driver Support
+
+`Option[T]` satisfies [sql/driver.Valuer](https://pkg.go.dev/database/sql/driver#Valuer) and [sql.Scanner](https://pkg.go.dev/database/sql#Scanner), so this type can be used by SQL interface on Golang.
+
+example of the primitive usage:
+
+```go
+sqlStmt := "CREATE TABLE tbl (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(32));"
+db.Exec(sqlStmt)
+
+tx, _ := db.Begin()
+func() {
+    stmt, _ := tx.Prepare("INSERT INTO tbl(id, name) values(?, ?)")
+    defer stmt.Close()
+    stmt.Exec(1, "foo")
+}()
+func() {
+    stmt, _ := tx.Prepare("INSERT INTO tbl(id) values(?)")
+    defer stmt.Close()
+    stmt.Exec(2) // name is NULL
+}()
+tx.Commit()
+
+var maybeName Option[string]
+
+row := db.QueryRow("SELECT name FROM tbl WHERE id = 1")
+row.Scan(&maybeName)
+fmt.Println(maybeName) // Some[foo]
+
+row := db.QueryRow("SELECT name FROM tbl WHERE id = 2")
+row.Scan(&maybeName)
+fmt.Println(maybeName) // None[]
+```
+
+## Known Issues
+
+The runtime raises a compile error like "methods cannot have type parameters", so `Map()`, `MapOr()`, `MapWithError()`, `MapOrWithError()`, `Zip()`, `ZipWith()`, `Unzip()` and `UnzipWith()` have been providing as functions. Basically, it would be better to provide them as the methods, but currently, it compromises with the limitation.
+
+## Author
+
+moznion (<moznion@mail.moznion.net>)
+

--- a/vendor/github.com/moznion/go-optional/convert_assign.go
+++ b/vendor/github.com/moznion/go-optional/convert_assign.go
@@ -1,0 +1,9 @@
+package optional
+
+import (
+	_ "database/sql"
+	_ "unsafe"
+)
+
+//go:linkname sqlConvertAssign database/sql.convertAssign
+func sqlConvertAssign(dest, src any) error

--- a/vendor/github.com/moznion/go-optional/option.go
+++ b/vendor/github.com/moznion/go-optional/option.go
@@ -1,0 +1,367 @@
+package optional
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrNoneValueTaken represents the error that is raised when None value is taken.
+	ErrNoneValueTaken = errors.New("none value taken")
+)
+
+// Option is a data type that must be Some (i.e. having a value) or None (i.e. doesn't have a value).
+// This type implements database/sql/driver.Valuer and database/sql.Scanner.
+type Option[T any] []T
+
+const (
+	value = iota
+)
+
+// Some is a function to make an Option type value with the actual value.
+func Some[T any](v T) Option[T] {
+	return Option[T]{
+		value: v,
+	}
+}
+
+// None is a function to make an Option type value that doesn't have a value.
+func None[T any]() Option[T] {
+	return nil
+}
+
+// FromNillable is a function to make an Option type value with the nillable value with value de-referencing.
+// If the given value is not nil, this returns Some[T] value. On the other hand, if the value is nil, this returns None[T].
+// This function does "dereference" for the value on packing that into Option value. If this value is not preferable, please consider using PtrFromNillable() instead.
+func FromNillable[T any](v *T) Option[T] {
+	if v == nil {
+		return None[T]()
+	}
+	return Some[T](*v)
+}
+
+// PtrFromNillable is a function to make an Option type value with the nillable value without value de-referencing.
+// If the given value is not nil, this returns Some[*T] value. On the other hand, if the value is nil, this returns None[*T].
+// This function doesn't "dereference" the value on packing that into the Option value; in other words, this puts the as-is pointer value into the Option envelope.
+// This behavior contrasts with the FromNillable() function's one.
+func PtrFromNillable[T any](v *T) Option[*T] {
+	if v == nil {
+		return None[*T]()
+	}
+	return Some[*T](v)
+}
+
+// IsNone returns whether the Option *doesn't* have a value or not.
+func (o Option[T]) IsNone() bool {
+	return o == nil
+}
+
+// IsSome returns whether the Option has a value or not.
+func (o Option[T]) IsSome() bool {
+	return o != nil
+}
+
+// Unwrap returns the value regardless of Some/None status.
+// If the Option value is Some, this method returns the actual value.
+// On the other hand, if the Option value is None, this method returns the *default* value according to the type.
+func (o Option[T]) Unwrap() T {
+	if o.IsNone() {
+		var defaultValue T
+		return defaultValue
+	}
+	return o[value]
+}
+
+// UnwrapAsPtr returns the contained value in receiver Option as a pointer.
+// This is similar to `Unwrap()` method but the difference is this method returns a pointer value instead of the actual value.
+// If the receiver Option value is None, this method returns nil.
+func (o Option[T]) UnwrapAsPtr() *T {
+	if o.IsNone() {
+		return nil
+	}
+	return &o[value]
+}
+
+// Take takes the contained value in Option.
+// If Option value is Some, this returns the value that is contained in Option.
+// On the other hand, this returns an ErrNoneValueTaken as the second return value.
+func (o Option[T]) Take() (T, error) {
+	if o.IsNone() {
+		var defaultValue T
+		return defaultValue, ErrNoneValueTaken
+	}
+	return o[value], nil
+}
+
+// TakeOr returns the actual value if the Option has a value.
+// On the other hand, this returns fallbackValue.
+func (o Option[T]) TakeOr(fallbackValue T) T {
+	if o.IsNone() {
+		return fallbackValue
+	}
+	return o[value]
+}
+
+// TakeOrElse returns the actual value if the Option has a value.
+// On the other hand, this executes fallbackFunc and returns the result value of that function.
+func (o Option[T]) TakeOrElse(fallbackFunc func() T) T {
+	if o.IsNone() {
+		return fallbackFunc()
+	}
+	return o[value]
+}
+
+// Or returns the Option value according to the actual value existence.
+// If the receiver's Option value is Some, this function pass-through that to return. Otherwise, this value returns the `fallbackOptionValue`.
+func (o Option[T]) Or(fallbackOptionValue Option[T]) Option[T] {
+	if o.IsNone() {
+		return fallbackOptionValue
+	}
+	return o
+}
+
+// OrElse returns the Option value according to the actual value existence.
+// If the receiver's Option value is Some, this function pass-through that to return. Otherwise, this executes `fallbackOptionFunc` and returns the result value of that function.
+func (o Option[T]) OrElse(fallbackOptionFunc func() Option[T]) Option[T] {
+	if o.IsNone() {
+		return fallbackOptionFunc()
+	}
+	return o
+}
+
+// Filter returns self if the Option has a value and the value matches the condition of the predicate function.
+// In other cases (i.e. it doesn't match with the predicate or the Option is None), this returns None value.
+func (o Option[T]) Filter(predicate func(v T) bool) Option[T] {
+	if o.IsNone() || !predicate(o[value]) {
+		return None[T]()
+	}
+	return o
+}
+
+// IfSome calls given function with the value of Option if the receiver value is Some.
+func (o Option[T]) IfSome(f func(v T)) {
+	if o.IsNone() {
+		return
+	}
+	f(o[value])
+}
+
+// IfSomeWithError calls given function with the value of Option if the receiver value is Some.
+// This method propagates the error of given function, and if the receiver value is None, this returns nil error.
+func (o Option[T]) IfSomeWithError(f func(v T) error) error {
+	if o.IsNone() {
+		return nil
+	}
+	return f(o[value])
+}
+
+// IfNone calls given function if the receiver value is None.
+func (o Option[T]) IfNone(f func()) {
+	if o.IsSome() {
+		return
+	}
+	f()
+}
+
+// IfNoneWithError calls given function if the receiver value is None.
+// This method propagates the error of given function, and if the receiver value is Some, this returns nil error.
+func (o Option[T]) IfNoneWithError(f func() error) error {
+	if o.IsSome() {
+		return nil
+	}
+	return f()
+}
+
+func (o Option[T]) String() string {
+	if o.IsNone() {
+		return "None[]"
+	}
+
+	v := o.Unwrap()
+	if stringer, ok := interface{}(v).(fmt.Stringer); ok {
+		return fmt.Sprintf("Some[%s]", stringer)
+	}
+	return fmt.Sprintf("Some[%v]", v)
+}
+
+// Map converts given Option value to another Option value according to the mapper function.
+// If given Option value is None, this also returns None.
+func Map[T, U any](option Option[T], mapper func(v T) U) Option[U] {
+	if option.IsNone() {
+		return None[U]()
+	}
+
+	return Some(mapper(option[value]))
+}
+
+// MapOr converts given Option value to another *actual* value according to the mapper function.
+// If given Option value is None, this returns fallbackValue.
+func MapOr[T, U any](option Option[T], fallbackValue U, mapper func(v T) U) U {
+	if option.IsNone() {
+		return fallbackValue
+	}
+	return mapper(option[value])
+}
+
+// MapWithError converts given Option value to another Option value according to the mapper function that has the ability to return the value with an error.
+// If given Option value is None, this returns (None, nil). Else if the mapper returns an error then this returns (None, error).
+// Unless of them, i.e. given Option value is Some and the mapper doesn't return the error, this returns (Some[U], nil).
+func MapWithError[T, U any](option Option[T], mapper func(v T) (U, error)) (Option[U], error) {
+	if option.IsNone() {
+		return None[U](), nil
+	}
+
+	u, err := mapper(option[value])
+	if err != nil {
+		return None[U](), err
+	}
+	return Some(u), nil
+}
+
+// MapOrWithError converts given Option value to another *actual* value according to the mapper function that has the ability to return the value with an error.
+// If given Option value is None, this returns (fallbackValue, nil). Else if the mapper returns an error then returns (_, error).
+// Unless of them, i.e. given Option value is Some and the mapper doesn't return the error, this returns (U, nil).
+func MapOrWithError[T, U any](option Option[T], fallbackValue U, mapper func(v T) (U, error)) (U, error) {
+	if option.IsNone() {
+		return fallbackValue, nil
+	}
+	return mapper(option[value])
+}
+
+// FlatMap converts give Option value to another Option value according to the mapper function.
+// The difference from the Map is the mapper function returns an Option value instead of the bare value.
+// If given Option value is None, this also returns None.
+func FlatMap[T, U any](option Option[T], mapper func(v T) Option[U]) Option[U] {
+	if option.IsNone() {
+		return None[U]()
+	}
+
+	return mapper(option[value])
+}
+
+// FlatMapOr converts given Option value to another *actual* value according to the mapper function.
+// The difference from the MapOr is the mapper function returns an Option value instead of the bare value.
+// If given Option value is None or mapper function returns None, this returns fallbackValue.
+func FlatMapOr[T, U any](option Option[T], fallbackValue U, mapper func(v T) Option[U]) U {
+	if option.IsNone() {
+		return fallbackValue
+	}
+
+	return (mapper(option[value])).TakeOr(fallbackValue)
+}
+
+// FlatMapWithError converts given Option value to another Option value according to the mapper function that has the ability to return the value with an error.
+// The difference from the MapWithError is the mapper function returns an Option value instead of the bare value.
+// If given Option value is None, this returns (None, nil). Else if the mapper returns an error then this returns (None, error).
+// Unless of them, i.e. given Option value is Some and the mapper doesn't return the error, this returns (Some[U], nil).
+func FlatMapWithError[T, U any](option Option[T], mapper func(v T) (Option[U], error)) (Option[U], error) {
+	if option.IsNone() {
+		return None[U](), nil
+	}
+
+	mapped, err := mapper(option[value])
+	if err != nil {
+		return None[U](), err
+	}
+	return mapped, nil
+}
+
+// FlatMapOrWithError converts given Option value to another *actual* value according to the mapper function that has the ability to return the value with an error.
+// The difference from the MapOrWithError is the mapper function returns an Option value instead of the bare value.
+// If given Option value is None, this returns (fallbackValue, nil). Else if the mapper returns an error then returns ($zero_value_of_type, error).
+// Unless of them, i.e. given Option value is Some and the mapper doesn't return the error, this returns (U, nil).
+func FlatMapOrWithError[T, U any](option Option[T], fallbackValue U, mapper func(v T) (Option[U], error)) (U, error) {
+	if option.IsNone() {
+		return fallbackValue, nil
+	}
+
+	maybe, err := mapper(option[value])
+	if err != nil {
+		var zeroValue U
+		return zeroValue, err
+	}
+
+	return maybe.TakeOr(fallbackValue), nil
+}
+
+// Pair is a data type that represents a tuple that has two elements.
+type Pair[T, U any] struct {
+	Value1 T
+	Value2 U
+}
+
+// Zip zips two Options into a Pair that has each Option's value.
+// If either one of the Options is None, this also returns None.
+func Zip[T, U any](opt1 Option[T], opt2 Option[U]) Option[Pair[T, U]] {
+	if opt1.IsSome() && opt2.IsSome() {
+		return Some(Pair[T, U]{
+			Value1: opt1[value],
+			Value2: opt2[value],
+		})
+	}
+
+	return None[Pair[T, U]]()
+}
+
+// ZipWith zips two Options into a typed value according to the zipper function.
+// If either one of the Options is None, this also returns None.
+func ZipWith[T, U, V any](opt1 Option[T], opt2 Option[U], zipper func(opt1 T, opt2 U) V) Option[V] {
+	if opt1.IsSome() && opt2.IsSome() {
+		return Some(zipper(opt1[value], opt2[value]))
+	}
+	return None[V]()
+}
+
+// Unzip extracts the values from a Pair and pack them into each Option value.
+// If the given zipped value is None, this returns None for all return values.
+func Unzip[T, U any](zipped Option[Pair[T, U]]) (Option[T], Option[U]) {
+	if zipped.IsNone() {
+		return None[T](), None[U]()
+	}
+
+	pair := zipped[value]
+	return Some(pair.Value1), Some(pair.Value2)
+}
+
+// UnzipWith extracts the values from the given value according to the unzipper function and pack the into each Option value.
+// If the given zipped value is None, this returns None for all return values.
+func UnzipWith[T, U, V any](zipped Option[V], unzipper func(zipped V) (T, U)) (Option[T], Option[U]) {
+	if zipped.IsNone() {
+		return None[T](), None[U]()
+	}
+
+	v1, v2 := unzipper(zipped[value])
+	return Some(v1), Some(v2)
+}
+
+var jsonNull = []byte("null")
+
+func (o Option[T]) MarshalJSON() ([]byte, error) {
+	if o.IsNone() {
+		return jsonNull, nil
+	}
+
+	marshal, err := json.Marshal(o.Unwrap())
+	if err != nil {
+		return nil, err
+	}
+	return marshal, nil
+}
+
+func (o *Option[T]) UnmarshalJSON(data []byte) error {
+	if len(data) <= 0 || bytes.Equal(data, jsonNull) {
+		*o = None[T]()
+		return nil
+	}
+
+	var v T
+	err := json.Unmarshal(data, &v)
+	if err != nil {
+		return err
+	}
+	*o = Some(v)
+
+	return nil
+}

--- a/vendor/github.com/moznion/go-optional/renovate.json
+++ b/vendor/github.com/moznion/go-optional/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "config:base"
+  ]
+}

--- a/vendor/github.com/moznion/go-optional/sql_driver.go
+++ b/vendor/github.com/moznion/go-optional/sql_driver.go
@@ -1,0 +1,32 @@
+package optional
+
+import (
+	"database/sql/driver"
+)
+
+// Scan assigns a value from a database driver.
+// This method is required from database/sql.Scanner interface.
+func (o *Option[T]) Scan(src any) error {
+	if src == nil {
+		*o = None[T]()
+		return nil
+	}
+
+	var v T
+	err := sqlConvertAssign(&v, src)
+	if err != nil {
+		return err
+	}
+
+	*o = Some[T](v)
+	return nil
+}
+
+// Value returns a driver Value.
+// This method is required from database/sql/driver.Valuer interface.
+func (o Option[T]) Value() (driver.Value, error) {
+	if o.IsNone() {
+		return nil, nil
+	}
+	return driver.DefaultParameterConverter.ConvertValue(o.Unwrap())
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -656,6 +656,9 @@ github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.2
 ## explicit; go 1.12
 github.com/modern-go/reflect2
+# github.com/moznion/go-optional v0.12.0
+## explicit; go 1.21
+github.com/moznion/go-optional
 # github.com/oklog/ulid v1.3.1
 ## explicit
 github.com/oklog/ulid


### PR DESCRIPTION
It seems we are currently using *bool a lot to distinguish between
{unset,true,false}. This commit instead uses the `go-optional`
library to distinguish between unset/undefined and the value.

It uses generics to works on every type.


[draft as this is incomplete and also lacks tests that check if toml unmarshal is working correctly but so far I really like the result, thanks @thozza ! ]