### PR TITLE
otk-gen-partition-table: add support for ppc64/s390x partition tables

### DIFF
--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -51,6 +51,7 @@ type InputCreate struct {
 // InputPartition represents a single user provided partition input
 type InputPartition struct {
 	Name       string `json:"name"`
+	Bootable   bool   `json:"bootable"`
 	Mountpoint string `json:"mountpoint"`
 	Label      string `json:"label"`
 	Size       string `json:"size"`
@@ -184,9 +185,10 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 			return nil, err
 		}
 		pt.Partitions = append(pt.Partitions, disk.Partition{
-			Size: uintSize,
-			UUID: part.PartUUID,
-			Type: part.PartType,
+			Size:     uintSize,
+			UUID:     part.PartUUID,
+			Type:     part.PartType,
+			Bootable: part.Bootable,
 			// XXX: support lvm,luks here
 			Payload: &disk.Filesystem{
 				Label:        part.Label,

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -184,13 +184,15 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 		if err != nil {
 			return nil, err
 		}
-		pt.Partitions = append(pt.Partitions, disk.Partition{
+		// XXX: support lvm,luks here
+		newPart := disk.Partition{
 			Size:     uintSize,
 			UUID:     part.PartUUID,
 			Type:     part.PartType,
 			Bootable: part.Bootable,
-			// XXX: support lvm,luks here
-			Payload: &disk.Filesystem{
+		}
+		if part.Type != "" {
+			newPart.Payload = &disk.Filesystem{
 				Label:        part.Label,
 				Type:         part.Type,
 				Mountpoint:   part.Mountpoint,
@@ -198,8 +200,9 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 				FSTabOptions: part.FSMntOps,
 				FSTabFreq:    part.FSFreq,
 				FSTabPassNo:  part.FSPassNo,
-			},
-		})
+			}
+		}
+		pt.Partitions = append(pt.Partitions, newPart)
 	}
 
 	return pt, nil

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 // see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
+// Note that this partition table contains all json keys for testing, some may
+// contradict each other
 var partInputsComplete = `
 {
   "properties": {
@@ -32,6 +34,7 @@ var partInputsComplete = `
   "partitions": [
     {
       "name": "root",
+      "bootable": true,
       "mountpoint": "/",
       "label": "root",
       "size": "7 GiB",
@@ -69,6 +72,7 @@ var expectedInput = &genpart.Input{
 	Partitions: []*genpart.InputPartition{
 		{
 			Name:       "root",
+			Bootable:   true,
 			Mountpoint: "/",
 			Label:      "root",
 			Size:       "7 GiB",
@@ -305,6 +309,26 @@ func TestIntegrationRealistic(t *testing.T) {
 	err := genpart.Run(inp, outp)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedSimplePartOutput, outp.String())
+}
+
+func TestGenPartitionTableBootable(t *testing.T) {
+	inp := &genpart.Input{
+		Properties: genpart.InputProperties{
+			Type: "dos",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Bootable:   true,
+				Mountpoint: "/",
+				Size:       "10 GiB",
+				Type:       "ext4",
+			},
+		},
+	}
+
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0))) /* #nosec G404 */
+	assert.NoError(t, err)
+	assert.Equal(t, true, output.Const.Internal.PartitionTable.Partitions[0].Bootable)
 }
 
 func TestGenPartitionTableMinimal(t *testing.T) {

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -331,6 +331,69 @@ func TestGenPartitionTableBootable(t *testing.T) {
 	assert.Equal(t, true, output.Const.Internal.PartitionTable.Partitions[0].Bootable)
 }
 
+func TestGenPartitionTableIntegrationPPC(t *testing.T) {
+	inp := &genpart.Input{
+		Properties: genpart.InputProperties{
+			Type:        "dos",
+			DefaultSize: "10 GiB",
+			UUID:        "0x14fc63d2",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Name:     "ppc-boot",
+				Bootable: true,
+				Size:     "4 MiB",
+				PartType: "41",
+				PartUUID: "",
+			},
+			{
+				Name:       "root",
+				Size:       "10 GiB",
+				Type:       "xfs",
+				Mountpoint: "/",
+			},
+		},
+	}
+	expectedOutput := &otkdisk.Data{
+		Const: otkdisk.Const{
+			KernelOptsList: []string{},
+			PartitionMap: map[string]otkdisk.Partition{
+				"root": {
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				},
+			},
+			Filename: "disk.img",
+			Internal: otkdisk.Internal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 10742661120,
+					UUID: "0x14fc63d2",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Bootable: true,
+							Start:    1048576,
+							Size:     4194304,
+							Type:     "41",
+						},
+						{
+							Start: 5242880,
+							Size:  10737418240,
+							Payload: &disk.Filesystem{
+								Type:       "xfs",
+								UUID:       "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+								Mountpoint: "/",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0))) /* #nosec G404 */
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, output)
+}
+
 func TestGenPartitionTableMinimal(t *testing.T) {
 	// XXX: think about what the smalltest inputs can be and validate
 	// that it's complete and/or provide defaults (e.g. for "type" for


### PR DESCRIPTION
This commit adds support for "raw" partitions without a "payload",
i.e. no filesystem or LVM volume or similar. This is used for the
PPC64/s390x partition table that looks like this:
```yaml
otk.define:
  filesystem:
    modifications:
    # empty
    otk.external.otk-gen-partition-table:
      modifications:
        ${filesystem.modifications}
      properties:
        type: dos
        default_size: "10 GiB"
        uuid: "0x14fc63d2"
      partitions:
        - name: ppc-boot
          bootable: true
          size: "4 MiB"
          part_uuid: ""
          part_type: "41"
        - name: boot
          mountpoint: /boot
          label: boot
          size: "1 GiB"
          type: "xfs"
          fs_mntops: defaults
          part_uuid: ""
        - name: root
          mountpoint: /
          type: "xfs"
          size: "2 GiB"
          fs_mntops: defaults
          part_uuid: ""
```
Thanks to Florian Schüller for the initial implementation/research
here, see also https://github.com/osbuild/images/pull/952 

---

otk-gen-partition-table: add `bootable` flag support

This commit adds support to mark partitions as bootable from
an `otk-gen-partition-table` input. E.g.:
```yaml
{
...
  "partitions": [
    {
...
      "bootable": true,
...
    },
```

