### PR TITLE
distro/rhel10: do not exclude nss package

### DIFF
--- a/pkg/distro/rhel/rhel10/qcow2.go
+++ b/pkg/distro/rhel/rhel10/qcow2.go
@@ -110,7 +110,6 @@ func qcow2CommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 			"langpacks-*",
 			"langpacks-en",
 			"libertas-sd8787-firmware",
-			"nss",
 			"plymouth",
 			"rng-tools",
 			"udisks2",


### PR DESCRIPTION
The package is required for openscap-scanner (OpenSCAP hardening). OpenSCAP package switched to NSS crypto backend in RHEL10.

See: https://issues.redhat.com/browse/RHEL-49502