### PR TITLE
Rename image(s) cmd flags to type(s) and add checkpoints to build

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -191,7 +191,7 @@ func run() error {
 	// image selection args
 	var distroName, imgTypeName, configFile string
 	flag.StringVar(&distroName, "distro", "", "distribution (required)")
-	flag.StringVar(&imgTypeName, "image", "", "image type name (required)")
+	flag.StringVar(&imgTypeName, "type", "", "image type name (required)")
 	flag.StringVar(&configFile, "config", "", "build config file (required)")
 
 	flag.Parse()

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -188,6 +188,10 @@ func run() error {
 	flag.StringVar(&osbuildStore, "store", ".osbuild", "osbuild store for intermediate pipeline trees")
 	flag.StringVar(&rpmCacheRoot, "rpmmd", "/tmp/rpmmd", "rpm metadata cache directory")
 
+	// osbuild checkpoint arg
+	var checkpoints cmdutil.MultiValue
+	flag.Var(&checkpoints, "checkpoints", "comma-separated list of pipeline names to checkpoint (passed to osbuild --checkpoint)")
+
 	// image selection args
 	var distroName, imgTypeName, configFile string
 	flag.StringVar(&distroName, "distro", "", "distribution (required)")
@@ -263,7 +267,7 @@ func run() error {
 	fmt.Printf("Building manifest: %s\n", manifestPath)
 
 	jobOutput := filepath.Join(outputDir, buildName)
-	_, err = osbuild.RunOSBuild(mf, osbuildStore, jobOutput, imgType.Exports(), nil, nil, false, os.Stderr)
+	_, err = osbuild.RunOSBuild(mf, osbuildStore, jobOutput, imgType.Exports(), checkpoints, nil, false, os.Stderr)
 	if err != nil {
 		return err
 	}

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -509,7 +509,7 @@ func main() {
 	var arches, distros, imgTypes multiValue
 	flag.Var(&arches, "arches", "comma-separated list of architectures (globs supported)")
 	flag.Var(&distros, "distros", "comma-separated list of distributions (globs supported)")
-	flag.Var(&imgTypes, "images", "comma-separated list of image types (globs supported)")
+	flag.Var(&imgTypes, "types", "comma-separated list of image types (globs supported)")
 
 	flag.Parse()
 

--- a/cmd/list-images/main.go
+++ b/cmd/list-images/main.go
@@ -71,7 +71,7 @@ func main() {
 	var json bool
 	flag.Var(&arches, "arches", "comma-separated list of architectures (globs supported)")
 	flag.Var(&distros, "distros", "comma-separated list of distributions (globs supported)")
-	flag.Var(&imgTypes, "images", "comma-separated list of image types (globs supported)")
+	flag.Var(&imgTypes, "types", "comma-separated list of image types (globs supported)")
 	flag.BoolVar(&json, "json", false, "print configs as json")
 	flag.Parse()
 

--- a/internal/cmdutil/multivalue.go
+++ b/internal/cmdutil/multivalue.go
@@ -1,0 +1,46 @@
+package cmdutil
+
+import (
+	"strings"
+
+	"github.com/gobwas/glob"
+)
+
+// MultiValue can be used as a flag.Var type to support comma-separated lists
+// of values on the command line. The [MultiValue.ResolveArgValues] method can
+// be used to validate the values and resolve globs.
+type MultiValue []string
+
+func (mv *MultiValue) String() string {
+	return strings.Join(*mv, ", ")
+}
+
+func (mv *MultiValue) Set(v string) error {
+	*mv = strings.Split(v, ",")
+	return nil
+}
+
+// ResolveArgValues returns a list of valid values from the MultiValue. Invalid
+// values are returned separately. Globs are expanded. If the args are empty,
+// the valueList is returned in full.
+func (args MultiValue) ResolveArgValues(valueList []string) ([]string, []string) {
+	if len(args) == 0 {
+		return valueList, nil
+	}
+	selection := make([]string, 0, len(args))
+	invalid := make([]string, 0, len(args))
+	for _, arg := range args {
+		g := glob.MustCompile(arg)
+		match := false
+		for _, v := range valueList {
+			if g.Match(v) {
+				selection = append(selection, v)
+				match = true
+			}
+		}
+		if !match {
+			invalid = append(invalid, arg)
+		}
+	}
+	return selection, invalid
+}

--- a/test/README.md
+++ b/test/README.md
@@ -5,7 +5,7 @@
 - [./cmd/build](../cmd/build) takes a config file as argument to build an image.  For example:
 ```
 go build -o bin/build ./cmd/build
-sudo ./bin/build --output ./buildtest --rpmmd /tmp/rpmmd --distro fedora-39 --image qcow2 --config test/configs/embed-containers.json
+sudo ./bin/build --output ./buildtest --rpmmd /tmp/rpmmd --distro fedora-39 --type qcow2 --config test/configs/embed-containers.json
 ```
 will build a Fedora 38 qcow2 image using the configuration specified in the file `embed-containers.json`
 

--- a/test/scripts/build-image
+++ b/test/scripts/build-image
@@ -29,7 +29,7 @@ def main():
     testlib.runcmd(["go", "build", "-o", "./bin/build", "./cmd/build"])
 
     cmd = ["sudo", "-E", "./bin/build", "--output", "./build",
-           "--distro", distro, "--image", image_type, "--config", config_path]
+           "--distro", distro, "--type", image_type, "--config", config_path]
     testlib.runcmd_nc(cmd, extra_env=testlib.rng_seed_env())
 
     print("✅ Build finished!!")

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -103,7 +103,7 @@ def list_images(distros=None, arches=None, images=None):
     if images:
         images_arg = ",".join(images)
     out, _ = runcmd(["go", "run", "./cmd/list-images", "--json",
-                     "--distros", distros_arg, "--arches", arches_arg, "--images", images_arg])
+                     "--distros", distros_arg, "--arches", arches_arg, "--types", images_arg])
     return json.loads(out)
 
 
@@ -212,7 +212,7 @@ def gen_manifests(outputdir, config_map=None, distros=None, arches=None, images=
     if arches:
         cmd.extend(["--arches", ",".join(arches)])
     if images:
-        cmd.extend(["--images", ",".join(images)])
+        cmd.extend(["--types", ",".join(images)])
     if commits:
         cmd.append("--commits")
     if skip_no_config:


### PR DESCRIPTION
These are a couple of changes I've been fiddling with while working on other stuff.
1. I think `--type` is a better name for the image type flag than `--image` for `cmd/build` and the same for the plural form for `cmd/gen-manifests` and `cmd/list-images`.
2. I caught myself doing checkpointing by editing the command or generating manifests and running them separately sometimes when experimenting with builds.  Let's just add a `--checkpoints` flag that gets passed down to osbuild.

We might add an `--osbuild-options` flag instead and use that to pass stuff down to osbuild in the future, but let's keep this short for now.