### PR TITLE
Test configs for RHEL 10

### DIFF
--- a/test/config-map.json
+++ b/test/config-map.json
@@ -1,6 +1,7 @@
 {
   "./configs/all-customizations.json": {
     "distros": [
+      "rhel-10*",
       "rhel-9*",
       "rhel-8*",
       "centos*",


### PR DESCRIPTION
The all-customizations config is limited to RHEL 8 and 9 because a lot of the customizations aren't supported on RHEL 7.  Let's also add RHEL 10 to the mix.