### PR TITLE
otk-gen-partition-table: add `part_type` to supported inputs

### DIFF
--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -55,6 +55,7 @@ type InputPartition struct {
 	Size       string `json:"size"`
 	Type       string `json:"type"`
 	PartUUID   string `json:"part_uuid"`
+	PartType   string `json:"part_type"`
 	FsUUID     string `json:"fs_uuid"`
 	FSMntOps   string `json:"fs_mntops"`
 	FSFreq     uint64 `json:"fs_freq"`
@@ -164,6 +165,7 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 		pt.Partitions = append(pt.Partitions, disk.Partition{
 			Size: uintSize,
 			UUID: part.PartUUID,
+			Type: part.PartType,
 			// XXX: support lvm,luks here
 			Payload: &disk.Filesystem{
 				Label:        part.Label,

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -34,7 +34,8 @@ var partInputsComplete = `
       "mountpoint": "/",
       "label": "root",
       "size": "7 GiB",
-      "type": "ext4"
+      "type": "ext4",
+      "part_uuid": "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
     },
     {
       "name": "home",
@@ -70,6 +71,7 @@ var expectedInput = &genpart.Input{
 			Label:      "root",
 			Size:       "7 GiB",
 			Type:       "ext4",
+			PartUUID:   "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
 		}, {
 			Name:       "home",
 			Mountpoint: "/home",
@@ -113,6 +115,7 @@ func TestUnmarshalOutput(t *testing.T) {
 					Partitions: []disk.Partition{
 						{
 							UUID: "911911",
+							Type: "119119",
 							Payload: &disk.Filesystem{
 								Type: "ext4",
 							},
@@ -143,7 +146,7 @@ func TestUnmarshalOutput(t *testing.T) {
           {
             "Start": 0,
             "Size": 0,
-            "Type": "",
+            "Type": "119119",
             "Bootable": false,
             "UUID": "911911",
             "Payload": {


### PR DESCRIPTION
We need this to generate bit-by-bit compatible manifests from otk to the ones that `images` generates.

See also https://github.com/osbuild/otk/pull/186

We should probably think about generating this automatically but this unblocks otk for now.