### PR TITLE
Revert "manifest: switch to `halt --eject` to avoid auto-reboot"

### DIFF
--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -507,7 +507,7 @@ reqpart --add-boot
 part swap --fstype=swap --size=1024
 part / --fstype=ext4 --grow
 
-halt --eject
+reboot --eject
 `
 
 	// Workaround for lack of --target-imgref in Anaconda, xref https://github.com/osbuild/images/issues/380


### PR DESCRIPTION
This reverts commit 002c25d5b2f664ace182e8f1aefaf1557814a8a3.

We are currently seeing issue with the `bootc-image-builder` iso tests, this maybe the culprit.

[edit: with this revert it seems like the error that we are curerntly seeing goes away so we need to look at this again - but let's first revert to unblock images]