### PR TITLE
[RFC] reporegistry: embed the test repo in the go binary for easier use

### DIFF
--- a/pkg/reporegistry/reporegistry.go
+++ b/pkg/reporegistry/reporegistry.go
@@ -2,10 +2,17 @@ package reporegistry
 
 import (
 	"fmt"
+	"io/fs"
 
 	"github.com/osbuild/images/pkg/distroidparser"
 	"github.com/osbuild/images/pkg/rpmmd"
+	"github.com/osbuild/images/test"
 )
+
+type TestRepoFS interface {
+	fs.ReadFileFS
+	fs.ReadDirFS
+}
 
 // RepoRegistry represents a database of distro and architecture
 // specific RPM repositories. Image types are considered only
@@ -16,7 +23,7 @@ type RepoRegistry struct {
 
 // New returns a new RepoRegistry instance with the data
 // loaded from the given repoConfigPaths
-func New(repoConfigPaths []string) (*RepoRegistry, error) {
+func New(fsys TestRepoFS, repoConfigPaths []string) (*RepoRegistry, error) {
 	repositories, err := LoadAllRepositories(repoConfigPaths)
 	if err != nil {
 		return nil, err
@@ -28,8 +35,8 @@ func New(repoConfigPaths []string) (*RepoRegistry, error) {
 // NewTestedDefault returns a new RepoRegistry instance with the data
 // loaded from the default test repositories
 func NewTestedDefault() (*RepoRegistry, error) {
-	testReposPath := []string{"./test/data"}
-	return New(testReposPath)
+	testReposPath := []string{"./data"}
+	return New(testdata.Content, testReposPath)
 }
 
 func NewFromDistrosRepoConfigs(distrosRepoConfigs rpmmd.DistrosRepoConfigs) *RepoRegistry {

--- a/pkg/rpmmd/repository.go
+++ b/pkg/rpmmd/repository.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -225,17 +226,11 @@ func GetVerStrFromPackageSpecListPanic(pkgs []PackageSpec, packageName string) s
 	return pkgVerStr
 }
 
-func LoadRepositoriesFromFile(filename string) (map[string][]RepoConfig, error) {
-	f, err := os.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
+func LoadRepositoriesFromReader(r io.Reader) (map[string][]RepoConfig, error) {
 	var reposMap map[string][]repository
 	repoConfigs := make(map[string][]RepoConfig)
 
-	err = json.NewDecoder(f).Decode(&reposMap)
+	err := json.NewDecoder(r).Decode(&reposMap)
 	if err != nil {
 		return nil, err
 	}
@@ -273,6 +268,16 @@ func LoadRepositoriesFromFile(filename string) (map[string][]RepoConfig, error) 
 	}
 
 	return repoConfigs, nil
+}
+
+func LoadRepositoriesFromFile(filename string) (map[string][]RepoConfig, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return LoadRepositoriesFromReader(f)
 }
 
 func (packages PackageList) Search(globPatterns ...string) (PackageList, error) {

--- a/test/testdata.go
+++ b/test/testdata.go
@@ -1,0 +1,6 @@
+package testdata
+
+import "embed"
+
+//go:embed data
+var Content embed.FS


### PR DESCRIPTION
[draft as this needs splitting into two commits, more tests and is also a bit of a discussion starter if it's a good idea, it will also make the binaries bigger, e.g. the "build" binary increases from 25MB -> 28MB (stripped), otoh only things that "import testdata" will be affected so should not be too bad]

Running `cmd/build/build` currently requires running it from a git checkout so that it can find the required repository files.

This commit embeds them into the binary via "go:embed" to make it easier to use `build` on it's own.

This will make working with `otk` to generate reference images easier.