### PR TITLE
Makefile: initial version of makefile, replace GH action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,6 @@ jobs:
       fail-fast: false  # if one fails, keep the other(s) running
     name: "🛃 Unit tests (Fedora ${{ matrix.fedora_version }})"
     runs-on: ubuntu-latest
-    container:
-      image: registry.fedoraproject.org/fedora:${{ matrix.fedora_version }}
 
     steps:
       - name: Check out code into the Go module directory
@@ -33,27 +31,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Install python3
-        # The Fedora 41 container doesn't have python3 installed by default
-        run: dnf -y install python3
-
-      - name: Set up repository for pinned osbuild commit
-        run: ./test/scripts/setup-osbuild-repo
-
-        # krb5-devel is needed to test internal/upload/koji package
-        # gcc is needed to build the mock depsolver binary for the unit tests
-        # gpgme-devel is needed for container upload dependencies
-      - name: Install build and test dependencies
-        run: dnf -y install krb5-devel gcc git-core go gpgme-devel osbuild-depsolve-dnf btrfs-progs-devel device-mapper-devel
-
-      - name: Mark the working directory as safe for git
-        run: git config --global --add safe.directory "$(pwd)"
-
       - name: Run unit tests
-        run: go test -race  ./...
-
-      - name: Run depsolver tests with force-dnf to make sure it's not skipped for any reason
-        run: go test -race ./pkg/dnfjson/... -force-dnf
+        run: make BASE_CONTAINER_IMAGE_TAG=${{matrix.fedora_version}} gh-action-test
 
   container-resolver-tests:
     name: "🛃 Container resolver tests"

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 dictionary.dic
 
 *~
+container_built*.info

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
     rev: v3.2.0
     hooks:
       - id: trailing-whitespace
+        exclude: ".*\\.md$"
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files

--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -79,3 +79,9 @@ cmds
 depsolving
 subcommand
 teardown
+Koji
+bootc
+btrfs
+devicemapper
+graphdriver
+subpackages

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,22 @@
+ARG BASE_CONTAINER_IMAGE=registry.fedoraproject.org/fedora:latest
+FROM ${BASE_CONTAINER_IMAGE}
+
+# The Fedora 41 container doesn't have python3 installed by default
+RUN dnf install -y python3
+
+WORKDIR /setup
+
+COPY ./test/scripts ./test/scripts/
+COPY Schutzfile .
+RUN ./test/scripts/setup-osbuild-repo
+
+# NOTE: keep in sync with README.md#Contributing
+RUN dnf -y install krb5-devel go gpgme-devel osbuild-depsolve-dnf btrfs-progs-devel device-mapper-devel
+
+COPY go.mod go.sum .
+RUN go mod download
+
+WORKDIR /app
+
+# Mark the working directory as safe for git
+RUN git config --global --add safe.directory /app

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: help
+help:
+	@echo 'Usage:'
+	@echo '  make <target>'
+	@echo ''
+	@echo 'Targets:'
+	@awk 'match($$0, /^([a-zA-Z_\/-]+):.*?## (.*)$$/, m) {printf "  \033[36m%-30s\033[0m %s\n", m[1], m[2]}' $(MAKEFILE_LIST) | sort
+
+BASE_CONTAINER_IMAGE_NAME?=registry.fedoraproject.org/fedora
+BASE_CONTAINER_IMAGE_TAG?=40
+BASE_CONTAINER_IMAGE?=${BASE_CONTAINER_IMAGE_NAME}:${BASE_CONTAINER_IMAGE_TAG}
+
+CONTAINERFILE=Containerfile
+CONTAINER_IMAGE?=osbuild-images_$(shell echo $(BASE_CONTAINER_IMAGE) | tr '/:.' '_')
+CONTAINER_EXECUTABLE?=podman
+
+container_built_$(CONTAINER_IMAGE).info: $(CONTAINERFILE) Schutzfile test/ go.mod go.sum # internal rule to build the container only if needed
+	$(CONTAINER_EXECUTABLE) build --build-arg BASE_CONTAINER_IMAGE="${BASE_CONTAINER_IMAGE}" \
+	                              --tag $(CONTAINER_IMAGE) \
+	                              -f $(CONTAINERFILE) .
+	echo "Container last built on" > $@
+	date >> $@
+
+.PHONY: gh-action-test
+gh-action-test: container_built_$(CONTAINER_IMAGE).info ## run all tests in a container (see BASE_CONTAINER_IMAGE_* in Makefile)
+	podman run -v .:/app:z --rm -t $(CONTAINER_IMAGE) make test
+
+.PHONY: test
+test: ## run all tests locally
+	go test -race  ./...
+	# Run depsolver tests with force-dnf to make sure it's not skipped for any reason
+	go test -race ./pkg/dnfjson/... -force-dnf
+
+clean: ## remove all build files
+	rm -f container_built*.info

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 Images
 ======
 
+This repository is, primarily, a Go library for generating osbuild manifests
+([more details here](./docs/developer/code-manifest-generation.md)).
+It also has some libraries for uploading artifacts to cloud platforms and Koji.
+The binaries implemented in `cmd/` are for development and testing purposes and not part of the library.
+
 ## Project
 
  * **Website**: <https://www.osbuild.org>
@@ -21,17 +26,25 @@ Please refer to the [developer guide](https://www.osbuild.org/docs/developer-gui
 
 See also the [local developer documentation](./docs/developer) for useful information about working with this specific project.
 
-The build-requirements for Fedora and rpm-based distributions are:
-- `btrfs-progs-devel`
-- `device-mapper-devel`
-- `gcc`
-- `git-core`
+The build-requirements of the Go library for Fedora and rpm-based distributions are:
+
 - `go`
 - `gpgme-devel`
-- `krb5-devel`
-- `osbuild-depsolve-dnf`
 
 (see also [`Containerfile`](Containerfile) )
+
+Other dependencies only needed in some cases are:
+
+- `btrfs-progs-devel`, `device-mapper-devel`  
+  build dependencies for the unit tests and projects that import `pkg/container`, which even in that case can be skipped using exclude_graphdriver_btrfs and exclude_graphdriver_devicemapper (see bootc-image-builder).
+- `krb5-devel`  
+  build dependency for the unit tests and projects that import `pkg/upload/koji`
+- `osbuild-depsolve-dnf`  
+  runtime dependency for the unit tests and projects that import `pkg/dnfjson`.
+  or to run `cmd/gen-manifests` and `cmd/build`
+- `osbuild` (and subpackages)  
+  runtime dependencies for `cmd/build`.
+
 
 ### Repository:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,16 @@ Please refer to the [developer guide](https://www.osbuild.org/docs/developer-gui
 See also the [local developer documentation](./docs/developer) for useful information about working with this specific project.
 
 The build-requirements for Fedora and rpm-based distributions are:
-- `gpgme-devel`, `btrfs-progs-devel`, `device-mapper-devel`
+- `btrfs-progs-devel`
+- `device-mapper-devel`
+- `gcc`
+- `git-core`
+- `go`
+- `gpgme-devel`
+- `krb5-devel`
+- `osbuild-depsolve-dnf`
+
+(see also [`Containerfile`](Containerfile) )
 
 ### Repository:
 


### PR DESCRIPTION
Implementing `make test` to be able to run the tests locally
and implements `make gh-action-test` to run github action "unit-tests-fedora" locally

Also changes the github action to just use the implementation in `Makefile`