### PR TITLE
osbuild: add support for `LVM` to `GenBootupdDevicesMounts()`

### DIFF
--- a/pkg/osbuild/bootupd_stage.go
+++ b/pkg/osbuild/bootupd_stage.go
@@ -89,7 +89,7 @@ func genMountsForBootupd(source string, pt *disk.PartitionTable) ([]Mount, error
 			continue
 		}
 
-		// TODO: support things like LVM here via supporting "disk.Container"
+		// TODO: support things like LUKS here via supporting "disk.Container"?
 		switch payload := part.Payload.(type) {
 		case disk.Mountable:
 			mount, err := genOsbuildMount(source, payload)
@@ -107,6 +107,20 @@ func genMountsForBootupd(source string, pt *disk.PartitionTable) ([]Mount, error
 				mount.Partition = common.ToPtr(idx + 1)
 				mounts = append(mounts, *mount)
 			}
+		case *disk.LVMVolumeGroup:
+			for i := range payload.LogicalVolumes {
+				lv := &payload.LogicalVolumes[i]
+				mountable, ok := lv.Payload.(disk.Mountable)
+				if !ok {
+					return nil, fmt.Errorf("expected LV payload %+[1]v to be mountable, got %[1]T", lv.Payload)
+				}
+				mount, err := genOsbuildMount(lv.Name, mountable)
+				if err != nil {
+					return nil, err
+				}
+				mount.Source = lv.Name
+				mounts = append(mounts, *mount)
+			}
 		default:
 			return nil, fmt.Errorf("type %T not supported by bootupd handling yet", part.Payload)
 		}
@@ -119,8 +133,7 @@ func genMountsForBootupd(source string, pt *disk.PartitionTable) ([]Mount, error
 	return mounts, nil
 }
 
-func GenBootupdDevicesMounts(filename string, pt *disk.PartitionTable, pltf platform.Platform) (map[string]Device, []Mount, error) {
-	devName := "disk"
+func genDevicesForBootupd(filename, devName string, pt *disk.PartitionTable) (map[string]Device, error) {
 	devices := map[string]Device{
 		devName: Device{
 			Type: "org.osbuild.loopback",
@@ -129,6 +142,28 @@ func GenBootupdDevicesMounts(filename string, pt *disk.PartitionTable, pltf plat
 				Partscan: true,
 			},
 		},
+	}
+	for idx, part := range pt.Partitions {
+		switch payload := part.Payload.(type) {
+		case *disk.LVMVolumeGroup:
+			for _, lv := range payload.LogicalVolumes {
+				// partitions start with "1", so add "1"
+				partNum := idx + 1
+				devices[lv.Name] = *NewLVM2LVDevice(devName, &LVM2LVDeviceOptions{Volume: lv.Name, VGPartnum: common.ToPtr(partNum)})
+			}
+		default:
+			// nothing
+		}
+	}
+
+	return devices, nil
+}
+
+func GenBootupdDevicesMounts(filename string, pt *disk.PartitionTable, pltf platform.Platform) (map[string]Device, []Mount, error) {
+	devName := "disk"
+	devices, err := genDevicesForBootupd(filename, devName, pt)
+	if err != nil {
+		return nil, nil, err
 	}
 	mounts, err := genMountsForBootupd(devName, pt)
 	if err != nil {

--- a/pkg/osbuild/lvm2_lv_device.go
+++ b/pkg/osbuild/lvm2_lv_device.go
@@ -5,6 +5,8 @@ package osbuild
 type LVM2LVDeviceOptions struct {
 	// Logical volume to activate
 	Volume string `json:"volume"`
+	// The partition the volume group is located on
+	VGPartnum *int `json:"vg_partnum,omitempty"`
 }
 
 func (LVM2LVDeviceOptions) isDeviceOptions() {}

--- a/pkg/osbuild/lvm2_lv_device_test.go
+++ b/pkg/osbuild/lvm2_lv_device_test.go
@@ -1,1 +1,45 @@
-package osbuild
+package osbuild_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+func TestLVM2LVDeviceMarshal(t *testing.T) {
+	opts := &osbuild.LVM2LVDeviceOptions{Volume: "some-volume"}
+	dev := osbuild.NewLVM2LVDevice("some-parent", opts)
+	b, err := json.MarshalIndent(dev, "", " ")
+	assert.NoError(t, err)
+	expectedJSON := `{
+ "type": "org.osbuild.lvm2.lv",
+ "parent": "some-parent",
+ "options": {
+  "volume": "some-volume"
+ }
+}`
+	assert.Equal(t, expectedJSON, string(b))
+}
+
+func TestLVM2LVDeviceMarshalWithVGPartition(t *testing.T) {
+	opts := &osbuild.LVM2LVDeviceOptions{
+		Volume:    "some-volume",
+		VGPartnum: common.ToPtr(4),
+	}
+	dev := osbuild.NewLVM2LVDevice("some-parent", opts)
+	b, err := json.MarshalIndent(dev, "", " ")
+	assert.NoError(t, err)
+	expectedJSON := `{
+ "type": "org.osbuild.lvm2.lv",
+ "parent": "some-parent",
+ "options": {
+  "volume": "some-volume",
+  "vg_partnum": 4
+ }
+}`
+	assert.Equal(t, expectedJSON, string(b))
+}


### PR DESCRIPTION
This is required for `bootc-image-builder` to support LVM. It works by using the new `vg_partition` option to the `org.osbuild.lvm2.lv` device and use it when generating the bootc/bootupd mounts.

This way all mounts can come from the same underlying loop device and bootc/bootupd can install the bootloader there. See also https://github.com/osbuild/osbuild/pull/1867

