### PR TITLE
osbuild: only mount the required mountpoints for bootc install (COMPOSER-2301)

### DIFF
--- a/pkg/osbuild/bootc_install_to_filesystem_stage.go
+++ b/pkg/osbuild/bootc_install_to_filesystem_stage.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/osbuild/images/pkg/platform"
+	"golang.org/x/exp/slices"
 )
 
 type BootcInstallToFilesystemOptions struct {
@@ -35,11 +36,22 @@ func NewBootcInstallToFilesystemStage(options *BootcInstallToFilesystemOptions, 
 		return nil, fmt.Errorf("expected exactly one container input but got: %v (%v)", len(inputs.Images.References), inputs.Images.References)
 	}
 
+	// Don't mount any custom mountpoints.
+	// Only mount the minimum required mounts for bootc:
+	//   /, /boot, and /boot/efi, if they are already defined.
+	requiredMountpoints := []string{"/", "/boot", "/boot/efi"}
+	reqMounts := make([]Mount, 0, len(mounts))
+	for _, mount := range mounts {
+		if slices.Contains(requiredMountpoints, mount.Target) {
+			reqMounts = append(reqMounts, mount)
+		}
+	}
+
 	return &Stage{
 		Type:    "org.osbuild.bootc.install-to-filesystem",
 		Options: options,
 		Inputs:  inputs,
 		Devices: devices,
-		Mounts:  mounts,
+		Mounts:  reqMounts,
 	}, nil
 }


### PR DESCRIPTION
bootc install to-filesystem requires a clean root to install, with only the required mountpoints present: /, /boot, and /boot/efi.  Do not mount any user-defined mountpoints when running the bootc install stage.

Content in bootc images cannot be separated across filesystems, therefore there cannot be any content under the custom mountpoints, so this change will not cause any issues of content not being on the correct filesystem.

See also the discussion at https://github.com/osbuild/bootc-image-builder/issues/579