### PR TITLE
pathpolicy: tweak error messages and add test

### DIFF
--- a/pkg/blueprint/filesystem_customizations_test.go
+++ b/pkg/blueprint/filesystem_customizations_test.go
@@ -1,0 +1,26 @@
+package blueprint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/pathpolicy"
+)
+
+func TestCheckMountpointsPolicy(t *testing.T) {
+	policy := pathpolicy.NewPathPolicies(map[string]pathpolicy.PathPolicy{
+		"/": {Exact: true},
+	})
+
+	mps := []FilesystemCustomization{
+		{Mountpoint: "/foo"},
+		{Mountpoint: "/boot/"},
+	}
+
+	expectedErr := `The following errors occurred while setting up custom mountpoints:
+path "/foo" is not allowed
+path "/boot/" must be canonical`
+	err := CheckMountpointsPolicy(mps, policy)
+	assert.EqualError(t, err, expectedErr)
+}

--- a/pkg/distro/fedora/distro_test.go
+++ b/pkg/distro/fedora/distro_test.go
@@ -748,7 +748,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 				} else if imgTypeName == "live-installer" {
 					assert.EqualError(t, err, fmt.Sprintf(distro.NoCustomizationsAllowedError, imgTypeName))
 				} else {
-					assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/etc\"]")
+					assert.EqualError(t, err, "The following errors occurred while setting up custom mountpoints:\npath \"/etc\" is not allowed")
 				}
 			}
 		}
@@ -896,7 +896,7 @@ func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 				} else if imgTypeName == "live-installer" {
 					assert.EqualError(t, err, fmt.Sprintf(distro.NoCustomizationsAllowedError, imgTypeName))
 				} else {
-					assert.EqualError(t, err, "The following custom mountpoints are not supported [\"//\" \"/var//\" \"/var//log/audit/\"]")
+					assert.EqualError(t, err, "The following errors occurred while setting up custom mountpoints:\npath \"//\" must be canonical\npath \"/var//\" must be canonical\npath \"/var//log/audit/\" must be canonical")
 				}
 			}
 		}

--- a/pkg/distro/rhel/rhel10/distro_test.go
+++ b/pkg/distro/rhel/rhel10/distro_test.go
@@ -418,7 +418,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
-			assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/etc\"]")
+			assert.EqualError(t, err, "The following errors occurred while setting up custom mountpoints:\npath \"/etc\" is not allowed")
 		}
 	}
 }
@@ -538,7 +538,7 @@ func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
-			assert.EqualError(t, err, "The following custom mountpoints are not supported [\"//\" \"/var//\" \"/var//log/audit/\"]")
+			assert.EqualError(t, err, "The following errors occurred while setting up custom mountpoints:\npath \"//\" must be canonical\npath \"/var//\" must be canonical\npath \"/var//log/audit/\" must be canonical")
 		}
 	}
 }

--- a/pkg/distro/rhel/rhel7/distro_test.go
+++ b/pkg/distro/rhel/rhel7/distro_test.go
@@ -296,7 +296,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
-			assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/etc\"]")
+			assert.EqualError(t, err, "The following errors occurred while setting up custom mountpoints:\npath \"/etc\" is not allowed")
 		}
 	}
 }
@@ -408,7 +408,7 @@ func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
-			assert.EqualError(t, err, "The following custom mountpoints are not supported [\"//\" \"/var//\" \"/var//log/audit/\"]")
+			assert.EqualError(t, err, "The following errors occurred while setting up custom mountpoints:\npath \"//\" must be canonical\npath \"/var//\" must be canonical\npath \"/var//log/audit/\" must be canonical")
 		}
 	}
 }

--- a/pkg/distro/rhel/rhel8/distro_test.go
+++ b/pkg/distro/rhel/rhel8/distro_test.go
@@ -682,7 +682,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 			} else if unsupported[imgTypeName] {
 				assert.Error(t, err)
 			} else {
-				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/etc\"]")
+				assert.EqualError(t, err, "The following errors occurred while setting up custom mountpoints:\npath \"/etc\" is not allowed")
 			}
 		}
 	}
@@ -842,7 +842,7 @@ func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 			if unsupported[imgTypeName] {
 				assert.Error(t, err)
 			} else {
-				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"//\" \"/var//\" \"/var//log/audit/\"]")
+				assert.EqualError(t, err, "The following errors occurred while setting up custom mountpoints:\npath \"//\" must be canonical\npath \"/var//\" must be canonical\npath \"/var//log/audit/\" must be canonical")
 			}
 		}
 	}

--- a/pkg/distro/rhel/rhel9/distro_test.go
+++ b/pkg/distro/rhel/rhel9/distro_test.go
@@ -676,7 +676,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 			} else if imgTypeName == "edge-installer" || imgTypeName == "edge-simplified-installer" || imgTypeName == "edge-raw-image" || imgTypeName == "edge-ami" || imgTypeName == "edge-vsphere" {
 				continue
 			} else {
-				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/etc\"]")
+				assert.EqualError(t, err, "The following errors occurred while setting up custom mountpoints:\npath \"/etc\" is not allowed")
 			}
 		}
 	}
@@ -806,7 +806,7 @@ func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 			if strings.HasPrefix(imgTypeName, "edge-") {
 				continue
 			} else {
-				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"//\" \"/var//\" \"/var//log/audit/\"]")
+				assert.EqualError(t, err, "The following errors occurred while setting up custom mountpoints:\npath \"//\" must be canonical\npath \"/var//\" must be canonical\npath \"/var//log/audit/\" must be canonical")
 			}
 		}
 	}

--- a/pkg/pathpolicy/path_policy.go
+++ b/pkg/pathpolicy/path_policy.go
@@ -26,15 +26,14 @@ func NewPathPolicies(entries map[string]PathPolicy) *PathPolicies {
 
 // Check a given path against the PathPolicies
 func (pol *PathPolicies) Check(fsPath string) error {
-
 	// Quickly check we have a path and it is absolute
 	if fsPath == "" || fsPath[0] != '/' {
-		return fmt.Errorf("path must be absolute")
+		return fmt.Errorf("path %q must be absolute", fsPath)
 	}
 
 	// ensure that only clean paths are valid
 	if fsPath != path.Clean(fsPath) {
-		return fmt.Errorf("path must be canonical")
+		return fmt.Errorf("path %q must be canonical", fsPath)
 	}
 
 	node, left := pol.Lookup(fsPath)
@@ -46,7 +45,7 @@ func (pol *PathPolicies) Check(fsPath string) error {
 	// 1) path is explicitly not allowed or
 	// 2) a subpath was match but an explicit match is required
 	if policy.Deny || (policy.Exact && len(left) > 0) {
-		return fmt.Errorf("path '%s ' is not allowed", fsPath)
+		return fmt.Errorf("path %q is not allowed", fsPath)
 	}
 
 	// exact match or recursive path allowed

--- a/pkg/pathpolicy/path_policy_test.go
+++ b/pkg/pathpolicy/path_policy_test.go
@@ -47,3 +47,13 @@ func TestPathPolicyCheck(t *testing.T) {
 		}
 	}
 }
+
+func TestPathPolicyErrors(t *testing.T) {
+	policy := NewPathPolicies(map[string]PathPolicy{
+		"/": {Exact: true},
+	})
+
+	assert.EqualError(t, policy.Check("/foo"), `path "/foo" is not allowed`)
+	assert.EqualError(t, policy.Check("./"), `path "./" must be absolute`)
+	assert.EqualError(t, policy.Check("/boot/"), `path "/boot/" must be canonical`)
+}


### PR DESCRIPTION
Trivial tweak for the errors returned from PathPolicies.Check() so that they are a bit more user friendly.

See also https://github.com/osbuild/bootc-image-builder/pull/601