### PR TITLE
gen-manifests: create predictable version/release numbers in mockDepsolve

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/gobwas/glob"
@@ -375,11 +376,15 @@ func mockDepsolve(packageSets map[string][]rpmmd.PackageSet, repos []rpmmd.RepoC
 		for _, pkgSet := range pkgSetChain {
 			for _, pkgName := range pkgSet.Include {
 				checksum := fmt.Sprintf("%x", sha256.Sum256([]byte(pkgName)))
+				// generate predictable but non-empty
+				// release/version numbers
+				ver := strconv.Itoa(int(pkgName[0]) % 9)
+				rel := strconv.Itoa(int(pkgName[1]) % 9)
 				spec := rpmmd.PackageSpec{
 					Name:           pkgName,
 					Epoch:          0,
-					Version:        "0",
-					Release:        "0",
+					Version:        ver,
+					Release:        rel + ".fk1",
 					Arch:           "noarch",
 					RemoteLocation: fmt.Sprintf("https://example.com/repo/packages/%s", pkgName),
 					Checksum:       "sha256:" + checksum,


### PR DESCRIPTION
The current code will only generate "0" version numbers for packages and releases. This limits the usefulness of this mock in the tests for otk. Instead generate predictable but (mostly) non-zero numbers based on the modulo of the first and second char of the pkgname.

Useful for e.g. https://github.com/osbuild/otk/pull/196 as it will ensure that the `fragment/grub2.yaml` actually changes depending on the kernel name.