### PR TITLE
platform: remove unused X86BootLoader type

### DIFF
--- a/pkg/platform/x86_64.go
+++ b/pkg/platform/x86_64.go
@@ -4,8 +4,6 @@ import (
 	"github.com/osbuild/images/pkg/arch"
 )
 
-type X86BootLoader uint64
-
 type X86 struct {
 	BasePlatform
 	BIOS       bool


### PR DESCRIPTION
I cannot find any places that use this type. Let's just drop it.