### PR TITLE
pkg/dnfjson/dnfjson_test.go: fix crashing on failing test

### DIFF
--- a/pkg/dnfjson/dnfjson_test.go
+++ b/pkg/dnfjson/dnfjson_test.go
@@ -131,13 +131,13 @@ func TestDepsolver(t *testing.T) {
 				return
 			} else {
 				assert.Nil(err)
-				assert.NotNil(res)
+				require.NotNil(t, res)
 			}
 
 			assert.Equal(expectedResult(s.RepoConfig), res.Packages)
 
 			if tc.sbomType != sbom.StandardTypeNone {
-				assert.NotNil(res.SBOM)
+				require.NotNil(t, res.SBOM)
 				assert.Equal(sbom.StandardTypeSpdx, res.SBOM.DocType)
 			} else {
 				assert.Nil(res.SBOM)


### PR DESCRIPTION
The tests are currently failing on fedora 41 (SBOM implementation missing for DNF5)
but that's no reason to really segfault just due to a failed test.