### PR TITLE
manifest: add `sync` to kickstart for bootc iso installer

### DIFF
--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -515,6 +515,7 @@ halt --eject
 bootc switch --mutate-in-place --transport %s %s
 
 # used during automatic image testing as finished marker
+sync
 if [ -c /dev/ttyS0 ]; then
     echo "Install finished" > /dev/ttyS0
 fi


### PR DESCRIPTION
Small followup for #714 - to add an extra level of safety call "sync" before signaling that the install is finished.

[draft as this will get a coresponding bib PR to ensure it works correctly]