### PR TITLE
github/workflows/test-osbuild-composer-intergation: fix integration test

### DIFF
--- a/.github/workflows/test-osbuild-composer-intergation.yml
+++ b/.github/workflows/test-osbuild-composer-intergation.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Allow replacing the osbuild/images module in .golangci.yml
         working-directory: osbuild-composer
         run: |
-          awk '/replace-local: false/ {print "    replace-local: true"; print "    replace-allow-list:\n      - github.com/osbuild/images"; next} 1' .golangci.yml > .golangci.yml.new
+          awk '/replace-local: false/ {print "    replace-local: true"; next} 1' .golangci.yml > .golangci.yml.new
           mv .golangci.yml.new .golangci.yml
 
       - name: Apt update


### PR DESCRIPTION
Due to https://github.com/osbuild/osbuild-composer/commit/7bdd0363 "replace-allow-list" is now already in `.golangci.yml` and should not be added twice or the `golangci-lint` test fails.