### PR TITLE
github: don't fail fast on cs unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,7 @@ jobs:
             image_tag: stream9
           - version: 10
             image_tag: stream10-development
+      fail-fast: false  # if one fails, keep the other(s) running
     name: "🛃 Unit tests (CentOS Stream ${{ matrix.centos_stream.version }})"
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
CentOS Stream 10 unit tests are currently failing due to an issue with the repositories and we are making it non-essential for merging. However, the fail-fast property defaults to true, which causes the CentOS Stream 9 tests to get cancelled when 10 fails.

Disable fail-fast so that C9S tests keep running when C10S tests fail.