### PR TITLE
cmd/otk-gen-partition-table: implement returning type in partition_map

### DIFF
--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -86,15 +86,15 @@ func makePartMap(pt *disk.PartitionTable) map[string]otkdisk.Partition {
 	for _, part := range pt.Partitions {
 		switch pl := part.Payload.(type) {
 		case *disk.Filesystem:
+			partMapDetails := otkdisk.Partition{
+				UUID: pl.UUID,
+				Type: pl.Type,
+			}
 			switch pl.Mountpoint {
 			case "/":
-				pm["root"] = otkdisk.Partition{
-					UUID: pl.UUID,
-				}
+				pm["root"] = partMapDetails
 			case "/boot":
-				pm["boot"] = otkdisk.Partition{
-					UUID: pl.UUID,
-				}
+				pm["boot"] = partMapDetails
 			}
 		}
 	}

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -108,6 +108,7 @@ func TestUnmarshalOutput(t *testing.T) {
 			PartitionMap: map[string]otkdisk.Partition{
 				"root": {
 					UUID: "12345",
+					Type: "119119",
 				},
 			},
 			Filename: "disk.img",
@@ -136,7 +137,8 @@ func TestUnmarshalOutput(t *testing.T) {
     ],
     "partition_map": {
       "root": {
-        "uuid": "12345"
+        "uuid": "12345",
+        "type": "119119"
       }
     },
     "internal": {
@@ -216,7 +218,8 @@ var expectedSimplePartOutput = `{
       "kernel_opts_list": [],
       "partition_map": {
         "root": {
-          "uuid": "9851898e-0b30-437d-8fad-51ec16c3697f"
+          "uuid": "9851898e-0b30-437d-8fad-51ec16c3697f",
+          "type": "ext4"
         }
       },
       "internal": {
@@ -329,6 +332,7 @@ func TestGenPartitionTableMinimal(t *testing.T) {
 			PartitionMap: map[string]otkdisk.Partition{
 				"root": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+					Type: "ext4",
 				},
 			},
 			Filename: "disk.img",
@@ -389,6 +393,7 @@ func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
 			PartitionMap: map[string]otkdisk.Partition{
 				"boot": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+					Type: "ext4",
 				},
 			},
 			Filename: "disk.img",
@@ -478,6 +483,7 @@ func TestGenPartitionTableCustomizationExtraMpPlusModificationPartitionMode(t *t
 			PartitionMap: map[string]otkdisk.Partition{
 				"root": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+					Type: "ext4",
 				},
 			},
 			Filename: "disk.img",
@@ -536,6 +542,7 @@ func TestGenPartitionTablePropertiesDefaultSize(t *testing.T) {
 			PartitionMap: map[string]otkdisk.Partition{
 				"root": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+					Type: "ext4",
 				},
 			},
 			Filename: "disk.img",
@@ -587,6 +594,7 @@ func TestGenPartitionTableModificationMinDiskSize(t *testing.T) {
 			PartitionMap: map[string]otkdisk.Partition{
 				"root": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+					Type: "ext4",
 				},
 			},
 			Filename: "disk.img",
@@ -637,6 +645,7 @@ func TestGenPartitionTableModificationFilename(t *testing.T) {
 			PartitionMap: map[string]otkdisk.Partition{
 				"root": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+					Type: "ext4",
 				},
 			},
 			Filename: "custom-disk.img",
@@ -698,6 +707,7 @@ func TestGenPartitionCreateESPDos(t *testing.T) {
 			PartitionMap: map[string]otkdisk.Partition{
 				"root": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+					Type: "ext4",
 				},
 			},
 			Filename: "disk.img",

--- a/internal/otkdisk/partition.go
+++ b/internal/otkdisk/partition.go
@@ -47,6 +47,7 @@ type Const struct {
 type Partition struct {
 	// NOTE: Not a UUID type because fat UUIDs are not compliant
 	UUID string `json:"uuid"`
+	Type string `json:"type"`
 }
 
 // Interal contains partition table data that is stricly internal and


### PR DESCRIPTION
to use the fact "type" in the partition_map we need to return it
used at least in the s390x otk example