### PR TITLE
blueprint: return nil instead of empty user slice in GetUsers()

### DIFF
--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -228,7 +228,7 @@ func (c *Customizations) GetTimezoneSettings() (*string, []string) {
 }
 
 func (c *Customizations) GetUsers() []UserCustomization {
-	if c == nil {
+	if c == nil || (c.SSHKey == nil && c.User == nil) {
 		return nil
 	}
 


### PR DESCRIPTION
Callers of GetUser() do not expect to receive an empty slice, which is causing unexpected condition handling.

https://github.com/osbuild/images/blob/e734c0c716d5d93d6daca1433491eb6e67d74945/pkg/distro/rhel/rhel9/options.go#L106-L107
https://github.com/osbuild/images/blob/e734c0c716d5d93d6daca1433491eb6e67d74945/pkg/distro/rhel/rhel9/options.go#L210-L211