### PR TITLE
fix / growth when converting a pt to btrfs and cover it with a test

### DIFF
--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -781,6 +781,7 @@ func (pt *PartitionTable) ensureBtrfs() error {
 					Mountpoint: "/",
 					Compress:   DefaultBtrfsCompression,
 					ReadOnly:   opts.ReadOnly(),
+					Size:       part.Size,
 				},
 			},
 		}


### PR DESCRIPTION
The first commit ensures that when converting the root partition to btrfs, the enlarged size from a blueprint mountpoint is carried over to the created btrfs subvolume.

The second commit adds a test to check whether the blueprint customizations are correctly applied to the partition table. It verifies that the correct mountable is created and that all sizeables above the mountable have at least the minimum size specified in the blueprint.