### PR TITLE
Remove dnsmasq from base package set for edge-commit in RHEL 9.6+ (THEEDGE-4012)

### DIFF
--- a/pkg/distro/rhel/rhel9/edge.go
+++ b/pkg/distro/rhel/rhel9/edge.go
@@ -670,7 +670,6 @@ func edgeCommitPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 			"NetworkManager-wifi",
 			"NetworkManager-wwan",
 			"wpa_supplicant",
-			"dnsmasq",
 			"traceroute",
 			"hostname",
 			"iproute",
@@ -723,6 +722,11 @@ func edgeCommitPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 
 	if common.VersionGreaterThanOrEqual(t.Arch().Distro().OsVersion(), "9.2") || !t.IsRHEL() {
 		ps.Include = append(ps.Include, "ignition", "ignition-edge", "ssh-key-dir")
+	}
+
+	if common.VersionLessThan(t.Arch().Distro().OsVersion(), "9.6") {
+		// dnsmasq removed in 9.6+ but kept in older versions
+		ps.Include = append(ps.Include, "dnsmasq")
 	}
 
 	return ps


### PR DESCRIPTION
CIS Level 1 server compliance requires to remove the dnsmasq package.  This is not possible with RHEL for Edge images because it is part of the base image.

THEEDGE-4012

~~DRAFT:~~
- ~~Based on PR #920.~~
- ~~The decision hasn't been finalised yet.~~