### PR TITLE
github: don't fail fast on Fedora unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
           - 39
           - 40
           - 41
+      fail-fast: false  # if one fails, keep the other(s) running
     name: "🛃 Unit tests (Fedora ${{ matrix.fedora_version }})"
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Fedora 41 unit tests are currently failing due to an issue with the repositories and are non-essential for merging (which is common for rawhide and early branching periods).
However, the fail-fast property defaults to true, which causes the other Fedora tests to get cancelled when F41 fails.

Disable fail-fast so that F40 tests keep running when F41 tests fail.

This is the same change we made for CS tests
3b81a908327c740b95a86b630d993dfad31fe5cb (#904)

This PR is simple but high priority for unblocking other PRs from merging.