### PR TITLE
image: add new `gce` pipeline to `BootcDiskImage`

### DIFF
--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -3,7 +3,9 @@ package image
 import (
 	"fmt"
 	"math/rand"
+	"regexp"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/disk"
@@ -89,5 +91,17 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 		fmt.Sprintf("%s.vmdk", fileBasename),
 		fmt.Sprintf("%s.vhd", fileBasename),
 	}
+
+	// XXX: copied from https://github.com/osbuild/images/blob/v0.85.0/pkg/image/disk.go#L102
+	gcePipeline := manifest.NewTar(buildPipeline, rawImage, "gce")
+	gcePipeline.Format = osbuild.TarArchiveFormatOldgnu
+	gcePipeline.RootNode = osbuild.TarRootNodeOmit
+	// these are required to successfully import the image to GCP
+	gcePipeline.ACLs = common.ToPtr(false)
+	gcePipeline.SELinux = common.ToPtr(false)
+	gcePipeline.Xattrs = common.ToPtr(false)
+	gcePipeline.Transform = fmt.Sprintf(`s/%s/disk.raw/`, regexp.QuoteMeta(rawImage.Filename()))
+	gcePipeline.SetFilename("image.tgz")
+
 	return nil
 }

--- a/pkg/image/bootc_disk_test.go
+++ b/pkg/image/bootc_disk_test.go
@@ -201,6 +201,10 @@ func TestBootcDiskImageExportPipelines(t *testing.T) {
 	// tar pipeline for ova
 	tarPipeline := findPipelineFromOsbuildManifest(t, osbuildManifest, "archive")
 	require.NotNil(tarPipeline)
+
+	// gce pipeline
+	gcePipeline := findPipelineFromOsbuildManifest(t, osbuildManifest, "gce")
+	require.NotNil(gcePipeline)
 }
 
 func TestBootcDiskImageInstantiateUsers(t *testing.T) {

--- a/pkg/manifest/export_test.go
+++ b/pkg/manifest/export_test.go
@@ -1,3 +1,11 @@
 package manifest
 
+import (
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
 var FindStage = findStage
+
+func (p *Tar) Serialize() osbuild.Pipeline {
+	return p.serialize()
+}

--- a/pkg/manifest/tar.go
+++ b/pkg/manifest/tar.go
@@ -10,12 +10,13 @@ type Tar struct {
 	Base
 	filename string
 
-	Format   osbuild.TarArchiveFormat
-	RootNode osbuild.TarRootNode
-	Paths    []string
-	ACLs     *bool
-	SELinux  *bool
-	Xattrs   *bool
+	Format    osbuild.TarArchiveFormat
+	RootNode  osbuild.TarRootNode
+	Paths     []string
+	ACLs      *bool
+	SELinux   *bool
+	Xattrs    *bool
+	Transform string
 
 	inputPipeline Pipeline
 }
@@ -50,13 +51,14 @@ func (p *Tar) serialize() osbuild.Pipeline {
 	pipeline := p.Base.serialize()
 
 	tarOptions := &osbuild.TarStageOptions{
-		Filename: p.Filename(),
-		Format:   p.Format,
-		ACLs:     p.ACLs,
-		SELinux:  p.SELinux,
-		Xattrs:   p.Xattrs,
-		RootNode: p.RootNode,
-		Paths:    p.Paths,
+		Filename:  p.Filename(),
+		Format:    p.Format,
+		ACLs:      p.ACLs,
+		SELinux:   p.SELinux,
+		Xattrs:    p.Xattrs,
+		RootNode:  p.RootNode,
+		Paths:     p.Paths,
+		Transform: p.Transform,
 	}
 	tarStage := osbuild.NewTarStage(tarOptions, p.inputPipeline.Name())
 	pipeline.AddStage(tarStage)

--- a/pkg/manifest/tar_test.go
+++ b/pkg/manifest/tar_test.go
@@ -1,0 +1,35 @@
+package manifest_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/osbuild"
+	"github.com/osbuild/images/pkg/runner"
+)
+
+func TestTarSerialize(t *testing.T) {
+	mani := manifest.New()
+	runner := &runner.Linux{}
+	build := manifest.NewBuild(&mani, runner, nil, nil)
+
+	// setup
+	rawImage := manifest.NewRawImage(build, nil)
+	tarPipeline := manifest.NewTar(build, rawImage, "tar-pipeline")
+	tarPipeline.SetFilename("filename.tar")
+	tarPipeline.Transform = "s/foo/bar"
+
+	// run
+	osbuildPipeline := tarPipeline.Serialize()
+
+	// assert
+	assert.Equal(t, "tar-pipeline", osbuildPipeline.Name)
+	assert.Equal(t, 1, len(osbuildPipeline.Stages))
+	tarStage := osbuildPipeline.Stages[0]
+	assert.Equal(t, &osbuild.TarStageOptions{
+		Filename:  "filename.tar",
+		Transform: "s/foo/bar",
+	}, tarStage.Options.(*osbuild.TarStageOptions))
+}

--- a/pkg/osbuild/tar_stage.go
+++ b/pkg/osbuild/tar_stage.go
@@ -42,6 +42,9 @@ type TarStageOptions struct {
 
 	// List of paths to include, instead of the whole tree
 	Paths []string `json:"paths,omitempty"`
+
+	// Pass --transform=...
+	Transform string `json:"transform,omitempty"`
 }
 
 func (TarStageOptions) isStageOptions() {}

--- a/pkg/osbuild/tar_stage_test.go
+++ b/pkg/osbuild/tar_stage_test.go
@@ -1,6 +1,7 @@
 package osbuild
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -76,4 +77,17 @@ func TestTarStageOptionsValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTarStageOptionsJSON(t *testing.T) {
+	stageOptions := &TarStageOptions{
+		Filename:  "archive.tar.xz",
+		Transform: "s/foo/bar/",
+	}
+	b, err := json.MarshalIndent(stageOptions, "", "  ")
+	assert.NoError(t, err)
+	assert.Equal(t, string(b), `{
+  "filename": "archive.tar.xz",
+  "transform": "s/foo/bar/"
+}`)
 }


### PR DESCRIPTION
There is a request that we provide a new image type that can
be imported directly into GCE. This requires a `tar.gz` with
a `disk.raw` inside and specific tar options.

This commit adds the needed pipeline to generate this.

Note that this will require a way to rename files during
the tar build as we do not want to hardcode the raw image
filename.

This needs https://github.com/osbuild/osbuild/pull/1886 and will be used in https://github.com/osbuild/bootc-image-builder/pull/646