### PR TITLE
[RHEL-9] Drop RHSM and RHUI-specific config from Azure and EC2 images (COMPOSER-2308)

### DIFF
--- a/pkg/distro/rhel/rhel9/ami.go
+++ b/pkg/distro/rhel/rhel9/ami.go
@@ -141,6 +141,20 @@ func defaultEc2ImageConfig() *distro.ImageConfig {
 	}
 }
 
+func appendEC2DracutX86_64(ic *distro.ImageConfig) *distro.ImageConfig {
+	ic.DracutConf = append(ic.DracutConf,
+		&osbuild.DracutConfStageOptions{
+			Filename: "ec2.conf",
+			Config: osbuild.DracutConfigFile{
+				AddDrivers: []string{
+					"nvme",
+					"xen-blkfront",
+				},
+			},
+		})
+	return ic
+}
+
 func defaultEc2ImageConfigX86_64() *distro.ImageConfig {
 	ic := defaultEc2ImageConfig()
 	return appendEC2DracutX86_64(ic)
@@ -399,18 +413,4 @@ func mkEC2ImgTypeAarch64() *rhel.ImageType {
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
-}
-
-func appendEC2DracutX86_64(ic *distro.ImageConfig) *distro.ImageConfig {
-	ic.DracutConf = append(ic.DracutConf,
-		&osbuild.DracutConfStageOptions{
-			Filename: "ec2.conf",
-			Config: osbuild.DracutConfigFile{
-				AddDrivers: []string{
-					"nvme",
-					"xen-blkfront",
-				},
-			},
-		})
-	return ic
 }

--- a/pkg/distro/rhel/rhel9/ami.go
+++ b/pkg/distro/rhel/rhel9/ami.go
@@ -2,7 +2,6 @@ package rhel9
 
 import (
 	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/customizations/subscription"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -13,7 +12,7 @@ import (
 const amiKernelOptions = "console=tty0 console=ttyS0,115200n8 net.ifnames=0 nvme_core.io_timeout=4294967295"
 
 // default EC2 images config (common for all architectures)
-func baseEc2ImageConfig() *distro.ImageConfig {
+func defaultEc2ImageConfig() *distro.ImageConfig {
 	return &distro.ImageConfig{
 		Locale:   common.ToPtr("en_US.UTF-8"),
 		Timezone: common.ToPtr("UTC"),
@@ -142,35 +141,8 @@ func baseEc2ImageConfig() *distro.ImageConfig {
 	}
 }
 
-func defaultEc2ImageConfig(osVersion string, rhsm bool) *distro.ImageConfig {
-	ic := baseEc2ImageConfig()
-	if rhsm && common.VersionLessThan(osVersion, "9.1") {
-		ic = appendRHSM(ic)
-		// Disable RHSM redhat.repo management
-		rhsmConf := ic.RHSMConfig[subscription.RHSMConfigNoSubscription]
-		rhsmConf.SubMan.Rhsm = subscription.SubManRHSMConfig{ManageRepos: common.ToPtr(false)}
-		ic.RHSMConfig[subscription.RHSMConfigNoSubscription] = rhsmConf
-	}
-	return ic
-}
-
-func defaultEc2ImageConfigX86_64(osVersion string, rhsm bool) *distro.ImageConfig {
-	ic := defaultEc2ImageConfig(osVersion, rhsm)
-	return appendEC2DracutX86_64(ic)
-}
-
-// Default AMI (custom image built by users) images config.
-// The configuration does not touch the RHSM configuration at all.
-// https://issues.redhat.com/browse/COMPOSER-2157
-func defaultAMIImageConfig() *distro.ImageConfig {
-	return baseEc2ImageConfig()
-}
-
-// Default AMI x86_64 (custom image built by users) images config.
-// The configuration does not touch the RHSM configuration at all.
-// https://issues.redhat.com/browse/COMPOSER-2157
-func defaultAMIImageConfigX86_64() *distro.ImageConfig {
-	ic := defaultAMIImageConfig()
+func defaultEc2ImageConfigX86_64() *distro.ImageConfig {
+	ic := defaultEc2ImageConfig()
 	return appendEC2DracutX86_64(ic)
 }
 
@@ -285,7 +257,7 @@ func rhelEc2SapPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	}.Append(ec2CommonPackageSet(t)).Append(SapPackageSet(t))
 }
 
-func mkEc2ImgTypeX86_64(osVersion string, rhsm bool) *rhel.ImageType {
+func mkEc2ImgTypeX86_64() *rhel.ImageType {
 	it := rhel.NewImageType(
 		"ec2",
 		"image.raw.xz",
@@ -303,7 +275,7 @@ func mkEc2ImgTypeX86_64(osVersion string, rhsm bool) *rhel.ImageType {
 	it.KernelOptions = amiKernelOptions
 	it.Bootable = true
 	it.DefaultSize = 10 * common.GibiByte
-	it.DefaultImageConfig = defaultEc2ImageConfigX86_64(osVersion, rhsm)
+	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -326,13 +298,13 @@ func mkAMIImgTypeX86_64() *rhel.ImageType {
 	it.KernelOptions = amiKernelOptions
 	it.Bootable = true
 	it.DefaultSize = 10 * common.GibiByte
-	it.DefaultImageConfig = defaultAMIImageConfigX86_64()
+	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
 }
 
-func mkEC2SapImgTypeX86_64(osVersion string, rhsm bool) *rhel.ImageType {
+func mkEC2SapImgTypeX86_64(osVersion string) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"ec2-sap",
 		"image.raw.xz",
@@ -351,13 +323,13 @@ func mkEC2SapImgTypeX86_64(osVersion string, rhsm bool) *rhel.ImageType {
 	it.KernelOptions = "console=ttyS0,115200n8 console=tty0 net.ifnames=0 nvme_core.io_timeout=4294967295 processor.max_cstate=1 intel_idle.max_cstate=1"
 	it.Bootable = true
 	it.DefaultSize = 10 * common.GibiByte
-	it.DefaultImageConfig = sapImageConfig(osVersion).InheritFrom(defaultEc2ImageConfigX86_64(osVersion, rhsm))
+	it.DefaultImageConfig = sapImageConfig(osVersion).InheritFrom(defaultEc2ImageConfigX86_64())
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
 }
 
-func mkEc2HaImgTypeX86_64(osVersion string, rhsm bool) *rhel.ImageType {
+func mkEc2HaImgTypeX86_64() *rhel.ImageType {
 	it := rhel.NewImageType(
 		"ec2-ha",
 		"image.raw.xz",
@@ -376,7 +348,7 @@ func mkEc2HaImgTypeX86_64(osVersion string, rhsm bool) *rhel.ImageType {
 	it.KernelOptions = amiKernelOptions
 	it.Bootable = true
 	it.DefaultSize = 10 * common.GibiByte
-	it.DefaultImageConfig = defaultEc2ImageConfigX86_64(osVersion, rhsm)
+	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -400,13 +372,13 @@ func mkAMIImgTypeAarch64() *rhel.ImageType {
 	it.KernelOptions = "console=ttyS0,115200n8 console=tty0 net.ifnames=0 nvme_core.io_timeout=4294967295 iommu.strict=0"
 	it.Bootable = true
 	it.DefaultSize = 10 * common.GibiByte
-	it.DefaultImageConfig = defaultAMIImageConfig()
+	it.DefaultImageConfig = defaultEc2ImageConfig()
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
 }
 
-func mkEC2ImgTypeAarch64(osVersion string, rhsm bool) *rhel.ImageType {
+func mkEC2ImgTypeAarch64() *rhel.ImageType {
 	it := rhel.NewImageType(
 		"ec2",
 		"image.raw.xz",
@@ -425,45 +397,10 @@ func mkEC2ImgTypeAarch64(osVersion string, rhsm bool) *rhel.ImageType {
 	it.KernelOptions = "console=ttyS0,115200n8 console=tty0 net.ifnames=0 nvme_core.io_timeout=4294967295 iommu.strict=0"
 	it.Bootable = true
 	it.DefaultSize = 10 * common.GibiByte
-	it.DefaultImageConfig = defaultEc2ImageConfig(osVersion, rhsm)
+	it.DefaultImageConfig = defaultEc2ImageConfig()
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
-}
-
-// Add RHSM config options to ImageConfig.
-// Used for RHEL distros.
-func appendRHSM(ic *distro.ImageConfig) *distro.ImageConfig {
-	rhsm := &distro.ImageConfig{
-		RHSMConfig: map[subscription.RHSMStatus]*subscription.RHSMConfig{
-			subscription.RHSMConfigNoSubscription: {
-				// RHBZ#1932802
-				SubMan: subscription.SubManConfig{
-					Rhsmcertd: subscription.SubManRHSMCertdConfig{
-						AutoRegistration: common.ToPtr(true),
-					},
-					// Don't disable RHSM redhat.repo management on the AMI
-					// image, which is BYOS and does not use RHUI for content.
-					// Otherwise subscribing the system manually after booting
-					// it would result in empty redhat.repo. Without RHUI, such
-					// system would have no way to get Red Hat content, but
-					// enable the repo management manually, which would be very
-					// confusing.
-				},
-			},
-			subscription.RHSMConfigWithSubscription: {
-				// RHBZ#1932802
-				SubMan: subscription.SubManConfig{
-					Rhsmcertd: subscription.SubManRHSMCertdConfig{
-						AutoRegistration: common.ToPtr(true),
-					},
-					// do not disable the redhat.repo management if the user
-					// explicitly request the system to be subscribed
-				},
-			},
-		},
-	}
-	return rhsm.InheritFrom(ic)
 }
 
 func appendEC2DracutX86_64(ic *distro.ImageConfig) *distro.ImageConfig {

--- a/pkg/distro/rhel/rhel9/ami.go
+++ b/pkg/distro/rhel/rhel9/ami.go
@@ -160,16 +160,6 @@ func defaultEc2ImageConfigX86_64() *distro.ImageConfig {
 	return appendEC2DracutX86_64(ic)
 }
 
-// common ec2 image build package set
-func ec2BuildPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	return distroBuildPackageSet(t).Append(
-		rpmmd.PackageSet{
-			Include: []string{
-				"python3-pyyaml",
-			},
-		})
-}
-
 // common ec2 image package set, which is the minimal super set of all ec2 image types
 func ec2BasePackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	ps := rpmmd.PackageSet{
@@ -322,8 +312,7 @@ func mkEC2SapImgTypeX86_64(osVersion string) *rhel.ImageType {
 		"image.raw.xz",
 		"application/xz",
 		map[string]rhel.PackageSetFunc{
-			rhel.BuildPkgsKey: ec2BuildPackageSet,
-			rhel.OSPkgsKey:    rhelEc2SapPackageSet,
+			rhel.OSPkgsKey: rhelEc2SapPackageSet,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -347,8 +336,7 @@ func mkEc2HaImgTypeX86_64() *rhel.ImageType {
 		"image.raw.xz",
 		"application/xz",
 		map[string]rhel.PackageSetFunc{
-			rhel.BuildPkgsKey: ec2BuildPackageSet,
-			rhel.OSPkgsKey:    rhelEc2HaPackageSet,
+			rhel.OSPkgsKey: rhelEc2HaPackageSet,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -372,8 +360,7 @@ func mkAMIImgTypeAarch64() *rhel.ImageType {
 		"image.raw",
 		"application/octet-stream",
 		map[string]rhel.PackageSetFunc{
-			rhel.BuildPkgsKey: ec2BuildPackageSet,
-			rhel.OSPkgsKey:    ec2PackageSet,
+			rhel.OSPkgsKey: ec2PackageSet,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -396,8 +383,7 @@ func mkEC2ImgTypeAarch64() *rhel.ImageType {
 		"image.raw.xz",
 		"application/xz",
 		map[string]rhel.PackageSetFunc{
-			rhel.BuildPkgsKey: ec2BuildPackageSet,
-			rhel.OSPkgsKey:    ec2PackageSet,
+			rhel.OSPkgsKey: ec2PackageSet,
 		},
 		rhel.DiskImage,
 		[]string{"build"},

--- a/pkg/distro/rhel/rhel9/ami.go
+++ b/pkg/distro/rhel/rhel9/ami.go
@@ -156,7 +156,8 @@ func ec2BuildPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 		})
 }
 
-func ec2CommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
+// common ec2 image package set, which is the minimal super set of all ec2 image types
+func ec2BasePackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	ps := rpmmd.PackageSet{
 		Include: []string{
 			"@core",
@@ -215,9 +216,9 @@ func ec2CommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	return ps
 }
 
-// rhel-ec2 image package set
-func rhelEc2PackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	ec2PackageSet := ec2CommonPackageSet(t)
+// plain ec2 image package set
+func ec2PackageSet(t *rhel.ImageType) rpmmd.PackageSet {
+	ec2PackageSet := ec2BasePackageSet(t)
 	ec2PackageSet = ec2PackageSet.Append(rpmmd.PackageSet{
 		Exclude: []string{
 			"alsa-lib",
@@ -228,15 +229,12 @@ func rhelEc2PackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 
 // rhel-ha-ec2 image package set
 func rhelEc2HaPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	ec2HaPackageSet := ec2CommonPackageSet(t)
+	ec2HaPackageSet := ec2PackageSet(t)
 	ec2HaPackageSet = ec2HaPackageSet.Append(rpmmd.PackageSet{
 		Include: []string{
 			"fence-agents-all",
 			"pacemaker",
 			"pcs",
-		},
-		Exclude: []string{
-			"alsa-lib",
 		},
 	})
 	return ec2HaPackageSet
@@ -254,7 +252,7 @@ func rhelEc2SapPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 			// COMPOSER-1829
 			"firewalld",
 		},
-	}.Append(ec2CommonPackageSet(t)).Append(SapPackageSet(t))
+	}.Append(ec2BasePackageSet(t)).Append(SapPackageSet(t))
 }
 
 func mkEc2ImgTypeX86_64() *rhel.ImageType {
@@ -263,7 +261,7 @@ func mkEc2ImgTypeX86_64() *rhel.ImageType {
 		"image.raw.xz",
 		"application/xz",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: rhelEc2PackageSet,
+			rhel.OSPkgsKey: ec2PackageSet,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -287,7 +285,7 @@ func mkAMIImgTypeX86_64() *rhel.ImageType {
 		"image.raw",
 		"application/octet-stream",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: ec2CommonPackageSet,
+			rhel.OSPkgsKey: ec2PackageSet,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -361,7 +359,7 @@ func mkAMIImgTypeAarch64() *rhel.ImageType {
 		"application/octet-stream",
 		map[string]rhel.PackageSetFunc{
 			rhel.BuildPkgsKey: ec2BuildPackageSet,
-			rhel.OSPkgsKey:    ec2CommonPackageSet,
+			rhel.OSPkgsKey:    ec2PackageSet,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -385,7 +383,7 @@ func mkEC2ImgTypeAarch64() *rhel.ImageType {
 		"application/xz",
 		map[string]rhel.PackageSetFunc{
 			rhel.BuildPkgsKey: ec2BuildPackageSet,
-			rhel.OSPkgsKey:    rhelEc2PackageSet,
+			rhel.OSPkgsKey:    ec2PackageSet,
 		},
 		rhel.DiskImage,
 		[]string{"build"},

--- a/pkg/distro/rhel/rhel9/ami.go
+++ b/pkg/distro/rhel/rhel9/ami.go
@@ -243,23 +243,10 @@ func ec2CommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	return ps
 }
 
-// common rhel ec2 RHUI image package set
-func rhelEc2CommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	ps := ec2CommonPackageSet(t)
-	// Include "redhat-cloud-client-configuration" on 9.1+ (COMPOSER-1805)
-	if common.VersionGreaterThanOrEqual(t.Arch().Distro().OsVersion(), "9.1") {
-		ps.Include = append(ps.Include, "redhat-cloud-client-configuration")
-	}
-	return ps
-}
-
 // rhel-ec2 image package set
 func rhelEc2PackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	ec2PackageSet := rhelEc2CommonPackageSet(t)
+	ec2PackageSet := ec2CommonPackageSet(t)
 	ec2PackageSet = ec2PackageSet.Append(rpmmd.PackageSet{
-		Include: []string{
-			"rh-amazon-rhui-client",
-		},
 		Exclude: []string{
 			"alsa-lib",
 		},
@@ -269,13 +256,12 @@ func rhelEc2PackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 
 // rhel-ha-ec2 image package set
 func rhelEc2HaPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	ec2HaPackageSet := rhelEc2CommonPackageSet(t)
+	ec2HaPackageSet := ec2CommonPackageSet(t)
 	ec2HaPackageSet = ec2HaPackageSet.Append(rpmmd.PackageSet{
 		Include: []string{
 			"fence-agents-all",
 			"pacemaker",
 			"pcs",
-			"rh-amazon-rhui-client-ha",
 		},
 		Exclude: []string{
 			"alsa-lib",
@@ -290,14 +276,13 @@ func rhelEc2HaPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 func rhelEc2SapPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	return rpmmd.PackageSet{
 		Include: []string{
-			"rh-amazon-rhui-client-sap-bundle-e4s",
 			"libcanberra-gtk2",
 		},
 		Exclude: []string{
 			// COMPOSER-1829
 			"firewalld",
 		},
-	}.Append(rhelEc2CommonPackageSet(t)).Append(SapPackageSet(t))
+	}.Append(ec2CommonPackageSet(t)).Append(SapPackageSet(t))
 }
 
 func mkEc2ImgTypeX86_64(osVersion string, rhsm bool) *rhel.ImageType {

--- a/pkg/distro/rhel/rhel9/azure.go
+++ b/pkg/distro/rhel/rhel9/azure.go
@@ -34,8 +34,8 @@ func mkAzureImgType(rd *rhel.Distribution) *rhel.ImageType {
 	return it
 }
 
-// Azure RHUI image type
-func mkAzureRhuiImgType(rd *rhel.Distribution) *rhel.ImageType {
+// Azure RHEL-internal image type
+func mkAzureInternalImgType(rd *rhel.Distribution) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"azure-rhui",
 		"disk.vhd.xz",
@@ -54,12 +54,12 @@ func mkAzureRhuiImgType(rd *rhel.Distribution) *rhel.ImageType {
 	it.Bootable = true
 	it.DefaultSize = 64 * common.GibiByte
 	it.DefaultImageConfig = defaultAzureImageConfig(rd)
-	it.BasePartitionTables = azureRhuiBasePartitionTables
+	it.BasePartitionTables = azureInternalBasePartitionTables
 
 	return it
 }
 
-func mkAzureSapRhuiImgType(rd *rhel.Distribution) *rhel.ImageType {
+func mkAzureSapInternalImgType(rd *rhel.Distribution) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"azure-sap-rhui",
 		"disk.vhd.xz",
@@ -78,7 +78,7 @@ func mkAzureSapRhuiImgType(rd *rhel.Distribution) *rhel.ImageType {
 	it.Bootable = true
 	it.DefaultSize = 64 * common.GibiByte
 	it.DefaultImageConfig = sapAzureImageConfig(rd)
-	it.BasePartitionTables = azureRhuiBasePartitionTables
+	it.BasePartitionTables = azureInternalBasePartitionTables
 
 	return it
 }
@@ -177,7 +177,7 @@ func azureSapPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 }
 
 // PARTITION TABLES
-func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
+func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	var bootSize uint64
 	switch {
 	case common.VersionLessThan(t.Arch().Distro().OsVersion(), "9.3") && t.IsRHEL():

--- a/pkg/distro/rhel/rhel9/azure.go
+++ b/pkg/distro/rhel/rhel9/azure.go
@@ -29,7 +29,7 @@ func mkAzureImgType() *rhel.ImageType {
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
 	it.DefaultSize = 4 * common.GibiByte
-	it.DefaultImageConfig = defaultAzureImageConfig
+	it.DefaultImageConfig = defaultAzureImageConfig()
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -53,7 +53,7 @@ func mkAzureByosImgType(rd distro.Distro) *rhel.ImageType {
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
 	it.DefaultSize = 4 * common.GibiByte
-	it.DefaultImageConfig = defaultAzureByosImageConfig.InheritFrom(defaultAzureImageConfig)
+	it.DefaultImageConfig = defaultAzureByosImageConfig.InheritFrom(defaultAzureImageConfig())
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -78,7 +78,7 @@ func mkAzureRhuiImgType() *rhel.ImageType {
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
 	it.DefaultSize = 64 * common.GibiByte
-	it.DefaultImageConfig = defaultAzureRhuiImageConfig.InheritFrom(defaultAzureImageConfig)
+	it.DefaultImageConfig = defaultAzureRhuiImageConfig.InheritFrom(defaultAzureImageConfig())
 	it.BasePartitionTables = azureRhuiBasePartitionTables
 
 	return it
@@ -440,157 +440,161 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 const defaultAzureKernelOptions = "ro loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
 
 // based on https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/deploying_rhel_9_on_microsoft_azure/assembly_deploying-a-rhel-image-as-a-virtual-machine-on-microsoft-azure_cloud-content-azure#making-configuration-changes_configure-the-image-azure
-var defaultAzureImageConfig = &distro.ImageConfig{
-	Timezone: common.ToPtr("Etc/UTC"),
-	Locale:   common.ToPtr("en_US.UTF-8"),
-	Keyboard: &osbuild.KeymapStageOptions{
-		Keymap: "us",
-		X11Keymap: &osbuild.X11KeymapOptions{
-			Layouts: []string{"us"},
-		},
-	},
-	Sysconfig: []*osbuild.SysconfigStageOptions{
-		{
-			Kernel: &osbuild.SysconfigKernelOptions{
-				UpdateDefault: true,
-				DefaultKernel: "kernel-core",
-			},
-			Network: &osbuild.SysconfigNetworkOptions{
-				Networking: true,
-				NoZeroConf: true,
+func defaultAzureImageConfig() *distro.ImageConfig {
+	ic := &distro.ImageConfig{
+		Timezone: common.ToPtr("Etc/UTC"),
+		Locale:   common.ToPtr("en_US.UTF-8"),
+		Keyboard: &osbuild.KeymapStageOptions{
+			Keymap: "us",
+			X11Keymap: &osbuild.X11KeymapOptions{
+				Layouts: []string{"us"},
 			},
 		},
-	},
-	EnabledServices: []string{
-		"firewalld",
-		"nm-cloud-setup.service",
-		"nm-cloud-setup.timer",
-		"sshd",
-		"waagent",
-	},
-	SshdConfig: &osbuild.SshdConfigStageOptions{
-		Config: osbuild.SshdConfigConfig{
-			ClientAliveInterval: common.ToPtr(180),
-		},
-	},
-	Modprobe: []*osbuild.ModprobeStageOptions{
-		{
-			Filename: "blacklist-amdgpu.conf",
-			Commands: osbuild.ModprobeConfigCmdList{
-				osbuild.NewModprobeConfigCmdBlacklist("amdgpu"),
-			},
-		},
-		{
-			Filename: "blacklist-intel-cstate.conf",
-			Commands: osbuild.ModprobeConfigCmdList{
-				osbuild.NewModprobeConfigCmdBlacklist("intel_cstate"),
-			},
-		},
-		{
-			Filename: "blacklist-floppy.conf",
-			Commands: osbuild.ModprobeConfigCmdList{
-				osbuild.NewModprobeConfigCmdBlacklist("floppy"),
-			},
-		},
-		{
-			Filename: "blacklist-nouveau.conf",
-			Commands: osbuild.ModprobeConfigCmdList{
-				osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
-				osbuild.NewModprobeConfigCmdBlacklist("lbm-nouveau"),
-			},
-		},
-		{
-			Filename: "blacklist-skylake-edac.conf",
-			Commands: osbuild.ModprobeConfigCmdList{
-				osbuild.NewModprobeConfigCmdBlacklist("skx_edac"),
-			},
-		},
-	},
-	CloudInit: []*osbuild.CloudInitStageOptions{
-		{
-			Filename: "10-azure-kvp.cfg",
-			Config: osbuild.CloudInitConfigFile{
-				Reporting: &osbuild.CloudInitConfigReporting{
-					Logging: &osbuild.CloudInitConfigReportingHandlers{
-						Type: "log",
-					},
-					Telemetry: &osbuild.CloudInitConfigReportingHandlers{
-						Type: "hyperv",
-					},
+		Sysconfig: []*osbuild.SysconfigStageOptions{
+			{
+				Kernel: &osbuild.SysconfigKernelOptions{
+					UpdateDefault: true,
+					DefaultKernel: "kernel-core",
+				},
+				Network: &osbuild.SysconfigNetworkOptions{
+					Networking: true,
+					NoZeroConf: true,
 				},
 			},
 		},
-		{
-			Filename: "91-azure_datasource.cfg",
-			Config: osbuild.CloudInitConfigFile{
-				Datasource: &osbuild.CloudInitConfigDatasource{
-					Azure: &osbuild.CloudInitConfigDatasourceAzure{
-						ApplyNetworkConfig: false,
+		EnabledServices: []string{
+			"firewalld",
+			"nm-cloud-setup.service",
+			"nm-cloud-setup.timer",
+			"sshd",
+			"waagent",
+		},
+		SshdConfig: &osbuild.SshdConfigStageOptions{
+			Config: osbuild.SshdConfigConfig{
+				ClientAliveInterval: common.ToPtr(180),
+			},
+		},
+		Modprobe: []*osbuild.ModprobeStageOptions{
+			{
+				Filename: "blacklist-amdgpu.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("amdgpu"),
+				},
+			},
+			{
+				Filename: "blacklist-intel-cstate.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("intel_cstate"),
+				},
+			},
+			{
+				Filename: "blacklist-floppy.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("floppy"),
+				},
+			},
+			{
+				Filename: "blacklist-nouveau.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
+					osbuild.NewModprobeConfigCmdBlacklist("lbm-nouveau"),
+				},
+			},
+			{
+				Filename: "blacklist-skylake-edac.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("skx_edac"),
+				},
+			},
+		},
+		CloudInit: []*osbuild.CloudInitStageOptions{
+			{
+				Filename: "10-azure-kvp.cfg",
+				Config: osbuild.CloudInitConfigFile{
+					Reporting: &osbuild.CloudInitConfigReporting{
+						Logging: &osbuild.CloudInitConfigReportingHandlers{
+							Type: "log",
+						},
+						Telemetry: &osbuild.CloudInitConfigReportingHandlers{
+							Type: "hyperv",
+						},
 					},
 				},
-				DatasourceList: []string{
-					"Azure",
+			},
+			{
+				Filename: "91-azure_datasource.cfg",
+				Config: osbuild.CloudInitConfigFile{
+					Datasource: &osbuild.CloudInitConfigDatasource{
+						Azure: &osbuild.CloudInitConfigDatasourceAzure{
+							ApplyNetworkConfig: false,
+						},
+					},
+					DatasourceList: []string{
+						"Azure",
+					},
 				},
 			},
 		},
-	},
-	PwQuality: &osbuild.PwqualityConfStageOptions{
-		Config: osbuild.PwqualityConfConfig{
-			Minlen:   common.ToPtr(6),
-			Minclass: common.ToPtr(3),
-			Dcredit:  common.ToPtr(0),
-			Ucredit:  common.ToPtr(0),
-			Lcredit:  common.ToPtr(0),
-			Ocredit:  common.ToPtr(0),
-		},
-	},
-	WAAgentConfig: &osbuild.WAAgentConfStageOptions{
-		Config: osbuild.WAAgentConfig{
-			RDFormat:     common.ToPtr(false),
-			RDEnableSwap: common.ToPtr(false),
-		},
-	},
-	Grub2Config: &osbuild.GRUB2Config{
-		DisableRecovery: common.ToPtr(true),
-		DisableSubmenu:  common.ToPtr(true),
-		Distributor:     "$(sed 's, release .*$,,g' /etc/system-release)",
-		Terminal:        []string{"serial", "console"},
-		Serial:          "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1",
-		Timeout:         10,
-		TimeoutStyle:    osbuild.GRUB2ConfigTimeoutStyleCountdown,
-	},
-	UdevRules: &osbuild.UdevRulesStageOptions{
-		Filename: "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules",
-		Rules: osbuild.UdevRules{
-			osbuild.UdevRuleComment{
-				Comment: []string{
-					"Accelerated Networking on Azure exposes a new SRIOV interface to the VM.",
-					"This interface is transparently bonded to the synthetic interface,",
-					"so NetworkManager should just ignore any SRIOV interfaces.",
-				},
-			},
-			osbuild.NewUdevRule(
-				[]osbuild.UdevKV{
-					{K: "SUBSYSTEM", O: "==", V: "net"},
-					{K: "DRIVERS", O: "==", V: "hv_pci"},
-					{K: "ACTION", O: "==", V: "add"},
-					{K: "ENV", A: "NM_UNMANAGED", O: "=", V: "1"},
-				},
-			),
-		},
-	},
-	SystemdUnit: []*osbuild.SystemdUnitStageOptions{
-		{
-			Unit:   "nm-cloud-setup.service",
-			Dropin: "10-rh-enable-for-azure.conf",
-			Config: osbuild.SystemdServiceUnitDropin{
-				Service: &osbuild.SystemdUnitServiceSection{
-					Environment: []osbuild.EnvironmentVariable{{Key: "NM_CLOUD_SETUP_AZURE", Value: "yes"}},
-				},
+		PwQuality: &osbuild.PwqualityConfStageOptions{
+			Config: osbuild.PwqualityConfConfig{
+				Minlen:   common.ToPtr(6),
+				Minclass: common.ToPtr(3),
+				Dcredit:  common.ToPtr(0),
+				Ucredit:  common.ToPtr(0),
+				Lcredit:  common.ToPtr(0),
+				Ocredit:  common.ToPtr(0),
 			},
 		},
-	},
-	DefaultTarget: common.ToPtr("multi-user.target"),
+		WAAgentConfig: &osbuild.WAAgentConfStageOptions{
+			Config: osbuild.WAAgentConfig{
+				RDFormat:     common.ToPtr(false),
+				RDEnableSwap: common.ToPtr(false),
+			},
+		},
+		Grub2Config: &osbuild.GRUB2Config{
+			DisableRecovery: common.ToPtr(true),
+			DisableSubmenu:  common.ToPtr(true),
+			Distributor:     "$(sed 's, release .*$,,g' /etc/system-release)",
+			Terminal:        []string{"serial", "console"},
+			Serial:          "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1",
+			Timeout:         10,
+			TimeoutStyle:    osbuild.GRUB2ConfigTimeoutStyleCountdown,
+		},
+		UdevRules: &osbuild.UdevRulesStageOptions{
+			Filename: "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules",
+			Rules: osbuild.UdevRules{
+				osbuild.UdevRuleComment{
+					Comment: []string{
+						"Accelerated Networking on Azure exposes a new SRIOV interface to the VM.",
+						"This interface is transparently bonded to the synthetic interface,",
+						"so NetworkManager should just ignore any SRIOV interfaces.",
+					},
+				},
+				osbuild.NewUdevRule(
+					[]osbuild.UdevKV{
+						{K: "SUBSYSTEM", O: "==", V: "net"},
+						{K: "DRIVERS", O: "==", V: "hv_pci"},
+						{K: "ACTION", O: "==", V: "add"},
+						{K: "ENV", A: "NM_UNMANAGED", O: "=", V: "1"},
+					},
+				),
+			},
+		},
+		SystemdUnit: []*osbuild.SystemdUnitStageOptions{
+			{
+				Unit:   "nm-cloud-setup.service",
+				Dropin: "10-rh-enable-for-azure.conf",
+				Config: osbuild.SystemdServiceUnitDropin{
+					Service: &osbuild.SystemdUnitServiceSection{
+						Environment: []osbuild.EnvironmentVariable{{Key: "NM_CLOUD_SETUP_AZURE", Value: "yes"}},
+					},
+				},
+			},
+		},
+		DefaultTarget: common.ToPtr("multi-user.target"),
+	}
+
+	return ic
 }
 
 // Diff of the default Image Config compare to the `defaultAzureImageConfig`
@@ -637,5 +641,5 @@ var defaultAzureRhuiImageConfig = &distro.ImageConfig{
 }
 
 func sapAzureImageConfig(rd distro.Distro) *distro.ImageConfig {
-	return sapImageConfig(rd.OsVersion()).InheritFrom(defaultAzureRhuiImageConfig.InheritFrom(defaultAzureImageConfig))
+	return sapImageConfig(rd.OsVersion()).InheritFrom(defaultAzureRhuiImageConfig.InheritFrom(defaultAzureImageConfig()))
 }

--- a/pkg/distro/rhel/rhel9/azure.go
+++ b/pkg/distro/rhel/rhel9/azure.go
@@ -11,32 +11,8 @@ import (
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-// Azure non-RHEL image type
+// Azure image type
 func mkAzureImgType(rd *rhel.Distribution) *rhel.ImageType {
-	it := rhel.NewImageType(
-		"vhd",
-		"disk.vhd",
-		"application/x-vhd",
-		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: azurePackageSet,
-		},
-		rhel.DiskImage,
-		[]string{"build"},
-		[]string{"os", "image", "vpc"},
-		[]string{"vpc"},
-	)
-
-	it.KernelOptions = defaultAzureKernelOptions
-	it.Bootable = true
-	it.DefaultSize = 4 * common.GibiByte
-	it.DefaultImageConfig = defaultAzureImageConfig(rd)
-	it.BasePartitionTables = defaultBasePartitionTables
-
-	return it
-}
-
-// Azure BYOS image type
-func mkAzureByosImgType(rd *rhel.Distribution) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"vhd",
 		"disk.vhd",

--- a/pkg/distro/rhel/rhel9/azure.go
+++ b/pkg/distro/rhel/rhel9/azure.go
@@ -66,7 +66,7 @@ func mkAzureRhuiImgType() *rhel.ImageType {
 		"disk.vhd.xz",
 		"application/xz",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: azureRhuiPackageSet,
+			rhel.OSPkgsKey: azurePackageSet,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -195,24 +195,10 @@ func azurePackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	return azureCommonPackageSet(t)
 }
 
-// Azure RHUI image package set
-func azureRhuiPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			"rhui-azure-rhel9",
-		},
-	}.Append(azureCommonPackageSet(t))
-}
-
 // Azure SAP image package set
-// Includes the common azure package set, the common SAP packages, and
-// the azure rhui sap package.
+// Includes the common azure package set, the common SAP packages
 func azureSapPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			"rhui-azure-rhel9-sap-ha",
-		},
-	}.Append(azureCommonPackageSet(t)).Append(SapPackageSet(t))
+	return azureCommonPackageSet(t).Append(SapPackageSet(t))
 }
 
 // PARTITION TABLES

--- a/pkg/distro/rhel/rhel9/azure.go
+++ b/pkg/distro/rhel/rhel9/azure.go
@@ -3,7 +3,6 @@ package rhel9
 import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
-	"github.com/osbuild/images/pkg/customizations/subscription"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
@@ -54,7 +53,7 @@ func mkAzureRhuiImgType(rd *rhel.Distribution) *rhel.ImageType {
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
 	it.DefaultSize = 64 * common.GibiByte
-	it.DefaultImageConfig = defaultAzureRhuiImageConfig.InheritFrom(defaultAzureImageConfig(rd))
+	it.DefaultImageConfig = defaultAzureImageConfig(rd)
 	it.BasePartitionTables = azureRhuiBasePartitionTables
 
 	return it
@@ -78,7 +77,7 @@ func mkAzureSapRhuiImgType(rd *rhel.Distribution) *rhel.ImageType {
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
 	it.DefaultSize = 64 * common.GibiByte
-	it.DefaultImageConfig = defaultAzureRhuiImageConfig.InheritFrom(sapAzureImageConfig(rd))
+	it.DefaultImageConfig = sapAzureImageConfig(rd)
 	it.BasePartitionTables = azureRhuiBasePartitionTables
 
 	return it
@@ -577,40 +576,6 @@ func defaultAzureImageConfig(rd *rhel.Distribution) *distro.ImageConfig {
 	return ic
 }
 
-// Diff of the default Image Config compare to the `defaultAzureImageConfig`
-var defaultAzureRhuiImageConfig = &distro.ImageConfig{
-	GPGKeyFiles: []string{
-		"/etc/pki/rpm-gpg/RPM-GPG-KEY-microsoft-azure-release",
-		"/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
-	},
-	RHSMConfig: map[subscription.RHSMStatus]*subscription.RHSMConfig{
-		subscription.RHSMConfigNoSubscription: {
-			DnfPlugins: subscription.SubManDNFPluginsConfig{
-				SubscriptionManager: subscription.DNFPluginConfig{
-					Enabled: common.ToPtr(false),
-				},
-			},
-			SubMan: subscription.SubManConfig{
-				Rhsmcertd: subscription.SubManRHSMCertdConfig{
-					AutoRegistration: common.ToPtr(true),
-				},
-				Rhsm: subscription.SubManRHSMConfig{
-					ManageRepos: common.ToPtr(false),
-				},
-			},
-		},
-		subscription.RHSMConfigWithSubscription: {
-			SubMan: subscription.SubManConfig{
-				Rhsmcertd: subscription.SubManRHSMCertdConfig{
-					AutoRegistration: common.ToPtr(true),
-				},
-				// do not disable the redhat.repo management if the user
-				// explicitly request the system to be subscribed
-			},
-		},
-	},
-}
-
 func sapAzureImageConfig(rd *rhel.Distribution) *distro.ImageConfig {
-	return sapImageConfig(rd.OsVersion()).InheritFrom(defaultAzureRhuiImageConfig.InheritFrom(defaultAzureImageConfig(rd)))
+	return sapImageConfig(rd.OsVersion()).InheritFrom(defaultAzureImageConfig(rd))
 }

--- a/pkg/distro/rhel/rhel9/distro.go
+++ b/pkg/distro/rhel/rhel9/distro.go
@@ -232,13 +232,8 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 		},
 	}
 
-	if rd.IsRHEL() { // RHEL-only (non-CentOS) image types
-		x86_64.AddImageTypes(azureX64Platform, mkAzureByosImgType(rd))
-		aarch64.AddImageTypes(azureAarch64Platform, mkAzureByosImgType(rd))
-	} else {
-		x86_64.AddImageTypes(azureX64Platform, mkAzureImgType(rd))
-		aarch64.AddImageTypes(azureAarch64Platform, mkAzureImgType(rd))
-	}
+	x86_64.AddImageTypes(azureX64Platform, mkAzureImgType(rd))
+	aarch64.AddImageTypes(azureAarch64Platform, mkAzureImgType(rd))
 
 	gceX86Platform := &platform.X86{
 		UEFIVendor: rd.Vendor(),
@@ -337,8 +332,8 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 	)
 
 	if rd.IsRHEL() { // RHEL-only (non-CentOS) image types
-		x86_64.AddImageTypes(azureX64Platform, mkAzureRhuiImgType(rd), mkAzureByosImgType(rd))
-		aarch64.AddImageTypes(azureAarch64Platform, mkAzureRhuiImgType(rd), mkAzureByosImgType(rd))
+		x86_64.AddImageTypes(azureX64Platform, mkAzureRhuiImgType(rd))
+		aarch64.AddImageTypes(azureAarch64Platform, mkAzureRhuiImgType(rd))
 
 		x86_64.AddImageTypes(azureX64Platform, mkAzureSapRhuiImgType(rd))
 

--- a/pkg/distro/rhel/rhel9/distro.go
+++ b/pkg/distro/rhel/rhel9/distro.go
@@ -332,10 +332,10 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 	)
 
 	if rd.IsRHEL() { // RHEL-only (non-CentOS) image types
-		x86_64.AddImageTypes(azureX64Platform, mkAzureRhuiImgType(rd))
-		aarch64.AddImageTypes(azureAarch64Platform, mkAzureRhuiImgType(rd))
+		x86_64.AddImageTypes(azureX64Platform, mkAzureInternalImgType(rd))
+		aarch64.AddImageTypes(azureAarch64Platform, mkAzureInternalImgType(rd))
 
-		x86_64.AddImageTypes(azureX64Platform, mkAzureSapRhuiImgType(rd))
+		x86_64.AddImageTypes(azureX64Platform, mkAzureSapInternalImgType(rd))
 
 		// keep the RHEL EC2 x86_64 images before 9.3 BIOS-only for backward compatibility
 		if common.VersionLessThan(rd.OsVersion(), "9.3") {

--- a/pkg/distro/rhel/rhel9/distro.go
+++ b/pkg/distro/rhel/rhel9/distro.go
@@ -364,9 +364,6 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 			},
 			mkEC2ImgTypeAarch64(rd.OsVersion(), rd.IsRHEL()),
 		)
-
-		// add GCE RHUI image to RHEL only
-		x86_64.AddImageTypes(gceX86Platform, mkGCERHUIImageType())
 	}
 
 	rd.AddArches(x86_64, aarch64, ppc64le, s390x)

--- a/pkg/distro/rhel/rhel9/distro.go
+++ b/pkg/distro/rhel/rhel9/distro.go
@@ -236,8 +236,8 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 		x86_64.AddImageTypes(azureX64Platform, mkAzureByosImgType(rd))
 		aarch64.AddImageTypes(azureAarch64Platform, mkAzureByosImgType(rd))
 	} else {
-		x86_64.AddImageTypes(azureX64Platform, mkAzureImgType())
-		aarch64.AddImageTypes(azureAarch64Platform, mkAzureImgType())
+		x86_64.AddImageTypes(azureX64Platform, mkAzureImgType(rd))
+		aarch64.AddImageTypes(azureAarch64Platform, mkAzureImgType(rd))
 	}
 
 	gceX86Platform := &platform.X86{
@@ -337,8 +337,8 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 	)
 
 	if rd.IsRHEL() { // RHEL-only (non-CentOS) image types
-		x86_64.AddImageTypes(azureX64Platform, mkAzureRhuiImgType(), mkAzureByosImgType(rd))
-		aarch64.AddImageTypes(azureAarch64Platform, mkAzureRhuiImgType(), mkAzureByosImgType(rd))
+		x86_64.AddImageTypes(azureX64Platform, mkAzureRhuiImgType(rd), mkAzureByosImgType(rd))
+		aarch64.AddImageTypes(azureAarch64Platform, mkAzureRhuiImgType(rd), mkAzureByosImgType(rd))
 
 		x86_64.AddImageTypes(azureX64Platform, mkAzureSapRhuiImgType(rd))
 

--- a/pkg/distro/rhel/rhel9/distro.go
+++ b/pkg/distro/rhel/rhel9/distro.go
@@ -353,7 +353,7 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 		}
 
 		// add ec2 image types to RHEL distro only
-		x86_64.AddImageTypes(ec2X86Platform, mkEc2ImgTypeX86_64(rd.OsVersion(), rd.IsRHEL()), mkEc2HaImgTypeX86_64(rd.OsVersion(), rd.IsRHEL()), mkEC2SapImgTypeX86_64(rd.OsVersion(), rd.IsRHEL()))
+		x86_64.AddImageTypes(ec2X86Platform, mkEc2ImgTypeX86_64(), mkEc2HaImgTypeX86_64(), mkEC2SapImgTypeX86_64(rd.OsVersion()))
 
 		aarch64.AddImageTypes(
 			&platform.Aarch64{
@@ -362,7 +362,7 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 					ImageFormat: platform.FORMAT_RAW,
 				},
 			},
-			mkEC2ImgTypeAarch64(rd.OsVersion(), rd.IsRHEL()),
+			mkEC2ImgTypeAarch64(),
 		)
 	}
 

--- a/pkg/distro/rhel/rhel9/distro_test.go
+++ b/pkg/distro/rhel/rhel9/distro_test.go
@@ -526,7 +526,6 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"edge-ami",
 				"edge-vsphere",
 				"gce",
-				"gce-rhui",
 				"tar",
 				"image-installer",
 				"oci",

--- a/pkg/distro/rhel/rhel9/gce.go
+++ b/pkg/distro/rhel/rhel9/gce.go
@@ -2,7 +2,6 @@ package rhel9
 
 import (
 	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/customizations/subscription"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -25,33 +24,10 @@ func mkGCEImageType() *rhel.ImageType {
 		[]string{"archive"},
 	)
 
+	it.NameAliases = []string{"gce-rhui"}
 	// The configuration for non-RHUI images does not touch the RHSM configuration at all.
 	// https://issues.redhat.com/browse/COMPOSER-2157
 	it.DefaultImageConfig = baseGCEImageConfig()
-	it.KernelOptions = gceKernelOptions
-	it.DefaultSize = 20 * common.GibiByte
-	it.Bootable = true
-	// TODO: the base partition table still contains the BIOS boot partition, but the image is UEFI-only
-	it.BasePartitionTables = defaultBasePartitionTables
-
-	return it
-}
-
-func mkGCERHUIImageType() *rhel.ImageType {
-	it := rhel.NewImageType(
-		"gce-rhui",
-		"image.tar.gz",
-		"application/gzip",
-		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: gceRhuiPackageSet,
-		},
-		rhel.DiskImage,
-		[]string{"build"},
-		[]string{"os", "image", "archive"},
-		[]string{"archive"},
-	)
-
-	it.DefaultImageConfig = defaultGceRhuiImageConfig()
 	it.KernelOptions = gceKernelOptions
 	it.DefaultSize = 20 * common.GibiByte
 	it.Bootable = true
@@ -156,33 +132,6 @@ func baseGCEImageConfig() *distro.ImageConfig {
 	return ic
 }
 
-func defaultGceRhuiImageConfig() *distro.ImageConfig {
-	ic := &distro.ImageConfig{
-		RHSMConfig: map[subscription.RHSMStatus]*subscription.RHSMConfig{
-			subscription.RHSMConfigNoSubscription: {
-				SubMan: subscription.SubManConfig{
-					Rhsmcertd: subscription.SubManRHSMCertdConfig{
-						AutoRegistration: common.ToPtr(true),
-					},
-					Rhsm: subscription.SubManRHSMConfig{
-						ManageRepos: common.ToPtr(false),
-					},
-				},
-			},
-			subscription.RHSMConfigWithSubscription: {
-				SubMan: subscription.SubManConfig{
-					Rhsmcertd: subscription.SubManRHSMCertdConfig{
-						AutoRegistration: common.ToPtr(true),
-					},
-					// do not disable the redhat.repo management if the user
-					// explicitly request the system to be subscribed
-				},
-			},
-		},
-	}
-	return ic.InheritFrom(baseGCEImageConfig())
-}
-
 func gceCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	ps := rpmmd.PackageSet{
 		Include: []string{
@@ -264,16 +213,7 @@ func gceCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	return ps
 }
 
-// GCE BYOS image
+// GCE image
 func gcePackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	return gceCommonPackageSet(t)
-}
-
-// GCE RHUI image
-func gceRhuiPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			"google-rhui-client-rhel9",
-		},
-	}.Append(gceCommonPackageSet(t))
 }


### PR DESCRIPTION
Drop the RHSM configuration from RHEL-9 Azure and EC2 image definitions, since it will be applies as a customization in the release configuration.

Additionally, unify the RHUI and non-RHUI image types as much as possible. Internally rename the original "RHUI" image types and functions to "internal", since they no longer have any RHUI-specific bits. However, these are still built only internally in Brew. We actually can't completely drop the RHUI image types, because these are built as compressed files in Brew. We could modify the implementation, but maybe let's just wait for OTK.

Lastly, drop the GCE RHUI image, which was never used and it is not built anywhere (only in osbuild-composer CI, but that can be fixed), even internally. The image could be built by customizing the GCE image type.