### PR TITLE
[RFC] gen-manifests: add excluded packages via `exclude:` prefix in mock

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -386,6 +386,20 @@ func mockDepsolve(packageSets map[string][]rpmmd.PackageSet, repos []rpmmd.RepoC
 				}
 				specSet = append(specSet, spec)
 			}
+			for _, excludeName := range pkgSet.Exclude {
+				pkgName := fmt.Sprintf("exclude:%s", excludeName)
+				checksum := fmt.Sprintf("%x", sha256.Sum256([]byte(pkgName)))
+				spec := rpmmd.PackageSpec{
+					Name:           pkgName,
+					Epoch:          0,
+					Version:        "0",
+					Release:        "0",
+					Arch:           "noarch",
+					RemoteLocation: fmt.Sprintf("https://example.com/repo/packages/%s", pkgName),
+					Checksum:       "sha256:" + checksum,
+				}
+				specSet = append(specSet, spec)
+			}
 		}
 		depsolvedSets[name] = specSet
 		repoSets[name] = repos


### PR DESCRIPTION
This commit adds excluded packages to the generated manifest when the `gen-manifests` command is run in the `mockDepsolve()` mode.

This allows us to compare the generated otk and images manifests with more confidence.