### PR TITLE
Distro/RHEL-10: remove dracut config for gdisk

### DIFF
--- a/pkg/distro/rhel/rhel10/ami.go
+++ b/pkg/distro/rhel/rhel10/ami.go
@@ -96,15 +96,6 @@ func baseEc2ImageConfig() *distro.ImageConfig {
 				},
 			},
 		},
-		// COMPOSER-1807
-		DracutConf: []*osbuild.DracutConfStageOptions{
-			{
-				Filename: "sgdisk.conf",
-				Config: osbuild.DracutConfigFile{
-					Install: []string{"sgdisk"},
-				},
-			},
-		},
 		SystemdUnit: []*osbuild.SystemdUnitStageOptions{
 			// RHBZ#1822863
 			{


### PR DESCRIPTION
The same has been removed from c10s images.

See https://gitlab.com/redhat/centos-stream/release-engineering/kickstarts/-/merge_requests/50
See https://issues.redhat.com/browse/RHEL-55750?focusedId=25451931&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-25451931