### PR TITLE
RHEL-10: remove gdisk from pkg sets of all images

### DIFF
--- a/pkg/distro/rhel/rhel10/ami.go
+++ b/pkg/distro/rhel/rhel10/ami.go
@@ -163,7 +163,6 @@ func ec2CommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 			"dhcpcd",
 			"yum-utils",
 			"dracut-config-generic",
-			"gdisk",
 			"grub2",
 			"langpacks-en",
 			"NetworkManager-cloud-setup",

--- a/pkg/distro/rhel/rhel10/azure.go
+++ b/pkg/distro/rhel/rhel10/azure.go
@@ -68,7 +68,6 @@ func azureCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 			"cloud-utils-growpart",
 			"dracut-config-generic",
 			"efibootmgr",
-			"gdisk",
 			"hyperv-daemons",
 			"kernel-core",
 			"kernel-modules",


### PR DESCRIPTION
The package was removed from c10s / el10.0 beta. I must add that after the development freeze ¯\_(ツ)_/¯.

See https://issues.redhat.com/browse/CS-2494