### PR TITLE
fix-fs-customization:exec start and stop logic

### DIFF
--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -521,8 +521,8 @@ func createMountpointService(serviceName string, mountpoints []string) *osbuild.
 		Type:            osbuild.Oneshot,
 		RemainAfterExit: false,
 		// compatibility with composefs, will require transient rootfs to be enabled too.
-		ExecStartPre: []string{"/bin/sh -c \"if grep -Uq composefs /run/ostree-booted; then chattr -i /; fi\""},
-		ExecStopPost: []string{"/bin/sh -c \"if grep -Uq composefs /run/ostree-booted; then chattr +i /; fi\""},
+		ExecStartPre: []string{"/bin/sh -c \"if grep -Uq composefs /run/ostree-booted; then echo 'Warning: composefs enabled! ensure transient rootfs is enabled too.'; else chattr -i /; fi\""},
+		ExecStopPost: []string{"/bin/sh -c \"if grep -Uq composefs /run/ostree-booted; then echo 'Warning: composefs enabled! ensure transient rootfs is enabled too.'; else chattr +i /; fi\""},
 		ExecStart:    []string{"mkdir -p " + strings.Join(mountpoints, " ")},
 	}
 


### PR DESCRIPTION
ExceStart/Stop should set `chattr` when ostree does not have composefs enabled. With composefs `chattr` is not required explicitly but tansient rootfs should be enabled to ensure the service can create the required mountpoints.

fixes: #837 