### PR TITLE
fedora-iot: move bootupd to f41

### DIFF
--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -182,10 +182,11 @@ func iotCommitPackageSet(t *imageType) rpmmd.PackageSet {
 				"podman-plugins", // deprecated in podman 5
 			},
 		})
-	} else {
+	}
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "41") {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
-				"bootupd", // added in F40+
+				"bootupd", // Added in F41+
 			},
 		})
 	}


### PR DESCRIPTION
This PR moves the addition of `bootupd` to the `iot-commit` package set from Fedora 40 to 41. 

The change to include `bootupd` was deferred to Fedora 41 and causes issues with the [bootloader in F40](https://github.com/fedora-iot/iot-distro/issues/58)

