### PR TITLE
add support in macOS crypt function

### DIFF
--- a/pkg/crypt/crypt.go
+++ b/pkg/crypt/crypt.go
@@ -2,6 +2,9 @@ package crypt
 
 import (
 	"crypto/rand"
+	"crypto/sha512"
+	"encoding/base64"
+	"fmt"
 	"math/big"
 	"strings"
 )
@@ -18,8 +21,14 @@ func CryptSHA512(phrase string) (string, error) {
 		return "", nil
 	}
 
-	hashSettings := "$6$" + salt
-	return crypt(phrase, hashSettings)
+	hash := sha512.New()
+	_, err = hash.Write([]byte(salt + phrase))
+	if err != nil {
+		return "", fmt.Errorf("failed to write hash: %w", err)
+	}
+
+	hashedPhrase := base64.StdEncoding.EncodeToString(hash.Sum(nil))
+	return fmt.Sprintf("$6$%s$%s", salt, hashedPhrase), nil
 }
 
 func genSalt(length int) (string, error) {


### PR DESCRIPTION
this commit generates a slat, hashes the password using SHA-512, and encodes the result in base64.
- Replaced the original CryptSHA512 function with a custom implementation using Go's standard `crypto/sha512` library.
- Removed dependency on system-specific cryptographic functions to ensure compatibility across different operating systems,
- Updated the relevant usage of the CryptSHA512 function in the codebase. including macOS