### PR TITLE
cmd/otk-*: do basic input validation to avoid crashing too easily

### DIFF
--- a/cmd/otk-make-fstab-stage/main.go
+++ b/cmd/otk-make-fstab-stage/main.go
@@ -20,6 +20,9 @@ func run(r io.Reader, w io.Writer) error {
 	if err := json.NewDecoder(r).Decode(&inp); err != nil {
 		return err
 	}
+	if err := inp.Tree.Validate(); err != nil {
+		return fmt.Errorf("cannot validate input data: %w", err)
+	}
 
 	opts, err := osbuild.NewFSTabStageOptions(inp.Tree.Const.Internal.PartitionTable)
 	if err != nil {

--- a/cmd/otk-make-fstab-stage/main_test.go
+++ b/cmd/otk-make-fstab-stage/main_test.go
@@ -62,3 +62,10 @@ func TestIntegration(t *testing.T) {
 
 	assert.Equal(t, expectedStages, fakeStdout.String())
 }
+
+func TestIntegrationNoPartitionTable(t *testing.T) {
+	fakeStdin := bytes.NewBufferString(`{}`)
+	fakeStdout := bytes.NewBuffer(nil)
+	err := makefstab.Run(fakeStdin, fakeStdout)
+	assert.EqualError(t, err, "cannot validate input data: no partition table")
+}

--- a/cmd/otk-make-partition-mounts-devices/main.go
+++ b/cmd/otk-make-partition-mounts-devices/main.go
@@ -25,6 +25,9 @@ func run(r io.Reader, w io.Writer) error {
 	if err := json.NewDecoder(r).Decode(&inp); err != nil {
 		return err
 	}
+	if err := inp.Tree.Validate(); err != nil {
+		return fmt.Errorf("cannot validate input data: %w", err)
+	}
 
 	rootMntName, mounts, devices, err := osbuild.GenMountsDevicesFromPT(inp.Tree.Const.Filename, inp.Tree.Const.Internal.PartitionTable)
 	if err != nil {

--- a/cmd/otk-make-partition-mounts-devices/main_test.go
+++ b/cmd/otk-make-partition-mounts-devices/main_test.go
@@ -81,3 +81,10 @@ func TestIntegration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOutput, fakeStdout.String())
 }
+
+func TestIntegrationNoPartitionTable(t *testing.T) {
+	fakeStdin := bytes.NewBufferString(`{}`)
+	fakeStdout := bytes.NewBuffer(nil)
+	err := mkdevmnt.Run(fakeStdin, fakeStdout)
+	assert.EqualError(t, err, "cannot validate input data: no partition table")
+}

--- a/cmd/otk-make-partition-stages/main.go
+++ b/cmd/otk-make-partition-stages/main.go
@@ -34,6 +34,9 @@ func run(r io.Reader, w io.Writer) error {
 	if err := json.NewDecoder(r).Decode(&inp); err != nil {
 		return err
 	}
+	if err := inp.Tree.Validate(); err != nil {
+		return fmt.Errorf("cannot validate input data: %w", err)
+	}
 
 	stages, err := makeImagePrepareStages(inp, inp.Tree.Const.Filename)
 	if err != nil {

--- a/cmd/otk-make-partition-stages/main_test.go
+++ b/cmd/otk-make-partition-stages/main_test.go
@@ -125,3 +125,10 @@ func TestModificationFname(t *testing.T) {
 
 	assert.Equal(t, expectedStages, fakeStdout.String())
 }
+
+func TestIntegrationNoPartitionTable(t *testing.T) {
+	fakeStdin := bytes.NewBufferString(`{}`)
+	fakeStdout := bytes.NewBuffer(nil)
+	err := makestages.Run(fakeStdin, fakeStdout)
+	assert.EqualError(t, err, "cannot validate input data: no partition table")
+}

--- a/internal/otkdisk/partition.go
+++ b/internal/otkdisk/partition.go
@@ -15,6 +15,11 @@ type Data struct {
 	Const Const `json:"const"`
 }
 
+// Validate does basic validation of the data
+func (d Data) Validate() error {
+	return d.Const.Internal.Validate()
+}
+
 // Const contains partition table data that is considered "constant",
 // i.e.  that should not be modified by the consumer as there may be
 // inter-dependencies between the values
@@ -50,6 +55,14 @@ type Partition struct {
 // "otk-{gen,make}-*" tools for their data exchange.
 type Internal struct {
 	PartitionTable *disk.PartitionTable `json:"partition-table"`
+}
+
+// Validate does basic validation of the internal data
+func (i Internal) Validate() error {
+	if i.PartitionTable == nil {
+		return fmt.Errorf("no partition table")
+	}
+	return nil
 }
 
 // PartType represents a partition type

--- a/internal/otkdisk/partition_test.go
+++ b/internal/otkdisk/partition_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/images/internal/otkdisk"
+	"github.com/osbuild/images/pkg/disk"
 )
 
 func TestPartTypeValidationHappy(t *testing.T) {
@@ -16,4 +17,14 @@ func TestPartTypeValidationHappy(t *testing.T) {
 func TestPartTypeValidationSad(t *testing.T) {
 	assert.EqualError(t, otkdisk.PartTypeUnset.Validate(), `unsupported partition type ""`)
 	assert.EqualError(t, otkdisk.PartType("foo").Validate(), `unsupported partition type "foo"`)
+}
+
+func TestDataValidates(t *testing.T) {
+	// sad
+	d := otkdisk.Data{}
+	assert.EqualError(t, d.Validate(), "no partition table")
+	// happy
+	d.Const.Internal.PartitionTable = &disk.PartitionTable{}
+	err := d.Validate()
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
This commit is a lesson from https://github.com/osbuild/otk/pull/186 as it is right now extremly easy to crash the otk disk externals with bad inputs.

This commit adds basic input validation, it's probably a good idea to also go deeper into the library and make it less trusting about pointers but that is (slightly) orthogonal.