### PR TITLE
test: build edge-commit with parent

### DIFF
--- a/test/config-map.json
+++ b/test/config-map.json
@@ -89,7 +89,8 @@
   },
   "./configs/edge-ostree-pull-user.json": {
     "image-types": [
-      "edge-ami"
+      "edge-ami",
+      "edge-commit"
     ]
   },
   "./configs/minimal-environment.json": {


### PR DESCRIPTION
We never had a test configuration where an ostree commit is built as child of another one.  Let's add a simple configuration where an ostree commit is built from an existing one.

The parent commit is the base image with no customizations (empty) and the child commit adds a user (edge-ostree-pull-user).