### PR TITLE
dnfjson: fix race in TestRunErrorEmptyOutput

### DIFF
--- a/pkg/dnfjson/dnfjson_test.go
+++ b/pkg/dnfjson/dnfjson_test.go
@@ -848,6 +848,7 @@ func TestRepoConfigMarshalAlsmostEmpty(t *testing.T) {
 func TestRunErrorEmptyOutput(t *testing.T) {
 	fakeDnfJsonPath := filepath.Join(t.TempDir(), "dnfjson")
 	fakeDnfJsonNoOutput := `#!/bin/sh -e
+cat - > "$0".stdin
 exit 1
 `
 	err := os.WriteFile(fakeDnfJsonPath, []byte(fakeDnfJsonNoOutput), 0o755)


### PR DESCRIPTION
This commit fixes a race in the `TestRunErrorEmptyOutput` test that was observed in PR#945:
```
2024-09-24T08:57:56.6596870Z === RUN   TestRunErrorEmptyOutput
2024-09-24T08:57:56.6597398Z     dnfjson_test.go:857:
2024-09-24T08:57:56.6598067Z         	Error Trace:	/__w/images/images/pkg/dnfjson/dnfjson_test.go:857
2024-09-24T08:57:56.6599180Z         	Error:      	Error message not equal:
2024-09-24T08:57:56.6600232Z         	            	expected: "DNF error occurred: InternalError: dnf-json output was empty"
2024-09-24T08:57:56.6601715Z         	            	actual  : "encoding request for /tmp/TestRunErrorEmptyOutput2675948157/001/dnfjson failed: write |1: broken pipe"
2024-09-24T08:57:56.6602938Z         	Test:       	TestRunErrorEmptyOutput
2024-09-24T08:57:56.6603675Z --- FAIL: TestRunErrorEmptyOutput (0.00s)
```

the issue is that the "fake dnfjson" script will exit early and potentially before the calling process finished writing the input to dnfjson. This leads to a different error then the expected error.

The fix is to ensure that the input is all read in the fake dnfjson before the program exits.