### PR TITLE
Add initial support for generating SPDX SBOM documents (COMPOSER-2274)

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -8,21 +8,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "d67fa48c170a0093807b12d674f13b175ba9d59b"
+        "commit": "3df75de65a5414866fa43133309c1fc67490a373"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "d67fa48c170a0093807b12d674f13b175ba9d59b"
+        "commit": "3df75de65a5414866fa43133309c1fc67490a373"
       }
     }
   },
   "fedora-39": {
     "dependencies": {
       "osbuild": {
-        "commit": "d67fa48c170a0093807b12d674f13b175ba9d59b"
+        "commit": "3df75de65a5414866fa43133309c1fc67490a373"
       }
     },
     "repos": [
@@ -65,7 +65,7 @@
   "fedora-40": {
     "dependencies": {
       "osbuild": {
-        "commit": "d67fa48c170a0093807b12d674f13b175ba9d59b"
+        "commit": "3df75de65a5414866fa43133309c1fc67490a373"
       }
     },
     "repos": [

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/osbuild/images/pkg/reporegistry"
 	"github.com/osbuild/images/pkg/rhsm/facts"
 	"github.com/osbuild/images/pkg/rpmmd"
+	"github.com/osbuild/images/pkg/sbom"
 )
 
 func makeManifest(
@@ -133,7 +134,7 @@ func depsolve(cacheDir string, packageSets map[string][]rpmmd.PackageSet, d dist
 	depsolvedSets := make(map[string][]rpmmd.PackageSpec)
 	repoSets := make(map[string][]rpmmd.RepoConfig)
 	for name, pkgSet := range packageSets {
-		pkgs, repos, err := solver.Depsolve(pkgSet)
+		pkgs, repos, _, err := solver.Depsolve(pkgSet, sbom.StandardTypeNone)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -134,12 +134,12 @@ func depsolve(cacheDir string, packageSets map[string][]rpmmd.PackageSet, d dist
 	depsolvedSets := make(map[string][]rpmmd.PackageSpec)
 	repoSets := make(map[string][]rpmmd.RepoConfig)
 	for name, pkgSet := range packageSets {
-		pkgs, repos, _, err := solver.Depsolve(pkgSet, sbom.StandardTypeNone)
+		res, err := solver.Depsolve(pkgSet, sbom.StandardTypeNone)
 		if err != nil {
 			return nil, nil, err
 		}
-		depsolvedSets[name] = pkgs
-		repoSets[name] = repos
+		depsolvedSets[name] = res.Packages
+		repoSets[name] = res.Repos
 	}
 	return depsolvedSets, repoSets, nil
 }

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/osbuild/images/pkg/reporegistry"
 	"github.com/osbuild/images/pkg/rhsm/facts"
 	"github.com/osbuild/images/pkg/rpmmd"
+	"github.com/osbuild/images/pkg/sbom"
 )
 
 type buildRequest struct {
@@ -357,7 +358,7 @@ func depsolve(cacheDir string, packageSets map[string][]rpmmd.PackageSet, d dist
 	depsolvedSets := make(map[string][]rpmmd.PackageSpec)
 	repoSets := make(map[string][]rpmmd.RepoConfig)
 	for name, pkgSet := range packageSets {
-		packages, repos, err := solver.Depsolve(pkgSet)
+		packages, repos, _, err := solver.Depsolve(pkgSet, sbom.StandardTypeNone)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -358,12 +358,12 @@ func depsolve(cacheDir string, packageSets map[string][]rpmmd.PackageSet, d dist
 	depsolvedSets := make(map[string][]rpmmd.PackageSpec)
 	repoSets := make(map[string][]rpmmd.RepoConfig)
 	for name, pkgSet := range packageSets {
-		packages, repos, _, err := solver.Depsolve(pkgSet, sbom.StandardTypeNone)
+		res, err := solver.Depsolve(pkgSet, sbom.StandardTypeNone)
 		if err != nil {
 			return nil, nil, err
 		}
-		depsolvedSets[name] = packages
-		repoSets[name] = repos
+		depsolvedSets[name] = res.Packages
+		repoSets[name] = res.Repos
 	}
 	return depsolvedSets, repoSets, nil
 }

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -14,6 +14,7 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/runner"
+	"github.com/osbuild/images/pkg/sbom"
 )
 
 func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos map[string][]rpmmd.RepoConfig, state_dir string) {
@@ -36,7 +37,7 @@ func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos
 
 	packageSpecs := make(map[string][]rpmmd.PackageSpec)
 	for name, chain := range manifest.GetPackageSetChains() {
-		packages, _, err := solver.Depsolve(chain)
+		packages, _, _, err := solver.Depsolve(chain, sbom.StandardTypeNone)
 		if err != nil {
 			panic(fmt.Sprintf("failed to depsolve for pipeline %s: %s\n", name, err.Error()))
 		}

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -37,11 +37,11 @@ func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos
 
 	packageSpecs := make(map[string][]rpmmd.PackageSpec)
 	for name, chain := range manifest.GetPackageSetChains() {
-		packages, _, _, err := solver.Depsolve(chain, sbom.StandardTypeNone)
+		res, err := solver.Depsolve(chain, sbom.StandardTypeNone)
 		if err != nil {
 			panic(fmt.Sprintf("failed to depsolve for pipeline %s: %s\n", name, err.Error()))
 		}
-		packageSpecs[name] = packages
+		packageSpecs[name] = res.Packages
 	}
 
 	if err := solver.CleanCache(); err != nil {

--- a/pkg/dnfjson/dnfjson.go
+++ b/pkg/dnfjson/dnfjson.go
@@ -724,10 +724,10 @@ type depsolveResult struct {
 	Repos    map[string]repoConfig `json:"repos"`
 
 	// (optional) contains the solver used, e.g. "dnf5"
-	Solver string `json:"solver"`
+	Solver string `json:"solver,omitempty"`
 
 	// (optional) contains the SBOM for the depsolved transaction
-	SBOM json.RawMessage `json:"sbom"`
+	SBOM json.RawMessage `json:"sbom,omitempty"`
 }
 
 // Package specification

--- a/pkg/sbom/document.go
+++ b/pkg/sbom/document.go
@@ -1,0 +1,70 @@
+package sbom
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type StandardType uint64
+
+const (
+	StandardTypeNone StandardType = iota
+	StandardTypeSpdx
+)
+
+func (t StandardType) String() string {
+	switch t {
+	case StandardTypeNone:
+		return "none"
+	case StandardTypeSpdx:
+		return "spdx"
+	default:
+		panic("invalid standard type")
+	}
+}
+
+func (t StandardType) MarshalJSON() ([]byte, error) {
+	var s string
+
+	if t == StandardTypeNone {
+		s = ""
+	} else {
+		s = t.String()
+	}
+
+	return json.Marshal(s)
+}
+
+func (t *StandardType) UnmarshalJSON(data []byte) error {
+	switch string(data) {
+	case `""`:
+		*t = StandardTypeNone
+	case `"spdx"`:
+		*t = StandardTypeSpdx
+	default:
+		return fmt.Errorf("invalid SBOM standard type: %s", data)
+	}
+	return nil
+}
+
+type Document struct {
+	// type of the document standard
+	DocType StandardType
+
+	// document in a specific standard JSON raw format
+	Document json.RawMessage
+}
+
+func NewDocument(docType StandardType, doc json.RawMessage) (*Document, error) {
+	switch docType {
+	case StandardTypeSpdx:
+		docType = StandardTypeSpdx
+	default:
+		return nil, fmt.Errorf("unsupported SBOM document type: %s", docType)
+	}
+
+	return &Document{
+		DocType:  docType,
+		Document: doc,
+	}, nil
+}

--- a/pkg/sbom/document_test.go
+++ b/pkg/sbom/document_test.go
@@ -1,0 +1,86 @@
+package sbom
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStandardTypeJSONUnmarhsall(t *testing.T) {
+	type testStruct struct {
+		Type     StandardType `json:"type"`
+		TypeOmit StandardType `json:"type_omit,omitempty"`
+	}
+
+	tests := []struct {
+		name string
+		data []byte
+		want testStruct
+	}{
+		{
+			name: "StandardTypeNone",
+			data: []byte(`{"type":""}`),
+			want: testStruct{
+				Type:     StandardTypeNone,
+				TypeOmit: StandardTypeNone,
+			},
+		},
+		{
+			name: "StandardTypeSpdx",
+			data: []byte(`{"type":"spdx","type_omit":"spdx"}`),
+			want: testStruct{
+				Type:     StandardTypeSpdx,
+				TypeOmit: StandardTypeSpdx,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ts testStruct
+			err := json.Unmarshal(tt.data, &ts)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, ts)
+		})
+	}
+}
+
+func TestStandardTypeJSONMarhsall(t *testing.T) {
+	type TestStruct struct {
+		Type     StandardType `json:"type"`
+		TypeOmit StandardType `json:"type_omit,omitempty"`
+	}
+
+	tests := []struct {
+		name string
+		want []byte
+		data TestStruct
+	}{
+		{
+			name: "StandardTypeNone",
+			want: []byte(`{"type":""}`),
+			data: TestStruct{
+				Type:     StandardTypeNone,
+				TypeOmit: StandardTypeNone,
+			},
+		},
+		{
+			name: "StandardTypeSpdx",
+			want: []byte(`{"type":"spdx","type_omit":"spdx"}`),
+			data: TestStruct{
+				Type:     StandardTypeSpdx,
+				TypeOmit: StandardTypeSpdx,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []byte
+			got, err := json.Marshal(tt.data)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This PR depends on https://github.com/osbuild/osbuild/pull/1818

- Add a simple `sbom` package for working with SBOM documents.
- Extend the `dnfjson` `Solver.Depsolve()` to support requesting SBOM documents for depsolved transactions.