### PR TITLE
blueprints: fix filesystem customizations to allow toml Undecoded()

### DIFF
--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -301,7 +301,7 @@ func (c *Customizations) GetFilesystemsMinSize() uint64 {
 	}
 	var agg uint64
 	for _, m := range c.Filesystem {
-		agg += m.MinSize
+		agg += uint64(m.MinSize)
 	}
 	// This ensures that file system customization `size` is a multiple of
 	// sector size (512)

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -3,9 +3,11 @@ package blueprint
 import (
 	"testing"
 
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/customizations/anaconda"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCheckAllowed(t *testing.T) {
@@ -492,4 +494,27 @@ func TestGetInstallerErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUnmarshalTOMLNoUndecoded(t *testing.T) {
+	testTOML := `
+[[customizations.filesystem]]
+mountpoint = "/foo"
+minsize = 1000
+`
+
+	var bp Blueprint
+	meta, err := toml.Decode(testTOML, &bp)
+	assert.NoError(t, err)
+	assert.Equal(t, Blueprint{
+		Customizations: &Customizations{
+			Filesystem: []FilesystemCustomization{
+				{
+					Mountpoint: "/foo",
+					MinSize:    1000,
+				},
+			},
+		},
+	}, bp)
+	assert.Equal(t, 0, len(meta.Undecoded()))
 }

--- a/pkg/blueprint/filesystem_customizations_test.go
+++ b/pkg/blueprint/filesystem_customizations_test.go
@@ -120,3 +120,19 @@ path "/boot/" must be canonical`
 	err := blueprint.CheckMountpointsPolicy(mps, policy)
 	assert.EqualError(t, err, expectedErr)
 }
+
+func TestReadConfigNoUndecoded(t *testing.T) {
+	testTOML := `
+mountpoint = "/foo"
+minsize = 1000
+`
+
+	var fsc blueprint.FilesystemCustomization
+	meta, err := toml.Decode(testTOML, &fsc)
+	assert.NoError(t, err)
+	assert.Equal(t, blueprint.FilesystemCustomization{
+		Mountpoint: "/foo",
+		MinSize:    1000,
+	}, fsc)
+	assert.Equal(t, 0, len(meta.Undecoded()))
+}


### PR DESCRIPTION
The current toml filesytem customizations will decode a `FilesystemCustomization` as a map[string]interface{}. This means that the underlying toml engine will not konw what keys inside the map are decoded and which are not decoded. This lead to the issue https://github.com/osbuild/bootc-image-builder/issues/655 in `bootc-image-builder` where we check if we have unencoded entries and if so error (in this case incorrectly).

This commit fixes the issue by moving the toml decoding from the struct/map[string]interface{} to primitive types. It's a bit ugly as is (partly because of the limited go type system) but with that the tests pass and len(meta.Undecoded()) is the expected zero.

I opened https://github.com/BurntSushi/toml/issues/425 to see if there is another way via a custom unmarshaler.

