### PR TITLE
cmd/otk-gen-partition-table: implement bootable flag for any partition

### DIFF
--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -61,7 +61,7 @@ type InputPartition struct {
 	FSMntOps   string `json:"fs_mntops"`
 	FSFreq     uint64 `json:"fs_freq"`
 	FSPassNo   uint64 `json:"fs_passno"`
-
+	Bootable   bool   `json:"bootable"`
 	// TODO: add sectorlvm,luks, see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
 }
 
@@ -183,10 +183,12 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 		if err != nil {
 			return nil, err
 		}
+
 		pt.Partitions = append(pt.Partitions, disk.Partition{
-			Size: uintSize,
-			UUID: part.PartUUID,
-			Type: part.PartType,
+			Size:     uintSize,
+			UUID:     part.PartUUID,
+			Type:     part.PartType,
+			Bootable: part.Bootable,
 			// XXX: support lvm,luks here
 			Payload: &disk.Filesystem{
 				Label:        part.Label,

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -739,3 +739,54 @@ func TestGenPartitionCreateESPDos(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOutput, output)
 }
+
+func TestGenPartitionTablePropertyBootable(t *testing.T) {
+	inp := &genpart.Input{
+		Properties: genpart.InputProperties{
+			Type:        "dos",
+			DefaultSize: "15 GiB",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Mountpoint: "/",
+				Size:       "10 GiB",
+				Type:       "ext4",
+				Bootable:   true,
+			},
+		},
+	}
+	expectedOutput := &otkdisk.Data{
+		Const: otkdisk.Const{
+			KernelOptsList: []string{},
+			PartitionMap: map[string]otkdisk.Partition{
+				"root": {
+					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+					Type: "ext4",
+				},
+			},
+			Filename: "disk.img",
+			Internal: otkdisk.Internal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 16106127360,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start:    1048576,
+							Size:     16105078784,
+							Bootable: true,
+							Payload: &disk.Filesystem{
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+								Mountpoint: "/",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0))) /* #nosec G404 */
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, output)
+}


### PR DESCRIPTION
on centos9 for s390x with qcow2 it seems that the root partition shall be bootable. With this fix, this can be defined.