### PR TITLE
otk-gen-partition-table: support EFI system on DOS partitions

### DIFF
--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -56,6 +56,9 @@ const (
 
 	// Extended Boot Loader Partition
 	XBootLDRPartitionGUID = "BC13C2FF-59E6-4262-A352-B275FD6F7172"
+
+	// DosFat16B used for the ESP-System partition
+	DosFat16B = "06"
 )
 
 // Entity is the base interface for all disk-related entities.

--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -224,7 +224,7 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 		Partitions: []disk.Partition{
 			{
 				Size:     200 * common.MebiByte,
-				Type:     "06",
+				Type:     disk.DosFat16B,
 				Bootable: true,
 				Payload: &disk.Filesystem{
 					Type:         "vfat",
@@ -319,7 +319,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 		Partitions: []disk.Partition{
 			{
 				Size:     501 * common.MebiByte,
-				Type:     "06",
+				Type:     disk.DosFat16B,
 				Bootable: true,
 				Payload: &disk.Filesystem{
 					Type:         "vfat",


### PR DESCRIPTION
The existing code to create EFI system partitions was making
assumptions about running on a GPT partition. This is no longer
true with https://github.com/osbuild/otk/pull/199 so this commit
fixes the code to create a valid ESP system partition on a DOS
partition table.
