### PR TITLE
image: add `vhd`/`vpc` support to `BootcDiskImage`

### DIFF
--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -75,6 +75,9 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 	vmdkPipeline := manifest.NewVMDK(hostPipeline, rawImage)
 	vmdkPipeline.SetFilename(fmt.Sprintf("%s.vmdk", fileBasename))
 
+	vhdPipeline := manifest.NewVPC(hostPipeline, rawImage)
+	vhdPipeline.SetFilename(fmt.Sprintf("%s.vhd", fileBasename))
+
 	ovfPipeline := manifest.NewOVF(hostPipeline, vmdkPipeline)
 	tarPipeline := manifest.NewTar(hostPipeline, ovfPipeline, "archive")
 	tarPipeline.Format = osbuild.TarArchiveFormatUstar
@@ -84,6 +87,7 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 		fmt.Sprintf("%s.ovf", fileBasename),
 		fmt.Sprintf("%s.mf", fileBasename),
 		fmt.Sprintf("%s.vmdk", fileBasename),
+		fmt.Sprintf("%s.vhd", fileBasename),
 	}
 	return nil
 }

--- a/pkg/image/bootc_disk_test.go
+++ b/pkg/image/bootc_disk_test.go
@@ -130,6 +130,15 @@ func TestBootcDiskImageInstantiateNoBuildpipelineForQcow2(t *testing.T) {
 	assert.Equal(t, qcowPipeline["build"], nil)
 }
 
+func TestBootcDiskImageInstantiateNoBuildpipelineForVpc(t *testing.T) {
+	osbuildManifest := makeBootcDiskImageOsbuildManifest(t, nil)
+
+	vpcPipeline := findPipelineFromOsbuildManifest(t, osbuildManifest, "vpc")
+	require.NotNil(t, vpcPipeline)
+	// no build pipeline for vpc
+	assert.Equal(t, vpcPipeline["build"], nil)
+}
+
 func TestBootcDiskImageInstantiateVmdk(t *testing.T) {
 	opts := &bootcDiskImageTestOpts{ImageFormat: platform.FORMAT_VMDK}
 	osbuildManifest := makeBootcDiskImageOsbuildManifest(t, opts)
@@ -184,6 +193,10 @@ func TestBootcDiskImageExportPipelines(t *testing.T) {
 	// vmdk pipeline for the vmdk
 	vmdkPipeline := findPipelineFromOsbuildManifest(t, osbuildManifest, "vmdk")
 	require.NotNil(vmdkPipeline)
+
+	// vpc pipeline for the vhd
+	vpcPipeline := findPipelineFromOsbuildManifest(t, osbuildManifest, "vpc")
+	require.NotNil(vpcPipeline)
 
 	// tar pipeline for ova
 	tarPipeline := findPipelineFromOsbuildManifest(t, osbuildManifest, "archive")


### PR DESCRIPTION
This will help konflux to build azure/vhd images directly. 

The corresponding `bib` change can be found in https://github.com/osbuild/bootc-image-builder/pull/634.

Closes: https://github.com/osbuild/bootc-image-builder/issues/132
