### PR TITLE
distro/rhel10: drop the openstack image type

### DIFF
--- a/pkg/distro/rhel/rhel10/distro.go
+++ b/pkg/distro/rhel/rhel10/distro.go
@@ -87,17 +87,6 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 			BIOS:       true,
 			UEFIVendor: rd.Vendor(),
 			BasePlatform: platform.BasePlatform{
-				ImageFormat: platform.FORMAT_QCOW2,
-			},
-		},
-		mkOpenstackImgType(),
-	)
-
-	x86_64.AddImageTypes(
-		&platform.X86{
-			BIOS:       true,
-			UEFIVendor: rd.Vendor(),
-			BasePlatform: platform.BasePlatform{
 				ImageFormat: platform.FORMAT_VMDK,
 			},
 		},
@@ -119,16 +108,6 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 		&platform.X86{},
 		mkTarImgType(),
 		mkWSLImgType(),
-	)
-
-	aarch64.AddImageTypes(
-		&platform.Aarch64{
-			UEFIVendor: rd.Vendor(),
-			BasePlatform: platform.BasePlatform{
-				ImageFormat: platform.FORMAT_QCOW2,
-			},
-		},
-		mkOpenstackImgType(),
 	)
 
 	aarch64.AddImageTypes(

--- a/pkg/distro/rhel/rhel10/distro_test.go
+++ b/pkg/distro/rhel/rhel10/distro_test.go
@@ -58,14 +58,6 @@ func TestFilenameFromType(t *testing.T) {
 			},
 		},
 		{
-			name: "openstack",
-			args: args{"openstack"},
-			want: wantResult{
-				filename: "disk.qcow2",
-				mimeType: "application/x-qemu-disk",
-			},
-		},
-		{
 			name: "vhd",
 			args: args{"vhd"},
 			want: wantResult{
@@ -192,7 +184,6 @@ func TestImageType_Name(t *testing.T) {
 			arch: "x86_64",
 			imgNames: []string{
 				"qcow2",
-				"openstack",
 				"vhd",
 				"vmdk",
 				"ova",
@@ -204,7 +195,6 @@ func TestImageType_Name(t *testing.T) {
 			arch: "aarch64",
 			imgNames: []string{
 				"qcow2",
-				"openstack",
 				"ami",
 				"tar",
 				"vhd",
@@ -283,7 +273,6 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 			arch: "x86_64",
 			imgNames: []string{
 				"qcow2",
-				"openstack",
 				"oci",
 				"vhd",
 				"vmdk",
@@ -297,7 +286,6 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 			arch: "aarch64",
 			imgNames: []string{
 				"qcow2",
-				"openstack",
 				"ami",
 				"tar",
 				"vhd",

--- a/pkg/distro/rhel/rhel10/qcow2.go
+++ b/pkg/distro/rhel/rhel10/qcow2.go
@@ -54,31 +54,6 @@ func mkOCIImgType(d *rhel.Distribution) *rhel.ImageType {
 	return it
 }
 
-func mkOpenstackImgType() *rhel.ImageType {
-	it := rhel.NewImageType(
-		"openstack",
-		"disk.qcow2",
-		"application/x-qemu-disk",
-		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: openstackCommonPackageSet,
-		},
-		rhel.DiskImage,
-		[]string{"build"},
-		[]string{"os", "image", "qcow2"},
-		[]string{"qcow2"},
-	)
-
-	it.DefaultImageConfig = &distro.ImageConfig{
-		Locale: common.ToPtr("en_US.UTF-8"),
-	}
-	it.KernelOptions = "ro"
-	it.DefaultSize = 4 * common.GibiByte
-	it.Bootable = true
-	it.BasePartitionTables = defaultBasePartitionTables
-
-	return it
-}
-
 func qcow2CommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	ps := rpmmd.PackageSet{
 		Include: []string{
@@ -149,28 +124,6 @@ func qcow2CommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 				"subscription-manager-cockpit",
 			},
 		})
-	}
-
-	return ps
-}
-
-func openstackCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	ps := rpmmd.PackageSet{
-		Include: []string{
-			// Defaults
-			"@core",
-			"langpacks-en",
-			"tuned",
-
-			// From the lorax kickstart
-			"cloud-init",
-			"qemu-guest-agent",
-			"spice-vdagent",
-		},
-		Exclude: []string{
-			"dracut-config-rescue",
-			"rng-tools",
-		},
 	}
 
 	return ps


### PR DESCRIPTION
OpenStack documentation points at the RHEL KVM Guest Image as the
official way to get RHEL up and running on OpenStack.

See https://docs.redhat.com/en/documentation/red_hat_openstack_platform/17.1/html/creating_and_managing_images/assembly_glance-creating-images_osp#proc_using-a-rhel-kvm-instance-image_glance-creating-rhel-kvm-images

osbuild-composer inherited the openstack image type from lorax-composer.
I'm not sure if something was different in the RHEL 7 times, or why
a separate image type was created back then. However nowadays, qcow2
is apparently the official option even for OpenStack, so we don't need
to carry a separate type forward. Thus, this commit drops it.