### PR TITLE
cloud/gcp: update guest OS features to match prod RHEL images

### DIFF
--- a/docs/image-types/rhel8/google-gce.md
+++ b/docs/image-types/rhel8/google-gce.md
@@ -135,6 +135,12 @@ RHEL Guest Images are imported with the following Guest OS features set:
 * UEFI_COMPATIBLE
 * VIRTIO_SCSI_MULTIQUEUE
 * SEV_CAPABLE
+* SEV_SNP_CAPABLE
+* SEV_LIVE_MIGRATABLE
+* SEV_LIVE_MIGRATABLE_V2
+* GVNIC
+* IDPF
+
 
 [daisy-tool]: https://github.com/GoogleCloudPlatform/compute-image-tools/tree/master/daisy
 [daisy-wf-image_build-el]: https://github.com/GoogleCloudPlatform/compute-image-tools/tree/master/daisy_workflows/image_build/enterprise_linux

--- a/pkg/cloud/gcp/compute.go
+++ b/pkg/cloud/gcp/compute.go
@@ -12,21 +12,42 @@ import (
 	"github.com/osbuild/images/internal/common"
 )
 
+// Default Guest OS Features [1]. Note that officially Google creates the
+// RHEL images in the rhel-cloud project in the rhel8,rhel9,etc image
+// families. Periodically we'll want to make sure that the lists here
+// are up to date with what is being produced there. You can see this
+// with a command like:
+//    gcloud compute images describe-from-family --project rhel-cloud rhel-9
+//
+// Note also for the time being that we should make sure the image upload
+// code for CoreOS [2] should be kept in sync with this until CoreOS
+// starts using OSBuild for image uploading.
+//
+// [1] https://cloud.google.com/compute/docs/images/create-custom#guest-os-features
+// [2] https://github.com/coreos/coreos-assembler/blob/main/mantle/platform/api/gcloud/image.go
+
 // Guest OS Features for RHEL8 images
 var GuestOsFeaturesRHEL8 []*computepb.GuestOsFeature = []*computepb.GuestOsFeature{
 	{Type: common.ToPtr(computepb.GuestOsFeature_UEFI_COMPATIBLE.String())},
 	{Type: common.ToPtr(computepb.GuestOsFeature_VIRTIO_SCSI_MULTIQUEUE.String())},
 	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_CAPABLE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_SNP_CAPABLE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_LIVE_MIGRATABLE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_LIVE_MIGRATABLE_V2.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_GVNIC.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_IDPF.String())},
 }
 
-// Guest OS Features for RHEL9 images.  Note that if you update this, also
-// consider changing the code in https://github.com/coreos/coreos-assembler/blob/0083086c4720b602b8243effb85c0a1f73f013dd/mantle/platform/api/gcloud/image.go#L105
-// for RHEL CoreOS which uses coreos-assembler today.
+// Guest OS Features for RHEL9 images.
 var GuestOsFeaturesRHEL9 []*computepb.GuestOsFeature = []*computepb.GuestOsFeature{
 	{Type: common.ToPtr(computepb.GuestOsFeature_UEFI_COMPATIBLE.String())},
 	{Type: common.ToPtr(computepb.GuestOsFeature_VIRTIO_SCSI_MULTIQUEUE.String())},
 	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_CAPABLE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_SNP_CAPABLE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_LIVE_MIGRATABLE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_LIVE_MIGRATABLE_V2.String())},
 	{Type: common.ToPtr(computepb.GuestOsFeature_GVNIC.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_IDPF.String())},
 }
 
 // GuestOsFeaturesByDistro returns the the list of Guest OS Features, which


### PR DESCRIPTION
We need to update these to match what is being set for the rhel9 and rhel8 images produced by Google (on behalf of Red Hat) today.

Also rework the comments to add context.

```
root@24de7c60b75c:~# gcloud compute images describe-from-family --project rhel-cloud rhel-8
architecture: X86_64
archiveSizeBytes: '9314286336'
creationTimestamp: '2024-09-10T13:40:19.727-07:00'
description: Red Hat, Red Hat Enterprise Linux, 8, x86_64 built on 20240910
diskSizeGb: '20'
enableConfidentialCompute: false
family: rhel-8
guestOsFeatures:
- type: UEFI_COMPATIBLE
- type: VIRTIO_SCSI_MULTIQUEUE
- type: SEV_CAPABLE
- type: SEV_SNP_CAPABLE
- type: SEV_LIVE_MIGRATABLE
- type: SEV_LIVE_MIGRATABLE_V2
- type: GVNIC
- type: IDPF
id: '2720211119037550684'
kind: compute#image
labelFingerprint: 42WmSpB8rSM=
licenseCodes:
- '601259152637613565'
licenses:
- https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/licenses/rhel-8-server
name: rhel-8-v20240910
rawDisk:
  containerType: TAR
  source: ''
selfLink: https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-8-v20240910
sourceType: RAW
status: READY
storageLocations:
- asia
- us
- eu
```

```
root@24de7c60b75c:~# gcloud compute images describe-from-family --project rhel-cloud rhel-9
architecture: X86_64
archiveSizeBytes: '8386093056'
creationTimestamp: '2024-09-10T13:40:19.697-07:00'
description: Red Hat, Red Hat Enterprise Linux, 9, x86_64 built on 20240910
diskSizeGb: '20'
enableConfidentialCompute: false
family: rhel-9
guestOsFeatures:
- type: UEFI_COMPATIBLE
- type: VIRTIO_SCSI_MULTIQUEUE
- type: SEV_CAPABLE
- type: SEV_SNP_CAPABLE
- type: SEV_LIVE_MIGRATABLE
- type: SEV_LIVE_MIGRATABLE_V2
- type: GVNIC
- type: IDPF
id: '4739446824535658588'
kind: compute#image
labelFingerprint: 42WmSpB8rSM=
licenseCodes:
- '7883559014960410759'
licenses:
- https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/licenses/rhel-9-server
name: rhel-9-v20240910
rawDisk:
  containerType: TAR
  source: ''
selfLink: https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-9-v20240910
sourceType: RAW
status: READY
storageLocations:
- asia
- eu
- us
```