### PR TITLE
cmd/build: add new `--manifest-only`, `--manifest-path` and `-arch` options

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -198,11 +198,11 @@ func run() error {
 	var distroName, imgTypeName, configFile string
 	flag.StringVar(&distroName, "distro", "", "distribution (required)")
 	flag.StringVar(&imgTypeName, "type", "", "image type name (required)")
-	flag.StringVar(&configFile, "config", "", "build config file (required)")
+	flag.StringVar(&configFile, "config", "", "build config file")
 
 	flag.Parse()
 
-	if distroName == "" || imgTypeName == "" || configFile == "" {
+	if distroName == "" || imgTypeName == "" {
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -213,9 +213,14 @@ func run() error {
 	}
 	distroFac := distrofactory.NewDefault()
 
-	config, err := buildconfig.New(configFile)
-	if err != nil {
-		return err
+	var config *buildconfig.BuildConfig
+	if configFile != "" {
+		config, err = buildconfig.New(configFile)
+		if err != nil {
+			return err
+		}
+	} else {
+		config = &buildconfig.BuildConfig{}
 	}
 
 	if err := os.MkdirAll(outputDir, 0777); err != nil {
@@ -254,7 +259,7 @@ func run() error {
 		return fmt.Errorf("no repositories defined for %s/%s\n", distroName, archName)
 	}
 
-	fmt.Printf("Generating manifest for %s\n", config.Name)
+	fmt.Printf("Generating manifest for %s", config.Name)
 	mf, err := makeManifest(config, imgType, distribution, repos, archName, rpmCacheRoot)
 	if err != nil {
 		return err

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -184,9 +184,11 @@ func filterRepos(repos []rpmmd.RepoConfig, typeName string) []rpmmd.RepoConfig {
 func run() error {
 	// common args
 	var outputDir, osbuildStore, rpmCacheRoot string
+	var manifestOnly bool
 	flag.StringVar(&outputDir, "output", ".", "artifact output directory")
 	flag.StringVar(&osbuildStore, "store", ".osbuild", "osbuild store for intermediate pipeline trees")
 	flag.StringVar(&rpmCacheRoot, "rpmmd", "/tmp/rpmmd", "rpm metadata cache directory")
+	flag.BoolVar(&manifestOnly, "manifest-only", false, "only build the manifest, do not run osbuild")
 
 	// osbuild checkpoint arg
 	var checkpoints cmdutil.MultiValue
@@ -252,7 +254,7 @@ func run() error {
 		return fmt.Errorf("no repositories defined for %s/%s\n", distroName, archName)
 	}
 
-	fmt.Printf("Generating manifest for %s: ", config.Name)
+	fmt.Printf("Generating manifest for %s\n", config.Name)
 	mf, err := makeManifest(config, imgType, distribution, repos, archName, rpmCacheRoot)
 	if err != nil {
 		return err
@@ -262,6 +264,9 @@ func run() error {
 	manifestPath := filepath.Join(buildDir, "manifest.json")
 	if err := save(mf, manifestPath); err != nil {
 		return err
+	}
+	if manifestOnly {
+		return nil
 	}
 
 	fmt.Printf("Building manifest: %s\n", manifestPath)

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -199,10 +199,11 @@ func run() error {
 	flag.Var(&checkpoints, "checkpoints", "comma-separated list of pipeline names to checkpoint (passed to osbuild --checkpoint)")
 
 	// image selection args
-	var distroName, imgTypeName, configFile string
+	var distroName, imgTypeName, configFile, targetArch string
 	flag.StringVar(&distroName, "distro", "", "distribution (required)")
 	flag.StringVar(&imgTypeName, "type", "", "image type name (required)")
 	flag.StringVar(&configFile, "config", "", "build config file")
+	flag.StringVar(&targetArch, "target-arch", "", "target architecture to use, mostly for -manifest-only")
 
 	flag.Parse()
 
@@ -232,7 +233,12 @@ func run() error {
 		return fmt.Errorf("invalid or unsupported distribution: %q", distroName)
 	}
 
-	archName := arch.Current().String()
+	var archName string
+	if targetArch != "" {
+		archName = targetArch
+	} else {
+		archName = arch.Current().String()
+	}
 	arch, err := distribution.GetArch(archName)
 	if err != nil {
 		return fmt.Errorf("invalid arch name %q for distro %q: %s\n", archName, distroName, err.Error())


### PR DESCRIPTION
This PR tweaks the `build` binary to make it easier for `otk` to use it to generate reference images. With the tweaks here the tests in otk can generate reference images via:
```
$ go run github.com/osbuild/images/cmd/build@latest -type -distro centos-9 type qcow2 -arch aarch64 -manifest-only -manifest-path test/data/reference-images/<our-location>
````
that can then be used to validate that the otk generated images are identical to the ones generated by `images`