### PR TITLE
[RFC] many: add `types.Option` generic and use in customizations

### DIFF
--- a/cmd/osbuild-playground/my-container.go
+++ b/cmd/osbuild-playground/my-container.go
@@ -3,6 +3,7 @@ package main
 import (
 	"math/rand"
 
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/artifact"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/platform"
@@ -54,7 +55,7 @@ func (img *MyContainer) InstantiateManifest(m *manifest.Manifest,
 	os.OSCustomizations.BasePackages = []string{"@core"}
 	os.OSCustomizations.Language = "en_US.UTF-8"
 	os.OSCustomizations.Hostname = "my-host"
-	os.OSCustomizations.Timezone = "UTC"
+	os.OSCustomizations.Timezone = types.Some("UTC")
 
 	// create an OCI container containing the OS tree created above
 	container := manifest.NewOCIContainer(build, os)

--- a/cmd/otk/osbuild-resolve-containers/main.go
+++ b/cmd/otk/osbuild-resolve-containers/main.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
 )
@@ -53,7 +54,7 @@ type ContainerInfo struct {
 	// The architecture of the image
 	Arch string `json:"arch"`
 
-	TLSVerify *bool `json:"tls-verify,omitempty"`
+	TLSVerify types.Option[bool] `json:"tls-verify,omitempty"`
 }
 
 func run(r io.Reader, w io.Writer) error {

--- a/cmd/otk/osbuild-resolve-containers/main_test.go
+++ b/cmd/otk/osbuild-resolve-containers/main_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/testregistry"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/stretchr/testify/assert"
@@ -54,7 +55,7 @@ func TestResolver(t *testing.T) {
 		inpContainers[idx] = blueprint.Container{
 			Source:       ref,
 			Name:         fmt.Sprintf("test/localhost/%s", ref), // add a prefix for the local name to override the source
-			TLSVerify:    common.ToPtr(false),
+			TLSVerify:    types.Some(false),
 			LocalStorage: false,
 		}
 	}
@@ -171,7 +172,7 @@ func TestResolverUnhappy(t *testing.T) {
 				"containers": []blueprint.Container{
 					{
 						Source:    tc.source,
-						TLSVerify: &tc.tlsverify,
+						TLSVerify: types.Some(tc.tlsverify),
 					},
 				},
 			}
@@ -197,7 +198,7 @@ func TestResolverRawJSON(t *testing.T) {
 		inpContainers[idx] = blueprint.Container{
 			Source:       ref,
 			Name:         fmt.Sprintf("test/localhost/%s", ref), // add a prefix for the local name to override the source
-			TLSVerify:    common.ToPtr(false),
+			TLSVerify:    types.Some(false),
 			LocalStorage: false,
 		}
 	}
@@ -244,7 +245,7 @@ func TestResolverRawJSON(t *testing.T) {
     }
   }
 }
-`, spec.Source, spec.Digest, spec.ImageID, fmt.Sprintf("test/localhost/%s", refs[0]), spec.ListDigest, spec.Arch, *spec.TLSVerify)
+`, spec.Source, spec.Digest, spec.ImageID, fmt.Sprintf("test/localhost/%s", refs[0]), spec.ListDigest, spec.Arch, spec.TLSVerify.Unwrap())
 			require.Equal(expected, outBuf.String())
 		})
 	}

--- a/internal/testregistry/testregistry.go
+++ b/internal/testregistry/testregistry.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containers/image/v5/manifest"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/container"
 )
@@ -386,7 +387,7 @@ func (reg *Registry) Resolve(target string, imgArch arch.Arch) (container.Spec, 
 		Digest:     checksum,
 		ImageID:    mf.ConfigDescriptor.Digest.String(),
 		LocalName:  target,
-		TLSVerify:  common.ToPtr(false),
+		TLSVerify:  types.Some(false),
 		ListDigest: listDigest,
 		Arch:       imgArch,
 	}, nil

--- a/internal/types/LICENSE
+++ b/internal/types/LICENSE
@@ -1,0 +1,8 @@
+Copyright 2021 Taiki Kawakami (a.k.a. moznion) https://moznion.net
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/internal/types/option.go
+++ b/internal/types/option.go
@@ -53,11 +53,20 @@ func (o Option[T]) IsNone() bool {
 	return o == nil
 }
 
+// IsZero returns True if the Option *doesn't* have a value
+// compat with the new go-1.24 IsZero() protocol
+func (o Option[T]) IsZero() bool {
+	return o.IsNone()
+}
+
 // IsSome returns whether the Option has a value or not.
 func (o Option[T]) IsSome() bool {
 	return o != nil
 }
 
+// XXX: this probably needs a different name to like UnwrapOrDefault()
+// or something
+//
 // Unwrap returns the value regardless of Some/None status.
 // If the Option value is Some, this method returns the actual value.
 // On the other hand, if the Option value is None, this method returns the *default* value according to the type.

--- a/internal/types/option.go
+++ b/internal/types/option.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+
+	"github.com/osbuild/images/internal/common"
 )
 
 // Option is a more constrained subset of the code in
@@ -114,4 +116,8 @@ func (o *Option[T]) UnmarshalTOML(data any) error {
 	}
 	*o = Some(b)
 	return nil
+}
+
+func (o *Option[T]) UnmarshalYAML(unmarshal func(any) error) error {
+	return common.UnmarshalYAMLviaJSON(o, unmarshal)
 }

--- a/internal/types/option.go
+++ b/internal/types/option.go
@@ -1,0 +1,117 @@
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Option is a more constrained subset of the code in
+//     https://github.com/moznion/go-optional
+//
+// It is not using an external go-optional lib directly because none
+// has toml unmarshal support and also because there is no support for
+// complex types in UnmarshalTOML (it only gives a single
+// reflect.Value of type any) so our optional "lib" must come with
+// limitations for this.
+//
+// Unfortunately there is no way I could find to import the code and
+// limit the supported types. So this is a copy of the subset.
+// Fortunatly the code is small, targeted and easy to follow so it
+// should not be too bad.
+
+type OptionTomlTypes interface {
+	~int | ~bool | ~string
+}
+
+// Option is a subset of github.com/moznion/go-optional for use with toml
+
+// Option is a data type that must be Some (i.e. having a value) or None (i.e. doesn't have a value).
+// This type implements database/sql/driver.Valuer and database/sql.Scanner.
+type Option[T OptionTomlTypes] []T
+
+const (
+	value = iota
+)
+
+// Some is a function to make an Option type value with the actual value.
+func Some[T OptionTomlTypes](v T) Option[T] {
+	return Option[T]{
+		value: v,
+	}
+}
+
+// None is a function to make an Option type value that doesn't have a value.
+func None[T OptionTomlTypes]() Option[T] {
+	return nil
+}
+
+// IsNone returns True if the Option *doesn't* have a value
+func (o Option[T]) IsNone() bool {
+	return o == nil
+}
+
+// IsSome returns whether the Option has a value or not.
+func (o Option[T]) IsSome() bool {
+	return o != nil
+}
+
+// Unwrap returns the value regardless of Some/None status.
+// If the Option value is Some, this method returns the actual value.
+// On the other hand, if the Option value is None, this method returns the *default* value according to the type.
+func (o Option[T]) Unwrap() T {
+	if o.IsNone() {
+		var defaultValue T
+		return defaultValue
+	}
+	return o[value]
+}
+
+// TakeOr returns the actual value if the Option has a value.
+// On the other hand, this returns fallbackValue.
+func (o Option[T]) TakeOr(fallbackValue T) T {
+	if o.IsNone() {
+		return fallbackValue
+	}
+	return o[value]
+}
+
+var jsonNull = []byte("null")
+
+func (o Option[T]) MarshalJSON() ([]byte, error) {
+	if o.IsNone() {
+		return jsonNull, nil
+	}
+
+	marshal, err := json.Marshal(o.Unwrap())
+	if err != nil {
+		return nil, err
+	}
+	return marshal, nil
+}
+
+func (o *Option[T]) UnmarshalJSON(data []byte) error {
+	if len(data) <= 0 || bytes.Equal(data, jsonNull) {
+		*o = None[T]()
+		return nil
+	}
+
+	var v T
+	err := json.Unmarshal(data, &v)
+	if err != nil {
+		return err
+	}
+	*o = Some(v)
+
+	return nil
+}
+
+// not part of github.com/moznion/go-optional
+func (o *Option[T]) UnmarshalTOML(data any) error {
+	b, ok := data.(T)
+	if !ok {
+		return fmt.Errorf("cannot use %[1]v (%[1]T) as bool", data)
+	}
+	*o = Some(b)
+	return nil
+}

--- a/internal/types/option_test.go
+++ b/internal/types/option_test.go
@@ -1,0 +1,80 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/internal/types"
+)
+
+type s1 struct {
+	Name string `toml:"name"`
+	Sub  s2     `toml:"sub"`
+}
+
+type s2 struct {
+	ValBool    types.Option[bool]   `toml:"val-bool"`
+	ValString  types.Option[string] `toml:"val-string"`
+	ValString2 types.Option[string] `toml:"val-string2"`
+}
+
+func TestTomlParseOption(t *testing.T) {
+	testTomlStr := `
+name = "some-name"
+[sub]
+val-bool = true
+val-string = "opt-string"
+`
+
+	var bp s1
+	err := toml.Unmarshal([]byte(testTomlStr), &bp)
+	assert.NoError(t, err)
+	assert.Equal(t, bp.Name, "some-name")
+	assert.Equal(t, types.Some(true), bp.Sub.ValBool)
+	assert.Equal(t, types.Some("opt-string"), bp.Sub.ValString)
+	assert.EqualValues(t, types.None[string](), bp.Sub.ValString2)
+}
+
+func TestTomlParseOptionBad(t *testing.T) {
+	testTomlStr := `
+[sub]
+val-bool = 1234
+`
+
+	var bp s1
+	err := toml.Unmarshal([]byte(testTomlStr), &bp)
+	assert.ErrorContains(t, err, "cannot use 1234 (int64) as bool")
+}
+
+// taken from https://github.com/moznion/go-optional
+func TestOption_IsNone(t *testing.T) {
+	assert.True(t, types.None[int]().IsNone())
+	assert.False(t, types.Some[int](123).IsNone())
+
+	var nilValue types.Option[int] = nil
+	assert.True(t, nilValue.IsNone())
+}
+
+func TestOption_IsSome(t *testing.T) {
+	assert.False(t, types.None[int]().IsSome())
+	assert.True(t, types.Some[int](123).IsSome())
+
+	var nilValue types.Option[int] = nil
+	assert.False(t, nilValue.IsSome())
+}
+
+func TestOption_Unwrap(t *testing.T) {
+	assert.Equal(t, "foo", types.Some[string]("foo").Unwrap())
+	assert.Equal(t, "", types.None[string]().Unwrap())
+	assert.Equal(t, false, types.None[bool]().Unwrap())
+}
+
+func TestOption_TakeOr(t *testing.T) {
+	v := types.Some[int](123).TakeOr(666)
+	assert.Equal(t, 123, v)
+
+	v = types.None[int]().TakeOr(666)
+	assert.Equal(t, 666, v)
+}

--- a/pkg/blueprint/blueprint.go
+++ b/pkg/blueprint/blueprint.go
@@ -1,6 +1,10 @@
 // Package blueprint contains primitives for representing weldr blueprints
 package blueprint
 
+import (
+	"github.com/osbuild/images/internal/types"
+)
+
 // A Blueprint is a high-level description of an image.
 type Blueprint struct {
 	Name        string    `json:"name" toml:"name"`
@@ -43,8 +47,8 @@ type Container struct {
 	Source string `json:"source" toml:"source"`
 	Name   string `json:"name,omitempty" toml:"name,omitempty"`
 
-	TLSVerify    *bool `json:"tls-verify,omitempty" toml:"tls-verify,omitempty"`
-	LocalStorage bool  `json:"local-storage,omitempty" toml:"local-storage,omitempty"`
+	TLSVerify    types.Option[bool] `json:"tls-verify,omitempty" toml:"tls-verify,omitempty"`
+	LocalStorage bool               `json:"local-storage,omitempty" toml:"local-storage,omitempty"`
 }
 
 // packages, modules, and groups all resolve to rpm packages right now. This

--- a/pkg/blueprint/blueprint_test.go
+++ b/pkg/blueprint/blueprint_test.go
@@ -186,3 +186,29 @@ func TestKernelNameCustomization(t *testing.T) {
 		}
 	}
 }
+
+func TestBlueprintParseSetHostnameOptional(t *testing.T) {
+	blueprint := `
+name = "test"
+
+[customizations]
+hostname = "my-hostname"
+`
+
+	var bp Blueprint
+	err := toml.Unmarshal([]byte(blueprint), &bp)
+	require.Nil(t, err)
+	assert.Equal(t, bp.Name, "test")
+	assert.Equal(t, "my-hostname", bp.Customizations.GetHostname().Unwrap())
+
+	blueprint = `{
+		"name": "test",
+		"customizations": {
+                  "hostname": "my-hostname"
+		}
+	  }`
+	err = json.Unmarshal([]byte(blueprint), &bp)
+	require.Nil(t, err)
+	assert.Equal(t, bp.Name, "test")
+	assert.Equal(t, "my-hostname", bp.Customizations.GetHostname().Unwrap())
+}

--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -71,17 +71,17 @@ type SSHKeyCustomization struct {
 }
 
 type UserCustomization struct {
-	Name               string   `json:"name" toml:"name"`
-	Description        *string  `json:"description,omitempty" toml:"description,omitempty"`
-	Password           *string  `json:"password,omitempty" toml:"password,omitempty"`
-	Key                *string  `json:"key,omitempty" toml:"key,omitempty"`
-	Home               *string  `json:"home,omitempty" toml:"home,omitempty"`
-	Shell              *string  `json:"shell,omitempty" toml:"shell,omitempty"`
-	Groups             []string `json:"groups,omitempty" toml:"groups,omitempty"`
-	UID                *int     `json:"uid,omitempty" toml:"uid,omitempty"`
-	GID                *int     `json:"gid,omitempty" toml:"gid,omitempty"`
-	ExpireDate         *int     `json:"expiredate,omitempty" toml:"expiredate,omitempty"`
-	ForcePasswordReset *bool    `json:"force_password_reset,omitempty" toml:"force_password_reset,omitempty"`
+	Name               string               `json:"name" toml:"name"`
+	Description        types.Option[string] `json:"description,omitempty" toml:"description,omitempty"`
+	Password           types.Option[string] `json:"password,omitempty" toml:"password,omitempty"`
+	Key                types.Option[string] `json:"key,omitempty" toml:"key,omitempty"`
+	Home               types.Option[string] `json:"home,omitempty" toml:"home,omitempty"`
+	Shell              types.Option[string] `json:"shell,omitempty" toml:"shell,omitempty"`
+	Groups             []string             `json:"groups,omitempty" toml:"groups,omitempty"`
+	UID                types.Option[int]    `json:"uid,omitempty" toml:"uid,omitempty"`
+	GID                types.Option[int]    `json:"gid,omitempty" toml:"gid,omitempty"`
+	ExpireDate         types.Option[int]    `json:"expiredate,omitempty" toml:"expiredate,omitempty"`
+	ForcePasswordReset types.Option[bool]   `json:"force_password_reset,omitempty" toml:"force_password_reset,omitempty"`
 }
 
 type GroupCustomization struct {
@@ -246,8 +246,8 @@ func (c *Customizations) GetUsers() []UserCustomization {
 	for idx := range users {
 		u := users[idx]
 		if u.Home != nil {
-			homedir := strings.TrimRight(*u.Home, "/")
-			u.Home = &homedir
+			homedir := strings.TrimRight(u.Home.Unwrap(), "/")
+			u.Home = types.Some(homedir)
 			users[idx] = u
 		}
 	}

--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -6,12 +6,13 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/cert"
 	"github.com/osbuild/images/pkg/customizations/anaconda"
 )
 
 type Customizations struct {
-	Hostname           *string                        `json:"hostname,omitempty" toml:"hostname,omitempty"`
+	Hostname           types.Option[string]           `json:"hostname,omitempty" toml:"hostname,omitempty"`
 	Kernel             *KernelCustomization           `json:"kernel,omitempty" toml:"kernel,omitempty"`
 	User               []UserCustomization            `json:"user,omitempty" toml:"user,omitempty"`
 	Group              []GroupCustomization           `json:"group,omitempty" toml:"group,omitempty"`
@@ -28,7 +29,7 @@ type Customizations struct {
 	Directories        []DirectoryCustomization       `json:"directories,omitempty" toml:"directories,omitempty"`
 	Files              []FileCustomization            `json:"files,omitempty" toml:"files,omitempty"`
 	Repositories       []RepositoryCustomization      `json:"repositories,omitempty" toml:"repositories,omitempty"`
-	FIPS               *bool                          `json:"fips,omitempty" toml:"fips,omitempty"`
+	FIPS               types.Option[bool]             `json:"fips,omitempty" toml:"fips,omitempty"`
 	ContainersStorage  *ContainerStorageCustomization `json:"containers-storage,omitempty" toml:"containers-storage,omitempty"`
 	Installer          *InstallerCustomization        `json:"installer,omitempty" toml:"installer,omitempty"`
 	RPM                *RPMCustomization              `json:"rpm,omitempty" toml:"rpm,omitempty"`
@@ -203,7 +204,7 @@ func (c *Customizations) CheckAllowed(allowed ...string) error {
 	return nil
 }
 
-func (c *Customizations) GetHostname() *string {
+func (c *Customizations) GetHostname() types.Option[string] {
 	if c == nil {
 		return nil
 	}
@@ -386,10 +387,10 @@ func (c *Customizations) GetRepositories() ([]RepositoryCustomization, error) {
 }
 
 func (c *Customizations) GetFIPS() bool {
-	if c == nil || c.FIPS == nil {
+	if c == nil {
 		return false
 	}
-	return *c.FIPS
+	return c.FIPS.Unwrap()
 }
 
 func (c *Customizations) GetContainerStorage() *ContainerStorageCustomization {

--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -90,8 +90,8 @@ type GroupCustomization struct {
 }
 
 type TimezoneCustomization struct {
-	Timezone   *string  `json:"timezone,omitempty" toml:"timezone,omitempty"`
-	NTPServers []string `json:"ntpservers,omitempty" toml:"ntpservers,omitempty"`
+	Timezone   types.Option[string] `json:"timezone,omitempty" toml:"timezone,omitempty"`
+	NTPServers []string             `json:"ntpservers,omitempty" toml:"ntpservers,omitempty"`
 }
 
 type LocaleCustomization struct {
@@ -224,7 +224,7 @@ func (c *Customizations) GetPrimaryLocale() (*string, *string) {
 	return &c.Locale.Languages[0], c.Locale.Keyboard
 }
 
-func (c *Customizations) GetTimezoneSettings() (*string, []string) {
+func (c *Customizations) GetTimezoneSettings() (types.Option[string], []string) {
 	if c == nil {
 		return nil, nil
 	}

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -36,9 +37,9 @@ func TestCheckAllowed(t *testing.T) {
 		},
 	}
 
-	expectedHostname := "Hostname"
+	expectedHostname := types.Some("Hostname")
 
-	x := Customizations{Hostname: &expectedHostname, User: expectedUsers}
+	x := Customizations{Hostname: expectedHostname, User: expectedUsers}
 
 	err := x.CheckAllowed("Hostname", "User")
 	assert.NoError(t, err)
@@ -53,14 +54,14 @@ func TestCheckAllowed(t *testing.T) {
 }
 
 func TestGetHostname(t *testing.T) {
-	expectedHostname := "Hostname"
+	expectedHostname := types.Some("Hostname")
 
 	TestCustomizations := Customizations{
-		Hostname: &expectedHostname,
+		Hostname: expectedHostname,
 	}
 
 	retHostname := TestCustomizations.GetHostname()
-	assert.Equal(t, &expectedHostname, retHostname)
+	assert.Equal(t, expectedHostname, retHostname)
 }
 
 func TestGetKernel(t *testing.T) {

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -137,13 +137,13 @@ func TestGetGroups(t *testing.T) {
 }
 
 func TestGetTimezoneSettings(t *testing.T) {
-	expectedTimezone := "testZONE"
+	expectedTimezone := types.Some("testZONE")
 	expectedNTPServers := []string{
 		"server",
 	}
 
 	expectedTimezoneCustomization := TimezoneCustomization{
-		Timezone:   &expectedTimezone,
+		Timezone:   expectedTimezone,
 		NTPServers: expectedNTPServers,
 	}
 
@@ -153,7 +153,7 @@ func TestGetTimezoneSettings(t *testing.T) {
 
 	retTimezone, retNTPServers := TestCustomizations.GetTimezoneSettings()
 
-	assert.Equal(t, expectedTimezone, *retTimezone)
+	assert.Equal(t, expectedTimezone, retTimezone)
 	assert.Equal(t, expectedNTPServers, retNTPServers)
 }
 

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -26,14 +26,14 @@ func TestCheckAllowed(t *testing.T) {
 	expectedUsers := []UserCustomization{
 		{
 			Name:        "John",
-			Description: &Desc,
-			Password:    &Pass,
-			Key:         &Key,
-			Home:        &Home,
-			Shell:       &Shell,
+			Description: types.Some(Desc),
+			Password:    types.Some(Pass),
+			Key:         types.Some(Key),
+			Home:        types.Some(Home),
+			Shell:       types.Some(Shell),
 			Groups:      Groups,
-			UID:         &UID,
-			GID:         &GID,
+			UID:         types.Some(UID),
+			GID:         types.Some(GID),
 		},
 	}
 
@@ -96,16 +96,16 @@ func TestGetUsers(t *testing.T) {
 	expectedUsers := []UserCustomization{
 		{
 			Name:               "John",
-			Description:        &Desc,
-			Password:           &Pass,
-			Key:                &Key,
-			Home:               &Home,
-			Shell:              &Shell,
+			Description:        types.Some(Desc),
+			Password:           types.Some(Pass),
+			Key:                types.Some(Key),
+			Home:               types.Some(Home),
+			Shell:              types.Some(Shell),
 			Groups:             Groups,
-			UID:                &UID,
-			GID:                &GID,
-			ExpireDate:         &ExpireDate,
-			ForcePasswordReset: &ForcePasswordReset,
+			UID:                types.Some(UID),
+			GID:                types.Some(GID),
+			ExpireDate:         types.Some(ExpireDate),
+			ForcePasswordReset: types.Some(ForcePasswordReset),
 		},
 	}
 

--- a/pkg/container/blocking_resolver_test.go
+++ b/pkg/container/blocking_resolver_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/testregistry"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/container"
 )
@@ -42,7 +43,7 @@ func TestBlockingResolver(t *testing.T) {
 			Source:    r,
 			Name:      "",
 			Digest:    common.ToPtr(""),
-			TLSVerify: common.ToPtr(false),
+			TLSVerify: types.Some(false),
 			Local:     false,
 		})
 	}
@@ -70,7 +71,7 @@ func TestBlockingResolverFail(t *testing.T) {
 		Source:    "invalid-reference@${IMAGE_DIGEST}",
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: types.Some(false),
 		Local:     false,
 	})
 	specs, err := resolver.Finish()
@@ -84,7 +85,7 @@ func TestBlockingResolverFail(t *testing.T) {
 		Source:    registry.GetRef("repo"),
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: types.Some(false),
 		Local:     false,
 	})
 	specs, err = resolver.Finish()
@@ -95,7 +96,7 @@ func TestBlockingResolverFail(t *testing.T) {
 		Source:    registry.GetRef("repo"),
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: types.Some(false),
 		Local:     false,
 	})
 	specs, err = resolver.Finish()
@@ -106,7 +107,7 @@ func TestBlockingResolverFail(t *testing.T) {
 		Source:    registry.GetRef("repo"),
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: types.Some(false),
 		Local:     false,
 	})
 	specs, err = resolver.Finish()
@@ -171,7 +172,7 @@ func TestBlockingResolverLocalManifest(t *testing.T) {
 		Source:    "localhost/multi-arch",
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: types.Some(false),
 		Local:     true,
 	})
 	specs, err := resolver.Finish()
@@ -189,7 +190,7 @@ func TestBlockingResolverLocalManifest(t *testing.T) {
 		Source:    "localhost/multi-arch",
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: types.Some(false),
 		Local:     true,
 	})
 	specs, err = resolver.Finish()

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -30,7 +30,7 @@ import (
 
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/osbuild/images/internal/common"
+	otypes "github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/arch"
 )
 
@@ -222,31 +222,31 @@ func (cl *Client) SetDockerCertPath(path string) {
 
 // SetSkipTLSVerify controls if TLS verification happens when
 // making requests. If nil is passed it falls back to the default.
-func (cl *Client) SetTLSVerify(verify *bool) {
-	if verify == nil {
+func (cl *Client) SetTLSVerify(verify otypes.Option[bool]) {
+	if verify.IsNone() {
 		cl.sysCtx.DockerInsecureSkipTLSVerify = types.OptionalBoolUndefined
 	} else {
-		cl.sysCtx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!*verify)
+		cl.sysCtx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!verify.Unwrap())
 	}
 }
 
 // GetSkipTLSVerify returns current TLS verification state.
-func (cl *Client) GetTLSVerify() *bool {
+func (cl *Client) GetTLSVerify() otypes.Option[bool] {
 
 	skip := cl.sysCtx.DockerInsecureSkipTLSVerify
 
 	if skip == types.OptionalBoolUndefined {
-		return nil
+		return otypes.None[bool]()
 	}
 
 	// NB: we invert the state, i.e. verify == (skip == false)
-	return common.ToPtr(skip == types.OptionalBoolFalse)
+	return otypes.Some(skip == types.OptionalBoolFalse)
 }
 
 // SkipTLSVerify is a convenience helper that internally calls
 // SetTLSVerify with false
 func (cl *Client) SkipTLSVerify() {
-	cl.SetTLSVerify(common.ToPtr(false))
+	cl.SetTLSVerify(otypes.Some(false))
 }
 
 func parseImageName(name string) (types.ImageReference, error) {

--- a/pkg/container/resolver.go
+++ b/pkg/container/resolver.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/osbuild/images/internal/types"
 )
 
 type resolveResult struct {
@@ -33,7 +35,7 @@ type SourceSpec struct {
 	Source    string
 	Name      string
 	Digest    *string
-	TLSVerify *bool
+	TLSVerify types.Option[bool]
 	Local     bool
 }
 

--- a/pkg/container/resolver_test.go
+++ b/pkg/container/resolver_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/testregistry"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/container"
 )
@@ -50,7 +51,7 @@ func TestResolver(t *testing.T) {
 			Source:    r,
 			Name:      "",
 			Digest:    common.ToPtr(""),
-			TLSVerify: common.ToPtr(false),
+			TLSVerify: types.Some(false),
 			Local:     false,
 		})
 	}
@@ -78,7 +79,7 @@ func TestResolverFail(t *testing.T) {
 		Source:    "invalid-reference@${IMAGE_DIGEST}",
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: types.Some(false),
 		Local:     false,
 	})
 	specs, err := resolver.Finish()
@@ -92,7 +93,7 @@ func TestResolverFail(t *testing.T) {
 		Source:    registry.GetRef("repo"),
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: types.Some(false),
 		Local:     false,
 	})
 	specs, err = resolver.Finish()
@@ -103,7 +104,7 @@ func TestResolverFail(t *testing.T) {
 		Source:    registry.GetRef("repo"),
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: types.Some(false),
 		Local:     false,
 	})
 	specs, err = resolver.Finish()
@@ -114,7 +115,7 @@ func TestResolverFail(t *testing.T) {
 		Source:    registry.GetRef("repo"),
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: types.Some(false),
 		Local:     false,
 	})
 	specs, err = resolver.Finish()
@@ -179,7 +180,7 @@ func TestResolverLocalManifest(t *testing.T) {
 		Source:    "localhost/multi-arch",
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: types.Some(false),
 		Local:     true,
 	})
 	specs, err := resolver.Finish()
@@ -197,7 +198,7 @@ func TestResolverLocalManifest(t *testing.T) {
 		Source:    "localhost/multi-arch",
 		Name:      "",
 		Digest:    common.ToPtr(""),
-		TLSVerify: common.ToPtr(false),
+		TLSVerify: types.Some(false),
 		Local:     true,
 	})
 	specs, err = resolver.Finish()

--- a/pkg/container/spec.go
+++ b/pkg/container/spec.go
@@ -4,6 +4,7 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/opencontainers/go-digest"
 
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/arch"
 )
 
@@ -13,12 +14,12 @@ import (
 // at the Source via Digest and ImageID. The latter one
 // should remain the same in the target image as well.
 type Spec struct {
-	Source       string // does not include the manifest digest
-	Digest       string // digest of the manifest at the Source
-	TLSVerify    *bool  // controls TLS verification
-	ImageID      string // container image identifier
-	LocalName    string // name to use inside the image
-	ListDigest   string // digest of the list manifest at the Source (optional)
+	Source       string             // does not include the manifest digest
+	Digest       string             // digest of the manifest at the Source
+	TLSVerify    types.Option[bool] // controls TLS verification
+	ImageID      string             // container image identifier
+	LocalName    string             // name to use inside the image
+	ListDigest   string             // digest of the list manifest at the Source (optional)
 	LocalStorage bool
 
 	Arch arch.Arch // the architecture of the image
@@ -27,7 +28,7 @@ type Spec struct {
 // NewSpec creates a new Spec from the essential information.
 // It also converts is the transition point from container
 // specific types (digest.Digest) to generic types (string).
-func NewSpec(source reference.Named, digest, imageID digest.Digest, tlsVerify *bool, listDigest string, localName string, localStorage bool) Spec {
+func NewSpec(source reference.Named, digest, imageID digest.Digest, tlsVerify types.Option[bool], listDigest string, localName string, localStorage bool) Spec {
 	if localName == "" {
 		localName = source.String()
 	}

--- a/pkg/customizations/kickstart/kickstart.go
+++ b/pkg/customizations/kickstart/kickstart.go
@@ -3,6 +3,7 @@ package kickstart
 import (
 	"fmt"
 
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/customizations/users"
 )
@@ -36,7 +37,7 @@ type Options struct {
 
 	Language *string
 	Keyboard *string
-	Timezone *string
+	Timezone types.Option[string]
 
 	// Users to create during installation
 	Users []users.User

--- a/pkg/customizations/users/users.go
+++ b/pkg/customizations/users/users.go
@@ -1,19 +1,22 @@
 package users
 
-import "github.com/osbuild/images/pkg/blueprint"
+import (
+	"github.com/osbuild/images/internal/types"
+	"github.com/osbuild/images/pkg/blueprint"
+)
 
 type User struct {
 	Name               string
-	Description        *string
-	Password           *string
-	Key                *string
-	Home               *string
-	Shell              *string
+	Description        types.Option[string]
+	Password           types.Option[string]
+	Key                types.Option[string]
+	Home               types.Option[string]
+	Shell              types.Option[string]
 	Groups             []string
-	UID                *int
-	GID                *int
-	ExpireDate         *int
-	ForcePasswordReset *bool
+	UID                types.Option[int]
+	GID                types.Option[int]
+	ExpireDate         types.Option[int]
+	ForcePasswordReset types.Option[bool]
 }
 
 type Group struct {

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/datasizes"
@@ -476,7 +477,7 @@ image_config:
 	assert.NoError(t, err)
 	assert.Equal(t, &distro.ImageConfig{
 		Locale:   common.ToPtr("C.UTF-8"),
-		Timezone: common.ToPtr("OverrideTZ"),
+		Timezone: types.Some("OverrideTZ"),
 		Users:    []users.User{users.User{Name: "testuser"}},
 	}, imgConfig)
 }
@@ -552,7 +553,7 @@ image_types:
 	assert.Equal(t, &distro.ImageConfig{
 		Hostname: common.ToPtr("test-arch-hn"),
 		Locale:   common.ToPtr("en_US.UTF-8"),
-		Timezone: common.ToPtr("OverrideTZ"),
+		Timezone: types.Some("OverrideTZ"),
 	}, imgConfig)
 
 }

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -11,9 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/blueprint"

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -4,15 +4,18 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
-	"slices"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/distro"
@@ -573,7 +576,7 @@ func TestDistro_ManifestFIPSWarning(t *testing.T) {
 			for _, imgTypeName := range arch.ListImageTypes() {
 				bp := blueprint.Blueprint{
 					Customizations: &blueprint.Customizations{
-						FIPS: &fips_enabled,
+						FIPS: types.Some(fips_enabled),
 					},
 				}
 				imgType, _ := arch.GetImageType(imgTypeName)

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -115,10 +115,10 @@ func osCustomizations(
 	}
 
 	timezone, ntpServers := c.GetTimezoneSettings()
-	if timezone != nil {
-		osc.Timezone = *timezone
-	} else if imageConfig.Timezone != nil {
-		osc.Timezone = *imageConfig.Timezone
+	if timezone.IsSome() {
+		osc.Timezone = timezone
+	} else {
+		osc.Timezone = imageConfig.Timezone
 	}
 
 	if len(ntpServers) > 0 {
@@ -497,7 +497,7 @@ func imageInstallerImage(workload workload.Workload,
 	}
 	img.Kickstart.Language = &img.OSCustomizations.Language
 	img.Kickstart.Keyboard = img.OSCustomizations.Keyboard
-	img.Kickstart.Timezone = &img.OSCustomizations.Timezone
+	img.Kickstart.Timezone = img.OSCustomizations.Timezone
 
 	if img.Kickstart.Unattended {
 		// NOTE: this is not supported right now because the

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -108,11 +108,7 @@ func osCustomizations(
 		osc.Keyboard = &imageConfig.Keyboard.Keymap
 	}
 
-	if hostname := c.GetHostname(); hostname != nil {
-		osc.Hostname = *hostname
-	} else if imageConfig.Hostname != nil {
-		osc.Hostname = *imageConfig.Hostname
-	}
+	osc.Hostname = c.GetHostname().TakeOr("localhost.localdomain")
 
 	if imageConfig.InstallWeakDeps != nil {
 		osc.InstallWeakDeps = *imageConfig.InstallWeakDeps

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/shell"
 	"github.com/osbuild/images/pkg/customizations/subscription"
@@ -15,8 +16,8 @@ import (
 
 // ImageConfig represents a (default) configuration applied to the image payload.
 type ImageConfig struct {
-	Hostname            *string                     `yaml:"hostname,omitempty"`
-	Timezone            *string                     `yaml:"timezone,omitempty"`
+	Hostname            *string `yaml:"hostname,omitempty"`
+	Timezone            types.Option[string]
 	TimeSynchronization *osbuild.ChronyStageOptions `yaml:"time_synchronization,omitempty"`
 	Locale              *string                     `yaml:"locale,omitempty"`
 	Keyboard            *osbuild.KeymapStageOptions

--- a/pkg/distro/image_config_test.go
+++ b/pkg/distro/image_config_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
@@ -19,7 +20,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 		{
 			name: "inheritance with overridden values",
 			distroConfig: &ImageConfig{
-				Timezone: common.ToPtr("America/New_York"),
+				Timezone: types.Some("America/New_York"),
 				TimeSynchronization: &osbuild.ChronyStageOptions{
 					Servers: []osbuild.ChronyConfigServer{{Hostname: "127.0.0.1"}},
 				},
@@ -32,7 +33,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				DefaultTarget:    common.ToPtr("multi-user.target"),
 			},
 			imageConfig: &ImageConfig{
-				Timezone: common.ToPtr("UTC"),
+				Timezone: types.Some("UTC"),
 				TimeSynchronization: &osbuild.ChronyStageOptions{
 					Servers: []osbuild.ChronyConfigServer{
 						{
@@ -47,7 +48,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				},
 			},
 			expectedConfig: &ImageConfig{
-				Timezone: common.ToPtr("UTC"),
+				Timezone: types.Some("UTC"),
 				TimeSynchronization: &osbuild.ChronyStageOptions{
 					Servers: []osbuild.ChronyConfigServer{
 						{
@@ -72,7 +73,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 		{
 			name: "empty image type configuration",
 			distroConfig: &ImageConfig{
-				Timezone: common.ToPtr("America/New_York"),
+				Timezone: types.Some("America/New_York"),
 				TimeSynchronization: &osbuild.ChronyStageOptions{
 					Servers: []osbuild.ChronyConfigServer{{Hostname: "127.0.0.1"}},
 				},
@@ -86,7 +87,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 			},
 			imageConfig: &ImageConfig{},
 			expectedConfig: &ImageConfig{
-				Timezone: common.ToPtr("America/New_York"),
+				Timezone: types.Some("America/New_York"),
 				TimeSynchronization: &osbuild.ChronyStageOptions{
 					Servers: []osbuild.ChronyConfigServer{{Hostname: "127.0.0.1"}},
 				},
@@ -103,7 +104,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 			name:         "empty distro configuration",
 			distroConfig: &ImageConfig{},
 			imageConfig: &ImageConfig{
-				Timezone: common.ToPtr("America/New_York"),
+				Timezone: types.Some("America/New_York"),
 				TimeSynchronization: &osbuild.ChronyStageOptions{
 					Servers: []osbuild.ChronyConfigServer{{Hostname: "127.0.0.1"}},
 				},
@@ -116,7 +117,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				DefaultTarget:    common.ToPtr("multi-user.target"),
 			},
 			expectedConfig: &ImageConfig{
-				Timezone: common.ToPtr("America/New_York"),
+				Timezone: types.Some("America/New_York"),
 				TimeSynchronization: &osbuild.ChronyStageOptions{
 					Servers: []osbuild.ChronyConfigServer{{Hostname: "127.0.0.1"}},
 				},
@@ -133,7 +134,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 			name:         "empty distro configuration",
 			distroConfig: nil,
 			imageConfig: &ImageConfig{
-				Timezone: common.ToPtr("America/New_York"),
+				Timezone: types.Some("America/New_York"),
 				TimeSynchronization: &osbuild.ChronyStageOptions{
 					Servers: []osbuild.ChronyConfigServer{{Hostname: "127.0.0.1"}},
 				},
@@ -146,7 +147,7 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				DefaultTarget:    common.ToPtr("multi-user.target"),
 			},
 			expectedConfig: &ImageConfig{
-				Timezone: common.ToPtr("America/New_York"),
+				Timezone: types.Some("America/New_York"),
 				TimeSynchronization: &osbuild.ChronyStageOptions{
 					Servers: []osbuild.ChronyConfigServer{{Hostname: "127.0.0.1"}},
 				},

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -122,9 +122,7 @@ func osCustomizations(
 		}
 	}
 
-	if hostname := c.GetHostname(); hostname != nil {
-		osc.Hostname = *hostname
-	}
+	osc.Hostname = c.GetHostname().Unwrap()
 
 	timezone, ntpServers := c.GetTimezoneSettings()
 	if timezone != nil {

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -125,10 +125,10 @@ func osCustomizations(
 	osc.Hostname = c.GetHostname().Unwrap()
 
 	timezone, ntpServers := c.GetTimezoneSettings()
-	if timezone != nil {
-		osc.Timezone = *timezone
-	} else if imageConfig.Timezone != nil {
-		osc.Timezone = *imageConfig.Timezone
+	if timezone.IsSome() {
+		osc.Timezone = timezone
+	} else {
+		osc.Timezone = imageConfig.Timezone
 	}
 
 	if len(ntpServers) > 0 {
@@ -732,7 +732,7 @@ func ImageInstallerImage(workload workload.Workload,
 	}
 	img.Kickstart.Language = &img.OSCustomizations.Language
 	img.Kickstart.Keyboard = img.OSCustomizations.Keyboard
-	img.Kickstart.Timezone = &img.OSCustomizations.Timezone
+	img.Kickstart.Timezone = img.OSCustomizations.Timezone
 
 	installerConfig, err := t.getDefaultInstallerConfig()
 	if err != nil {

--- a/pkg/distro/rhel/rhel7/ami.go
+++ b/pkg/distro/rhel/rhel7/ami.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/datasizes"
@@ -67,7 +68,7 @@ func ec2ImageConfig() *distro.ImageConfig {
 	}
 
 	return &distro.ImageConfig{
-		Timezone: common.ToPtr("UTC"),
+		Timezone: types.Some("UTC"),
 		TimeSynchronization: &osbuild.ChronyStageOptions{
 			Servers: []osbuild.ChronyConfigServer{
 				{

--- a/pkg/distro/rhel/rhel7/azure.go
+++ b/pkg/distro/rhel/rhel7/azure.go
@@ -2,6 +2,7 @@ package rhel7
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/subscription"
 	"github.com/osbuild/images/pkg/datasizes"
@@ -38,7 +39,7 @@ func mkAzureRhuiImgType() *rhel.ImageType {
 }
 
 var azureDefaultImgConfig = &distro.ImageConfig{
-	Timezone: common.ToPtr("Etc/UTC"),
+	Timezone: types.Some("Etc/UTC"),
 	Locale:   common.ToPtr("en_US.UTF-8"),
 	GPGKeyFiles: []string{
 		"/etc/pki/rpm-gpg/RPM-GPG-KEY-microsoft-azure-release",

--- a/pkg/distro/rhel/rhel8/ami.go
+++ b/pkg/distro/rhel/rhel8/ami.go
@@ -2,6 +2,7 @@ package rhel8
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/customizations/subscription"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
@@ -154,7 +155,7 @@ func mkEc2SapImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 // default EC2 images config (common for all architectures)
 func baseEc2ImageConfig() *distro.ImageConfig {
 	return &distro.ImageConfig{
-		Timezone: common.ToPtr("UTC"),
+		Timezone: types.Some("UTC"),
 		TimeSynchronization: &osbuild.ChronyStageOptions{
 			Servers: []osbuild.ChronyConfigServer{
 				{

--- a/pkg/distro/rhel/rhel8/azure.go
+++ b/pkg/distro/rhel/rhel8/azure.go
@@ -2,6 +2,7 @@ package rhel8
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/shell"
 	"github.com/osbuild/images/pkg/customizations/subscription"
@@ -352,7 +353,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 
 // based on https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deploying_rhel_8_on_microsoft_azure/assembly_deploying-a-rhel-image-as-a-virtual-machine-on-microsoft-azure_cloud-content-azure#making-configuration-changes_configure-the-image-azure
 var defaultAzureImageConfig = &distro.ImageConfig{
-	Timezone: common.ToPtr("Etc/UTC"),
+	Timezone: types.Some("Etc/UTC"),
 	Locale:   common.ToPtr("en_US.UTF-8"),
 	Keyboard: &osbuild.KeymapStageOptions{
 		Keymap: "us",

--- a/pkg/distro/rhel/rhel8/gce.go
+++ b/pkg/distro/rhel/rhel8/gce.go
@@ -2,6 +2,7 @@ package rhel8
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/customizations/subscription"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
@@ -55,7 +56,7 @@ func mkGceRhuiImgType(rd distro.Distro) *rhel.ImageType {
 // https://issues.redhat.com/browse/COMPOSER-2157
 func defaultGceByosImageConfig(rd distro.Distro) *distro.ImageConfig {
 	ic := &distro.ImageConfig{
-		Timezone: common.ToPtr("UTC"),
+		Timezone: types.Some("UTC"),
 		TimeSynchronization: &osbuild.ChronyStageOptions{
 			Servers: []osbuild.ChronyConfigServer{{Hostname: "metadata.google.internal"}},
 		},

--- a/pkg/distro/rhel/rhel9/ami.go
+++ b/pkg/distro/rhel/rhel9/ami.go
@@ -2,6 +2,7 @@ package rhel9
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
@@ -18,7 +19,7 @@ func amiKernelOptions() []string {
 func defaultEc2ImageConfig() *distro.ImageConfig {
 	return &distro.ImageConfig{
 		Locale:   common.ToPtr("en_US.UTF-8"),
-		Timezone: common.ToPtr("UTC"),
+		Timezone: types.Some("UTC"),
 		TimeSynchronization: &osbuild.ChronyStageOptions{
 			Servers: []osbuild.ChronyConfigServer{
 				{

--- a/pkg/distro/rhel/rhel9/azure.go
+++ b/pkg/distro/rhel/rhel9/azure.go
@@ -2,6 +2,7 @@ package rhel9
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
@@ -330,7 +331,7 @@ func defaultAzureKernelOptions(rd *rhel.Distribution, a arch.Arch) []string {
 // based on https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/deploying_rhel_9_on_microsoft_azure/assembly_deploying-a-rhel-image-as-a-virtual-machine-on-microsoft-azure_cloud-content-azure#making-configuration-changes_configure-the-image-azure
 func defaultAzureImageConfig(rd *rhel.Distribution) *distro.ImageConfig {
 	ic := &distro.ImageConfig{
-		Timezone: common.ToPtr("Etc/UTC"),
+		Timezone: types.Some("Etc/UTC"),
 		Locale:   common.ToPtr("en_US.UTF-8"),
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",

--- a/pkg/distro/rhel/rhel9/gce.go
+++ b/pkg/distro/rhel/rhel9/gce.go
@@ -2,6 +2,7 @@ package rhel9
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
@@ -39,7 +40,7 @@ func mkGCEImageType() *rhel.ImageType {
 
 func baseGCEImageConfig() *distro.ImageConfig {
 	ic := &distro.ImageConfig{
-		Timezone: common.ToPtr("UTC"),
+		Timezone: types.Some("UTC"),
 		TimeSynchronization: &osbuild.ChronyStageOptions{
 			Servers: []osbuild.ChronyConfigServer{{Hostname: "metadata.google.internal"}},
 		},

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
@@ -221,7 +221,9 @@ func (p *AnacondaInstaller) serializeEnd() {
 
 func installerRootUser() osbuild.UsersStageOptionsUser {
 	return osbuild.UsersStageOptionsUser{
-		Password: common.ToPtr(""),
+		// lock root accont by default
+		// XXX: this could just be "Password: nil"
+		Password: types.Some(""),
 	}
 }
 
@@ -289,11 +291,11 @@ func (p *AnacondaInstaller) payloadStages() []*osbuild.Stage {
 	installShell := "/usr/libexec/anaconda/run-anaconda"
 	installPassword := ""
 	installUser := osbuild.UsersStageOptionsUser{
-		UID:      &installUID,
-		GID:      &installGID,
-		Home:     &installHome,
-		Shell:    &installShell,
-		Password: &installPassword,
+		UID:      types.Some(installUID),
+		GID:      types.Some(installGID),
+		Home:     types.Some(installHome),
+		Shell:    types.Some(installShell),
+		Password: types.Some(installPassword),
 	}
 
 	usersStageOptions := &osbuild.UsersStageOptions{

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -714,10 +714,7 @@ func (p *AnacondaInstallerISOTree) makeKickstartStages(stageOptions *osbuild.Kic
 			stageOptions.Keyboard = *kickstartOptions.Keyboard
 		}
 
-		stageOptions.Timezone = "UTC"
-		if kickstartOptions.Timezone != nil {
-			stageOptions.Timezone = *kickstartOptions.Timezone
-		}
+		stageOptions.Timezone = kickstartOptions.Timezone.TakeOr("UTC")
 
 		stageOptions.Reboot = &osbuild.RebootOptions{Eject: true}
 		stageOptions.RootPassword = &osbuild.RootPasswordOptions{Lock: true}

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/environment"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/internal/workload"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/container"
@@ -78,7 +79,7 @@ type OSCustomizations struct {
 	Keyboard         *string
 	X11KeymapLayouts []string
 	Hostname         string
-	Timezone         string
+	Timezone         types.Option[string]
 	EnabledServices  []string
 	DisabledServices []string
 	MaskedServices   []string
@@ -533,8 +534,8 @@ func (p *OS) serialize() osbuild.Pipeline {
 		pipeline.AddStage(osbuild.NewHostnameStage(&osbuild.HostnameStageOptions{Hostname: p.OSCustomizations.Hostname}))
 	}
 
-	if p.OSCustomizations.Timezone != "" {
-		pipeline.AddStage(osbuild.NewTimezoneStage(&osbuild.TimezoneStageOptions{Zone: p.OSCustomizations.Timezone}))
+	if p.OSCustomizations.Timezone.IsSome() {
+		pipeline.AddStage(osbuild.NewTimezoneStage(&osbuild.TimezoneStageOptions{Zone: p.OSCustomizations.Timezone.Unwrap()}))
 	}
 
 	if p.OSCustomizations.ChronyConfig != nil {

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -978,7 +978,7 @@ func usersFirstBootOptions(users []users.User) *osbuild.FirstBootStageOptions {
 			sshdir := filepath.Join(home, ".ssh")
 
 			cmds = append(cmds, fmt.Sprintf("mkdir -p %s", sshdir))
-			cmds = append(cmds, fmt.Sprintf("sh -c 'echo %q >> %q'", *user.Key, filepath.Join(sshdir, "authorized_keys")))
+			cmds = append(cmds, fmt.Sprintf("sh -c 'echo %q >> %q'", user.Key.Unwrap(), filepath.Join(sshdir, "authorized_keys")))
 			cmds = append(cmds, fmt.Sprintf("chown %s:%s -Rc %s", user.Name, user.Name, sshdir))
 		}
 	}

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/testdisk"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/bootc"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
@@ -351,7 +352,7 @@ func TestLanguageDoesNotIncludeLocaleStage(t *testing.T) {
 func TestTimezoneIncludesTimezoneStage(t *testing.T) {
 	os := manifest.NewTestOS()
 
-	os.OSCustomizations.Timezone = "Etc/UTC"
+	os.OSCustomizations.Timezone = types.Some("Etc/UTC")
 
 	pipeline := os.Serialize()
 	st := manifest.FindStage("org.osbuild.timezone", pipeline.Stages)

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/users"
@@ -414,7 +415,8 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 		userOptions := &osbuild.UsersStageOptions{
 			Users: map[string]osbuild.UsersStageOptionsUser{
 				"root": {
-					Password: common.ToPtr("!locked"), // this is treated as crypted and locks/disables the password
+					// XXX: using "" or nil here is used in other places
+					Password: types.Some("!locked"), // this is treated as crypted and locks/disables the password
 				},
 			},
 		}

--- a/pkg/manifest/raw_bootc_test.go
+++ b/pkg/manifest/raw_bootc_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/testdisk"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/users"
@@ -60,7 +61,7 @@ func TestRawBootcImageSerialize(t *testing.T) {
 
 	rawBootcPipeline := manifest.NewRawBootcImage(build, containers, pf)
 	rawBootcPipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
-	rawBootcPipeline.Users = []users.User{{Name: "root", Key: common.ToPtr("some-ssh-key")}}
+	rawBootcPipeline.Users = []users.User{{Name: "root", Key: types.Some("some-ssh-key")}}
 	rawBootcPipeline.KernelOptionsAppend = []string{"karg1", "karg2"}
 
 	rawBootcPipeline.SerializeStart(manifest.Inputs{Containers: []container.Spec{{Source: "foo"}}})

--- a/pkg/osbuild/skopeo_index_source.go
+++ b/pkg/osbuild/skopeo_index_source.go
@@ -2,6 +2,8 @@ package osbuild
 
 import (
 	"fmt"
+
+	"github.com/osbuild/images/internal/types"
 )
 
 const SourceNameSkopeoIndex = "org.osbuild.skopeo-index"
@@ -13,8 +15,8 @@ type SkopeoIndexSource struct {
 func (SkopeoIndexSource) isSource() {}
 
 type SkopeoIndexSourceImage struct {
-	Name      string `json:"name"`
-	TLSVerify *bool  `json:"tls-verify,omitempty"`
+	Name      string             `json:"name"`
+	TLSVerify types.Option[bool] `json:"tls-verify,omitempty"`
 }
 
 type SkopeoIndexSourceItem struct {
@@ -39,7 +41,7 @@ func NewSkopeoIndexSource() *SkopeoIndexSource {
 
 // AddItem adds a source item to the source; will panic
 // if any of the supplied options are invalid or missing
-func (source *SkopeoIndexSource) AddItem(name, image string, tlsVerify *bool) {
+func (source *SkopeoIndexSource) AddItem(name, image string, tlsVerify types.Option[bool]) {
 	item := SkopeoIndexSourceItem{
 		Image: SkopeoIndexSourceImage{
 			Name:      name,

--- a/pkg/osbuild/skopeo_source.go
+++ b/pkg/osbuild/skopeo_source.go
@@ -3,6 +3,8 @@ package osbuild
 import (
 	"fmt"
 	"regexp"
+
+	"github.com/osbuild/images/internal/types"
 )
 
 const SourceNameSkopeo = "org.osbuild.skopeo"
@@ -19,9 +21,9 @@ type SkopeoSource struct {
 func (SkopeoSource) isSource() {}
 
 type SkopeopSourceImage struct {
-	Name      string `json:"name,omitempty"`
-	Digest    string `json:"digest,omitempty"`
-	TLSVerify *bool  `json:"tls-verify,omitempty"`
+	Name      string             `json:"name,omitempty"`
+	Digest    string             `json:"digest,omitempty"`
+	TLSVerify types.Option[bool] `json:"tls-verify,omitempty"`
 }
 
 type SkopeoSourceItem struct {
@@ -29,7 +31,7 @@ type SkopeoSourceItem struct {
 }
 
 // NewSkopeoSourceItem creates a new source item for name and digest
-func NewSkopeoSourceItem(name, digest string, tlsVerify *bool) SkopeoSourceItem {
+func NewSkopeoSourceItem(name, digest string, tlsVerify types.Option[bool]) SkopeoSourceItem {
 	item := SkopeoSourceItem{
 		Image: SkopeopSourceImage{
 			Name:      name,
@@ -64,7 +66,7 @@ func NewSkopeoSource() *SkopeoSource {
 
 // AddItem adds a source item to the source; will panic
 // if any of the supplied options are invalid or missing
-func (source *SkopeoSource) AddItem(name, digest, image string, tlsVerify *bool) {
+func (source *SkopeoSource) AddItem(name, digest, image string, tlsVerify types.Option[bool]) {
 	item := NewSkopeoSourceItem(name, digest, tlsVerify)
 	if !skopeoDigestPattern.MatchString(image) {
 		panic(fmt.Errorf("item %#v has invalid image id", image))

--- a/pkg/osbuild/skopeo_source_test.go
+++ b/pkg/osbuild/skopeo_source_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/images/internal/assertx"
-	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 )
 
 func TestNewSkopeoSource(t *testing.T) {
@@ -16,14 +16,14 @@ func TestNewSkopeoSource(t *testing.T) {
 
 	source := NewSkopeoSource()
 
-	source.AddItem("name", testDigest, imageID, common.ToPtr(false))
+	source.AddItem("name", testDigest, imageID, types.Some(false))
 	assert.Len(t, source.Items, 1)
 
 	item, ok := source.Items[imageID]
 	assert.True(t, ok)
 	assert.Equal(t, item.Image.Name, "name")
 	assert.Equal(t, item.Image.Digest, testDigest)
-	assert.Equal(t, item.Image.TLSVerify, common.ToPtr(false), false)
+	assert.Equal(t, item.Image.TLSVerify, types.Some(false), false)
 
 	testDigest = "sha256:d49eebefb6c7ce5505594bef652bd4adc36f413861bd44209d9b9486310b1264"
 	imageID = "sha256:d2ab8fea7f08a22f03b30c13c6ea443121f25e87202a7496e93736efa6fe345a"

--- a/pkg/osbuild/users_stage_test.go
+++ b/pkg/osbuild/users_stage_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/types"
 	"github.com/osbuild/images/pkg/customizations/users"
 )
 
@@ -28,15 +28,15 @@ func TestNewUsersStageOptionsPassword(t *testing.T) {
 	users := []users.User{
 		{
 			Name:     "bart",
-			Password: &Pass,
+			Password: types.Some(Pass),
 		},
 		{
 			Name:     "lisa",
-			Password: &CryptPass,
+			Password: types.Some(CryptPass),
 		},
 		{
 			Name:     "maggie",
-			Password: &EmptyPass,
+			Password: types.Some(EmptyPass),
 		},
 		{
 			Name: "homer",
@@ -48,10 +48,10 @@ func TestNewUsersStageOptionsPassword(t *testing.T) {
 	require.NotNil(t, options)
 
 	// bart's password should now be a hash
-	assert.True(t, strings.HasPrefix(*options.Users["bart"].Password, "$6$"))
+	assert.True(t, strings.HasPrefix(options.Users["bart"].Password.Unwrap(), "$6$"))
 
 	// lisa's password should be left alone (already hashed)
-	assert.Equal(t, CryptPass, *options.Users["lisa"].Password)
+	assert.Equal(t, CryptPass, options.Users["lisa"].Password.Unwrap())
 
 	// maggie's password should now be nil (locked account)
 	assert.Nil(t, options.Users["maggie"].Password)
@@ -63,24 +63,24 @@ func TestNewUsersStageOptionsPassword(t *testing.T) {
 func TestGenUsersStageSameAsNewUsersStageOptions(t *testing.T) {
 	users := []users.User{
 		{
-			Name: "user1", UID: common.ToPtr(1000), GID: common.ToPtr(1000),
+			Name: "user1", UID: types.Some(1000), GID: types.Some(1000),
 			Groups:      []string{"grp1"},
-			Description: common.ToPtr("some-descr"),
-			Home:        common.ToPtr("/home/user1"),
-			Shell:       common.ToPtr("/bin/zsh"),
-			Key:         common.ToPtr("some-key"),
+			Description: types.Some("some-descr"),
+			Home:        types.Some("/home/user1"),
+			Shell:       types.Some("/bin/zsh"),
+			Key:         types.Some("some-key"),
 		},
 	}
 	expected := &UsersStageOptions{
 		Users: map[string]UsersStageOptionsUser{
 			"user1": {
-				UID:         common.ToPtr(1000),
-				GID:         common.ToPtr(1000),
+				UID:         types.Some(1000),
+				GID:         types.Some(1000),
 				Groups:      []string{"grp1"},
-				Description: common.ToPtr("some-descr"),
-				Home:        common.ToPtr("/home/user1"),
-				Shell:       common.ToPtr("/bin/zsh"),
-				Key:         common.ToPtr("some-key")},
+				Description: types.Some("some-descr"),
+				Home:        types.Some("/home/user1"),
+				Shell:       types.Some("/bin/zsh"),
+				Key:         types.Some("some-key")},
 		},
 	}
 


### PR DESCRIPTION
For customizations we currently use pointers when we want to distinguish between set or unset value. This works fine and is supported by json/toml marshaling natively. However we lose some safety because there is always the risk of dereferencing a pointer and extra checks for `nil`. 

This PR introduces a new `types.Option` that wraps the primitive types bool,int,string [0] so that they are there is a distinction between "set" (Some) and "unset" (None) [1]. This allows us to do things like:
```go
-       if hostname := c.GetHostname(); hostname != nil {
-               osc.Hostname = *hostname
-       } else {
-               osc.Hostname = "localhost.localdomain"
-       }
+       osc.Hostname = c.GetHostname().TakeOr("localhost.localdomain")
```
or
```go
-       if hostname := c.GetHostname(); hostname != nil {
-               osc.Hostname = *hostname
-       }
+       osc.Hostname = c.GetHostname().Unwrap()
```
And there is overall a much smaller risk of making mistakes while also be more explicit (well, minor as arguably is as `*` is also a strong indicator).

This PR converts a small subset to show what it would look like, it's a lot of busywork so maybe not worth the effort but I like it over the pointers (but I understand if other wouldn't).


[0] Sadly the go type system and toml make it hard to do the same for structs which would be extremely nice, see the commit message/code comments for details.
[1] Of course this is very much inspired by the rust std::Some type and the go-optional libraries.