### PR TITLE
README: link to docs/developer in Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Images
 
 Please refer to the [developer guide](https://www.osbuild.org/docs/developer-guide/index) to learn about our workflow, code style and more.
 
+See also the [local developer documentation](./docs/developer) for useful information about working with this specific project.
+
 The build-requirements for Fedora and rpm-based distributions are:
 - `gpgme-devel`, `btrfs-progs-devel`, `device-mapper-devel`
 


### PR DESCRIPTION
The section links to the general osbuild team developer guide, but the local developer documentation is also very useful.  The page is already linked from the HACKING.md file, but that could be missed by someone focusing on the README and following the link to osbuild.org.

Sidenote: We need to document the `btrfs-progs-devel` and `device-mapper-devel` dependencies better.  They're not required for building the binaries or running the tests.  They're only needed when using local container storage, which we don't test in our unit tests (or our integration tests, for that matter).  So maybe we should also be testing that here instead of relying on bootc-image-builder and osbuild-composer.