### PR TITLE
osbuild: add test for essential mounts in NewBootcInstallToFilesystemStage

### DIFF
--- a/pkg/osbuild/bootc_install_to_filesystem_stage_test.go
+++ b/pkg/osbuild/bootc_install_to_filesystem_stage_test.go
@@ -46,6 +46,30 @@ func TestBootcInstallToFilesystemStageNewHappy(t *testing.T) {
 	assert.Equal(t, stage, expectedStage)
 }
 
+func TestBootcInstallToFilesystemStageNewEssentialMountsOnly(t *testing.T) {
+	devices := makeOsbuildDevices("dev-for-/", "dev-for-/boot/efi", "dev-for-/var/log")
+	mounts := makeOsbuildMounts("/", "/boot/efi", "/var/log")
+	inputs := makeFakeContainerInputs()
+	pf := &platform.X86{
+		BasePlatform: platform.BasePlatform{},
+		UEFIVendor:   "test",
+	}
+
+	expectedStage := &osbuild.Stage{
+		Type:    "org.osbuild.bootc.install-to-filesystem",
+		Options: (*osbuild.BootcInstallToFilesystemOptions)(nil),
+		Inputs:  inputs,
+		Devices: devices,
+		Mounts: []osbuild.Mount{
+			{Name: "mnt-for-/", Type: "org.osbuild.ext4", Source: "dev-for-/", Target: "/"},
+			{Name: "mnt-for-/boot/efi", Type: "org.osbuild.vfat", Source: "dev-for-/boot/efi", Target: "/boot/efi"},
+		},
+	}
+	stage, err := osbuild.NewBootcInstallToFilesystemStage(nil, inputs, devices, mounts, pf)
+	require.Nil(t, err)
+	assert.Equal(t, expectedStage, stage)
+}
+
 func TestBootcInstallToFilesystemStageNewNoContainers(t *testing.T) {
 	devices := makeOsbuildDevices("dev-for-/", "dev-for-/boot", "dev-for-/boot/efi")
 	mounts := makeOsbuildMounts("/", "/boot", "/boot/efi")
@@ -155,7 +179,7 @@ func TestBootcInstallToFilesystemStageJsonHappy(t *testing.T) {
     },
     {
       "name": "mnt-for-/boot/efi",
-      "type": "org.osbuild.ext4",
+      "type": "org.osbuild.vfat",
       "source": "dev-for-/boot/efi",
       "target": "/boot/efi"
     }

--- a/pkg/osbuild/bootupd_stage_test.go
+++ b/pkg/osbuild/bootupd_stage_test.go
@@ -2,6 +2,8 @@ package osbuild_test
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,8 +19,12 @@ import (
 func makeOsbuildMounts(targets ...string) []osbuild.Mount {
 	var mnts []osbuild.Mount
 	for _, target := range targets {
+		fstype := "ext4"
+		if strings.HasSuffix(target, "/boot/efi") {
+			fstype = "vfat"
+		}
 		mnts = append(mnts, osbuild.Mount{
-			Type:   "org.osbuild.ext4",
+			Type:   fmt.Sprintf("org.osbuild.%s", fstype),
 			Name:   "mnt-for-" + target,
 			Source: "dev-for-" + target,
 			Target: target,
@@ -156,7 +162,7 @@ func TestBootupdStageJsonHappy(t *testing.T) {
     },
     {
       "name": "mnt-for-/boot/efi",
-      "type": "org.osbuild.ext4",
+      "type": "org.osbuild.vfat",
       "source": "dev-for-/boot/efi",
       "target": "/boot/efi"
     }


### PR DESCRIPTION
Small tweak for the tests for `NewBootcInstallToFilesystemStage` so that we also test that only the essential mounts are used in the `org.osbuild.bootc.install-to-filesystem`. This also makes the fake creation for /boot/efi more realistic by moving the fs to `vfat`.

Tiny followup for https://github.com/osbuild/images/pull/846