### PR TITLE
osbuild: add support for `LVM` to `GenBootupdDevicesMounts()`

### DIFF
--- a/pkg/osbuild/lvm2_lv_device.go
+++ b/pkg/osbuild/lvm2_lv_device.go
@@ -5,6 +5,8 @@ package osbuild
 type LVM2LVDeviceOptions struct {
 	// Logical volume to activate
 	Volume string `json:"volume"`
+	// Detect the pv for the given parent automatically
+	Detectpv *bool `json:"detectpv,omitempty"`
 }
 
 func (LVM2LVDeviceOptions) isDeviceOptions() {}

--- a/pkg/osbuild/lvm2_lv_device_test.go
+++ b/pkg/osbuild/lvm2_lv_device_test.go
@@ -1,1 +1,45 @@
-package osbuild
+package osbuild_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+func TestLVM2LVDeviceMarshal(t *testing.T) {
+	opts := &osbuild.LVM2LVDeviceOptions{Volume: "some-volume"}
+	dev := osbuild.NewLVM2LVDevice("some-parent", opts)
+	b, err := json.MarshalIndent(dev, "", " ")
+	assert.NoError(t, err)
+	expectedJSON := `{
+ "type": "org.osbuild.lvm2.lv",
+ "parent": "some-parent",
+ "options": {
+  "volume": "some-volume"
+ }
+}`
+	assert.Equal(t, expectedJSON, string(b))
+}
+
+func TestLVM2LVDeviceMarshalWithDetectpv(t *testing.T) {
+	opts := &osbuild.LVM2LVDeviceOptions{
+		Volume:   "some-volume",
+		Detectpv: common.ToPtr(true),
+	}
+	dev := osbuild.NewLVM2LVDevice("some-parent", opts)
+	b, err := json.MarshalIndent(dev, "", " ")
+	assert.NoError(t, err)
+	expectedJSON := `{
+ "type": "org.osbuild.lvm2.lv",
+ "parent": "some-parent",
+ "options": {
+  "volume": "some-volume",
+  "detectpv": true
+ }
+}`
+	assert.Equal(t, expectedJSON, string(b))
+}


### PR DESCRIPTION
This is required for `bootc-image-builder` to support LVM. It works by adding a new `Detectpv` option to the `org.osbuild.lvm2.lv` device and use it when generating the bootc/bootupd mounts.

This way all mounts can come from the same underlying loop device and bootc/bootupd can install the bootloader there. See also https://github.com/osbuild/osbuild/pull/1861