### PR TITLE
cmd: New otk external: otk-make-ostree-source

### DIFF
--- a/cmd/otk/osbuild-make-ostree-source/export_test.go
+++ b/cmd/otk/osbuild-make-ostree-source/export_test.go
@@ -1,0 +1,5 @@
+package main
+
+var (
+	Run = run
+)

--- a/cmd/otk/osbuild-make-ostree-source/main.go
+++ b/cmd/otk/osbuild-make-ostree-source/main.go
@@ -6,33 +6,17 @@ import (
 	"io"
 	"os"
 
+	"github.com/osbuild/images/internal/otkostree"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
 )
-
-// TODO: move structs to common package with resolver external
 
 type Input struct {
 	Tree InputTree `json:"tree"`
 }
 
 type InputTree struct {
-	Const InputConst `json:"const"`
-}
-
-type InputConst struct {
-	// Ref of the commit (can be empty).
-	Ref string `json:"ref,omitempty"`
-
-	// URL of the repo where the commit can be fetched.
-	URL string `json:"url"`
-
-	// Secrets type to use when pulling the ostree commit content
-	// (e.g. org.osbuild.rhsm.consumer).
-	Secrets string `json:"secrets,omitempty"`
-
-	// Checksum of the commit.
-	Checksum string `json:"checksum"`
+	Const otkostree.ResolvedConst `json:"const"`
 }
 
 type Output struct {

--- a/cmd/otk/osbuild-make-ostree-source/main.go
+++ b/cmd/otk/osbuild-make-ostree-source/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/osbuild/images/pkg/osbuild"
+	"github.com/osbuild/images/pkg/ostree"
+)
+
+// TODO: move structs to common package with resolver external
+
+type Input struct {
+	Tree InputTree `json:"tree"`
+}
+
+type InputTree struct {
+	Const InputConst `json:"const"`
+}
+
+type InputConst struct {
+	// Ref of the commit (can be empty).
+	Ref string `json:"ref,omitempty"`
+
+	// URL of the repo where the commit can be fetched.
+	URL string `json:"url"`
+
+	// Secrets type to use when pulling the ostree commit content
+	// (e.g. org.osbuild.rhsm.consumer).
+	Secrets string `json:"secrets,omitempty"`
+
+	// Checksum of the commit.
+	Checksum string `json:"checksum"`
+}
+
+type Output struct {
+	OSTreeSource osbuild.OSTreeSource `json:"org.osbuild.ostree"`
+}
+
+func run(r io.Reader, w io.Writer) error {
+	var inp Input
+	if err := json.NewDecoder(r).Decode(&inp); err != nil {
+		return err
+	}
+
+	ostreeSource := osbuild.NewOSTreeSource()
+	ostreeSource.AddItem(ostree.CommitSpec{
+		Ref:      inp.Tree.Const.Ref,
+		URL:      inp.Tree.Const.URL,
+		Secrets:  inp.Tree.Const.Secrets,
+		Checksum: inp.Tree.Const.Checksum,
+	})
+
+	output := Output{
+		OSTreeSource: *ostreeSource,
+	}
+	out := map[string]interface{}{
+		"tree": output,
+	}
+	outputJson, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cannot marshal response: %w", err)
+	}
+	fmt.Fprintf(w, "%s\n", outputJson)
+	return nil
+}
+
+func main() {
+	if err := run(os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v", err.Error())
+		os.Exit(1)
+	}
+}

--- a/cmd/otk/osbuild-make-ostree-source/main_test.go
+++ b/cmd/otk/osbuild-make-ostree-source/main_test.go
@@ -1,0 +1,85 @@
+package main_test
+
+import (
+	"bytes"
+	"testing"
+
+	sourcemaker "github.com/osbuild/images/cmd/otk/osbuild-make-ostree-source"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourceMakerBasic(t *testing.T) {
+	require := require.New(t)
+
+	input := `
+{
+  "tree": {
+	"const": {
+	  "ref": "does/not/matter",
+	  "checksum": "d04105393ca0617856b34f897842833d785522e41617e17dca2063bf97e294ef",
+	  "url": "https://ostree.example.org/repo"
+	}
+  }
+}`
+
+	expOutput := `{
+  "tree": {
+    "org.osbuild.ostree": {
+      "items": {
+        "d04105393ca0617856b34f897842833d785522e41617e17dca2063bf97e294ef": {
+          "remote": {
+            "url": "https://ostree.example.org/repo"
+          }
+        }
+      }
+    }
+  }
+}
+`
+
+	inpBuf := bytes.NewBuffer([]byte(input))
+	outBuf := &bytes.Buffer{}
+
+	require.NoError(sourcemaker.Run(inpBuf, outBuf))
+	require.Equal(expOutput, outBuf.String())
+}
+
+func TestSourceMakerWithSecrets(t *testing.T) {
+	require := require.New(t)
+
+	input := `
+{
+  "tree": {
+    "const": {
+      "ref": "does/not/matter",
+      "checksum": "d04105393ca0617856b34f897842833d785522e41617e17dca2063bf97e294ef",
+      "url": "https://ostree.example.org/repo",
+      "secrets": "org.osbuild.rhsm.consumer"
+    }
+  }
+}`
+
+	expOutput := `{
+  "tree": {
+    "org.osbuild.ostree": {
+      "items": {
+        "d04105393ca0617856b34f897842833d785522e41617e17dca2063bf97e294ef": {
+          "remote": {
+            "url": "https://ostree.example.org/repo",
+            "secrets": {
+              "name": "org.osbuild.rhsm.consumer"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`
+
+	inpBuf := bytes.NewBuffer([]byte(input))
+	outBuf := &bytes.Buffer{}
+
+	require.NoError(sourcemaker.Run(inpBuf, outBuf))
+	require.Equal(expOutput, outBuf.String())
+}

--- a/cmd/otk/osbuild-resolve-ostree-commit/main.go
+++ b/cmd/otk/osbuild-resolve-ostree-commit/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/osbuild/images/internal/cmdutil"
+	"github.com/osbuild/images/internal/otkostree"
 	"github.com/osbuild/images/pkg/ostree"
 )
 
@@ -31,22 +32,7 @@ type Input struct {
 // Output contains everything needed to write a manifest that requires pulling
 // an ostree commit.
 type Output struct {
-	Const OutputConst `json:"const"`
-}
-
-type OutputConst struct {
-	// Ref of the commit (can be empty).
-	Ref string `json:"ref,omitempty"`
-
-	// URL of the repo where the commit can be fetched.
-	URL string `json:"url"`
-
-	// Secrets type to use when pulling the ostree commit content
-	// (e.g. org.osbuild.rhsm.consumer).
-	Secrets string `json:"secrets,omitempty"`
-
-	// Checksum of the commit.
-	Checksum string `json:"checksum"`
+	Const otkostree.ResolvedConst `json:"const"`
 }
 
 // for mocking in testing
@@ -78,7 +64,7 @@ func run(r io.Reader, w io.Writer) error {
 
 	output := map[string]Output{
 		"tree": {
-			Const: OutputConst{
+			Const: otkostree.ResolvedConst{
 				Ref:      commitSpec.Ref,
 				URL:      commitSpec.URL,
 				Secrets:  commitSpec.Secrets,

--- a/internal/otkostree/types.go
+++ b/internal/otkostree/types.go
@@ -1,0 +1,16 @@
+package otkostree
+
+type ResolvedConst struct {
+	// Ref of the commit (can be empty).
+	Ref string `json:"ref,omitempty"`
+
+	// URL of the repo where the commit can be fetched.
+	URL string `json:"url"`
+
+	// Secrets type to use when pulling the ostree commit content
+	// (e.g. org.osbuild.rhsm.consumer).
+	Secrets string `json:"secrets,omitempty"`
+
+	// Checksum of the commit.
+	Checksum string `json:"checksum"`
+}


### PR DESCRIPTION
A new command for otk that creates the org.osbuild.ostree source object based on the resolved ostree commit data generated from the osbuild-resolve-ostree-commit command.