### PR TITLE
cmd: add "archName" to gen-manifests mock dnf solver URLs

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -416,7 +416,7 @@ func mockDepsolve(packageSets map[string][]rpmmd.PackageSet, repos []rpmmd.RepoC
 				panic(err)
 			}
 			url.Host = "example.com"
-			url.Path = "pseudo-repo-pkg:" + url.Path
+			url.Path = fmt.Sprintf("passed-arch:%s/passed-repo:%s", archName, url.Path)
 			specSet = append(specSet, rpmmd.PackageSpec{
 				Name:           url.String(),
 				RemoteLocation: url.String(),


### PR DESCRIPTION
This commit adds the manifest name to the mock depsolve URL output so that we can test for it from inside otk. This will help with issues like https://github.com/osbuild/otk/pull/255/files#r1782953752

This will require a re-generate of all otk reference manifests.