### PR TITLE
Add default OpenSCAP datastream for RHEL10 & cs10 images

### DIFF
--- a/pkg/customizations/oscap/oscap.go
+++ b/pkg/customizations/oscap/oscap.go
@@ -37,11 +37,13 @@ const (
 	StigGui               Profile = "xccdf_org.ssgproject.content_profile_stig_gui"
 
 	// datastream fallbacks
-	defaultFedoraDatastream  string = "/usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml"
-	defaultCentos8Datastream string = "/usr/share/xml/scap/ssg/content/ssg-centos8-ds.xml"
-	defaultCentos9Datastream string = "/usr/share/xml/scap/ssg/content/ssg-cs9-ds.xml"
-	defaultRHEL8Datastream   string = "/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml"
-	defaultRHEL9Datastream   string = "/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml"
+	defaultFedoraDatastream   string = "/usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml"
+	defaultCentos8Datastream  string = "/usr/share/xml/scap/ssg/content/ssg-centos8-ds.xml"
+	defaultCentos9Datastream  string = "/usr/share/xml/scap/ssg/content/ssg-cs9-ds.xml"
+	defaultCentos10Datastream string = "/usr/share/xml/scap/ssg/content/ssg-cs10-ds.xml"
+	defaultRHEL8Datastream    string = "/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml"
+	defaultRHEL9Datastream    string = "/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml"
+	defaultRHEL10Datastream   string = "/usr/share/xml/scap/ssg/content/ssg-rhel10-ds.xml"
 
 	// oscap related directories
 	DataDir string = "/oscap_data"
@@ -137,6 +139,13 @@ func DefaultRHEL9Datastream(isRHEL bool) string {
 		return defaultRHEL9Datastream
 	}
 	return defaultCentos9Datastream
+}
+
+func DefaultRHEL10Datastream(isRHEL bool) string {
+	if isRHEL {
+		return defaultRHEL10Datastream
+	}
+	return defaultCentos10Datastream
 }
 
 func IsProfileAllowed(profile string, allowlist []Profile) bool {

--- a/pkg/distro/rhel/rhel10/distro.go
+++ b/pkg/distro/rhel/rhel10/distro.go
@@ -65,6 +65,7 @@ func defaultDistroImageConfig(d *rhel.Distribution) *distro.ImageConfig {
 				},
 			},
 		},
+		DefaultOSCAPDatastream: common.ToPtr(oscap.DefaultRHEL10Datastream(d.IsRHEL())),
 	}
 }
 

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -229,6 +229,14 @@
       "ami"
     ]
   },
+  "./configs/oscap-rhel10.json": {
+    "distros": [
+      "rhel-10.0"
+    ],
+    "image-types": [
+      "ami"
+    ]
+  },
   "./configs/ostree.json": {
     "image-types": [
       "edge-commit",

--- a/test/configs/oscap-rhel10.json
+++ b/test/configs/oscap-rhel10.json
@@ -1,0 +1,27 @@
+{
+  "name": "oscap-rhel10",
+  "blueprint": {
+    "packages": [
+      {
+        "name": "xmlstarlet"
+      },
+      {
+        "name": "openscap-utils"
+      },
+      {
+        "name": "jq"
+      }
+    ],
+    "customizations": {
+      "openscap": {
+        "profile_id": "xccdf_org.ssgproject.content_profile_cis",
+        "datastream": "/usr/share/xml/scap/ssg/content/ssg-rhel10-ds.xml",
+        "tailoring": {
+          "unselected": [
+            "grub2_password"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
We were missing the default OpenSCAP datastream for RHEL10 and centos stream 10 distros.