### PR TITLE
blueprint: some test tweaks

### DIFF
--- a/pkg/blueprint/filesystem_customizations_test.go
+++ b/pkg/blueprint/filesystem_customizations_test.go
@@ -10,7 +10,32 @@ import (
 	"github.com/osbuild/images/pkg/pathpolicy"
 )
 
-// Happy tests for unmarshallers are in blueprint_test.go
+// ensure all fields that are supported are filled here
+var allFieldsFsc = FilesystemCustomization{
+	Mountpoint: "/data",
+	MinSize:    1234567890,
+}
+
+func TestFilesystemCustomizationMarshalUnmarshalTOML(t *testing.T) {
+	b, err := toml.Marshal(allFieldsFsc)
+	assert.NoError(t, err)
+
+	var fsc FilesystemCustomization
+	err = toml.Unmarshal(b, &fsc)
+	assert.NoError(t, err)
+	assert.Equal(t, fsc, allFieldsFsc)
+}
+
+func TestFilesystemCustomizationMarshalUnmarshalJSON(t *testing.T) {
+	b, err := json.Marshal(allFieldsFsc)
+	assert.NoError(t, err)
+
+	var fsc FilesystemCustomization
+	err = json.Unmarshal(b, &fsc)
+	assert.NoError(t, err)
+	assert.Equal(t, fsc, allFieldsFsc)
+}
+
 func TestFilesystemCustomizationUnmarshalTOMLUnhappy(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/pkg/blueprint/filesystem_customizations_test.go
+++ b/pkg/blueprint/filesystem_customizations_test.go
@@ -1,4 +1,4 @@
-package blueprint
+package blueprint_test
 
 import (
 	"encoding/json"
@@ -7,11 +7,12 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/pathpolicy"
 )
 
 // ensure all fields that are supported are filled here
-var allFieldsFsc = FilesystemCustomization{
+var allFieldsFsc = blueprint.FilesystemCustomization{
 	Mountpoint: "/data",
 	MinSize:    1234567890,
 }
@@ -20,7 +21,7 @@ func TestFilesystemCustomizationMarshalUnmarshalTOML(t *testing.T) {
 	b, err := toml.Marshal(allFieldsFsc)
 	assert.NoError(t, err)
 
-	var fsc FilesystemCustomization
+	var fsc blueprint.FilesystemCustomization
 	err = toml.Unmarshal(b, &fsc)
 	assert.NoError(t, err)
 	assert.Equal(t, fsc, allFieldsFsc)
@@ -30,7 +31,7 @@ func TestFilesystemCustomizationMarshalUnmarshalJSON(t *testing.T) {
 	b, err := json.Marshal(allFieldsFsc)
 	assert.NoError(t, err)
 
-	var fsc FilesystemCustomization
+	var fsc blueprint.FilesystemCustomization
 	err = json.Unmarshal(b, &fsc)
 	assert.NoError(t, err)
 	assert.Equal(t, fsc, allFieldsFsc)
@@ -64,7 +65,7 @@ func TestFilesystemCustomizationUnmarshalTOMLUnhappy(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			var fsc FilesystemCustomization
+			var fsc blueprint.FilesystemCustomization
 			err := toml.Unmarshal([]byte(c.input), &fsc)
 			assert.EqualError(t, err, c.err)
 		})
@@ -96,7 +97,7 @@ func TestFilesystemCustomizationUnmarshalJSONUnhappy(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			var fsc FilesystemCustomization
+			var fsc blueprint.FilesystemCustomization
 			err := json.Unmarshal([]byte(c.input), &fsc)
 			assert.EqualError(t, err, c.err)
 		})
@@ -108,7 +109,7 @@ func TestCheckMountpointsPolicy(t *testing.T) {
 		"/": {Exact: true},
 	})
 
-	mps := []FilesystemCustomization{
+	mps := []blueprint.FilesystemCustomization{
 		{Mountpoint: "/foo"},
 		{Mountpoint: "/boot/"},
 	}
@@ -116,6 +117,6 @@ func TestCheckMountpointsPolicy(t *testing.T) {
 	expectedErr := `The following errors occurred while setting up custom mountpoints:
 path "/foo" is not allowed
 path "/boot/" must be canonical`
-	err := CheckMountpointsPolicy(mps, policy)
+	err := blueprint.CheckMountpointsPolicy(mps, policy)
 	assert.EqualError(t, err, expectedErr)
 }


### PR DESCRIPTION
Small followup for https://github.com/osbuild/images/pull/885

blueprint: extend TestBlueprintParse to make "drift" less
 likely

By using the same content encoded in toml/json it is less likely
that there is drift between json/toml when unmarshaling.

---

blueprint: add marshal/unmarshal symetry test

Ensure that marshal/unmarshal are symetric by marshaling and then
unmarshaling to ensure all fields are marshaled/unmarhaled to
the same struct values.


----

blueprint: move test to `blueprint_test` test pattern

