### PR TITLE
add support for swap partitions and logical volumes

### DIFF
--- a/internal/testdisk/partition.go
+++ b/internal/testdisk/partition.go
@@ -174,6 +174,7 @@ func MakeFakeLVMPartitionTable(mntPoints ...string) *disk.PartitionTable {
 		Start: size,
 		Size:  9 * common.GiB,
 		Payload: &disk.LVMVolumeGroup{
+			Name:           "rootvg",
 			LogicalVolumes: lvs,
 		},
 	})

--- a/pkg/blueprint/filesystem_customizations.go
+++ b/pkg/blueprint/filesystem_customizations.go
@@ -9,9 +9,17 @@ import (
 	"github.com/osbuild/images/pkg/pathpolicy"
 )
 
+type FilesystemType string
+
+const (
+	FilesystemTypeUnset FilesystemType = ""
+	FilesystemTypeSwap  FilesystemType = "swap"
+)
+
 type FilesystemCustomization struct {
-	Mountpoint string `json:"mountpoint,omitempty" toml:"mountpoint,omitempty"`
-	MinSize    uint64 `json:"minsize,omitempty" toml:"minsize,omitempty"`
+	Mountpoint string         `json:"mountpoint,omitempty" toml:"mountpoint,omitempty"`
+	MinSize    uint64         `json:"minsize,omitempty" toml:"minsize,omitempty"`
+	Type       FilesystemType `json:"type,omitempty" toml:"type,omitempty"`
 }
 
 func (fsc *FilesystemCustomization) UnmarshalTOML(data interface{}) error {
@@ -35,6 +43,13 @@ func (fsc *FilesystemCustomization) UnmarshalTOML(data interface{}) error {
 		fsc.MinSize = minSize
 	default:
 		return fmt.Errorf("TOML unmarshal: minsize must be integer or string, got %v of type %T", d["minsize"], d["minsize"])
+	}
+
+	switch d["type"].(type) {
+	case string:
+		fsc.Type = FilesystemType(d["type"].(string))
+	default:
+		return fmt.Errorf("TOML unmarshal: type must be string, got %v of type %T", d["type"], d["type"])
 	}
 
 	return nil

--- a/pkg/disk/btrfs.go
+++ b/pkg/disk/btrfs.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/google/uuid"
+	"github.com/osbuild/images/pkg/blueprint"
 )
 
 const DefaultBtrfsCompression = "zstd:1"
@@ -56,7 +57,10 @@ func (b *Btrfs) GetItemCount() uint {
 func (b *Btrfs) GetChild(n uint) Entity {
 	return &b.Subvolumes[n]
 }
-func (b *Btrfs) CreateMountpoint(mountpoint string, size uint64) (Entity, error) {
+func (b *Btrfs) CreateMountpoint(mountpoint string, size uint64, fstype blueprint.FilesystemType) (Entity, error) {
+	if fstype == blueprint.FilesystemTypeSwap {
+		return nil, fmt.Errorf("btrfs subvolumes cannot be swap")
+	}
 	name := mountpoint
 	if name == "/" {
 		name = "root"

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -27,6 +27,7 @@ import (
 	"slices"
 
 	"github.com/google/uuid"
+	"github.com/osbuild/images/pkg/blueprint"
 )
 
 const (
@@ -56,6 +57,8 @@ const (
 
 	// Extended Boot Loader Partition
 	XBootLDRPartitionGUID = "BC13C2FF-59E6-4262-A352-B275FD6F7172"
+
+	SwapPartitionGUID = "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F"
 )
 
 // Entity is the base interface for all disk-related entities.
@@ -114,11 +117,10 @@ type Mountable interface {
 }
 
 // A MountpointCreator is a container that is able to create new volumes.
-//
-// CreateMountpoint creates a new mountpoint with the given size and
-// returns the entity that represents the new mountpoint.
 type MountpointCreator interface {
-	CreateMountpoint(mountpoint string, size uint64) (Entity, error)
+	// CreateMountpoint creates a new mountpoint with the given size and type
+	// and returns the entity that represents the new mountpoint.
+	CreateMountpoint(mountpoint string, size uint64, fsType blueprint.FilesystemType) (Entity, error)
 
 	// AlignUp will align the given bytes according to the
 	// requirements of the container type.

--- a/pkg/disk/filesystem.go
+++ b/pkg/disk/filesystem.go
@@ -52,6 +52,11 @@ func (fs *Filesystem) GetMountpoint() string {
 	if fs == nil {
 		return ""
 	}
+
+	if fs.Type == "swap" {
+		return "none"
+	}
+
 	return fs.Mountpoint
 }
 

--- a/pkg/disk/filesystem.go
+++ b/pkg/disk/filesystem.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 
 	"github.com/google/uuid"
+	"github.com/osbuild/images/pkg/blueprint"
 )
 
 // Filesystem related functions
@@ -99,9 +100,17 @@ func (fs *Filesystem) GenUUID(rng *rand.Rand) {
 	}
 }
 
-func createFilesystem(mountpoint string) *Filesystem {
+func createFilesystem(mountpoint string, fstype blueprint.FilesystemType) *Filesystem {
+	var typ string
+	switch fstype {
+	case blueprint.FilesystemTypeSwap:
+		typ = "swap"
+	default:
+		typ = "xfs"
+	}
+
 	return &Filesystem{
-		Type:         "xfs",
+		Type:         typ,
 		Mountpoint:   mountpoint,
 		FSTabOptions: "defaults",
 		FSTabFreq:    0,

--- a/pkg/disk/filesystem.go
+++ b/pkg/disk/filesystem.go
@@ -98,3 +98,13 @@ func (fs *Filesystem) GenUUID(rng *rand.Rand) {
 		fs.UUID = uuid.Must(newRandomUUIDFromReader(rng)).String()
 	}
 }
+
+func createFilesystem(mountpoint string) *Filesystem {
+	return &Filesystem{
+		Type:         "xfs",
+		Mountpoint:   mountpoint,
+		FSTabOptions: "defaults",
+		FSTabFreq:    0,
+		FSTabPassNo:  0,
+	}
+}

--- a/pkg/disk/lvm.go
+++ b/pkg/disk/lvm.go
@@ -72,16 +72,7 @@ func (vg *LVMVolumeGroup) GetChild(n uint) Entity {
 }
 
 func (vg *LVMVolumeGroup) CreateMountpoint(mountpoint string, size uint64) (Entity, error) {
-
-	filesystem := Filesystem{
-		Type:         "xfs",
-		Mountpoint:   mountpoint,
-		FSTabOptions: "defaults",
-		FSTabFreq:    0,
-		FSTabPassNo:  0,
-	}
-
-	return vg.CreateLogicalVolume(mountpoint, size, &filesystem)
+	return vg.CreateLogicalVolume(mountpoint, size, createFilesystem(mountpoint))
 }
 
 func (vg *LVMVolumeGroup) CreateLogicalVolume(lvName string, size uint64, payload Entity) (Entity, error) {

--- a/pkg/disk/lvm.go
+++ b/pkg/disk/lvm.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/blueprint"
 )
 
 // Default physical extent size in bytes: logical volumes
@@ -71,8 +72,8 @@ func (vg *LVMVolumeGroup) GetChild(n uint) Entity {
 	return &vg.LogicalVolumes[n]
 }
 
-func (vg *LVMVolumeGroup) CreateMountpoint(mountpoint string, size uint64) (Entity, error) {
-	return vg.CreateLogicalVolume(mountpoint, size, createFilesystem(mountpoint))
+func (vg *LVMVolumeGroup) CreateMountpoint(mountpoint string, size uint64, fstype blueprint.FilesystemType) (Entity, error) {
+	return vg.CreateLogicalVolume(mountpoint, size, createFilesystem(mountpoint, fstype))
 }
 
 func (vg *LVMVolumeGroup) CreateLogicalVolume(lvName string, size uint64, payload Entity) (Entity, error) {

--- a/pkg/disk/lvm_test.go
+++ b/pkg/disk/lvm_test.go
@@ -3,6 +3,7 @@ package disk
 import (
 	"testing"
 
+	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,15 +16,15 @@ func TestLVMVCreateMountpoint(t *testing.T) {
 		Description: "root volume group",
 	}
 
-	entity, err := vg.CreateMountpoint("/", 0)
+	entity, err := vg.CreateMountpoint("/", 0, blueprint.FilesystemTypeUnset)
 	assert.NoError(err)
 	rootlv := entity.(*LVMLogicalVolume)
 	assert.Equal("rootlv", rootlv.Name)
 
-	_, err = vg.CreateMountpoint("/home_test", 0)
+	_, err = vg.CreateMountpoint("/home_test", 0, blueprint.FilesystemTypeUnset)
 	assert.NoError(err)
 
-	entity, err = vg.CreateMountpoint("/home/test", 0)
+	entity, err = vg.CreateMountpoint("/home/test", 0, blueprint.FilesystemTypeUnset)
 	assert.NoError(err)
 
 	dedup := entity.(*LVMLogicalVolume)
@@ -31,11 +32,11 @@ func TestLVMVCreateMountpoint(t *testing.T) {
 
 	// Lets collide it
 	for i := 0; i < 98; i++ {
-		_, err = vg.CreateMountpoint("/home/test", 0)
+		_, err = vg.CreateMountpoint("/home/test", 0, blueprint.FilesystemTypeUnset)
 		assert.NoError(err)
 	}
 
-	_, err = vg.CreateMountpoint("/home/test", 0)
+	_, err = vg.CreateMountpoint("/home/test", 0, blueprint.FilesystemTypeUnset)
 	assert.Error(err)
 }
 

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -324,17 +324,9 @@ func (pt *PartitionTable) EnsureDirectorySizes(dirSizeMap map[string]uint64) {
 }
 
 func (pt *PartitionTable) CreateMountpoint(mountpoint string, size uint64) (Entity, error) {
-	filesystem := Filesystem{
-		Type:         "xfs",
-		Mountpoint:   mountpoint,
-		FSTabOptions: "defaults",
-		FSTabFreq:    0,
-		FSTabPassNo:  0,
-	}
-
 	partition := Partition{
 		Size:    size,
-		Payload: &filesystem,
+		Payload: createFilesystem(mountpoint),
 	}
 
 	n := len(pt.Partitions)

--- a/pkg/osbuild/bootupd_stage.go
+++ b/pkg/osbuild/bootupd_stage.go
@@ -96,6 +96,10 @@ func genMountsForBootupd(source string, pt *disk.PartitionTable) ([]Mount, error
 			if err != nil {
 				return nil, err
 			}
+			if mount == nil {
+				continue
+
+			}
 			mount.Partition = common.ToPtr(idx + 1)
 			mounts = append(mounts, *mount)
 		case *disk.Btrfs:
@@ -103,6 +107,9 @@ func genMountsForBootupd(source string, pt *disk.PartitionTable) ([]Mount, error
 				mount, err := genOsbuildMount(source, &payload.Subvolumes[i])
 				if err != nil {
 					return nil, err
+				}
+				if mount == nil {
+					continue
 				}
 				mount.Partition = common.ToPtr(idx + 1)
 				mounts = append(mounts, *mount)
@@ -117,6 +124,9 @@ func genMountsForBootupd(source string, pt *disk.PartitionTable) ([]Mount, error
 				mount, err := genOsbuildMount(lv.Name, mountable)
 				if err != nil {
 					return nil, err
+				}
+				if mount == nil {
+					continue
 				}
 				mount.Source = lv.Name
 				mounts = append(mounts, *mount)
@@ -147,6 +157,7 @@ func genDevicesForBootupd(filename, devName string, pt *disk.PartitionTable) (ma
 		switch payload := part.Payload.(type) {
 		case *disk.LVMVolumeGroup:
 			for _, lv := range payload.LogicalVolumes {
+				// TODO: ignore swap LVs. It's harmless to create a device for them, but it's also pointless.
 				// partitions start with "1", so add "1"
 				partNum := idx + 1
 				devices[lv.Name] = *NewLVM2LVDevice(devName, &LVM2LVDeviceOptions{Volume: lv.Name, VGPartnum: common.ToPtr(partNum)})

--- a/pkg/osbuild/bootupd_stage_test.go
+++ b/pkg/osbuild/bootupd_stage_test.go
@@ -248,6 +248,19 @@ var fakePt = &disk.PartitionTable{
 				FSTabPassNo:  1,
 			},
 		},
+
+		{
+			Size: 2 * common.GibiByte,
+			Type: disk.SwapPartitionGUID,
+			Payload: &disk.Filesystem{
+				Type:         "swap",
+				Label:        "swap",
+				Mountpoint:   "/",
+				FSTabOptions: "defaults",
+				FSTabFreq:    1,
+				FSTabPassNo:  1,
+			},
+		},
 	},
 }
 
@@ -301,7 +314,7 @@ func TestGenBootupdDevicesMountsHappyBtrfs(t *testing.T) {
 		UEFIVendor:   "test",
 	}
 
-	devices, mounts, err := osbuild.GenBootupdDevicesMounts(filename, testdisk.MakeFakeBtrfsPartitionTable("/", "/home", "/boot/efi", "/boot"), pf)
+	devices, mounts, err := osbuild.GenBootupdDevicesMounts(filename, testdisk.MakeFakeBtrfsPartitionTable("/", "/home", "/boot/efi", "/boot", "swap"), pf)
 	require.Nil(t, err)
 	assert.Equal(t, devices, map[string]osbuild.Device{
 		"disk": {
@@ -319,7 +332,7 @@ func TestGenBootupdDevicesMountsHappyBtrfs(t *testing.T) {
 			Source:    "disk",
 			Target:    "/",
 			Options:   osbuild.BtrfsMountOptions{Subvol: "root", Compress: "zstd:1"},
-			Partition: common.ToPtr(3),
+			Partition: common.ToPtr(4),
 		},
 		{
 			Name:      "boot",
@@ -341,7 +354,7 @@ func TestGenBootupdDevicesMountsHappyBtrfs(t *testing.T) {
 			Source:    "disk",
 			Target:    "/home",
 			Options:   osbuild.BtrfsMountOptions{Subvol: "/home", Compress: "zstd:1"},
-			Partition: common.ToPtr(3),
+			Partition: common.ToPtr(4),
 		},
 	}, mounts)
 }
@@ -353,7 +366,7 @@ func TestGenBootupdDevicesMountsHappyLVM(t *testing.T) {
 		UEFIVendor:   "test",
 	}
 
-	fakePt := testdisk.MakeFakeLVMPartitionTable("/", "/home", "/boot/efi", "/boot")
+	fakePt := testdisk.MakeFakeLVMPartitionTable("/", "/home", "/boot/efi", "/boot", "swap")
 	devices, mounts, err := osbuild.GenBootupdDevicesMounts(filename, fakePt, pf)
 	require.Nil(t, err)
 	assert.Equal(t, devices, map[string]osbuild.Device{
@@ -377,6 +390,14 @@ func TestGenBootupdDevicesMountsHappyLVM(t *testing.T) {
 			Parent: "disk",
 			Options: &osbuild.LVM2LVDeviceOptions{
 				Volume:    "lv-for-/home",
+				VGPartnum: common.ToPtr(3),
+			},
+		},
+		"lv-for-swap": {
+			Type:   "org.osbuild.lvm2.lv",
+			Parent: "disk",
+			Options: &osbuild.LVM2LVDeviceOptions{
+				Volume:    "lv-for-swap",
 				VGPartnum: common.ToPtr(3),
 			},
 		},

--- a/pkg/osbuild/device.go
+++ b/pkg/osbuild/device.go
@@ -244,6 +244,8 @@ func pathEscape(path string) string {
 // - source is the name of the device that the mount should be created from.
 // The name of the mount is derived from the mountpoint of the mountable, escaped with pathEscape. This shouldn't
 // create any conflicts, as the mountpoint is unique within the partition table.
+// This function returns nil if the Mountable is swap, as it doesn't make sense to do anything with it
+// during build.
 func genOsbuildMount(source string, mnt disk.Mountable) (*Mount, error) {
 	mountpoint := mnt.GetMountpoint()
 	name := pathEscape(mountpoint)
@@ -261,6 +263,8 @@ func genOsbuildMount(source string, mnt disk.Mountable) (*Mount, error) {
 		} else {
 			return nil, fmt.Errorf("mounting bare btrfs partition is unsupported: %s", mountpoint)
 		}
+	case "swap":
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("unknown fs type " + t)
 	}
@@ -283,6 +287,9 @@ func GenMountsDevicesFromPT(filename string, pt *disk.PartitionTable) (string, [
 		mount, err := genOsbuildMount(leafDeviceName, mnt)
 		if err != nil {
 			return err
+		}
+		if mount == nil {
+			return nil
 		}
 
 		mountpoint := mnt.GetMountpoint()

--- a/pkg/osbuild/device_test.go
+++ b/pkg/osbuild/device_test.go
@@ -189,7 +189,7 @@ func TestMountsDeviceFromPtNoRootErrors(t *testing.T) {
 
 func TestMountsDeviceFromPtHappy(t *testing.T) {
 	filename := "fake-disk.img"
-	fakePt := testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
+	fakePt := testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi", "swap")
 	fsRootMntName, mounts, devices, err := GenMountsDevicesFromPT(filename, fakePt)
 	require.Nil(t, err)
 	assert.Equal(t, fsRootMntName, "-")
@@ -225,7 +225,7 @@ func TestMountsDeviceFromPtHappy(t *testing.T) {
 
 func TestMountsDeviceFromBrfs(t *testing.T) {
 	filename := "fake-disk.img"
-	fakePt := testdisk.MakeFakeBtrfsPartitionTable("/", "/boot")
+	fakePt := testdisk.MakeFakeBtrfsPartitionTable("/", "/boot", "swap")
 	fsRootMntName, mounts, devices, err := GenMountsDevicesFromPT(filename, fakePt)
 	require.Nil(t, err)
 	assert.Equal(t, "-", fsRootMntName)
@@ -245,7 +245,7 @@ func TestMountsDeviceFromBrfs(t *testing.T) {
 			Type: "org.osbuild.loopback",
 			Options: &LoopbackDeviceOptions{
 				Filename: "fake-disk.img",
-				Start:    1 * common.GiB / 512,
+				Start:    2 * common.GiB / 512,
 				Size:     9 * common.GiB / 512,
 			},
 		},

--- a/pkg/osbuild/fstab_stage_test.go
+++ b/pkg/osbuild/fstab_stage_test.go
@@ -3,7 +3,10 @@ package osbuild
 import (
 	"testing"
 
+	"github.com/osbuild/images/internal/testdisk"
+	"github.com/osbuild/images/pkg/disk"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewFSTabStage(t *testing.T) {
@@ -49,4 +52,36 @@ func TestAddFilesystem(t *testing.T) {
 		assert.Equal(t, options.FileSystems[i], fs)
 	}
 	assert.Equal(t, len(filesystems), len(options.FileSystems))
+}
+
+func TestNewFSTabStageOptions(t *testing.T) {
+	pt := testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi", "/home")
+
+	opts, err := NewFSTabStageOptions(pt)
+	require.NoError(t, err)
+
+	assert.Equal(t, &FSTabStageOptions{
+		FileSystems: []*FSTabEntry{
+			{
+				UUID:    disk.RootPartitionUUID,
+				VFSType: "ext4",
+				Path:    "/",
+			},
+			{
+				UUID:    disk.FilesystemDataUUID,
+				VFSType: "ext4",
+				Path:    "/boot",
+			},
+			{
+				UUID:    disk.EFIFilesystemUUID,
+				VFSType: "vfat",
+				Path:    "/boot/efi",
+			},
+			{
+				UUID:    disk.FilesystemDataUUID,
+				VFSType: "ext4",
+				Path:    "/home",
+			},
+		},
+	}, opts)
 }

--- a/pkg/osbuild/fstab_stage_test.go
+++ b/pkg/osbuild/fstab_stage_test.go
@@ -55,7 +55,7 @@ func TestAddFilesystem(t *testing.T) {
 }
 
 func TestNewFSTabStageOptions(t *testing.T) {
-	pt := testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi", "/home")
+	pt := testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi", "/home", "swap")
 
 	opts, err := NewFSTabStageOptions(pt)
 	require.NoError(t, err)
@@ -81,6 +81,10 @@ func TestNewFSTabStageOptions(t *testing.T) {
 				UUID:    disk.FilesystemDataUUID,
 				VFSType: "ext4",
 				Path:    "/home",
+			},
+			{
+				VFSType: "swap",
+				Path:    "none",
 			},
 		},
 	}, opts)

--- a/pkg/osbuild/mkfs_stage.go
+++ b/pkg/osbuild/mkfs_stage.go
@@ -65,6 +65,12 @@ func GenMkfsStages(pt *disk.PartitionTable, filename string) []*Stage {
 				Label: fsSpec.Label,
 			}
 			stage = NewMkfsExt4Stage(options, stageDevices)
+		case "swap":
+			options := &MkswapStageOptions{
+				UUID:  fsSpec.UUID,
+				Label: fsSpec.Label,
+			}
+			stage = NewMkswapStage(options, stageDevices)
 		default:
 			panic("unknown fs type " + t)
 		}

--- a/pkg/osbuild/mkswap_stage.go
+++ b/pkg/osbuild/mkswap_stage.go
@@ -1,0 +1,16 @@
+package osbuild
+
+type MkswapStageOptions struct {
+	UUID  string `json:"uuid"`
+	Label string `json:"label,omitempty"`
+}
+
+func (MkswapStageOptions) isStageOptions() {}
+
+func NewMkswapStage(options *MkswapStageOptions, devices map[string]Device) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.mkswap",
+		Options: options,
+		Devices: devices,
+	}
+}


### PR DESCRIPTION
```toml
[[customizations.filesystem]]
type = "swap"
minsize = "10 GiB"
```

now creates a swap partition (or a LV, the usual decision rules between a regular partition an LV apply).

---

After some pondering, I decided that swap is just `Filesystem` with type `swap` and a mountpoint forced/faked to `none`. Thus, I added a new `type` field into the filesystem customization. For now, it supports unset and swap only, but extending it should not be hard. ;)

However, swap is a weird mountpoint:
- It's not possible nor desirable to mount it during build time, so I have to filter it out when generating mounts.
- It's not possible to create a swap mountpoint as a btrfs subvolume, so I had to invent a new mechanism that finds a different container if the firstly selected fails. Example: By default, we create new filesystem as close as possible to the root mountpoint. So, if / is a btrfs subvolume, we make all extra mountpoints sibling subvolumes. However, it's not possible to create a swap subvolume, so in this case the code goes up and tries to create the swap partition as a sibling to the btrfs partition. So swap is created in this case as either a top-level partition, or as an LV (if you have btrfs inside an LV for some reason).

In other cases, it shares properties of other mountpoints:
- It must have an mkswap stage.
- It must be inserted into fstab.

So is `swap` actually a `Filesystem`? It's murky. I'm open to suggestions. The other alternative would be to define a new `Swap` entity that does not implement `Mountable`, but then we would need to have special cases for swap when generating `mkfs` stages and `fstab`. Also, the `MountpointCreator` mechanism would have to be separate (`SwapCreator`?). This sounds more convoluted to me.

One can also argue that it's not needed to define a new `type` in the filesystem customization, `mountpoint == swap` would also do the trick. However, I think that swap is rather a filesystem type (see e.g. fstab) than a mountpoint path.

TODO list (nothing feels blocking, though):
- The code generates an LV device for swap for the bootc stage. I ran out of time while investigating this, but I'm worried that we will need to restructure the code quite a bit to remove this. Nevertheless, it's not harmful, just pointless.
- I would love to see integration tests for this. Maybe Achilleas can help me with adding it into one of the test blueprints. (I ran out of time to do this before my PTO).
- I relaxed the unmarshal validation rules for both TOML and JSON a bit. I think they should be more strict again, e.g. a non-swap mountpoint must not have an empty path. However, this validation should probably live outside the unmarshaller.

Depends on:
- #885 
- osbuild/osbuild#1872