### PR TITLE
go.mod: use go 1.22.0

### DIFF
--- a/.github/workflows/gitlab-helper.yml
+++ b/.github/workflows/gitlab-helper.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/test-osbuild-composer-intergation.yml
+++ b/.github/workflows/test-osbuild-composer-intergation.yml
@@ -50,10 +50,10 @@ jobs:
     name: "⌨ osbuild-composer Golang Lint"
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
         id: go
 
       - name: Check out osbuild-composer main branch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,10 +60,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
         id: go
 
       - name: Check out code into the Go module directory
@@ -130,10 +130,10 @@ jobs:
     name: "⌨ Lint"
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
         id: go
 
       - name: Check out code into the Go module directory

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -218,11 +218,7 @@ func getDiskSizeFrom(input *Input) (diskSize uint64, err error) {
 			return 0, err
 		}
 	}
-	// TODO: use max() once we move to go1.21
-	if defaultSize > modMinSize {
-		return defaultSize, nil
-	}
-	return modMinSize, nil
+	return max(defaultSize, modMinSize), nil
 }
 
 func genPartitionTable(genPartInput *Input, rng *rand.Rand) (*Output, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/osbuild/images
 
-go 1.21.0
+go 1.22.0
 
-toolchain go1.22.5
+toolchain go1.23.1
 
 require (
 	cloud.google.com/go/compute v1.28.0

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION=1.21.11
+GO_VERSION=1.22.0
 GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
 
 # this is the official way to get a different version of golang


### PR DESCRIPTION
#947 needed a go version update in the go.mod which dependabot didn't change.
After I added the change myself, I remembered it needs changes in more places.

Instead of polluting the dependabot PR with all this, let's do the change separately so it's more visible and I'll have dependabot rebase the PR after it's merged.