### PR TITLE
Use new Anaconda config options in RHEL 9+ and Fedora

### DIFF
--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -455,6 +455,11 @@ func EdgeInstallerImage(workload workload.Workload,
 	img.Platform = t.platform
 	img.ExtraBasePackages = packageSets[InstallerPkgsKey]
 
+	if t.Arch().Distro().Releasever() == "8" {
+		// NOTE: RHEL 8 only supports the older Anaconda configs
+		img.UseLegacyAnacondaConfig = true
+	}
+
 	img.Kickstart, err = kickstart.New(customizations)
 	if err != nil {
 		return nil, err
@@ -652,6 +657,11 @@ func ImageInstallerImage(workload workload.Workload,
 	}
 
 	img.ExtraBasePackages = packageSets[InstallerPkgsKey]
+
+	if t.Arch().Distro().Releasever() == "8" {
+		// NOTE: RHEL 8 only supports the older Anaconda configs
+		img.UseLegacyAnacondaConfig = true
+	}
 
 	img.Kickstart, err = kickstart.New(customizations)
 	if err != nil {

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -46,6 +46,10 @@ type AnacondaContainerInstaller struct {
 	Kickstart *kickstart.Options
 
 	UseRHELLoraxTemplates bool
+
+	// Uses the old, deprecated, Anaconda config option "kickstart-modules".
+	// Only for RHEL 8.
+	UseLegacyAnacondaConfig bool
 }
 
 func NewAnacondaContainerInstaller(container container.SourceSpec, ref string) *AnacondaContainerInstaller {
@@ -75,6 +79,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	)
 
 	anacondaPipeline.UseRHELLoraxTemplates = img.UseRHELLoraxTemplates
+	anacondaPipeline.UseLegacyAnacondaConfig = img.UseLegacyAnacondaConfig
 
 	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include
 	anacondaPipeline.ExcludePackages = img.ExtraBasePackages.Exclude

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -42,6 +42,10 @@ type AnacondaOSTreeInstaller struct {
 	DisabledAnacondaModules   []string
 	AdditionalDrivers         []string
 	FIPS                      bool
+
+	// Uses the old, deprecated, Anaconda config option "kickstart-modules".
+	// Only for RHEL 8.
+	UseLegacyAnacondaConfig bool
 }
 
 func NewAnacondaOSTreeInstaller(commit ostree.SourceSpec) *AnacondaOSTreeInstaller {
@@ -80,6 +84,8 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline.Variant = img.Variant
 	anacondaPipeline.Biosdevname = (img.Platform.GetArch() == arch.ARCH_X86_64)
 	anacondaPipeline.Checkpoint()
+
+	anacondaPipeline.UseLegacyAnacondaConfig = img.UseLegacyAnacondaConfig
 	anacondaPipeline.AdditionalDracutModules = img.AdditionalDracutModules
 	anacondaPipeline.AdditionalAnacondaModules = img.AdditionalAnacondaModules
 	if img.FIPS {

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -72,6 +72,10 @@ type AnacondaTarInstaller struct {
 	DisabledAnacondaModules   []string
 	AdditionalDracutModules   []string
 	AdditionalDrivers         []string
+
+	// Uses the old, deprecated, Anaconda config option "kickstart-modules".
+	// Only for RHEL 8.
+	UseLegacyAnacondaConfig bool
 }
 
 func NewAnacondaTarInstaller() *AnacondaTarInstaller {
@@ -127,6 +131,8 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	}
 	anacondaPipeline.Variant = img.Variant
 	anacondaPipeline.Biosdevname = (img.Platform.GetArch() == arch.ARCH_X86_64)
+
+	anacondaPipeline.UseLegacyAnacondaConfig = img.UseLegacyAnacondaConfig
 	anacondaPipeline.AdditionalAnacondaModules = img.AdditionalAnacondaModules
 	if img.OSCustomizations.FIPS {
 		anacondaPipeline.AdditionalAnacondaModules = append(

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -80,6 +80,10 @@ type AnacondaInstaller struct {
 
 	// Temporary
 	UseRHELLoraxTemplates bool
+
+	// Uses the old, deprecated, Anaconda config option "kickstart-modules".
+	// Only for RHEL 8.
+	UseLegacyAnacondaConfig bool
 }
 
 func NewAnacondaInstaller(installerType AnacondaInstallerType,
@@ -271,7 +275,14 @@ func (p *AnacondaInstaller) payloadStages() []*osbuild.Stage {
 		LoraxPath = "99-generic/runtime-postinstall.tmpl"
 	}
 
-	stages = append(stages, osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptionsLegacy(p.AdditionalAnacondaModules, p.DisabledAnacondaModules)))
+	var anacondaStageOptions *osbuild.AnacondaStageOptions
+	if p.UseLegacyAnacondaConfig {
+		anacondaStageOptions = osbuild.NewAnacondaStageOptionsLegacy(p.AdditionalAnacondaModules, p.DisabledAnacondaModules)
+	} else {
+		anacondaStageOptions = osbuild.NewAnacondaStageOptions(p.AdditionalAnacondaModules, p.DisabledAnacondaModules)
+	}
+	stages = append(stages, osbuild.NewAnacondaStage(anacondaStageOptions))
+
 	stages = append(stages, osbuild.NewLoraxScriptStage(&osbuild.LoraxScriptStageOptions{
 		Path:     LoraxPath,
 		BaseArch: p.platform.GetArch().String(),

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -271,7 +271,7 @@ func (p *AnacondaInstaller) payloadStages() []*osbuild.Stage {
 		LoraxPath = "99-generic/runtime-postinstall.tmpl"
 	}
 
-	stages = append(stages, osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptions(p.AdditionalAnacondaModules, p.DisabledAnacondaModules)))
+	stages = append(stages, osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptionsLegacy(p.AdditionalAnacondaModules, p.DisabledAnacondaModules)))
 	stages = append(stages, osbuild.NewLoraxScriptStage(&osbuild.LoraxScriptStageOptions{
 		Path:     LoraxPath,
 		BaseArch: p.platform.GetArch().String(),

--- a/pkg/osbuild/anaconda_stage.go
+++ b/pkg/osbuild/anaconda_stage.go
@@ -7,6 +7,13 @@ import (
 
 type AnacondaStageOptions struct {
 	// Kickstart modules to enable
+	//
+	// Deprecated:
+	//  RHEL 9:  Available but marked deprecated
+	//  RHEL 10: Removed
+	//  Fedora:  Removed
+	//
+	// https://bugzilla.redhat.com/show_bug.cgi?id=2023855#c10
 	KickstartModules []string `json:"kickstart-modules"`
 }
 

--- a/pkg/osbuild/anaconda_stage.go
+++ b/pkg/osbuild/anaconda_stage.go
@@ -82,3 +82,12 @@ func NewAnacondaStageOptionsLegacy(enableModules, disableModules []string) *Anac
 		KickstartModules: filterEnabledModules(states),
 	}
 }
+
+func NewAnacondaStageOptions(enableModules, disableModules []string) *AnacondaStageOptions {
+	states := defaultModuleStates()
+	setModuleStates(states, enableModules, disableModules)
+
+	return &AnacondaStageOptions{
+		ActivatableModules: filterEnabledModules(states),
+	}
+}

--- a/pkg/osbuild/anaconda_stage.go
+++ b/pkg/osbuild/anaconda_stage.go
@@ -14,7 +14,18 @@ type AnacondaStageOptions struct {
 	//  Fedora:  Removed
 	//
 	// https://bugzilla.redhat.com/show_bug.cgi?id=2023855#c10
-	KickstartModules []string `json:"kickstart-modules"`
+	KickstartModules []string `json:"kickstart-modules,omitempty"`
+
+	// Kickstart modules to activate
+	//
+	// Replaced kickstart-modules in newer versions.
+	ActivatableModules []string `json:"activatable-modules,omitempty"`
+
+	// Kickstart modules to forbid
+	ForbiddenModules []string `json:"forbidden-modules,omitempty"`
+
+	// Kickstart modules to activate but are allowed to fail
+	OptionalModules []string `json:"optional-modules,omitempty"`
 }
 
 func (AnacondaStageOptions) isStageOptions() {}

--- a/pkg/osbuild/anaconda_stage.go
+++ b/pkg/osbuild/anaconda_stage.go
@@ -74,7 +74,7 @@ func filterEnabledModules(moduleStates map[string]bool) []string {
 	return enabled
 }
 
-func NewAnacondaStageOptions(enableModules, disableModules []string) *AnacondaStageOptions {
+func NewAnacondaStageOptionsLegacy(enableModules, disableModules []string) *AnacondaStageOptions {
 	states := defaultModuleStates()
 	setModuleStates(states, enableModules, disableModules)
 

--- a/pkg/osbuild/anaconda_stage_test.go
+++ b/pkg/osbuild/anaconda_stage_test.go
@@ -149,7 +149,7 @@ func TestAnacondaStageOptions(t *testing.T) {
 		tc := testCases[name]
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
-			options := osbuild.NewAnacondaStageOptions(tc.enable, tc.disable)
+			options := osbuild.NewAnacondaStageOptionsLegacy(tc.enable, tc.disable)
 
 			require.NotNil(options)
 			require.ElementsMatch(options.KickstartModules, tc.expected)


### PR DESCRIPTION
Add the new Anaconda stage options introduced in https://github.com/osbuild/osbuild/pull/1320 and use the new `activatable-modules` option by default.

The legacy Anaconda config (`kickstart-modules`) is now only used in RHEL 8 installers.

See also https://bugzilla.redhat.com/show_bug.cgi?id=2023855#c10

Fixes #833 
