### PR TITLE
reporegistry: add NoReposLoadedError and use it

### DIFF
--- a/pkg/reporegistry/error.go
+++ b/pkg/reporegistry/error.go
@@ -1,0 +1,13 @@
+package reporegistry
+
+import "fmt"
+
+// NoReposLoadedError is an error type that is returned when no repositories
+// are loaded from the given paths.
+type NoReposLoadedError struct {
+	Paths []string
+}
+
+func (e *NoReposLoadedError) Error() string {
+	return fmt.Sprintf("no repositories found in the given paths: %v", e.Paths)
+}

--- a/pkg/reporegistry/reporegistry.go
+++ b/pkg/reporegistry/reporegistry.go
@@ -23,9 +23,6 @@ func New(repoConfigPaths []string) (*RepoRegistry, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(repositories) == 0 {
-		return nil, fmt.Errorf("no repositories found in the given paths: %v", repoConfigPaths)
-	}
 
 	return &RepoRegistry{repositories}, nil
 }

--- a/pkg/reporegistry/repository.go
+++ b/pkg/reporegistry/repository.go
@@ -1,7 +1,6 @@
 package reporegistry
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -66,6 +65,10 @@ func LoadAllRepositories(confPaths []string) (rpmmd.DistrosRepoConfigs, error) {
 		}
 	}
 
+	if len(distrosRepoConfigs) == 0 {
+		return nil, &NoReposLoadedError{confPaths}
+	}
+
 	return distrosRepoConfigs, nil
 }
 
@@ -93,7 +96,7 @@ func LoadRepositories(confPaths []string, distro string) (map[string][]rpmmd.Rep
 	}
 
 	if repoConfigs == nil {
-		return nil, fmt.Errorf("LoadRepositories failed: none of the provided paths contain distro configuration")
+		return nil, &NoReposLoadedError{confPaths}
 	}
 
 	return repoConfigs, nil


### PR DESCRIPTION
Add `NoReposLoadedError` custom error type for the case when any function that is supposed to load repository configs, does not load any. Use it in all functions that are directly loading repositories from configuration files.

I considered `NoReposError` name, but that could be later added for functions such as `RepoRegistry.ReposBy...()`, in case there are no repositories in the RepoRegistry for the given image type / arch.

This is a follow-up to https://github.com/osbuild/osbuild-composer/pull/4378