### PR TITLE
Add ostree commit resolver for otk: otk-resolve-ostree-commit (COMPOSER-2349)

### DIFF
--- a/cmd/otk-resolve-ostree-commit/export_test.go
+++ b/cmd/otk-resolve-ostree-commit/export_test.go
@@ -1,0 +1,5 @@
+package main
+
+var (
+	Run = run
+)

--- a/cmd/otk-resolve-ostree-commit/main.go
+++ b/cmd/otk-resolve-ostree-commit/main.go
@@ -1,0 +1,44 @@
+package main
+
+// All otk external inputs are nested under a top-level "tree"
+type Tree struct {
+	Tree Input `json:"tree"`
+}
+
+// Input represents the user-provided inputs that will be used to resolve an
+// ostree commit ID.
+type Input struct {
+	// URL of the repo where the commit can be fetched.
+	URL string `json:"url"`
+
+	// Ref to resolve.
+	Ref string `json:"ref"`
+
+	// Whether to use RHSM secrets when resolving and fetching the commit.
+	RHSM bool `json:"rhsm,omitempty"`
+}
+
+// Output contains everything needed to write a manifest that requires pulling
+// an ostree commit.
+type Output struct {
+	Const OutputConst `json:"const"`
+}
+
+type OutputConst struct {
+	// Ref of the commit (can be empty).
+	Ref string `json:"ref,omitempty"`
+
+	// URL of the repo where the commit can be fetched.
+	URL string `json:"url"`
+
+	// Secrets type to use when pulling the ostree commit content
+	// (e.g. org.osbuild.rhsm.consumer).
+	Secrets string `json:"secrets,omitempty"`
+
+	// Checksum of the commit.
+	Checksum string `json:"checksum"`
+}
+
+func main() {
+
+}

--- a/cmd/otk-resolve-ostree-commit/main_test.go
+++ b/cmd/otk-resolve-ostree-commit/main_test.go
@@ -1,0 +1,79 @@
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	resolver "github.com/osbuild/images/cmd/otk-resolve-ostree-commit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Create a test server that responds with the commit ID that corresponds to
+// the ref.
+func createTestServer(refIDs map[string]string) *httptest.Server {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/refs/heads/", func(w http.ResponseWriter, r *http.Request) {
+		reqRef := strings.TrimPrefix(r.URL.Path, "/refs/heads/")
+		id, ok := refIDs[reqRef]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprint(w, id)
+	})
+
+	return httptest.NewServer(handler)
+}
+
+func TestResolver(t *testing.T) {
+	commitMap := map[string]string{
+		"centos/9/x86_64/edge": "d04105393ca0617856b34f897842833d785522e41617e17dca2063bf97e294ef",
+		"fake/ref/f":           "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		"fake/ref/9":           "9999999999999999999999999999999999999999999999999999999999999999",
+		"test/ref/alpha":       "9b1ea9a8e10dc27d4ea40545bec028ad8e360dd26d18de64b0f6217833a8443d",
+		"test/ref/one":         "7433e1b49fb136d61dcca49ebe34e713fdbb8e29bf328fe90819628f71b86105",
+	}
+
+	require := require.New(t)
+	assert := assert.New(t)
+
+	repoServer := createTestServer(commitMap)
+	defer repoServer.Close()
+
+	url := repoServer.URL
+	for ref, id := range commitMap {
+		inputReq, err := json.Marshal(map[string]map[string]string{
+			"tree": {
+				"url": url,
+				"ref": ref,
+			},
+		})
+		require.NoError(err)
+
+		inpBuf := bytes.NewBuffer(inputReq)
+		outBuf := &bytes.Buffer{}
+
+		assert.NoError(resolver.Run(inpBuf, outBuf))
+
+		var output map[string]map[string]map[string]string
+		require.NoError(json.Unmarshal(outBuf.Bytes(), &output))
+
+		expOutput := map[string]map[string]map[string]string{
+			"tree": {
+				"const": {
+					"url":      url,
+					"ref":      ref,
+					"checksum": id,
+				},
+			},
+		}
+		assert.Equal(expOutput, output)
+	}
+
+}

--- a/cmd/otk-resolve-ostree-commit/main_test.go
+++ b/cmd/otk-resolve-ostree-commit/main_test.go
@@ -14,6 +14,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var commitMap = map[string]string{
+	"centos/9/x86_64/edge": "d04105393ca0617856b34f897842833d785522e41617e17dca2063bf97e294ef",
+	"fake/ref/f":           "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+	"fake/ref/9":           "9999999999999999999999999999999999999999999999999999999999999999",
+	"test/ref/alpha":       "9b1ea9a8e10dc27d4ea40545bec028ad8e360dd26d18de64b0f6217833a8443d",
+	"test/ref/one":         "7433e1b49fb136d61dcca49ebe34e713fdbb8e29bf328fe90819628f71b86105",
+}
+
 // Create a test server that responds with the commit ID that corresponds to
 // the ref.
 func createTestServer(refIDs map[string]string) *httptest.Server {
@@ -32,14 +40,6 @@ func createTestServer(refIDs map[string]string) *httptest.Server {
 }
 
 func TestResolver(t *testing.T) {
-	commitMap := map[string]string{
-		"centos/9/x86_64/edge": "d04105393ca0617856b34f897842833d785522e41617e17dca2063bf97e294ef",
-		"fake/ref/f":           "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-		"fake/ref/9":           "9999999999999999999999999999999999999999999999999999999999999999",
-		"test/ref/alpha":       "9b1ea9a8e10dc27d4ea40545bec028ad8e360dd26d18de64b0f6217833a8443d",
-		"test/ref/one":         "7433e1b49fb136d61dcca49ebe34e713fdbb8e29bf328fe90819628f71b86105",
-	}
-
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -75,5 +75,119 @@ func TestResolver(t *testing.T) {
 		}
 		assert.Equal(expOutput, output)
 	}
+}
 
+func TestResolverByID(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	for _, id := range commitMap {
+		inputReq, err := json.Marshal(map[string]map[string]string{
+			"tree": {
+				"ref": id,
+			},
+		})
+		require.NoError(err)
+
+		inpBuf := bytes.NewBuffer(inputReq)
+		outBuf := &bytes.Buffer{}
+
+		assert.NoError(resolver.Run(inpBuf, outBuf))
+
+		var output map[string]map[string]map[string]string
+		require.NoError(json.Unmarshal(outBuf.Bytes(), &output))
+
+		expOutput := map[string]map[string]map[string]string{
+			"tree": {
+				"const": {
+					"ref":      id,
+					"checksum": id,
+					"url":      "",
+				},
+			},
+		}
+		assert.Equal(expOutput, output)
+	}
+}
+func TestResolverIDwithURL(t *testing.T) {
+
+	require := require.New(t)
+	assert := assert.New(t)
+
+	// the URL is not used when the ref is a commit ID, but it should be returned in the output
+	url := "https://doesnt-matter.example.org"
+	for _, id := range commitMap {
+		inputReq, err := json.Marshal(map[string]map[string]string{
+			"tree": {
+				"ref": id,
+				"url": url,
+			},
+		})
+		require.NoError(err)
+
+		inpBuf := bytes.NewBuffer(inputReq)
+		outBuf := &bytes.Buffer{}
+
+		assert.NoError(resolver.Run(inpBuf, outBuf))
+
+		var output map[string]map[string]map[string]string
+		require.NoError(json.Unmarshal(outBuf.Bytes(), &output))
+
+		expOutput := map[string]map[string]map[string]string{
+			"tree": {
+				"const": {
+					"ref":      id,
+					"checksum": id,
+					"url":      url,
+				},
+			},
+		}
+		assert.Equal(expOutput, output)
+	}
+}
+
+func TestResolverErrors(t *testing.T) {
+
+	repoServer := createTestServer(commitMap)
+	defer repoServer.Close()
+
+	type testCase struct {
+		url          string
+		ref          string
+		errSubstring string
+	}
+
+	testCases := map[string]testCase{
+		"bad-ref": {
+			url:          "doesn't matter",
+			ref:          "---",
+			errSubstring: "Invalid ostree ref or commit",
+		},
+		"ref-not-found": {
+			url:          repoServer.URL,
+			ref:          "good/ref/but/does-not-exist",
+			errSubstring: "returned status: 404 Not Found",
+		},
+	}
+
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+
+			inputReq, err := json.Marshal(map[string]map[string]string{
+				"tree": {
+					"url": tc.url,
+					"ref": tc.ref,
+				},
+			})
+			require.NoError(err)
+
+			inpBuf := bytes.NewBuffer(inputReq)
+			outBuf := &bytes.Buffer{}
+
+			assert.ErrorContains(resolver.Run(inpBuf, outBuf), tc.errSubstring)
+		})
+	}
 }

--- a/pkg/ostree/ostree.go
+++ b/pkg/ostree/ostree.go
@@ -152,7 +152,10 @@ func ResolveRef(location, ref string, consumerCerts bool, subs *rhsm.Subscriptio
 	if consumerCerts {
 		if subs == nil {
 			subs, err = rhsm.LoadSystemSubscriptions()
-			if subs.Consumer == nil || err != nil {
+			if err != nil {
+				return "", NewResolveRefError("error adding rhsm certificates when resolving ref: %s", err)
+			}
+			if subs.Consumer == nil {
 				return "", NewResolveRefError("error adding rhsm certificates when resolving ref")
 			}
 		}


### PR DESCRIPTION
New `cmd` for resolving ostree commits for otk.

The resolver is a simple call to ostree.Resolve() which handles resolving ostree input options to an ostree.CommitSpec.

The resolver returns the input as-is when the ref is a commit ID (there is nothing to resolve).  This can happen when a user wants to pull an ostree commit by its ID rather than specifying a ref to resolve.