### PR TITLE
disk: drop Entity.IsContainer()

### DIFF
--- a/pkg/disk/btrfs.go
+++ b/pkg/disk/btrfs.go
@@ -25,10 +25,6 @@ func (b *Btrfs) EntityName() string {
 	return "btrfs"
 }
 
-func (b *Btrfs) IsContainer() bool {
-	return true
-}
-
 func (b *Btrfs) Clone() Entity {
 	if b == nil {
 		return nil
@@ -120,10 +116,6 @@ type BtrfsSubvolume struct {
 
 	// UUID of the parent volume
 	UUID string
-}
-
-func (subvol *BtrfsSubvolume) IsContainer() bool {
-	return false
 }
 
 func (bs *BtrfsSubvolume) Clone() Entity {

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -60,10 +60,6 @@ const (
 
 // Entity is the base interface for all disk-related entities.
 type Entity interface {
-	// IsContainer indicates if the implementing type can
-	// contain any other entities.
-	IsContainer() bool
-
 	// Clone returns a deep copy of the entity.
 	Clone() Entity
 }

--- a/pkg/disk/filesystem.go
+++ b/pkg/disk/filesystem.go
@@ -31,10 +31,6 @@ func (fs *Filesystem) EntityName() string {
 	return "filesystem"
 }
 
-func (fs *Filesystem) IsContainer() bool {
-	return false
-}
-
 // Clone the filesystem structure
 func (fs *Filesystem) Clone() Entity {
 	if fs == nil {

--- a/pkg/disk/luks.go
+++ b/pkg/disk/luks.go
@@ -58,10 +58,6 @@ func (lc *LUKSContainer) EntityName() string {
 	return "luks"
 }
 
-func (lc *LUKSContainer) IsContainer() bool {
-	return true
-}
-
 func (lc *LUKSContainer) GetItemCount() uint {
 	if lc.Payload == nil {
 		return 0

--- a/pkg/disk/lvm.go
+++ b/pkg/disk/lvm.go
@@ -27,10 +27,6 @@ func (vg *LVMVolumeGroup) EntityName() string {
 	return "lvm"
 }
 
-func (vg *LVMVolumeGroup) IsContainer() bool {
-	return true
-}
-
 func (vg *LVMVolumeGroup) Clone() Entity {
 	if vg == nil {
 		return nil
@@ -168,10 +164,6 @@ type LVMLogicalVolume struct {
 	Name    string
 	Size    uint64
 	Payload Entity
-}
-
-func (lv *LVMLogicalVolume) IsContainer() bool {
-	return true
 }
 
 func (lv *LVMLogicalVolume) Clone() Entity {

--- a/pkg/disk/partition.go
+++ b/pkg/disk/partition.go
@@ -21,10 +21,6 @@ type Partition struct {
 	Payload PayloadEntity
 }
 
-func (p *Partition) IsContainer() bool {
-	return true
-}
-
 func (p *Partition) Clone() Entity {
 	if p == nil {
 		return nil

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -160,10 +160,6 @@ func NewPartitionTable(basePT *PartitionTable, mountpoints []blueprint.Filesyste
 	return newPT, nil
 }
 
-func (pt *PartitionTable) IsContainer() bool {
-	return true
-}
-
 func (pt *PartitionTable) Clone() Entity {
 	if pt == nil {
 		return nil

--- a/pkg/disk/partition_table_internal_test.go
+++ b/pkg/disk/partition_table_internal_test.go
@@ -46,9 +46,8 @@ func validatePTSize(pt *PartitionTable) error {
 // validateEntitySize checks that every sizeable under a given Entity can be
 // contained in the given size.
 func validateEntitySize(ent Entity, size uint64) error {
-	if ent.IsContainer() {
+	if cont, ok := ent.(Container); ok {
 		containerTotal := uint64(0)
-		cont := ent.(Container)
 		for idx := uint(0); idx < cont.GetItemCount(); idx++ {
 			child := cont.GetChild(idx)
 			var childSize uint64


### PR DESCRIPTION
This method is actually only used in tests, and it's actually not
needed as we can just use a type assertion like everywhere else.