### PR TITLE
cmd/otk-resolve-ostree-commit: support mocking ostree resolve calls

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -338,16 +338,7 @@ func mockResolveCommits(commitSources map[string][]ostree.SourceSpec) map[string
 	for name, commitSources := range commitSources {
 		commitSpecs := make([]ostree.CommitSpec, len(commitSources))
 		for idx, commitSource := range commitSources {
-			checksum := fmt.Sprintf("%x", sha256.Sum256([]byte(commitSource.URL+commitSource.Ref)))
-			spec := ostree.CommitSpec{
-				Ref:      commitSource.Ref,
-				URL:      commitSource.URL,
-				Checksum: checksum,
-			}
-			if commitSource.RHSM {
-				spec.Secrets = "org.osbuild.rhsm.consumer"
-			}
-			commitSpecs[idx] = spec
+			commitSpecs[idx] = cmdutil.MockOSTreeResolve(commitSource)
 		}
 		commits[name] = commitSpecs
 	}

--- a/cmd/otk-resolve-ostree-commit/export_test.go
+++ b/cmd/otk-resolve-ostree-commit/export_test.go
@@ -3,3 +3,16 @@ package main
 var (
 	Run = run
 )
+
+func MockEnvLookup() (restore func()) {
+	saved := osLookupEnv
+	osLookupEnv = func(key string) (string, bool) {
+		if key == "OTK_UNDER_TEST" {
+			return "1", true
+		}
+		return "", false
+	}
+	return func() {
+		osLookupEnv = saved
+	}
+}

--- a/cmd/otk-resolve-ostree-commit/main_test.go
+++ b/cmd/otk-resolve-ostree-commit/main_test.go
@@ -191,3 +191,35 @@ func TestResolverErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestMockResolve(t *testing.T) {
+	restore := resolver.MockEnvLookup()
+	defer restore()
+
+	assert := assert.New(t)
+
+	inputReq := `
+{
+  "tree": {
+    "ref": "otk/ostree/test",
+    "url": "https://ostree.example.org/repo"
+  }
+}
+`
+	expOutput := `{
+  "tree": {
+    "const": {
+      "ref": "otk/ostree/test",
+      "url": "https://ostree.example.org/repo",
+      "checksum": "5c1c0655481926623eca85109dd4017c8dba320ea1473c42b43005db6d900a60"
+    }
+  }
+}
+`
+	input := bytes.NewBuffer([]byte(inputReq))
+	output := &bytes.Buffer{}
+
+	assert.NoError(resolver.Run(input, output))
+
+	assert.Equal(expOutput, output.String())
+}

--- a/internal/cmdutil/mock.go
+++ b/internal/cmdutil/mock.go
@@ -1,0 +1,21 @@
+package cmdutil
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/osbuild/images/pkg/ostree"
+)
+
+func MockOSTreeResolve(commitSource ostree.SourceSpec) ostree.CommitSpec {
+	checksum := fmt.Sprintf("%x", sha256.Sum256([]byte(commitSource.URL+commitSource.Ref)))
+	spec := ostree.CommitSpec{
+		Ref:      commitSource.Ref,
+		URL:      commitSource.URL,
+		Checksum: checksum,
+	}
+	if commitSource.RHSM {
+		spec.Secrets = "org.osbuild.rhsm.consumer"
+	}
+	return spec
+}


### PR DESCRIPTION
Read the OTK_UNDER_TEST env var, which we use in otk to enable test mode for our resolvers, and return a mocked checksum.