### PR TITLE
pathpolicy: move to generics and unexport pathTrie

### DIFF
--- a/pkg/pathpolicy/path_policy.go
+++ b/pkg/pathpolicy/path_policy.go
@@ -10,18 +10,15 @@ type PathPolicy struct {
 	Exact bool // require and exact match, no subdirs
 }
 
-type PathPolicies = PathTrie
+type PathPolicies struct {
+	pathTrie *PathTrie[PathPolicy]
+}
 
 // Create a new PathPolicies trie from a map of path to PathPolicy
 func NewPathPolicies(entries map[string]PathPolicy) *PathPolicies {
-
-	noType := make(map[string]interface{}, len(entries))
-
-	for k, v := range entries {
-		noType[k] = v
+	return &PathPolicies{
+		pathTrie: NewPathTrieFromMap[PathPolicy](entries),
 	}
-
-	return NewPathTrieFromMap(noType)
 }
 
 // Check a given path against the PathPolicies
@@ -37,11 +34,8 @@ func (pol *PathPolicies) Check(fsPath string) error {
 		return fmt.Errorf("path must be canonical")
 	}
 
-	node, left := pol.Lookup(fsPath)
-	policy, ok := node.Payload.(PathPolicy)
-	if !ok {
-		panic("programming error: invalid path trie payload")
-	}
+	node, left := pol.pathTrie.Lookup(fsPath)
+	policy := node.Payload
 
 	// 1) path is explicitly not allowed or
 	// 2) a subpath was match but an explicit match is required

--- a/pkg/pathpolicy/path_policy.go
+++ b/pkg/pathpolicy/path_policy.go
@@ -11,13 +11,13 @@ type PathPolicy struct {
 }
 
 type PathPolicies struct {
-	pathTrie *PathTrie[PathPolicy]
+	pathTrie *pathTrie[PathPolicy]
 }
 
 // Create a new PathPolicies trie from a map of path to PathPolicy
 func NewPathPolicies(entries map[string]PathPolicy) *PathPolicies {
 	return &PathPolicies{
-		pathTrie: NewPathTrieFromMap[PathPolicy](entries),
+		pathTrie: newPathTrieFromMap[PathPolicy](entries),
 	}
 }
 

--- a/pkg/pathpolicy/path_tree_test.go
+++ b/pkg/pathpolicy/path_tree_test.go
@@ -8,18 +8,18 @@ import (
 	"github.com/osbuild/images/internal/common"
 )
 
-func TestNewPathTrieFromMap(t *testing.T) {
+func TestNewpathTrieFromMap(t *testing.T) {
 	assert := assert.New(t)
 
 	type testCase struct {
 		entries map[string]*int
-		trie    *PathTrie[*int]
+		trie    *pathTrie[*int]
 	}
 
 	tests := []testCase{
 		{
 			entries: map[string]*int{},
-			trie: &PathTrie[*int]{
+			trie: &pathTrie[*int]{
 				Name: []string{},
 			},
 		},
@@ -27,7 +27,7 @@ func TestNewPathTrieFromMap(t *testing.T) {
 			entries: map[string]*int{
 				"/": common.ToPtr(1),
 			},
-			trie: &PathTrie[*int]{
+			trie: &pathTrie[*int]{
 				Name:    []string{},
 				Payload: common.ToPtr(1),
 			},
@@ -43,14 +43,14 @@ func TestNewPathTrieFromMap(t *testing.T) {
 				"/boot":                        common.ToPtr(7),
 				"/boot/efi":                    common.ToPtr(8),
 			},
-			trie: &PathTrie[*int]{
+			trie: &pathTrie[*int]{
 				Name:    []string{},
 				Payload: common.ToPtr(1),
-				Paths: []*PathTrie[*int]{
+				Paths: []*pathTrie[*int]{
 					{
 						Name:    []string{"boot"},
 						Payload: common.ToPtr(7),
-						Paths: []*PathTrie[*int]{
+						Paths: []*pathTrie[*int]{
 							{
 								Name:    []string{"efi"},
 								Payload: common.ToPtr(8),
@@ -60,11 +60,11 @@ func TestNewPathTrieFromMap(t *testing.T) {
 					{
 						Name:    []string{"var"},
 						Payload: common.ToPtr(2),
-						Paths: []*PathTrie[*int]{
+						Paths: []*pathTrie[*int]{
 							{
 								Name:    []string{"lib", "chrony"},
 								Payload: common.ToPtr(3),
-								Paths: []*PathTrie[*int]{
+								Paths: []*pathTrie[*int]{
 									{
 										Name:    []string{"logs"},
 										Payload: common.ToPtr(4),
@@ -74,7 +74,7 @@ func TestNewPathTrieFromMap(t *testing.T) {
 							{
 								Name:    []string{"lib", "osbuild"},
 								Payload: common.ToPtr(5),
-								Paths: []*PathTrie[*int]{
+								Paths: []*pathTrie[*int]{
 									{
 										Name:    []string{"store", "cache"},
 										Payload: common.ToPtr(6),
@@ -89,7 +89,7 @@ func TestNewPathTrieFromMap(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		have := NewPathTrieFromMap(tc.entries)
+		have := newPathTrieFromMap(tc.entries)
 		assert.NotNil(have)
 		assert.Equal(tc.trie, have)
 	}
@@ -109,7 +109,7 @@ func TestPathTrieLookup(t *testing.T) {
 		"/var/lib/chrony/logs":         "/var/lib/chrony/logs",
 	}
 
-	trie := NewPathTrieFromMap(entries)
+	trie := newPathTrieFromMap(entries)
 
 	testCases := map[string]string{
 		"/":                         "/",

--- a/pkg/pathpolicy/path_tree_test.go
+++ b/pkg/pathpolicy/path_tree_test.go
@@ -12,28 +12,28 @@ func TestNewPathTrieFromMap(t *testing.T) {
 	assert := assert.New(t)
 
 	type testCase struct {
-		entries map[string]interface{}
-		trie    *PathTrie
+		entries map[string]*int
+		trie    *PathTrie[*int]
 	}
 
 	tests := []testCase{
 		{
-			entries: map[string]interface{}{},
-			trie: &PathTrie{
+			entries: map[string]*int{},
+			trie: &PathTrie[*int]{
 				Name: []string{},
 			},
 		},
 		{
-			entries: map[string]interface{}{
+			entries: map[string]*int{
 				"/": common.ToPtr(1),
 			},
-			trie: &PathTrie{
+			trie: &PathTrie[*int]{
 				Name:    []string{},
 				Payload: common.ToPtr(1),
 			},
 		},
 		{
-			entries: map[string]interface{}{
+			entries: map[string]*int{
 				"/":                            common.ToPtr(1),
 				"/var":                         common.ToPtr(2),
 				"/var/lib/chrony":              common.ToPtr(3),
@@ -43,14 +43,14 @@ func TestNewPathTrieFromMap(t *testing.T) {
 				"/boot":                        common.ToPtr(7),
 				"/boot/efi":                    common.ToPtr(8),
 			},
-			trie: &PathTrie{
+			trie: &PathTrie[*int]{
 				Name:    []string{},
 				Payload: common.ToPtr(1),
-				Paths: []*PathTrie{
+				Paths: []*PathTrie[*int]{
 					{
 						Name:    []string{"boot"},
 						Payload: common.ToPtr(7),
-						Paths: []*PathTrie{
+						Paths: []*PathTrie[*int]{
 							{
 								Name:    []string{"efi"},
 								Payload: common.ToPtr(8),
@@ -60,11 +60,11 @@ func TestNewPathTrieFromMap(t *testing.T) {
 					{
 						Name:    []string{"var"},
 						Payload: common.ToPtr(2),
-						Paths: []*PathTrie{
+						Paths: []*PathTrie[*int]{
 							{
 								Name:    []string{"lib", "chrony"},
 								Payload: common.ToPtr(3),
-								Paths: []*PathTrie{
+								Paths: []*PathTrie[*int]{
 									{
 										Name:    []string{"logs"},
 										Payload: common.ToPtr(4),
@@ -74,7 +74,7 @@ func TestNewPathTrieFromMap(t *testing.T) {
 							{
 								Name:    []string{"lib", "osbuild"},
 								Payload: common.ToPtr(5),
-								Paths: []*PathTrie{
+								Paths: []*PathTrie[*int]{
 									{
 										Name:    []string{"store", "cache"},
 										Payload: common.ToPtr(6),
@@ -98,7 +98,7 @@ func TestNewPathTrieFromMap(t *testing.T) {
 func TestPathTrieLookup(t *testing.T) {
 	assert := assert.New(t)
 
-	entries := map[string]interface{}{
+	entries := map[string]string{
 		"/":                            "/",
 		"/boot":                        "/boot",
 		"/boot/efi":                    "/boot/efi",

--- a/pkg/pathpolicy/path_trie.go
+++ b/pkg/pathpolicy/path_trie.go
@@ -16,14 +16,14 @@ func pathTrieSplitPath(path string) []string {
 	return strings.Split(path, "/")
 }
 
-type PathTrie struct {
+type PathTrie[T any] struct {
 	Name    []string
-	Paths   []*PathTrie
-	Payload interface{}
+	Paths   []*PathTrie[T]
+	Payload T
 }
 
 // match checks if the given trie is a prefix of path
-func (trie *PathTrie) match(path []string) bool {
+func (trie *PathTrie[T]) match(path []string) bool {
 	if len(trie.Name) > len(path) {
 		return false
 	}
@@ -37,12 +37,12 @@ func (trie *PathTrie) match(path []string) bool {
 	return true
 }
 
-func (trie *PathTrie) get(path []string) (*PathTrie, []string) {
+func (trie *PathTrie[T]) get(path []string) (*PathTrie[T], []string) {
 	if len(path) < 1 {
 		panic("programming error: expected root node")
 	}
 
-	var node *PathTrie
+	var node *PathTrie[T]
 	for i := range trie.Paths {
 		if trie.Paths[i].match(path) {
 			node = trie.Paths[i]
@@ -67,11 +67,11 @@ func (trie *PathTrie) get(path []string) (*PathTrie, []string) {
 	return node.get(path[prefix:])
 }
 
-func (trie *PathTrie) add(path []string) *PathTrie {
-	node := &PathTrie{Name: path}
+func (trie *PathTrie[T]) add(path []string) *PathTrie[T] {
+	node := &PathTrie[T]{Name: path}
 
 	if trie.Paths == nil {
-		trie.Paths = make([]*PathTrie, 0, 1)
+		trie.Paths = make([]*PathTrie[T], 0, 1)
 	}
 
 	trie.Paths = append(trie.Paths, node)
@@ -81,8 +81,8 @@ func (trie *PathTrie) add(path []string) *PathTrie {
 
 // Construct a new trie from a map of paths to their payloads.
 // Returns the root node of the trie.
-func NewPathTrieFromMap(entries map[string]interface{}) *PathTrie {
-	root := &PathTrie{Name: []string{}}
+func NewPathTrieFromMap[T any](entries map[string]T) *PathTrie[T] {
+	root := &PathTrie[T]{Name: []string{}}
 
 	keys := make([]string, 0, len(entries))
 	for k := range entries {
@@ -107,7 +107,7 @@ func NewPathTrieFromMap(entries map[string]interface{}) *PathTrie {
 // Lookup returns the node that is the prefix of path and
 // the unmatched path segment. Must be called on the root
 // trie node.
-func (root *PathTrie) Lookup(path string) (*PathTrie, []string) {
+func (root *PathTrie[T]) Lookup(path string) (*PathTrie[T], []string) {
 
 	if len(root.Name) != 0 {
 		panic("programming error: lookup on non-root trie node")

--- a/pkg/pathpolicy/path_trie.go
+++ b/pkg/pathpolicy/path_trie.go
@@ -16,14 +16,14 @@ func pathTrieSplitPath(path string) []string {
 	return strings.Split(path, "/")
 }
 
-type PathTrie[T any] struct {
+type pathTrie[T any] struct {
 	Name    []string
-	Paths   []*PathTrie[T]
+	Paths   []*pathTrie[T]
 	Payload T
 }
 
 // match checks if the given trie is a prefix of path
-func (trie *PathTrie[T]) match(path []string) bool {
+func (trie *pathTrie[T]) match(path []string) bool {
 	if len(trie.Name) > len(path) {
 		return false
 	}
@@ -37,12 +37,12 @@ func (trie *PathTrie[T]) match(path []string) bool {
 	return true
 }
 
-func (trie *PathTrie[T]) get(path []string) (*PathTrie[T], []string) {
+func (trie *pathTrie[T]) get(path []string) (*pathTrie[T], []string) {
 	if len(path) < 1 {
 		panic("programming error: expected root node")
 	}
 
-	var node *PathTrie[T]
+	var node *pathTrie[T]
 	for i := range trie.Paths {
 		if trie.Paths[i].match(path) {
 			node = trie.Paths[i]
@@ -67,11 +67,11 @@ func (trie *PathTrie[T]) get(path []string) (*PathTrie[T], []string) {
 	return node.get(path[prefix:])
 }
 
-func (trie *PathTrie[T]) add(path []string) *PathTrie[T] {
-	node := &PathTrie[T]{Name: path}
+func (trie *pathTrie[T]) add(path []string) *pathTrie[T] {
+	node := &pathTrie[T]{Name: path}
 
 	if trie.Paths == nil {
-		trie.Paths = make([]*PathTrie[T], 0, 1)
+		trie.Paths = make([]*pathTrie[T], 0, 1)
 	}
 
 	trie.Paths = append(trie.Paths, node)
@@ -81,8 +81,8 @@ func (trie *PathTrie[T]) add(path []string) *PathTrie[T] {
 
 // Construct a new trie from a map of paths to their payloads.
 // Returns the root node of the trie.
-func NewPathTrieFromMap[T any](entries map[string]T) *PathTrie[T] {
-	root := &PathTrie[T]{Name: []string{}}
+func newPathTrieFromMap[T any](entries map[string]T) *pathTrie[T] {
+	root := &pathTrie[T]{Name: []string{}}
 
 	keys := make([]string, 0, len(entries))
 	for k := range entries {
@@ -107,7 +107,7 @@ func NewPathTrieFromMap[T any](entries map[string]T) *PathTrie[T] {
 // Lookup returns the node that is the prefix of path and
 // the unmatched path segment. Must be called on the root
 // trie node.
-func (root *PathTrie[T]) Lookup(path string) (*PathTrie[T], []string) {
+func (root *pathTrie[T]) Lookup(path string) (*pathTrie[T], []string) {
 
 	if len(root.Name) != 0 {
 		panic("programming error: lookup on non-root trie node")


### PR DESCRIPTION
pathpolicy: move `PathTrie` to a generic

With generics support in go it seems like a good idea to move the
`PathTrie` to a generic.

---

pathpolicy: unexport `PathTrie` as it's an implementation
 detail

The `pathpolicy` packages is currently exporting the `PathTrie`
data structure. It seems this is not really used outside of the
package itself and more an implementation detail than a public
API. So just unexport it.

