### PR TITLE
os: disable dracut for ostree based systems on rpm installation

### DIFF
--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -424,6 +424,12 @@ func (p *OS) serialize() osbuild.Pipeline {
 	if p.OSTreeRef != "" {
 		rpmOptions.OSTreeBooted = common.ToPtr(true)
 		rpmOptions.DBPath = "/usr/share/rpm"
+		// The dracut-config-rescue package will create a rescue kernel when
+		// installed. This creates an issue with ostree-based images because
+		// rpm-ostree requires that only one kernel exists in the image.
+		// Disabling dracut for ostree-based systems resolves this issue.
+		// Dracut will be run by rpm-ostree itself while composing the image.
+		// https://github.com/osbuild/images/issues/624
 		rpmOptions.DisableDracut = true
 	}
 	pipeline.AddStage(osbuild.NewRPMStage(rpmOptions, osbuild.NewRpmStageSourceFilesInputs(p.packageSpecs)))

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -424,6 +424,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 	if p.OSTreeRef != "" {
 		rpmOptions.OSTreeBooted = common.ToPtr(true)
 		rpmOptions.DBPath = "/usr/share/rpm"
+		rpmOptions.DisableDracut = true
 	}
 	pipeline.AddStage(osbuild.NewRPMStage(rpmOptions, osbuild.NewRpmStageSourceFilesInputs(p.packageSpecs)))
 

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -91,6 +91,22 @@
       "edge-ami"
     ]
   },
+  "./configs/minimal-environment.json": {
+    "image-types": [
+      "edge-container"
+    ],
+    "distros": [
+      "rhel-9*"
+    ]
+  },
+  "./configs/edge-ostree-pull-user-minimalenv.json": {
+    "image-types": [
+      "edge-ami"
+    ],
+    "distros": [
+      "rhel-9*"
+    ]
+  },
   "./configs/embed-containers-2.json": {
     "image-types": [
       "edge-container"

--- a/test/configs/edge-ostree-pull-user-minimalenv.json
+++ b/test/configs/edge-ostree-pull-user-minimalenv.json
@@ -1,0 +1,25 @@
+{
+  "name": "edge-ostree-pull-user-minimalenv",
+  "blueprint": {
+    "customizations": {
+      "user": [
+        {
+          "groups": [
+            "wheel"
+          ],
+          "key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNebAh6SjpAn8wB53K4695cGnHGuCtl4RdaX3futZgJUultHyzeYHnzMO7d4++qnRL+Rworew62LKP560uvtncc= github.com/osbuild/images",
+          "name": "osbuild"
+        }
+      ]
+    }
+  },
+  "depends": {
+    "config": "minimal-environment.json",
+    "image-type": "edge-container"
+  },
+  "options": {
+    "ostree": {
+      "url": "http://example.com/repo"
+    }
+  }
+}

--- a/test/configs/minimal-environment.json
+++ b/test/configs/minimal-environment.json
@@ -1,0 +1,10 @@
+{
+  "name": "minimal-environment",
+  "blueprint": {
+    "groups": [
+      {
+        "name": "minimal-environment"
+      }
+    ]
+  }
+}

--- a/test/scripts/generate-ostree-build-config
+++ b/test/scripts/generate-ostree-build-config
@@ -280,7 +280,7 @@ def setup_dependencies(manifests, config_map, distro, arch):
     finally:
         if container_ids:
             print("📦 Stopping containers")
-            out, _ = testlib.runcmd(["sudo", "podman", "stop", " ".join(container_ids)])
+            out, _ = testlib.runcmd(["sudo", "podman", "stop", *container_ids])
             print(out.decode())
 
 


### PR DESCRIPTION
Installing the `minimal-environment` RPM group implies the installation
of `dracut-config-rescue` which makes `org.osbuild.ostree.preptree` to
fail because `rpm-ostree` detects multiple kernels within the tree
(the usual one and the rescue one). Disabling dracut during the rpm
installation prevents the rescue kernel/initrd to be generated and
makes `rpm-ostree` to finish the compose succesfully.

`rpm-ostree` runs dracut on his own during the compose so this doesn't
seem to affect the final result.

Resolves: #624
