### PR TITLE
workflow: generate PR comments when non-required tests fail and let the action itself succeed (part 1)

### DIFF
--- a/.github/workflows/comment-integration-failure.yml
+++ b/.github/workflows/comment-integration-failure.yml
@@ -1,0 +1,29 @@
+---
+name: "Schutzbot comments"
+# This workflow runs when the [integration] workflow reports a failure through
+# an artifact. The [integration] workflow itself doesn't fail if the testing or
+# linting fails, instead it reports a failure through a shared artifact that
+# this workflow reads and reports on. The failure is communicated to the author
+# and reviewers of a PR without causing a failed action to appear.
+#
+# This workflow is run on a workflow_run trigger to have access to secrets.
+#
+# TODO: Actually do what the comment says.
+
+on:
+  workflow_run:
+    workflows: ["[integration]"]
+    types: [completed]
+
+jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Add comment
+        uses: mshick/add-pr-comment@v2
+        with:
+          repo-token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+          message: |
+            The [integration] workflow failed


### PR DESCRIPTION
The purpose of this new workflow is to run when certain actions are allowed to cause errors without failing but PR authors and reviewers should be notified of issues.  The goal is, instead of having actions that are allowed to fail and are marked as not required, the actions themselves will succeed but will communicate an error message through a shared artifact that this action can read and use to post a comment on the PR.

The action is run as a 'workflow_run' to have access to secrets (Schutzbot's access token).

The action is not finalised in this commit.

The plan is to merge this into `main` as is, so that GitHub will pick up the new workflow and we can iterate on the implementation in a follow-up PR, since GitHub will not run actions defined in workflows that are not part of the main branch but will run modified versions of a pre-existing action.