### PR TITLE
blueprint: fix filesystem customization parsing

### DIFF
--- a/pkg/blueprint/blueprint_test.go
+++ b/pkg/blueprint/blueprint_test.go
@@ -23,16 +23,16 @@ version = "2.4.*"
 
 [[customizations.filesystem]]
 mountpoint = "/var"
-size = 2147483648
+minsize = 2147483648
 
 [[customizations.filesystem]]
 mountpoint = "/opt"
-size = "20 GB"
+minsize = "20 GB"
 `
 
 	var bp Blueprint
 	err := toml.Unmarshal([]byte(blueprint), &bp)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, bp.Name, "test")
 	assert.Equal(t, "/var", bp.Customizations.Filesystem[0].Mountpoint)
 	assert.Equal(t, uint64(2147483648), bp.Customizations.Filesystem[0].MinSize)
@@ -49,7 +49,7 @@ size = "20 GB"
 		}
 	  }`
 	err = json.Unmarshal([]byte(blueprint), &bp)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, bp.Name, "test")
 	assert.Equal(t, "/opt", bp.Customizations.Filesystem[0].Mountpoint)
 	assert.Equal(t, uint64(20*common.GiB), bp.Customizations.Filesystem[0].MinSize)

--- a/pkg/blueprint/filesystem_customizations.go
+++ b/pkg/blueprint/filesystem_customizations.go
@@ -57,14 +57,13 @@ func (fsc *FilesystemCustomization) UnmarshalJSON(data []byte) error {
 	// The JSON specification only mentions float64 and Go defaults to it: https://go.dev/blog/json
 	switch d["minsize"].(type) {
 	case float64:
-		// Note that it uses different key than the TOML version
 		fsc.MinSize = uint64(d["minsize"].(float64))
 	case string:
-		size, err := common.DataSizeToUint64(d["minsize"].(string))
+		minSize, err := common.DataSizeToUint64(d["minsize"].(string))
 		if err != nil {
-			return fmt.Errorf("JSON unmarshal: size is not valid filesystem size (%w)", err)
+			return fmt.Errorf("JSON unmarshal: minsize is not valid filesystem size (%w)", err)
 		}
-		fsc.MinSize = size
+		fsc.MinSize = minSize
 	default:
 		return fmt.Errorf("JSON unmarshal: minsize must be float64 number or string, got %v of type %T", d["minsize"], d["minsize"])
 	}

--- a/pkg/blueprint/filesystem_customizations.go
+++ b/pkg/blueprint/filesystem_customizations.go
@@ -24,17 +24,17 @@ func (fsc *FilesystemCustomization) UnmarshalTOML(data interface{}) error {
 		return fmt.Errorf("TOML unmarshal: mountpoint must be string, got %v of type %T", d["mountpoint"], d["mountpoint"])
 	}
 
-	switch d["size"].(type) {
+	switch d["minsize"].(type) {
 	case int64:
-		fsc.MinSize = uint64(d["size"].(int64))
+		fsc.MinSize = uint64(d["minsize"].(int64))
 	case string:
-		size, err := common.DataSizeToUint64(d["size"].(string))
+		minSize, err := common.DataSizeToUint64(d["minsize"].(string))
 		if err != nil {
-			return fmt.Errorf("TOML unmarshal: size is not valid filesystem size (%w)", err)
+			return fmt.Errorf("TOML unmarshal: minsize is not valid filesystem size (%w)", err)
 		}
-		fsc.MinSize = size
+		fsc.MinSize = minSize
 	default:
-		return fmt.Errorf("TOML unmarshal: size must be integer or string, got %v of type %T", d["size"], d["size"])
+		return fmt.Errorf("TOML unmarshal: minsize must be integer or string, got %v of type %T", d["minsize"], d["minsize"])
 	}
 
 	return nil

--- a/pkg/blueprint/filesystem_customizations_test.go
+++ b/pkg/blueprint/filesystem_customizations_test.go
@@ -1,12 +1,82 @@
 package blueprint
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/images/pkg/pathpolicy"
 )
+
+// Happy tests for unmarshallers are in blueprint_test.go
+func TestFilesystemCustomizationUnmarshalTOMLUnhappy(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		err   string
+	}{
+		{
+			name: "mountpoint not string",
+			input: `mountpoint = 42
+			minsize = 42`,
+			err: "toml: line 0: TOML unmarshal: mountpoint must be string, got 42 of type int64",
+		},
+		{
+			name: "misize nor string nor int",
+			input: `mountpoint="/"
+			minsize = true`,
+			err: "toml: line 0: TOML unmarshal: minsize must be integer or string, got true of type bool",
+		},
+		{
+			name: "misize not parseable",
+			input: `mountpoint="/"
+			minsize = "20 KG"`,
+			err: "toml: line 0: TOML unmarshal: minsize is not valid filesystem size (unknown data size units in string: 20 KG)",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var fsc FilesystemCustomization
+			err := toml.Unmarshal([]byte(c.input), &fsc)
+			assert.EqualError(t, err, c.err)
+		})
+	}
+}
+
+func TestFilesystemCustomizationUnmarshalJSONUnhappy(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		err   string
+	}{
+		{
+			name:  "mountpoint not string",
+			input: `{"mountpoint": 42, "minsize": 42}`,
+			err:   "JSON unmarshal: mountpoint must be string, got 42 of type float64",
+		},
+		{
+			name:  "misize nor string nor int",
+			input: `{"mountpoint":"/", "minsize": true}`,
+			err:   "JSON unmarshal: minsize must be float64 number or string, got true of type bool",
+		},
+		{
+			name:  "misize not parseable",
+			input: `{ "mountpoint": "/", "minsize": "20 KG"}`,
+			err:   "JSON unmarshal: minsize is not valid filesystem size (unknown data size units in string: 20 KG)",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var fsc FilesystemCustomization
+			err := json.Unmarshal([]byte(c.input), &fsc)
+			assert.EqualError(t, err, c.err)
+		})
+	}
+}
 
 func TestCheckMountpointsPolicy(t *testing.T) {
 	policy := pathpolicy.NewPathPolicies(map[string]pathpolicy.PathPolicy{


### PR DESCRIPTION
In the filesystem customization, the toml tags clearly sets the `MinSize` field's key to `minsize`, this is also reflected in `bootc-image-builder` docs. However, the custom unmarshallers are actually wrong, they still refer to the old `size` name (see #825).

This PR fixes the unmarshallers, and adds more test coverage.