### PR TITLE
github: drop `-v` from `go test`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,10 +50,10 @@ jobs:
         run: git config --global --add safe.directory "$(pwd)"
 
       - name: Run unit tests
-        run: go test -v -race  ./...
+        run: go test -race  ./...
 
       - name: Run depsolver tests with force-dnf to make sure it's not skipped for any reason
-        run: go test -v -race ./pkg/dnfjson/... -force-dnf
+        run: go test -race ./pkg/dnfjson/... -force-dnf
 
   container-resolver-tests:
     name: "🛃 Container resolver tests"


### PR DESCRIPTION
This commit removes `-v` from `go test`. The test output is very long (17k lines according to GH) and most is just:
```
...
--- PASS: TestRPMDeduplication (0.00s)
...
```
but when trying to find a failing test (like in PR#945) scrolling through to find the actual failing one becomes a bit cumbersome.

So this commit drops `-v`.