### PR TITLE
osbuild: add openscap profile and compliance policy id to facts 

### DIFF
--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -145,7 +145,7 @@ func osCustomizations(
 	}
 
 	if t.IsRHEL() && options.Facts != nil {
-		osc.FactAPIType = &options.Facts.APIType
+		osc.RHSMFacts = options.Facts
 	}
 
 	var err error

--- a/pkg/osbuild/rhsm_facts_stage.go
+++ b/pkg/osbuild/rhsm_facts_stage.go
@@ -5,7 +5,9 @@ type RHSMFactsStageOptions struct {
 }
 
 type RHSMFacts struct {
-	ApiType string `json:"image-builder.osbuild-composer.api-type"`
+	ApiType            string `json:"image-builder.osbuild-composer.api-type"`
+	OpenSCAPProfileID  string `json:"image-builder.insights.openscap-profile-id,omitempty"`
+	CompliancePolicyID string `json:"image-builder.insights.compliance-policy-id,omitempty"`
 }
 
 func (RHSMFactsStageOptions) isStageOptions() {}

--- a/pkg/osbuild/rhsm_facts_stage_test.go
+++ b/pkg/osbuild/rhsm_facts_stage_test.go
@@ -32,6 +32,25 @@ func TestRHSMFactsStageJson(t *testing.T) {
 			},
 			JsonString: fmt.Sprintf(`{"facts":{"image-builder.osbuild-composer.api-type":"%s"}}`, "test-api"),
 		},
+		{
+			Options: RHSMFactsStageOptions{
+				Facts: RHSMFacts{
+					ApiType:           "test-api",
+					OpenSCAPProfileID: "test-profile-id",
+				},
+			},
+			JsonString: fmt.Sprintf(`{"facts":{"image-builder.osbuild-composer.api-type":"%s","image-builder.insights.openscap-profile-id":"%s"}}`, "test-api", "test-profile-id"),
+		},
+		{
+			Options: RHSMFactsStageOptions{
+				Facts: RHSMFacts{
+					ApiType:            "test-api",
+					OpenSCAPProfileID:  "test-profile-id",
+					CompliancePolicyID: "test-compliance-policy-id",
+				},
+			},
+			JsonString: fmt.Sprintf(`{"facts":{"image-builder.osbuild-composer.api-type":"%s","image-builder.insights.openscap-profile-id":"%s","image-builder.insights.compliance-policy-id":"%s"}}`, "test-api", "test-profile-id", "test-compliance-policy-id"),
+		},
 	}
 	for _, test := range tests {
 		marshaledJson, err := json.Marshal(test.Options)

--- a/pkg/rhsm/facts/facts.go
+++ b/pkg/rhsm/facts/facts.go
@@ -1,6 +1,10 @@
 package facts
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
 
 type APIType uint64
 
@@ -25,5 +29,7 @@ const (
 // The ImageOptions specify things to be stored into the Insights facts
 // storage. This mostly relates to how the build of the image was performed.
 type ImageOptions struct {
-	APIType APIType
+	APIType            APIType
+	OpenSCAPProfileID  string
+	CompliancePolicyID uuid.UUID
 }


### PR DESCRIPTION
Allows registered systems to be coupled to existing compliance policies.

---

As it stands this would require composer to fill in these facts in the image options as it does for the api types. For the openscap profile id we could fill it in automatically if an openscap customisation is defined, open to opinions.