### PR TITLE
pkg/osbuild: replace openscap with compliance in rhsm facts

### DIFF
--- a/pkg/osbuild/rhsm_facts_stage.go
+++ b/pkg/osbuild/rhsm_facts_stage.go
@@ -6,7 +6,7 @@ type RHSMFactsStageOptions struct {
 
 type RHSMFacts struct {
 	ApiType            string `json:"image-builder.osbuild-composer.api-type"`
-	OpenSCAPProfileID  string `json:"image-builder.insights.openscap-profile-id,omitempty"`
+	OpenSCAPProfileID  string `json:"image-builder.insights.compliance-profile-id,omitempty"`
 	CompliancePolicyID string `json:"image-builder.insights.compliance-policy-id,omitempty"`
 }
 

--- a/pkg/osbuild/rhsm_facts_stage_test.go
+++ b/pkg/osbuild/rhsm_facts_stage_test.go
@@ -39,7 +39,7 @@ func TestRHSMFactsStageJson(t *testing.T) {
 					OpenSCAPProfileID: "test-profile-id",
 				},
 			},
-			JsonString: fmt.Sprintf(`{"facts":{"image-builder.osbuild-composer.api-type":"%s","image-builder.insights.openscap-profile-id":"%s"}}`, "test-api", "test-profile-id"),
+			JsonString: fmt.Sprintf(`{"facts":{"image-builder.osbuild-composer.api-type":"%s","image-builder.insights.compliance-profile-id":"%s"}}`, "test-api", "test-profile-id"),
 		},
 		{
 			Options: RHSMFactsStageOptions{
@@ -49,7 +49,7 @@ func TestRHSMFactsStageJson(t *testing.T) {
 					CompliancePolicyID: "test-compliance-policy-id",
 				},
 			},
-			JsonString: fmt.Sprintf(`{"facts":{"image-builder.osbuild-composer.api-type":"%s","image-builder.insights.openscap-profile-id":"%s","image-builder.insights.compliance-policy-id":"%s"}}`, "test-api", "test-profile-id", "test-compliance-policy-id"),
+			JsonString: fmt.Sprintf(`{"facts":{"image-builder.osbuild-composer.api-type":"%s","image-builder.insights.compliance-profile-id":"%s","image-builder.insights.compliance-policy-id":"%s"}}`, "test-api", "test-profile-id", "test-compliance-policy-id"),
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
The name `openscap` should be avoided in favour of compliance where possible.