### PR TITLE
blueprint: remove the sshkey customization

### DIFF
--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -12,7 +12,6 @@ import (
 type Customizations struct {
 	Hostname           *string                        `json:"hostname,omitempty" toml:"hostname,omitempty"`
 	Kernel             *KernelCustomization           `json:"kernel,omitempty" toml:"kernel,omitempty"`
-	SSHKey             []SSHKeyCustomization          `json:"sshkey,omitempty" toml:"sshkey,omitempty"`
 	User               []UserCustomization            `json:"user,omitempty" toml:"user,omitempty"`
 	Group              []GroupCustomization           `json:"group,omitempty" toml:"group,omitempty"`
 	Timezone           *TimezoneCustomization         `json:"timezone,omitempty" toml:"timezone,omitempty"`
@@ -228,24 +227,11 @@ func (c *Customizations) GetTimezoneSettings() (*string, []string) {
 }
 
 func (c *Customizations) GetUsers() []UserCustomization {
-	if c == nil || (c.SSHKey == nil && c.User == nil) {
+	if c == nil || c.User == nil {
 		return nil
 	}
 
-	users := []UserCustomization{}
-
-	// prepend sshkey for backwards compat (overridden by users)
-	if len(c.SSHKey) > 0 {
-		for idx := range c.SSHKey {
-			keyc := c.SSHKey[idx]
-			users = append(users, UserCustomization{
-				Name: keyc.User,
-				Key:  &keyc.Key,
-			})
-		}
-	}
-
-	users = append(users, c.User...)
+	users := c.User
 
 	// sanitize user home directory in blueprint: if it has a trailing slash,
 	// it might lead to the directory not getting the correct selinux labels

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -76,24 +76,6 @@ func TestGetKernel(t *testing.T) {
 	assert.Equal(t, &expectedKernel, retKernel)
 }
 
-func TestSSHKey(t *testing.T) {
-	expectedSSHKeys := []SSHKeyCustomization{
-		{
-			User: "test-user",
-			Key:  "test-key",
-		},
-	}
-	TestCustomizations := Customizations{
-		SSHKey: expectedSSHKeys,
-	}
-
-	retUser := TestCustomizations.GetUsers()[0].Name
-	retKey := *TestCustomizations.GetUsers()[0].Key
-
-	assert.Equal(t, expectedSSHKeys[0].User, retUser)
-	assert.Equal(t, expectedSSHKeys[0].Key, retKey)
-}
-
 func TestGetUsers(t *testing.T) {
 	Desc := "Test descritpion"
 	Pass := "testpass"

--- a/test/configs/all-customizations.json
+++ b/test/configs/all-customizations.json
@@ -22,13 +22,11 @@
       "kernel": {
         "append": "debug"
       },
-      "sshkey": [
-        {
-          "user": "user1",
-          "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
-        }
-      ],
       "user": [
+        {
+          "name": "user1",
+          "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+        },
         {
           "name": "user2",
           "description": "description 2",

--- a/test/configs/all-with-fips.json
+++ b/test/configs/all-with-fips.json
@@ -23,13 +23,11 @@
         "append": "debug"
       },
       "fips": true,
-      "sshkey": [
-        {
-          "user": "user1",
-          "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
-        }
-      ],
       "user": [
+        {
+          "name": "user1",
+          "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+        },
         {
           "name": "user2",
           "description": "description 2",

--- a/test/configs/oscap-generic.json
+++ b/test/configs/oscap-generic.json
@@ -22,13 +22,11 @@
       "kernel": {
         "append": "debug"
       },
-      "sshkey": [
-        {
-          "user": "user1",
-          "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
-        }
-      ],
       "user": [
+        {
+          "name": "user1",
+          "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+        },
         {
           "name": "user2",
           "description": "description 2",


### PR DESCRIPTION
This is something I've mentioned a few times in the past but never got around to doing.  With the upcoming changes to partitioning (#926), I think this is a good opportunity to start with a proof of concept and the canonical example for customization simplification in images.  The general idea is that blueprints in osbuild-composer are the **canonical, user-facing version of the structure**.  The images counterpart has no obligation to maintain backwards compatibility, or even have the same exact structure as the real blueprints.

Extra considerations:
- We (well, @croissanne) recently (re)introduced the idea of moving blueprints out into its own project, and having a schema for the _actual real_ blueprint format.  I think this is a great idea and takes care of any issues of divergence between blueprint implementations.
- bootc-image-builder uses the blueprints code from this repository directly.  The particular change in this PR does not affect that project, since we never supported the sshkey customization there.
- In the past we discussed renaming the package and objects in this repository to something other than `blueprint`, to avoid any confusion about what they are.  In that case, any common structure would be considered incidental, and there would be much less implication about the structures here being a separate implementation of the same configs.

---

Both the sshkey and users customizations have been around since the beginning of time [1].  The users customization was always a superset of the sshkey, so we have code in blueprints to convert sshkeys into users.

The blueprint code in images is not exposed directly to users.  The code responsible for deserializing blueprint toml files lives in osbuild-composer and is directly translated to the equivalent types in osbuild/images.  We can simplify the code and types here to only contain the customizations that are strictly necessary and we don't need to maintain backwards compatibility.

The blueprint conversion code in osbuild-composer should convert all sshkeys to users before passing them down to osbuild/images functions.

[1] 967b0e8ce0e87c77a7c681b0c9f86d70f84711a5