### PR TITLE
pkg: extra new `datasizes` package for `DataSizeToUint64`

### DIFF
--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/dnfjson"
 	"github.com/osbuild/images/pkg/image"
@@ -22,7 +22,7 @@ func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos
 	solver := dnfjson.NewSolver(d.ModulePlatformID(), d.Releasever(), arch.Name(), d.Name(), path.Join(state_dir, "rpmmd"))
 
 	// Set cache size to 1 GiB
-	solver.SetMaxCacheSize(1 * common.GiB)
+	solver.SetMaxCacheSize(1 * datasizes.GiB)
 
 	manifest := manifest.New()
 

--- a/cmd/otk/osbuild-gen-partition-table/main.go
+++ b/cmd/otk/osbuild-gen-partition-table/main.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/osbuild/images/internal/buildconfig"
 	"github.com/osbuild/images/internal/cmdutil"
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/otkdisk"
 	"github.com/osbuild/images/pkg/blueprint"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
 )
@@ -120,7 +120,7 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 
 	var startOffset uint64
 	if input.Properties.StartOffset != "" {
-		startOffset, err = common.DataSizeToUint64(input.Properties.StartOffset)
+		startOffset, err = datasizes.Parse(input.Properties.StartOffset)
 		if err != nil {
 			return nil, err
 		}
@@ -137,7 +137,7 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 			return nil, fmt.Errorf("internal error: bios partition *must* go first")
 		}
 		pt.Partitions = append(pt.Partitions, disk.Partition{
-			Size:     1 * common.MebiByte,
+			Size:     1 * datasizes.MebiByte,
 			Bootable: true,
 			Type:     disk.BIOSBootPartitionGUID,
 			UUID:     disk.BIOSBootPartitionUUID,
@@ -148,7 +148,7 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 		if size == "" {
 			size = "1 GiB"
 		}
-		uintSize, err := common.DataSizeToUint64(size)
+		uintSize, err := datasizes.Parse(size)
 		if err != nil {
 			return nil, err
 		}
@@ -180,7 +180,7 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 	}
 
 	for _, part := range input.Partitions {
-		uintSize, err := common.DataSizeToUint64(part.Size)
+		uintSize, err := datasizes.Parse(part.Size)
 		if err != nil {
 			return nil, err
 		}
@@ -212,13 +212,13 @@ func getDiskSizeFrom(input *Input) (diskSize uint64, err error) {
 	var defaultSize, modMinSize uint64
 
 	if input.Properties.DefaultSize != "" {
-		defaultSize, err = common.DataSizeToUint64(input.Properties.DefaultSize)
+		defaultSize, err = datasizes.Parse(input.Properties.DefaultSize)
 		if err != nil {
 			return 0, err
 		}
 	}
 	if input.Modifications.MinDiskSize != "" {
-		modMinSize, err = common.DataSizeToUint64(input.Modifications.MinDiskSize)
+		modMinSize, err = datasizes.Parse(input.Modifications.MinDiskSize)
 		if err != nil {
 			return 0, err
 		}

--- a/cmd/otk/osbuild-gen-partition-table/main_test.go
+++ b/cmd/otk/osbuild-gen-partition-table/main_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	genpart "github.com/osbuild/images/cmd/otk/osbuild-gen-partition-table"
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/otkdisk"
 	"github.com/osbuild/images/pkg/blueprint"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 )
 
@@ -465,7 +465,7 @@ func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
 			Filesystems: []blueprint.FilesystemCustomization{
 				{
 					Mountpoint: "/var/log",
-					MinSize:    3 * common.GigaByte,
+					MinSize:    3 * datasizes.GigaByte,
 				},
 			},
 		},
@@ -554,7 +554,7 @@ func TestGenPartitionTableCustomizationExtraMpPlusModificationPartitionMode(t *t
 			Filesystems: []blueprint.FilesystemCustomization{
 				{
 					Mountpoint: "/var/log",
-					MinSize:    3 * common.GigaByte,
+					MinSize:    3 * datasizes.GigaByte,
 				},
 			},
 		},

--- a/cmd/otk/osbuild-make-grub2-inst-stage/main_test.go
+++ b/cmd/otk/osbuild-make-grub2-inst-stage/main_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	makeGrub2Inst "github.com/osbuild/images/cmd/otk/osbuild-make-grub2-inst-stage"
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/otkdisk"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 )
 
@@ -17,14 +17,14 @@ var fakePt = &disk.PartitionTable{
 	Type: "gpt",
 	Partitions: []disk.Partition{
 		{
-			Size:     1 * common.MiB,
-			Start:    1 * common.MiB,
+			Size:     1 * datasizes.MiB,
+			Start:    1 * datasizes.MiB,
 			Bootable: true,
 			Type:     disk.BIOSBootPartitionGUID,
 			UUID:     disk.BIOSBootPartitionUUID,
 		},
 		{
-			Size: 1 * common.GiB,
+			Size: 1 * datasizes.GiB,
 			Payload: &disk.Filesystem{
 				Type:       "ext4",
 				Mountpoint: "/",

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -2,25 +2,6 @@ package common
 
 import "fmt"
 
-const (
-	KiloByte = 1000                      // kB
-	KibiByte = 1024                      // KiB
-	MegaByte = 1000 * 1000               // MB
-	MebiByte = 1024 * 1024               // MiB
-	GigaByte = 1000 * 1000 * 1000        // GB
-	GibiByte = 1024 * 1024 * 1024        // GiB
-	TeraByte = 1000 * 1000 * 1000 * 1000 // TB
-	TebiByte = 1024 * 1024 * 1024 * 1024 // TiB
-
-	// shorthands
-	KiB = KibiByte
-	MB  = MegaByte
-	MiB = MebiByte
-	GB  = GigaByte
-	GiB = GibiByte
-	TiB = TebiByte
-)
-
 // These constants are set during buildtime using additional
 // compiler flags. Not all of them are necessarily defined
 // because RPMs can be build from a tarball and spec file without

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -1,6 +1,8 @@
 package common
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // These constants are set during buildtime using additional
 // compiler flags. Not all of them are necessarily defined

--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 )
 
@@ -25,54 +23,6 @@ func IsStringInSortedSlice(slice []string, s string) bool {
 		return true
 	}
 	return false
-}
-
-// DataSizeToUint64 converts a size specified as a string in KB/KiB/MB/etc. to
-// a number of bytes represented by uint64.
-func DataSizeToUint64(size string) (uint64, error) {
-	// Pre-process the input
-	size = strings.TrimSpace(size)
-
-	// Get the number from the string
-	plain_number := regexp.MustCompile(`[[:digit:]]+`)
-	number_as_str := plain_number.FindString(size)
-	if number_as_str == "" {
-		return 0, fmt.Errorf("the size string doesn't contain any number: %s", size)
-	}
-
-	// Parse the number into integer
-	return_size, err := strconv.ParseUint(number_as_str, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse size as integer: %s", number_as_str)
-	}
-
-	// List of all supported units (from kB to TB and KiB to TiB)
-	supported_units := []struct {
-		re       *regexp.Regexp
-		multiple uint64
-	}{
-		{regexp.MustCompile(`^\s*[[:digit:]]+\s*kB$`), KiloByte},
-		{regexp.MustCompile(`^\s*[[:digit:]]+\s*KiB$`), KibiByte},
-		{regexp.MustCompile(`^\s*[[:digit:]]+\s*MB$`), MegaByte},
-		{regexp.MustCompile(`^\s*[[:digit:]]+\s*MiB$`), MebiByte},
-		{regexp.MustCompile(`^\s*[[:digit:]]+\s*GB$`), GigaByte},
-		{regexp.MustCompile(`^\s*[[:digit:]]+\s*GiB$`), GibiByte},
-		{regexp.MustCompile(`^\s*[[:digit:]]+\s*TB$`), TeraByte},
-		{regexp.MustCompile(`^\s*[[:digit:]]+\s*TiB$`), TebiByte},
-		{regexp.MustCompile(`^\s*[[:digit:]]+$`), 1},
-	}
-
-	for _, unit := range supported_units {
-		if unit.re.MatchString(size) {
-			return_size *= unit.multiple
-			return return_size, nil
-		}
-	}
-
-	// In case the strign didn't match any of the above regexes, return nil
-	// even if a number was found. This is to prevent users from submitting
-	// unknown units.
-	return 0, fmt.Errorf("unknown data size units in string: %s", size)
 }
 
 // NopSeekCloser returns an io.ReadSeekCloser with a no-op Close method

--- a/internal/common/helpers_test.go
+++ b/internal/common/helpers_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPanicOnError(t *testing.T) {
@@ -18,43 +17,6 @@ func TestIsStringInSortedSlice(t *testing.T) {
 	assert.False(t, IsStringInSortedSlice([]string{"bart", "lisa", "marge"}, "homer"))
 	assert.False(t, IsStringInSortedSlice([]string{"bart", "lisa", "marge"}, ""))
 	assert.False(t, IsStringInSortedSlice([]string{}, "homer"))
-}
-
-func TestDataSizeToUint64(t *testing.T) {
-	cases := []struct {
-		input   string
-		success bool
-		output  uint64
-	}{
-		{"123", true, 123},
-		{"123 kB", true, 123000},
-		{"123 KiB", true, 123 * 1024},
-		{"123 MB", true, 123 * 1000 * 1000},
-		{"123 MiB", true, 123 * 1024 * 1024},
-		{"123 GB", true, 123 * 1000 * 1000 * 1000},
-		{"123 GiB", true, 123 * 1024 * 1024 * 1024},
-		{"123 TB", true, 123 * 1000 * 1000 * 1000 * 1000},
-		{"123 TiB", true, 123 * 1024 * 1024 * 1024 * 1024},
-		{"123kB", true, 123000},
-		{"123KiB", true, 123 * 1024},
-		{" 123  ", true, 123},
-		{"  123kB  ", true, 123000},
-		{"  123KiB  ", true, 123 * 1024},
-		{"123 KB", false, 0},
-		{"123 mb", false, 0},
-		{"123 PB", false, 0},
-		{"123 PiB", false, 0},
-	}
-
-	for _, c := range cases {
-		result, err := DataSizeToUint64(c.input)
-		if c.success {
-			require.Nil(t, err)
-			assert.EqualValues(t, c.output, result)
-		} else {
-			assert.NotNil(t, err)
-		}
-	}
 }
 
 func TestSystemdMountUnit(t *testing.T) {

--- a/internal/testdisk/partition.go
+++ b/internal/testdisk/partition.go
@@ -1,11 +1,11 @@
 package testdisk
 
 import (
-	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 )
 
-const FakePartitionSize = uint64(789) * common.MiB
+const FakePartitionSize = uint64(789) * datasizes.MiB
 
 // MakeFakePartitionTable is a helper to create partition table structs
 // for tests. It uses sensible defaults for common scenarios.
@@ -43,7 +43,7 @@ func MakeFakeBtrfsPartitionTable(mntPoints ...string) *disk.PartitionTable {
 	var subvolumes []disk.BtrfsSubvolume
 	pt := &disk.PartitionTable{
 		Type:       "gpt",
-		Size:       10 * common.GiB,
+		Size:       10 * datasizes.GiB,
 		Partitions: []disk.Partition{},
 	}
 	size := uint64(0)
@@ -52,24 +52,24 @@ func MakeFakeBtrfsPartitionTable(mntPoints ...string) *disk.PartitionTable {
 		case "/boot":
 			pt.Partitions = append(pt.Partitions, disk.Partition{
 				Start: size,
-				Size:  1 * common.GiB,
+				Size:  1 * datasizes.GiB,
 				Payload: &disk.Filesystem{
 					Type:       "ext4",
 					Mountpoint: mntPoint,
 				},
 			})
-			size += 1 * common.GiB
+			size += 1 * datasizes.GiB
 		case "/boot/efi":
 			pt.Partitions = append(pt.Partitions, disk.Partition{
 				Start: size,
-				Size:  100 * common.MiB,
+				Size:  100 * datasizes.MiB,
 				Payload: &disk.Filesystem{
 					Type:       "vfat",
 					Mountpoint: mntPoint,
 					UUID:       disk.EFIFilesystemUUID,
 				},
 			})
-			size += 100 * common.MiB
+			size += 100 * datasizes.MiB
 		default:
 			name := mntPoint
 			if name == "/" {
@@ -89,14 +89,14 @@ func MakeFakeBtrfsPartitionTable(mntPoints ...string) *disk.PartitionTable {
 
 	pt.Partitions = append(pt.Partitions, disk.Partition{
 		Start: size,
-		Size:  9 * common.GiB,
+		Size:  9 * datasizes.GiB,
 		Payload: &disk.Btrfs{
 			UUID:       disk.RootPartitionUUID,
 			Subvolumes: subvolumes,
 		},
 	})
 
-	size += 9 * common.GiB
+	size += 9 * datasizes.GiB
 	pt.Size = size
 
 	return pt
@@ -108,7 +108,7 @@ func MakeFakeLVMPartitionTable(mntPoints ...string) *disk.PartitionTable {
 	var lvs []disk.LVMLogicalVolume
 	pt := &disk.PartitionTable{
 		Type:       "gpt",
-		Size:       10 * common.GiB,
+		Size:       10 * datasizes.GiB,
 		Partitions: []disk.Partition{},
 	}
 	size := uint64(0)
@@ -117,24 +117,24 @@ func MakeFakeLVMPartitionTable(mntPoints ...string) *disk.PartitionTable {
 		case "/boot":
 			pt.Partitions = append(pt.Partitions, disk.Partition{
 				Start: size,
-				Size:  1 * common.GiB,
+				Size:  1 * datasizes.GiB,
 				Payload: &disk.Filesystem{
 					Type:       "ext4",
 					Mountpoint: mntPoint,
 				},
 			})
-			size += 1 * common.GiB
+			size += 1 * datasizes.GiB
 		case "/boot/efi":
 			pt.Partitions = append(pt.Partitions, disk.Partition{
 				Start: size,
-				Size:  100 * common.MiB,
+				Size:  100 * datasizes.MiB,
 				Payload: &disk.Filesystem{
 					Type:       "vfat",
 					Mountpoint: mntPoint,
 					UUID:       disk.EFIFilesystemUUID,
 				},
 			})
-			size += 100 * common.MiB
+			size += 100 * datasizes.MiB
 		default:
 			name := "lv-for-" + mntPoint
 			if name == "/" {
@@ -155,13 +155,13 @@ func MakeFakeLVMPartitionTable(mntPoints ...string) *disk.PartitionTable {
 
 	pt.Partitions = append(pt.Partitions, disk.Partition{
 		Start: size,
-		Size:  9 * common.GiB,
+		Size:  9 * datasizes.GiB,
 		Payload: &disk.LVMVolumeGroup{
 			LogicalVolumes: lvs,
 		},
 	})
 
-	size += 9 * common.GiB
+	size += 9 * datasizes.GiB
 	pt.Size = size
 
 	return pt

--- a/pkg/blueprint/blueprint_test.go
+++ b/pkg/blueprint/blueprint_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 )
 
 func TestBlueprintParse(t *testing.T) {
@@ -67,7 +67,7 @@ minsize = "20 GiB"
 	assert.Equal(t, "/var", bp.Customizations.Filesystem[0].Mountpoint)
 	assert.Equal(t, uint64(2147483648), bp.Customizations.Filesystem[0].MinSize)
 	assert.Equal(t, "/opt", bp.Customizations.Filesystem[1].Mountpoint)
-	assert.Equal(t, uint64(20*common.GiB), bp.Customizations.Filesystem[1].MinSize)
+	assert.Equal(t, uint64(20*datasizes.GiB), bp.Customizations.Filesystem[1].MinSize)
 }
 
 func TestGetPackages(t *testing.T) {

--- a/pkg/blueprint/filesystem_customizations.go
+++ b/pkg/blueprint/filesystem_customizations.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/pathpolicy"
 )
 
@@ -32,7 +32,7 @@ func (fsc *FilesystemCustomization) UnmarshalTOML(data interface{}) error {
 		}
 		fsc.MinSize = uint64(minSize)
 	case string:
-		minSize, err := common.DataSizeToUint64(d["minsize"].(string))
+		minSize, err := datasizes.Parse(d["minsize"].(string))
 		if err != nil {
 			return fmt.Errorf("TOML unmarshal: minsize is not valid filesystem size (%w)", err)
 		}
@@ -63,7 +63,7 @@ func (fsc *FilesystemCustomization) UnmarshalJSON(data []byte) error {
 	case float64:
 		fsc.MinSize = uint64(d["minsize"].(float64))
 	case string:
-		minSize, err := common.DataSizeToUint64(d["minsize"].(string))
+		minSize, err := datasizes.Parse(d["minsize"].(string))
 		if err != nil {
 			return fmt.Errorf("JSON unmarshal: minsize is not valid filesystem size (%w)", err)
 		}

--- a/pkg/datasizes/constants.go
+++ b/pkg/datasizes/constants.go
@@ -1,0 +1,20 @@
+package datasizes
+
+const (
+	KiloByte = 1000                      // kB
+	KibiByte = 1024                      // KiB
+	MegaByte = 1000 * 1000               // MB
+	MebiByte = 1024 * 1024               // MiB
+	GigaByte = 1000 * 1000 * 1000        // GB
+	GibiByte = 1024 * 1024 * 1024        // GiB
+	TeraByte = 1000 * 1000 * 1000 * 1000 // TB
+	TebiByte = 1024 * 1024 * 1024 * 1024 // TiB
+
+	// shorthands
+	KiB = KibiByte
+	MB  = MegaByte
+	MiB = MebiByte
+	GB  = GigaByte
+	GiB = GibiByte
+	TiB = TebiByte
+)

--- a/pkg/datasizes/parse.go
+++ b/pkg/datasizes/parse.go
@@ -1,0 +1,56 @@
+package datasizes
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Parse converts a size specified as a string in KB/KiB/MB/etc. to
+// a number of bytes represented by uint64.
+func Parse(size string) (uint64, error) {
+	// Pre-process the input
+	size = strings.TrimSpace(size)
+
+	// Get the number from the string
+	plain_number := regexp.MustCompile(`[[:digit:]]+`)
+	number_as_str := plain_number.FindString(size)
+	if number_as_str == "" {
+		return 0, fmt.Errorf("the size string doesn't contain any number: %s", size)
+	}
+
+	// Parse the number into integer
+	return_size, err := strconv.ParseUint(number_as_str, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse size as integer: %s", number_as_str)
+	}
+
+	// List of all supported units (from kB to TB and KiB to TiB)
+	supported_units := []struct {
+		re       *regexp.Regexp
+		multiple uint64
+	}{
+		{regexp.MustCompile(`^\s*[[:digit:]]+\s*kB$`), KiloByte},
+		{regexp.MustCompile(`^\s*[[:digit:]]+\s*KiB$`), KibiByte},
+		{regexp.MustCompile(`^\s*[[:digit:]]+\s*MB$`), MegaByte},
+		{regexp.MustCompile(`^\s*[[:digit:]]+\s*MiB$`), MebiByte},
+		{regexp.MustCompile(`^\s*[[:digit:]]+\s*GB$`), GigaByte},
+		{regexp.MustCompile(`^\s*[[:digit:]]+\s*GiB$`), GibiByte},
+		{regexp.MustCompile(`^\s*[[:digit:]]+\s*TB$`), TeraByte},
+		{regexp.MustCompile(`^\s*[[:digit:]]+\s*TiB$`), TebiByte},
+		{regexp.MustCompile(`^\s*[[:digit:]]+$`), 1},
+	}
+
+	for _, unit := range supported_units {
+		if unit.re.MatchString(size) {
+			return_size *= unit.multiple
+			return return_size, nil
+		}
+	}
+
+	// In case the strign didn't match any of the above regexes, return nil
+	// even if a number was found. This is to prevent users from submitting
+	// unknown units.
+	return 0, fmt.Errorf("unknown data size units in string: %s", size)
+}

--- a/pkg/datasizes/parse_test.go
+++ b/pkg/datasizes/parse_test.go
@@ -1,0 +1,47 @@
+package datasizes_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/pkg/datasizes"
+)
+
+func TestDataSizeToUint64(t *testing.T) {
+	cases := []struct {
+		input   string
+		success bool
+		output  uint64
+	}{
+		{"123", true, 123},
+		{"123 kB", true, 123000},
+		{"123 KiB", true, 123 * 1024},
+		{"123 MB", true, 123 * 1000 * 1000},
+		{"123 MiB", true, 123 * 1024 * 1024},
+		{"123 GB", true, 123 * 1000 * 1000 * 1000},
+		{"123 GiB", true, 123 * 1024 * 1024 * 1024},
+		{"123 TB", true, 123 * 1000 * 1000 * 1000 * 1000},
+		{"123 TiB", true, 123 * 1024 * 1024 * 1024 * 1024},
+		{"123kB", true, 123000},
+		{"123KiB", true, 123 * 1024},
+		{" 123  ", true, 123},
+		{"  123kB  ", true, 123000},
+		{"  123KiB  ", true, 123 * 1024},
+		{"123 KB", false, 0},
+		{"123 mb", false, 0},
+		{"123 PB", false, 0},
+		{"123 PiB", false, 0},
+	}
+
+	for _, c := range cases {
+		result, err := datasizes.Parse(c.input)
+		if c.success {
+			require.Nil(t, err)
+			assert.EqualValues(t, c.output, result)
+		} else {
+			assert.NotNil(t, err)
+		}
+	}
+}

--- a/pkg/disk/disk_test.go
+++ b/pkg/disk/disk_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/blueprint"
+	"github.com/osbuild/images/pkg/datasizes"
 )
 
 const (
-	KiB = common.KiB
-	MiB = common.MiB
-	GiB = common.GiB
+	KiB = datasizes.KiB
+	MiB = datasizes.MiB
+	GiB = datasizes.GiB
 )
 
 func TestDisk_AlignUp(t *testing.T) {

--- a/pkg/disk/luks.go
+++ b/pkg/disk/luks.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 )
 
 // Argon2id defines parameters for the key derivation function for LUKS.
@@ -116,7 +116,7 @@ func (lc *LUKSContainer) MetadataSize() uint64 {
 	}
 
 	// 16 MiB is the default size for the LUKS2 header
-	return 16 * common.MiB
+	return 16 * datasizes.MiB
 }
 
 func (lc *LUKSContainer) minSize(size uint64) uint64 {

--- a/pkg/disk/lvm.go
+++ b/pkg/disk/lvm.go
@@ -5,12 +5,12 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 )
 
 // Default physical extent size in bytes: logical volumes
 // created inside the VG will be aligned to this.
-const LVMDefaultExtentSize = 4 * common.MebiByte
+const LVMDefaultExtentSize = 4 * datasizes.MebiByte
 
 type LVMVolumeGroup struct {
 	Name        string
@@ -143,7 +143,7 @@ func (vg *LVMVolumeGroup) MetadataSize() uint64 {
 	// of the metadata and its location and thus the start of the physical
 	// extent. For now we assume the default which results in a start of
 	// the physical extent 1 MiB
-	return 1 * common.MiB
+	return 1 * datasizes.MiB
 }
 
 func (vg *LVMVolumeGroup) minSize(size uint64) uint64 {

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/blueprint"
+	"github.com/osbuild/images/pkg/datasizes"
 )
 
 type PartitionTable struct {
@@ -692,7 +692,7 @@ func (pt *PartitionTable) ensureLVM() error {
 	// we need a /boot partition to boot LVM, ensure one exists
 	bootPath := entityPath(pt, "/boot")
 	if bootPath == nil {
-		_, err := pt.CreateMountpoint("/boot", 512*common.MiB)
+		_, err := pt.CreateMountpoint("/boot", 512*datasizes.MiB)
 
 		if err != nil {
 			return err
@@ -751,7 +751,7 @@ func (pt *PartitionTable) ensureBtrfs() error {
 	// we need a /boot partition to boot btrfs, ensure one exists
 	bootPath := entityPath(pt, "/boot")
 	if bootPath == nil {
-		_, err := pt.CreateMountpoint("/boot", 512*common.MiB)
+		_, err := pt.CreateMountpoint("/boot", 512*datasizes.MiB)
 		if err != nil {
 			return fmt.Errorf("failed to create /boot partition when ensuring btrfs: %w", err)
 		}

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -4,11 +4,11 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/internal/testdisk"
-	"github.com/osbuild/images/pkg/disk"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/internal/testdisk"
+	"github.com/osbuild/images/pkg/datasizes"
+	"github.com/osbuild/images/pkg/disk"
 )
 
 func TestPartitionTable_GetMountpointSize(t *testing.T) {
@@ -33,13 +33,13 @@ func TestPartitionTable_GenerateUUIDs(t *testing.T) {
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     1 * common.MebiByte,
+				Size:     1 * datasizes.MebiByte,
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 2 * common.GibiByte,
+				Size: 2 * datasizes.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				Payload: &disk.Filesystem{
 					// create mixed xfs root filesystem and a btrfs /var partition
@@ -52,7 +52,7 @@ func TestPartitionTable_GenerateUUIDs(t *testing.T) {
 				},
 			},
 			{
-				Size: 10 * common.GibiByte,
+				Size: 10 * datasizes.GibiByte,
 				Payload: &disk.Btrfs{
 					Subvolumes: []disk.BtrfsSubvolume{
 						{
@@ -87,7 +87,7 @@ func TestPartitionTable_GenerateUUIDs_VFAT(t *testing.T) {
 		Type: "dos",
 		Partitions: []disk.Partition{
 			{
-				Size: 2 * common.GibiByte,
+				Size: 2 * datasizes.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				Payload: &disk.Filesystem{
 					Type:       "vfat",

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -11,6 +11,7 @@ import (
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/oscap"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
@@ -209,7 +210,7 @@ var (
 			LockRootUser:              common.ToPtr(true),
 			IgnitionPlatform:          common.ToPtr("metal"),
 		},
-		defaultSize:         10 * common.GibiByte,
+		defaultSize:         10 * datasizes.GibiByte,
 		rpmOstree:           true,
 		bootable:            true,
 		bootISO:             true,
@@ -238,7 +239,7 @@ var (
 			LockRootUser:              common.ToPtr(true),
 			IgnitionPlatform:          common.ToPtr("metal"),
 		},
-		defaultSize:         4 * common.GibiByte,
+		defaultSize:         4 * datasizes.GibiByte,
 		rpmOstree:           true,
 		bootable:            true,
 		image:               iotImage,
@@ -268,7 +269,7 @@ var (
 			LockRootUser:              common.ToPtr(true),
 			IgnitionPlatform:          common.ToPtr("qemu"),
 		},
-		defaultSize:         10 * common.GibiByte,
+		defaultSize:         10 * datasizes.GibiByte,
 		rpmOstree:           true,
 		bootable:            true,
 		image:               iotImage,
@@ -292,7 +293,7 @@ var (
 		},
 		kernelOptions:       cloudKernelOptions,
 		bootable:            true,
-		defaultSize:         5 * common.GibiByte,
+		defaultSize:         5 * datasizes.GibiByte,
 		image:               diskImage,
 		buildPipelines:      []string{"build"},
 		payloadPipelines:    []string{"os", "image", "qcow2"},
@@ -320,7 +321,7 @@ var (
 		defaultImageConfig:  vmdkDefaultImageConfig,
 		kernelOptions:       cloudKernelOptions,
 		bootable:            true,
-		defaultSize:         2 * common.GibiByte,
+		defaultSize:         2 * datasizes.GibiByte,
 		image:               diskImage,
 		buildPipelines:      []string{"build"},
 		payloadPipelines:    []string{"os", "image", "vmdk"},
@@ -338,7 +339,7 @@ var (
 		defaultImageConfig:  vmdkDefaultImageConfig,
 		kernelOptions:       cloudKernelOptions,
 		bootable:            true,
-		defaultSize:         2 * common.GibiByte,
+		defaultSize:         2 * datasizes.GibiByte,
 		image:               diskImage,
 		buildPipelines:      []string{"build"},
 		payloadPipelines:    []string{"os", "image", "vmdk", "ovf", "archive"},
@@ -412,7 +413,7 @@ var (
 		rpmOstree:           false,
 		kernelOptions:       defaultKernelOptions,
 		bootable:            true,
-		defaultSize:         2 * common.GibiByte,
+		defaultSize:         2 * datasizes.GibiByte,
 		image:               diskImage,
 		buildPipelines:      []string{"build"},
 		payloadPipelines:    []string{"os", "image", "xz"},

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -13,6 +13,7 @@ import (
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/oscap"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/image"
@@ -97,8 +98,8 @@ func (t *imageType) ISOLabel() (string, error) {
 
 func (t *imageType) Size(size uint64) uint64 {
 	// Microsoft Azure requires vhd images to be rounded up to the nearest MB
-	if t.name == "vhd" && size%common.MebiByte != 0 {
-		size = (size/common.MebiByte + 1) * common.MebiByte
+	if t.name == "vhd" && size%datasizes.MebiByte != 0 {
+		size = (size/datasizes.MebiByte + 1) * datasizes.MebiByte
 	}
 	if size == 0 {
 		size = t.defaultSize

--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -1,8 +1,8 @@
 package fedora
 
 import (
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 )
@@ -13,13 +13,13 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     1 * common.MebiByte,
+				Size:     1 * datasizes.MebiByte,
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 200 * common.MebiByte,
+				Size: 200 * datasizes.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -33,7 +33,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 500 * common.MebiByte,
+				Size: 500 * datasizes.MebiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -46,7 +46,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * common.GibiByte,
+				Size: 2 * datasizes.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -65,7 +65,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size: 200 * common.MebiByte,
+				Size: 200 * datasizes.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -79,7 +79,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 500 * common.MebiByte,
+				Size: 500 * datasizes.MebiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -92,7 +92,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * common.GibiByte,
+				Size: 2 * datasizes.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -111,12 +111,12 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "dos",
 		Partitions: []disk.Partition{
 			{
-				Size:     4 * common.MebiByte,
+				Size:     4 * datasizes.MebiByte,
 				Type:     "41",
 				Bootable: true,
 			},
 			{
-				Size: 500 * common.MebiByte,
+				Size: 500 * datasizes.MebiByte,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
@@ -127,7 +127,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * common.GibiByte,
+				Size: 2 * datasizes.GibiByte,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Mountpoint:   "/",
@@ -144,7 +144,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "dos",
 		Partitions: []disk.Partition{
 			{
-				Size: 500 * common.MebiByte,
+				Size: 500 * datasizes.MebiByte,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
@@ -155,7 +155,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size:     2 * common.GibiByte,
+				Size:     2 * datasizes.GibiByte,
 				Bootable: true,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
@@ -173,10 +173,10 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type:        "gpt",
-		StartOffset: 8 * common.MebiByte,
+		StartOffset: 8 * datasizes.MebiByte,
 		Partitions: []disk.Partition{
 			{
-				Size: 200 * common.MebiByte,
+				Size: 200 * datasizes.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -190,7 +190,7 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 1 * common.GibiByte,
+				Size: 1 * datasizes.GibiByte,
 				Type: disk.XBootLDRPartitionGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -203,7 +203,7 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * common.GibiByte,
+				Size: 2 * datasizes.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -220,10 +220,10 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
 		UUID:        "0xc1748067",
 		Type:        "dos",
-		StartOffset: 8 * common.MebiByte,
+		StartOffset: 8 * datasizes.MebiByte,
 		Partitions: []disk.Partition{
 			{
-				Size:     200 * common.MebiByte,
+				Size:     200 * datasizes.MebiByte,
 				Type:     disk.DosFat16B,
 				Bootable: true,
 				Payload: &disk.Filesystem{
@@ -237,7 +237,7 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 1 * common.GibiByte,
+				Size: 1 * datasizes.GibiByte,
 				Type: "83",
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
@@ -249,7 +249,7 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * common.GibiByte,
+				Size: 2 * datasizes.GibiByte,
 				Type: "83",
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
@@ -268,10 +268,10 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type:        "gpt",
-		StartOffset: 8 * common.MebiByte,
+		StartOffset: 8 * datasizes.MebiByte,
 		Partitions: []disk.Partition{
 			{
-				Size: 501 * common.MebiByte,
+				Size: 501 * datasizes.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -285,7 +285,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 1 * common.GibiByte,
+				Size: 1 * datasizes.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -298,7 +298,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2569 * common.MebiByte,
+				Size: 2569 * datasizes.MebiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -315,10 +315,10 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
 		UUID:        "0xc1748067",
 		Type:        "dos",
-		StartOffset: 8 * common.MebiByte,
+		StartOffset: 8 * datasizes.MebiByte,
 		Partitions: []disk.Partition{
 			{
-				Size:     501 * common.MebiByte,
+				Size:     501 * datasizes.MebiByte,
 				Type:     disk.DosFat16B,
 				Bootable: true,
 				Payload: &disk.Filesystem{
@@ -332,7 +332,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 1 * common.GibiByte,
+				Size: 1 * datasizes.GibiByte,
 				Type: "83",
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
@@ -344,7 +344,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2569 * common.MebiByte,
+				Size: 2569 * datasizes.MebiByte,
 				Type: "83",
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
@@ -365,7 +365,7 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size: 501 * common.MebiByte,
+				Size: 501 * datasizes.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -379,7 +379,7 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 1 * common.GibiByte,
+				Size: 1 * datasizes.GibiByte,
 				Type: disk.XBootLDRPartitionGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -413,7 +413,7 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 						Description: "built with lvm2 and osbuild",
 						LogicalVolumes: []disk.LVMLogicalVolume{
 							{
-								Size: 8 * common.GibiByte,
+								Size: 8 * datasizes.GibiByte,
 								Name: "rootlv",
 								Payload: &disk.Filesystem{
 									Type:         "ext4",
@@ -435,7 +435,7 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size: 501 * common.MebiByte,
+				Size: 501 * datasizes.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -449,7 +449,7 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 1 * common.GibiByte,
+				Size: 1 * datasizes.GibiByte,
 				Type: disk.XBootLDRPartitionGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -483,7 +483,7 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 						Description: "built with lvm2 and osbuild",
 						LogicalVolumes: []disk.LVMLogicalVolume{
 							{
-								Size: 8 * common.GibiByte,
+								Size: 8 * datasizes.GibiByte,
 								Name: "rootlv",
 								Payload: &disk.Filesystem{
 									Type:         "ext4",

--- a/pkg/distro/rhel/imagetype.go
+++ b/pkg/distro/rhel/imagetype.go
@@ -6,11 +6,11 @@ import (
 
 	"slices"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/environment"
 	"github.com/osbuild/images/internal/workload"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/image"
@@ -140,8 +140,8 @@ func (t *ImageType) ISOLabel() (string, error) {
 
 func (t *ImageType) Size(size uint64) uint64 {
 	// Microsoft Azure requires vhd images to be rounded up to the nearest MB
-	if t.name == "vhd" && size%common.MebiByte != 0 {
-		size = (size/common.MebiByte + 1) * common.MebiByte
+	if t.name == "vhd" && size%datasizes.MebiByte != 0 {
+		size = (size/datasizes.MebiByte + 1) * datasizes.MebiByte
 	}
 	if size == 0 {
 		size = t.DefaultSize

--- a/pkg/distro/rhel/rhel10/ami.go
+++ b/pkg/distro/rhel/rhel10/ami.go
@@ -2,6 +2,7 @@ package rhel10
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -217,7 +218,7 @@ func mkAMIImgTypeX86_64() *rhel.ImageType {
 
 	it.KernelOptions = amiKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultAMIImageConfigX86_64()
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -241,7 +242,7 @@ func mkAMIImgTypeAarch64() *rhel.ImageType {
 
 	it.KernelOptions = "console=ttyS0,115200n8 console=tty0 nvme_core.io_timeout=4294967295 iommu.strict=0"
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultAMIImageConfig()
 	it.BasePartitionTables = defaultBasePartitionTables
 

--- a/pkg/distro/rhel/rhel10/azure.go
+++ b/pkg/distro/rhel/rhel10/azure.go
@@ -2,6 +2,7 @@ package rhel10
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -25,7 +26,7 @@ func mkAzureImgType() *rhel.ImageType {
 
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 4 * common.GibiByte
+	it.DefaultSize = 4 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultAzureImageConfig
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -49,7 +50,7 @@ func mkAzureByosImgType(rd distro.Distro) *rhel.ImageType {
 
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 4 * common.GibiByte
+	it.DefaultSize = 4 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultAzureImageConfig
 	it.BasePartitionTables = defaultBasePartitionTables
 

--- a/pkg/distro/rhel/rhel10/gce.go
+++ b/pkg/distro/rhel/rhel10/gce.go
@@ -2,6 +2,7 @@ package rhel10
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -26,7 +27,7 @@ func mkGCEImageType() *rhel.ImageType {
 
 	it.DefaultImageConfig = baseGCEImageConfig()
 	it.KernelOptions = gceKernelOptions
-	it.DefaultSize = 20 * common.GibiByte
+	it.DefaultSize = 20 * datasizes.GibiByte
 	it.Bootable = true
 	// TODO: the base partition table still contains the BIOS boot partition, but the image is UEFI-only
 	it.BasePartitionTables = defaultBasePartitionTables

--- a/pkg/distro/rhel/rhel10/partition_tables.go
+++ b/pkg/distro/rhel/rhel10/partition_tables.go
@@ -1,8 +1,8 @@
 package rhel10
 
 import (
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro/rhel"
 )
@@ -15,13 +15,13 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
-					Size:     1 * common.MebiByte,
+					Size:     1 * datasizes.MebiByte,
 					Bootable: true,
 					Type:     disk.BIOSBootPartitionGUID,
 					UUID:     disk.BIOSBootPartitionUUID,
 				},
 				{
-					Size: 200 * common.MebiByte,
+					Size: 200 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -35,7 +35,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 2 * common.GibiByte,
+					Size: 2 * datasizes.GibiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.RootPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -55,7 +55,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
-					Size: 200 * common.MebiByte,
+					Size: 200 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -69,7 +69,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 2 * common.GibiByte,
+					Size: 2 * datasizes.GibiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.RootPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -89,12 +89,12 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "dos",
 			Partitions: []disk.Partition{
 				{
-					Size:     4 * common.MebiByte,
+					Size:     4 * datasizes.MebiByte,
 					Type:     "41",
 					Bootable: true,
 				},
 				{
-					Size: 2 * common.GibiByte,
+					Size: 2 * datasizes.GibiByte,
 					Payload: &disk.Filesystem{
 						Type:         "xfs",
 						Mountpoint:   "/",
@@ -112,7 +112,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "dos",
 			Partitions: []disk.Partition{
 				{
-					Size:     2 * common.GibiByte,
+					Size:     2 * datasizes.GibiByte,
 					Bootable: true,
 					Payload: &disk.Filesystem{
 						Type:         "xfs",

--- a/pkg/distro/rhel/rhel10/qcow2.go
+++ b/pkg/distro/rhel/rhel10/qcow2.go
@@ -3,6 +3,7 @@ package rhel10
 import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/customizations/subscription"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -24,7 +25,7 @@ func mkQcow2ImgType(d *rhel.Distribution) *rhel.ImageType {
 
 	it.DefaultImageConfig = qcowImageConfig(d)
 	it.KernelOptions = "console=tty0 console=ttyS0,115200n8 no_timer_check"
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -47,7 +48,7 @@ func mkOCIImgType(d *rhel.Distribution) *rhel.ImageType {
 
 	it.DefaultImageConfig = qcowImageConfig(d)
 	it.KernelOptions = "console=tty0 console=ttyS0,115200n8 no_timer_check"
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
 

--- a/pkg/distro/rhel/rhel10/vmdk.go
+++ b/pkg/distro/rhel/rhel10/vmdk.go
@@ -2,6 +2,7 @@ package rhel10
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -28,7 +29,7 @@ func mkVMDKImgType() *rhel.ImageType {
 	}
 	it.KernelOptions = vmdkKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 4 * common.GibiByte
+	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -53,7 +54,7 @@ func mkOVAImgType() *rhel.ImageType {
 	}
 	it.KernelOptions = vmdkKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 4 * common.GibiByte
+	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it

--- a/pkg/distro/rhel/rhel7/ami.go
+++ b/pkg/distro/rhel/rhel7/ami.go
@@ -6,6 +6,7 @@ import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
@@ -38,7 +39,7 @@ func mkEc2ImgTypeX86_64() *rhel.ImageType {
 	it.DefaultImageConfig = ec2ImageConfig()
 	it.KernelOptions = ec2KernelOptions
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = ec2PartitionTables
 
 	return it
@@ -259,16 +260,16 @@ func ec2PartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
-			Size: 10 * common.GibiByte,
+			Size: 10 * datasizes.GibiByte,
 			Partitions: []disk.Partition{
 				{
-					Size:     1 * common.MebiByte,
+					Size:     1 * datasizes.MebiByte,
 					Bootable: true,
 					Type:     disk.BIOSBootPartitionGUID,
 					UUID:     disk.BIOSBootPartitionUUID,
 				},
 				{
-					Size: 6144 * common.MebiByte,
+					Size: 6144 * datasizes.MebiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.RootPartitionUUID,
 					Payload: &disk.Filesystem{

--- a/pkg/distro/rhel/rhel7/azure.go
+++ b/pkg/distro/rhel/rhel7/azure.go
@@ -4,6 +4,7 @@ import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/subscription"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
@@ -34,7 +35,7 @@ func mkAzureRhuiImgType() *rhel.ImageType {
 	it.KernelOptions = "ro crashkernel=auto console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 scsi_mod.use_blk_mq=y"
 	it.DefaultImageConfig = azureDefaultImgConfig
 	it.Bootable = true
-	it.DefaultSize = 64 * common.GibiByte
+	it.DefaultSize = 64 * datasizes.GibiByte
 	it.BasePartitionTables = azureRhuiBasePartitionTables
 
 	return it
@@ -286,10 +287,10 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
-			Size: 64 * common.GibiByte,
+			Size: 64 * datasizes.GibiByte,
 			Partitions: []disk.Partition{
 				{
-					Size: 500 * common.MebiByte,
+					Size: 500 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -302,7 +303,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 					},
 				},
 				{
-					Size: 500 * common.MebiByte,
+					Size: 500 * datasizes.MebiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.FilesystemDataUUID,
 					Payload: &disk.Filesystem{
@@ -314,7 +315,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 					},
 				},
 				{
-					Size:     2 * common.MebiByte,
+					Size:     2 * datasizes.MebiByte,
 					Bootable: true,
 					Type:     disk.BIOSBootPartitionGUID,
 					UUID:     disk.BIOSBootPartitionUUID,
@@ -327,7 +328,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 						Description: "built with lvm2 and osbuild",
 						LogicalVolumes: []disk.LVMLogicalVolume{
 							{
-								Size: 1 * common.GibiByte,
+								Size: 1 * datasizes.GibiByte,
 								Name: "homelv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -339,7 +340,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 								},
 							},
 							{
-								Size: 2 * common.GibiByte,
+								Size: 2 * datasizes.GibiByte,
 								Name: "rootlv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -351,7 +352,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 								},
 							},
 							{
-								Size: 2 * common.GibiByte,
+								Size: 2 * datasizes.GibiByte,
 								Name: "tmplv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -363,7 +364,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 								},
 							},
 							{
-								Size: 10 * common.GibiByte,
+								Size: 10 * datasizes.GibiByte,
 								Name: "usrlv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -375,7 +376,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 								},
 							},
 							{
-								Size: 10 * common.GibiByte, // firedrill: 8 GB
+								Size: 10 * datasizes.GibiByte,
 								Name: "varlv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",

--- a/pkg/distro/rhel/rhel7/partition_tables.go
+++ b/pkg/distro/rhel/rhel7/partition_tables.go
@@ -1,8 +1,8 @@
 package rhel7
 
 import (
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro/rhel"
 )
@@ -15,13 +15,13 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
-					Size:     1 * common.MebiByte,
+					Size:     1 * datasizes.MebiByte,
 					Bootable: true,
 					Type:     disk.BIOSBootPartitionGUID,
 					UUID:     disk.BIOSBootPartitionUUID,
 				},
 				{
-					Size: 200 * common.MebiByte,
+					Size: 200 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -35,7 +35,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 500 * common.MebiByte,
+					Size: 500 * datasizes.MebiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.FilesystemDataUUID,
 					Payload: &disk.Filesystem{
@@ -48,7 +48,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 2 * common.GibiByte,
+					Size: 2 * datasizes.GibiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.RootPartitionUUID,
 					Payload: &disk.Filesystem{

--- a/pkg/distro/rhel/rhel7/qcow2.go
+++ b/pkg/distro/rhel/rhel7/qcow2.go
@@ -3,6 +3,7 @@ package rhel7
 import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/customizations/subscription"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -28,7 +29,7 @@ func mkQcow2ImgType() *rhel.ImageType {
 
 	it.KernelOptions = "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto"
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = qcow2DefaultImgConfig
 	it.BasePartitionTables = defaultBasePartitionTables
 

--- a/pkg/distro/rhel/rhel8/ami.go
+++ b/pkg/distro/rhel/rhel8/ami.go
@@ -3,6 +3,7 @@ package rhel8
 import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/customizations/subscription"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -32,7 +33,7 @@ func mkAmiImgTypeX86_64() *rhel.ImageType {
 	it.DefaultImageConfig = defaultAMIImageConfigX86_64()
 	it.KernelOptions = amiX86KernelOptions
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = ec2PartitionTables
 
 	return it
@@ -56,7 +57,7 @@ func mkEc2ImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64(rd)
 	it.KernelOptions = amiX86KernelOptions
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = ec2PartitionTables
 
 	return it
@@ -80,7 +81,7 @@ func mkEc2HaImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64(rd)
 	it.KernelOptions = amiX86KernelOptions
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = ec2PartitionTables
 
 	return it
@@ -103,7 +104,7 @@ func mkAmiImgTypeAarch64() *rhel.ImageType {
 	it.DefaultImageConfig = defaultAMIImageConfig()
 	it.KernelOptions = amiAarch64KernelOptions
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = ec2PartitionTables
 
 	return it
@@ -127,7 +128,7 @@ func mkEc2ImgTypeAarch64(rd *rhel.Distribution) *rhel.ImageType {
 	it.DefaultImageConfig = defaultEc2ImageConfig(rd)
 	it.KernelOptions = amiAarch64KernelOptions
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = ec2PartitionTables
 
 	return it
@@ -151,7 +152,7 @@ func mkEc2SapImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 	it.DefaultImageConfig = defaultEc2SapImageConfigX86_64(rd)
 	it.KernelOptions = amiSapKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = ec2PartitionTables
 
 	return it

--- a/pkg/distro/rhel/rhel8/azure.go
+++ b/pkg/distro/rhel/rhel8/azure.go
@@ -5,6 +5,7 @@ import (
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/shell"
 	"github.com/osbuild/images/pkg/customizations/subscription"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
@@ -33,7 +34,7 @@ func mkAzureRhuiImgType() *rhel.ImageType {
 	it.DefaultImageConfig = defaultAzureRhuiImageConfig.InheritFrom(defaultVhdImageConfig())
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 64 * common.GibiByte
+	it.DefaultSize = 64 * datasizes.GibiByte
 	it.BasePartitionTables = azureRhuiBasePartitionTables
 
 	return it
@@ -57,7 +58,7 @@ func mkAzureSapRhuiImgType(rd *rhel.Distribution) *rhel.ImageType {
 	it.DefaultImageConfig = defaultAzureRhuiImageConfig.InheritFrom(sapAzureImageConfig(rd))
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 64 * common.GibiByte
+	it.DefaultSize = 64 * datasizes.GibiByte
 	it.BasePartitionTables = azureRhuiBasePartitionTables
 
 	return it
@@ -80,7 +81,7 @@ func mkAzureByosImgType() *rhel.ImageType {
 	it.DefaultImageConfig = defaultAzureByosImageConfig.InheritFrom(defaultVhdImageConfig())
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 4 * common.GibiByte
+	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -104,7 +105,7 @@ func mkAzureImgType() *rhel.ImageType {
 	it.DefaultImageConfig = defaultVhdImageConfig()
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 4 * common.GibiByte
+	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -128,7 +129,7 @@ func mkAzureEap7RhuiImgType() *rhel.ImageType {
 	it.DefaultImageConfig = defaultAzureEapImageConfig.InheritFrom(defaultAzureRhuiImageConfig.InheritFrom(defaultAzureImageConfig))
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 64 * common.GibiByte
+	it.DefaultSize = 64 * datasizes.GibiByte
 	it.BasePartitionTables = azureRhuiBasePartitionTables
 	it.Workload = eapWorkload()
 
@@ -287,10 +288,10 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
-			Size: 64 * common.GibiByte,
+			Size: 64 * datasizes.GibiByte,
 			Partitions: []disk.Partition{
 				{
-					Size: 500 * common.MebiByte,
+					Size: 500 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -303,7 +304,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 					},
 				},
 				{
-					Size: 500 * common.MebiByte,
+					Size: 500 * datasizes.MebiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.FilesystemDataUUID,
 					Payload: &disk.Filesystem{
@@ -315,7 +316,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 					},
 				},
 				{
-					Size:     2 * common.MebiByte,
+					Size:     2 * datasizes.MebiByte,
 					Bootable: true,
 					Type:     disk.BIOSBootPartitionGUID,
 					UUID:     disk.BIOSBootPartitionUUID,
@@ -328,7 +329,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 						Description: "built with lvm2 and osbuild",
 						LogicalVolumes: []disk.LVMLogicalVolume{
 							{
-								Size: 1 * common.GibiByte,
+								Size: 1 * datasizes.GibiByte,
 								Name: "homelv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -340,7 +341,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 								},
 							},
 							{
-								Size: 2 * common.GibiByte,
+								Size: 2 * datasizes.GibiByte,
 								Name: "rootlv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -352,7 +353,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 								},
 							},
 							{
-								Size: 2 * common.GibiByte,
+								Size: 2 * datasizes.GibiByte,
 								Name: "tmplv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -364,7 +365,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 								},
 							},
 							{
-								Size: 10 * common.GibiByte,
+								Size: 10 * datasizes.GibiByte,
 								Name: "usrlv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -376,7 +377,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 								},
 							},
 							{
-								Size: 10 * common.GibiByte,
+								Size: 10 * datasizes.GibiByte,
 								Name: "varlv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -397,10 +398,10 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
-			Size: 64 * common.GibiByte,
+			Size: 64 * datasizes.GibiByte,
 			Partitions: []disk.Partition{
 				{
-					Size: 500 * common.MebiByte,
+					Size: 500 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -413,7 +414,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 					},
 				},
 				{
-					Size: 500 * common.MebiByte,
+					Size: 500 * datasizes.MebiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.FilesystemDataUUID,
 					Payload: &disk.Filesystem{
@@ -432,7 +433,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 						Description: "built with lvm2 and osbuild",
 						LogicalVolumes: []disk.LVMLogicalVolume{
 							{
-								Size: 1 * common.GibiByte,
+								Size: 1 * datasizes.GibiByte,
 								Name: "homelv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -444,7 +445,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 								},
 							},
 							{
-								Size: 2 * common.GibiByte,
+								Size: 2 * datasizes.GibiByte,
 								Name: "rootlv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -456,7 +457,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 								},
 							},
 							{
-								Size: 2 * common.GibiByte,
+								Size: 2 * datasizes.GibiByte,
 								Name: "tmplv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -468,7 +469,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 								},
 							},
 							{
-								Size: 10 * common.GibiByte,
+								Size: 10 * datasizes.GibiByte,
 								Name: "usrlv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -480,7 +481,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 								},
 							},
 							{
-								Size: 10 * common.GibiByte,
+								Size: 10 * datasizes.GibiByte,
 								Name: "varlv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",

--- a/pkg/distro/rhel/rhel8/distro_internal_test.go
+++ b/pkg/distro/rhel/rhel8/distro_internal_test.go
@@ -6,13 +6,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/osbuild/images/internal/common"
-
-	"github.com/osbuild/images/pkg/blueprint"
-	"github.com/osbuild/images/pkg/distro"
-	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/pkg/blueprint"
+	"github.com/osbuild/images/pkg/datasizes"
+	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distro/rhel"
 )
 
 // math/rand is good enough in this case
@@ -70,7 +70,7 @@ func TestEC2Partitioning(t *testing.T) {
 
 					bootSize, err := pt.GetMountpointSize("/boot")
 					require.NoError(t, err)
-					require.Equal(t, tt.aarch64bootSizeMiB*common.MiB, bootSize)
+					require.Equal(t, tt.aarch64bootSizeMiB*datasizes.MiB, bootSize)
 				})
 
 			}

--- a/pkg/distro/rhel/rhel8/edge.go
+++ b/pkg/distro/rhel/rhel8/edge.go
@@ -6,6 +6,7 @@ import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
@@ -88,7 +89,7 @@ func mkEdgeRawImgType() *rhel.ImageType {
 		Locale:       common.ToPtr("C.UTF-8"),
 		LockRootUser: common.ToPtr(true),
 	}
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.RPMOSTree = true
 	it.Bootable = true
 	it.BasePartitionTables = edgeBasePartitionTables
@@ -175,7 +176,7 @@ func mkEdgeSimplifiedInstallerImgType(rd *rhel.Distribution) *rhel.ImageType {
 			"prefixdevname-tools",
 		},
 	}
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.RPMOSTree = true
 	it.Bootable = true
 	it.BootISO = true
@@ -212,7 +213,7 @@ func mkMinimalRawImgType() *rhel.ImageType {
 	}
 	it.KernelOptions = "ro"
 	it.Bootable = true
-	it.DefaultSize = 2 * common.GibiByte
+	it.DefaultSize = 2 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it

--- a/pkg/distro/rhel/rhel8/gce.go
+++ b/pkg/distro/rhel/rhel8/gce.go
@@ -3,6 +3,7 @@ package rhel8
 import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/customizations/subscription"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -28,7 +29,7 @@ func mkGceImgType(rd distro.Distro) *rhel.ImageType {
 	it.DefaultImageConfig = defaultGceByosImageConfig(rd)
 	it.KernelOptions = gceKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 20 * common.GibiByte
+	it.DefaultSize = 20 * datasizes.GibiByte
 	// TODO: the base partition table still contains the BIOS boot partition, but the image is UEFI-only
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -52,7 +53,7 @@ func mkGceRhuiImgType(rd distro.Distro) *rhel.ImageType {
 	it.DefaultImageConfig = defaultGceRhuiImageConfig(rd)
 	it.KernelOptions = gceKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 20 * common.GibiByte
+	it.DefaultSize = 20 * datasizes.GibiByte
 	// TODO: the base partition table still contains the BIOS boot partition, but the image is UEFI-only
 	it.BasePartitionTables = defaultBasePartitionTables
 

--- a/pkg/distro/rhel/rhel8/partition_tables.go
+++ b/pkg/distro/rhel/rhel8/partition_tables.go
@@ -3,6 +3,7 @@ package rhel8
 import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro/rhel"
 )
@@ -15,13 +16,13 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
-					Size:     1 * common.MebiByte,
+					Size:     1 * datasizes.MebiByte,
 					Bootable: true,
 					Type:     disk.BIOSBootPartitionGUID,
 					UUID:     disk.BIOSBootPartitionUUID,
 				},
 				{
-					Size: 100 * common.MebiByte,
+					Size: 100 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -34,7 +35,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 2 * common.GibiByte,
+					Size: 2 * datasizes.GibiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.RootPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -55,7 +56,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
-					Size: 100 * common.MebiByte,
+					Size: 100 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -68,7 +69,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 2 * common.GibiByte,
+					Size: 2 * datasizes.GibiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.RootPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -89,12 +90,12 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "dos",
 			Partitions: []disk.Partition{
 				{
-					Size:     4 * common.MebiByte,
+					Size:     4 * datasizes.MebiByte,
 					Type:     "41",
 					Bootable: true,
 				},
 				{
-					Size: 2 * common.GibiByte,
+					Size: 2 * datasizes.GibiByte,
 					Payload: &disk.Filesystem{
 						Type:         "xfs",
 						Mountpoint:   "/",
@@ -112,7 +113,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "dos",
 			Partitions: []disk.Partition{
 				{
-					Size:     2 * common.GibiByte,
+					Size:     2 * datasizes.GibiByte,
 					Bootable: true,
 					Payload: &disk.Filesystem{
 						Type:         "xfs",
@@ -138,13 +139,13 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
-					Size:     1 * common.MebiByte,
+					Size:     1 * datasizes.MebiByte,
 					Bootable: true,
 					Type:     disk.BIOSBootPartitionGUID,
 					UUID:     disk.BIOSBootPartitionUUID,
 				},
 				{
-					Size: 127 * common.MebiByte,
+					Size: 127 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -158,7 +159,7 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 384 * common.MebiByte,
+					Size: 384 * datasizes.MebiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.FilesystemDataUUID,
 					Payload: &disk.Filesystem{
@@ -171,7 +172,7 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 2 * common.GibiByte,
+					Size: 2 * datasizes.GibiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.RootPartitionUUID,
 					Payload: &disk.LUKSContainer{
@@ -207,7 +208,7 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
-					Size: 127 * common.MebiByte,
+					Size: 127 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -221,7 +222,7 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 384 * common.MebiByte,
+					Size: 384 * datasizes.MebiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.FilesystemDataUUID,
 					Payload: &disk.Filesystem{
@@ -234,7 +235,7 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 2 * common.GibiByte,
+					Size: 2 * datasizes.GibiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.RootPartitionUUID,
 					Payload: &disk.LUKSContainer{
@@ -275,9 +276,9 @@ func ec2PartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	var aarch64BootSize uint64
 	switch {
 	case common.VersionLessThan(t.Arch().Distro().OsVersion(), "8.10") && t.IsRHEL():
-		aarch64BootSize = 512 * common.MebiByte
+		aarch64BootSize = 512 * datasizes.MebiByte
 	default:
-		aarch64BootSize = 1 * common.GibiByte
+		aarch64BootSize = 1 * datasizes.GibiByte
 	}
 
 	x86PartitionTable := disk.PartitionTable{
@@ -285,13 +286,13 @@ func ec2PartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     1 * common.MebiByte,
+				Size:     1 * datasizes.MebiByte,
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 200 * common.MebiByte,
+				Size: 200 * datasizes.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -304,7 +305,7 @@ func ec2PartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 				},
 			},
 			{
-				Size: 2 * common.GibiByte,
+				Size: 2 * datasizes.GibiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -325,13 +326,13 @@ func ec2PartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
-					Size:     1 * common.MebiByte,
+					Size:     1 * datasizes.MebiByte,
 					Bootable: true,
 					Type:     disk.BIOSBootPartitionGUID,
 					UUID:     disk.BIOSBootPartitionUUID,
 				},
 				{
-					Size: 2 * common.GibiByte,
+					Size: 2 * datasizes.GibiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.RootPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -357,7 +358,7 @@ func ec2PartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
-					Size: 200 * common.MebiByte,
+					Size: 200 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -382,7 +383,7 @@ func ec2PartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 2 * common.GibiByte,
+					Size: 2 * datasizes.GibiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.RootPartitionUUID,
 					Payload: &disk.Filesystem{

--- a/pkg/distro/rhel/rhel8/qcow2.go
+++ b/pkg/distro/rhel/rhel8/qcow2.go
@@ -3,6 +3,7 @@ package rhel8
 import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/customizations/subscription"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -25,7 +26,7 @@ func mkQcow2ImgType(rd *rhel.Distribution) *rhel.ImageType {
 	it.DefaultImageConfig = qcowImageConfig(rd)
 	it.KernelOptions = "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto"
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -48,7 +49,7 @@ func mkOCIImgType(rd *rhel.Distribution) *rhel.ImageType {
 	it.DefaultImageConfig = qcowImageConfig(rd)
 	it.KernelOptions = "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto"
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -69,7 +70,7 @@ func mkOpenstackImgType() *rhel.ImageType {
 	)
 
 	it.KernelOptions = "ro net.ifnames=0"
-	it.DefaultSize = 4 * common.GibiByte
+	it.DefaultSize = 4 * datasizes.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
 

--- a/pkg/distro/rhel/rhel8/vmdk.go
+++ b/pkg/distro/rhel/rhel8/vmdk.go
@@ -1,7 +1,7 @@
 package rhel8
 
 import (
-	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -24,7 +24,7 @@ func mkVmdkImgType() *rhel.ImageType {
 
 	it.KernelOptions = vmdkKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 4 * common.GibiByte
+	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -46,7 +46,7 @@ func mkOvaImgType() *rhel.ImageType {
 
 	it.KernelOptions = vmdkKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 4 * common.GibiByte
+	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it

--- a/pkg/distro/rhel/rhel9/ami.go
+++ b/pkg/distro/rhel/rhel9/ami.go
@@ -2,6 +2,7 @@ package rhel9
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -276,7 +277,7 @@ func mkEc2ImgTypeX86_64() *rhel.ImageType {
 	it.Compression = "xz"
 	it.KernelOptions = amiKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -299,7 +300,7 @@ func mkAMIImgTypeX86_64() *rhel.ImageType {
 
 	it.KernelOptions = amiKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -323,7 +324,7 @@ func mkEC2SapImgTypeX86_64(osVersion string) *rhel.ImageType {
 	it.Compression = "xz"
 	it.KernelOptions = "console=ttyS0,115200n8 console=tty0 net.ifnames=0 nvme_core.io_timeout=4294967295 processor.max_cstate=1 intel_idle.max_cstate=1"
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = sapImageConfig(osVersion).InheritFrom(defaultEc2ImageConfigX86_64())
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -347,7 +348,7 @@ func mkEc2HaImgTypeX86_64() *rhel.ImageType {
 	it.Compression = "xz"
 	it.KernelOptions = amiKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -370,7 +371,7 @@ func mkAMIImgTypeAarch64() *rhel.ImageType {
 
 	it.KernelOptions = "console=ttyS0,115200n8 console=tty0 net.ifnames=0 nvme_core.io_timeout=4294967295 iommu.strict=0"
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfig()
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -394,7 +395,7 @@ func mkEC2ImgTypeAarch64() *rhel.ImageType {
 	it.Compression = "xz"
 	it.KernelOptions = "console=ttyS0,115200n8 console=tty0 net.ifnames=0 nvme_core.io_timeout=4294967295 iommu.strict=0"
 	it.Bootable = true
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfig()
 	it.BasePartitionTables = defaultBasePartitionTables
 

--- a/pkg/distro/rhel/rhel9/azure.go
+++ b/pkg/distro/rhel/rhel9/azure.go
@@ -3,6 +3,7 @@ package rhel9
 import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
@@ -27,7 +28,7 @@ func mkAzureImgType(rd *rhel.Distribution) *rhel.ImageType {
 
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 4 * common.GibiByte
+	it.DefaultSize = 4 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultAzureImageConfig(rd)
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -52,7 +53,7 @@ func mkAzureInternalImgType(rd *rhel.Distribution) *rhel.ImageType {
 	it.Compression = "xz"
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 64 * common.GibiByte
+	it.DefaultSize = 64 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultAzureImageConfig(rd)
 	it.BasePartitionTables = azureInternalBasePartitionTables
 
@@ -76,7 +77,7 @@ func mkAzureSapInternalImgType(rd *rhel.Distribution) *rhel.ImageType {
 	it.Compression = "xz"
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 64 * common.GibiByte
+	it.DefaultSize = 64 * datasizes.GibiByte
 	it.DefaultImageConfig = sapAzureImageConfig(rd)
 	it.BasePartitionTables = azureInternalBasePartitionTables
 
@@ -182,13 +183,13 @@ func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, b
 	switch {
 	case common.VersionLessThan(t.Arch().Distro().OsVersion(), "9.3") && t.IsRHEL():
 		// RHEL <= 9.2 had only 500 MiB /boot
-		bootSize = 500 * common.MebiByte
+		bootSize = 500 * datasizes.MebiByte
 	case common.VersionLessThan(t.Arch().Distro().OsVersion(), "9.4") && t.IsRHEL():
 		// RHEL 9.3 had 600 MiB /boot, see RHEL-7999
-		bootSize = 600 * common.MebiByte
+		bootSize = 600 * datasizes.MebiByte
 	default:
 		// RHEL >= 9.4 needs to have even a bigger /boot, see COMPOSER-2155
-		bootSize = 1 * common.GibiByte
+		bootSize = 1 * datasizes.GibiByte
 	}
 
 	switch t.Arch().Name() {
@@ -196,10 +197,10 @@ func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, b
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
-			Size: 64 * common.GibiByte,
+			Size: 64 * datasizes.GibiByte,
 			Partitions: []disk.Partition{
 				{
-					Size: 500 * common.MebiByte,
+					Size: 500 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -224,7 +225,7 @@ func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, b
 					},
 				},
 				{
-					Size:     2 * common.MebiByte,
+					Size:     2 * datasizes.MebiByte,
 					Bootable: true,
 					Type:     disk.BIOSBootPartitionGUID,
 					UUID:     disk.BIOSBootPartitionUUID,
@@ -237,7 +238,7 @@ func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, b
 						Description: "built with lvm2 and osbuild",
 						LogicalVolumes: []disk.LVMLogicalVolume{
 							{
-								Size: 1 * common.GibiByte,
+								Size: 1 * datasizes.GibiByte,
 								Name: "homelv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -249,7 +250,7 @@ func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, b
 								},
 							},
 							{
-								Size: 2 * common.GibiByte,
+								Size: 2 * datasizes.GibiByte,
 								Name: "rootlv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -261,7 +262,7 @@ func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, b
 								},
 							},
 							{
-								Size: 2 * common.GibiByte,
+								Size: 2 * datasizes.GibiByte,
 								Name: "tmplv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -273,7 +274,7 @@ func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, b
 								},
 							},
 							{
-								Size: 10 * common.GibiByte,
+								Size: 10 * datasizes.GibiByte,
 								Name: "usrlv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -285,7 +286,7 @@ func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, b
 								},
 							},
 							{
-								Size: 10 * common.GibiByte,
+								Size: 10 * datasizes.GibiByte,
 								Name: "varlv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -305,10 +306,10 @@ func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, b
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type: "gpt",
-			Size: 64 * common.GibiByte,
+			Size: 64 * datasizes.GibiByte,
 			Partitions: []disk.Partition{
 				{
-					Size: 500 * common.MebiByte,
+					Size: 500 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -340,7 +341,7 @@ func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, b
 						Description: "built with lvm2 and osbuild",
 						LogicalVolumes: []disk.LVMLogicalVolume{
 							{
-								Size: 1 * common.GibiByte,
+								Size: 1 * datasizes.GibiByte,
 								Name: "homelv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -352,7 +353,7 @@ func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, b
 								},
 							},
 							{
-								Size: 2 * common.GibiByte,
+								Size: 2 * datasizes.GibiByte,
 								Name: "rootlv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -364,7 +365,7 @@ func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, b
 								},
 							},
 							{
-								Size: 2 * common.GibiByte,
+								Size: 2 * datasizes.GibiByte,
 								Name: "tmplv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -376,7 +377,7 @@ func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, b
 								},
 							},
 							{
-								Size: 10 * common.GibiByte,
+								Size: 10 * datasizes.GibiByte,
 								Name: "usrlv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",
@@ -388,7 +389,7 @@ func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, b
 								},
 							},
 							{
-								Size: 10 * common.GibiByte,
+								Size: 10 * datasizes.GibiByte,
 								Name: "varlv",
 								Payload: &disk.Filesystem{
 									Type:         "xfs",

--- a/pkg/distro/rhel/rhel9/distro_internal_test.go
+++ b/pkg/distro/rhel/rhel9/distro_internal_test.go
@@ -6,13 +6,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/blueprint"
-	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/osbuild/images/pkg/blueprint"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distro/rhel"
 )
 
 // math/rand is good enough in this case
@@ -65,7 +65,7 @@ func TestEC2Partitioning(t *testing.T) {
 
 					bootSize, err := pt.GetMountpointSize("/boot")
 					require.NoError(t, err)
-					require.Equal(t, tt.bootSizeMiB*common.MiB, bootSize)
+					require.Equal(t, tt.bootSizeMiB*datasizes.MiB, bootSize)
 				})
 
 			}

--- a/pkg/distro/rhel/rhel9/edge.go
+++ b/pkg/distro/rhel/rhel9/edge.go
@@ -7,6 +7,7 @@ import (
 	"github.com/osbuild/images/internal/environment"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
@@ -114,7 +115,7 @@ func mkEdgeRawImgType(d *rhel.Distribution) *rhel.ImageType {
 		it.KernelOptions += " rw coreos.no_persist_ip"
 	}
 
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.RPMOSTree = true
 	it.Bootable = true
 	it.BasePartitionTables = edgeBasePartitionTables
@@ -203,7 +204,7 @@ func mkEdgeSimplifiedInstallerImgType(d *rhel.Distribution) *rhel.ImageType {
 		},
 	}
 
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.RPMOSTree = true
 	it.BootISO = true
 	it.Bootable = true
@@ -248,7 +249,7 @@ func mkEdgeAMIImgType(d *rhel.Distribution) *rhel.ImageType {
 		it.KernelOptions += " rw coreos.no_persist_ip"
 	}
 
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.RPMOSTree = true
 	it.Bootable = true
 	it.BasePartitionTables = edgeBasePartitionTables
@@ -287,7 +288,7 @@ func mkEdgeVsphereImgType(d *rhel.Distribution) *rhel.ImageType {
 		it.KernelOptions += " rw coreos.no_persist_ip"
 	}
 
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.RPMOSTree = true
 	it.Bootable = true
 	it.BasePartitionTables = edgeBasePartitionTables
@@ -319,7 +320,7 @@ func mkMinimalrawImgType() *rhel.ImageType {
 		Files: []*fsnode.File{initialSetupKickstart()},
 	}
 	it.KernelOptions = "ro"
-	it.DefaultSize = 2 * common.GibiByte
+	it.DefaultSize = 2 * datasizes.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = minimalrawPartitionTables
 
@@ -363,9 +364,9 @@ func initialSetupKickstart() *fsnode.File {
 // Partition tables
 func minimalrawPartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	// RHEL >= 9.3 needs to have a bigger /boot, see RHEL-7999
-	bootSize := uint64(600) * common.MebiByte
+	bootSize := uint64(600) * datasizes.MebiByte
 	if common.VersionLessThan(t.Arch().Distro().OsVersion(), "9.3") && t.IsRHEL() {
-		bootSize = 500 * common.MebiByte
+		bootSize = 500 * datasizes.MebiByte
 	}
 
 	switch t.Arch().Name() {
@@ -373,10 +374,10 @@ func minimalrawPartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 		return disk.PartitionTable{
 			UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type:        "gpt",
-			StartOffset: 8 * common.MebiByte,
+			StartOffset: 8 * datasizes.MebiByte,
 			Partitions: []disk.Partition{
 				{
-					Size: 200 * common.MebiByte,
+					Size: 200 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -403,7 +404,7 @@ func minimalrawPartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 2 * common.GibiByte,
+					Size: 2 * datasizes.GibiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.RootPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -421,10 +422,10 @@ func minimalrawPartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 		return disk.PartitionTable{
 			UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 			Type:        "gpt",
-			StartOffset: 8 * common.MebiByte,
+			StartOffset: 8 * datasizes.MebiByte,
 			Partitions: []disk.Partition{
 				{
-					Size: 200 * common.MebiByte,
+					Size: 200 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -451,7 +452,7 @@ func minimalrawPartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 2 * common.GibiByte,
+					Size: 2 * datasizes.GibiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.RootPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -478,13 +479,13 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
-					Size:     1 * common.MebiByte, // 1MB
+					Size:     1 * datasizes.MebiByte,
 					Bootable: true,
 					Type:     disk.BIOSBootPartitionGUID,
 					UUID:     disk.BIOSBootPartitionUUID,
 				},
 				{
-					Size: 127 * common.MebiByte, // 127 MB
+					Size: 127 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -498,7 +499,7 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 384 * common.MebiByte, // 384 MB
+					Size: 384 * datasizes.MebiByte,
 					Type: disk.XBootLDRPartitionGUID,
 					UUID: disk.FilesystemDataUUID,
 					Payload: &disk.Filesystem{
@@ -532,7 +533,7 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 							Description: "built with lvm2 and osbuild",
 							LogicalVolumes: []disk.LVMLogicalVolume{
 								{
-									Size: 9 * common.GiB, // 9 GiB
+									Size: 9 * datasizes.GiB, // 9 GiB
 									Name: "rootlv",
 									Payload: &disk.Filesystem{
 										Type:         "xfs",
@@ -555,7 +556,7 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
-					Size: 127 * common.MebiByte, // 127 MB
+					Size: 127 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -569,7 +570,7 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 384 * common.MebiByte, // 384 MB
+					Size: 384 * datasizes.MebiByte,
 					Type: disk.XBootLDRPartitionGUID,
 					UUID: disk.FilesystemDataUUID,
 					Payload: &disk.Filesystem{
@@ -603,7 +604,7 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 							Description: "built with lvm2 and osbuild",
 							LogicalVolumes: []disk.LVMLogicalVolume{
 								{
-									Size: 9 * common.GiB, // 9 GiB
+									Size: 9 * datasizes.GiB, // 9 GiB
 									Name: "rootlv",
 									Payload: &disk.Filesystem{
 										Type:         "xfs",

--- a/pkg/distro/rhel/rhel9/gce.go
+++ b/pkg/distro/rhel/rhel9/gce.go
@@ -2,6 +2,7 @@ package rhel9
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -29,7 +30,7 @@ func mkGCEImageType() *rhel.ImageType {
 	// https://issues.redhat.com/browse/COMPOSER-2157
 	it.DefaultImageConfig = baseGCEImageConfig()
 	it.KernelOptions = gceKernelOptions
-	it.DefaultSize = 20 * common.GibiByte
+	it.DefaultSize = 20 * datasizes.GibiByte
 	it.Bootable = true
 	// TODO: the base partition table still contains the BIOS boot partition, but the image is UEFI-only
 	it.BasePartitionTables = defaultBasePartitionTables

--- a/pkg/distro/rhel/rhel9/partition_tables.go
+++ b/pkg/distro/rhel/rhel9/partition_tables.go
@@ -3,6 +3,7 @@ package rhel9
 import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro/rhel"
 )
@@ -12,13 +13,13 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	switch {
 	case common.VersionLessThan(t.Arch().Distro().OsVersion(), "9.3") && t.IsRHEL():
 		// RHEL <= 9.2 had only 500 MiB /boot
-		bootSize = 500 * common.MebiByte
+		bootSize = 500 * datasizes.MebiByte
 	case common.VersionLessThan(t.Arch().Distro().OsVersion(), "9.4") && t.IsRHEL():
 		// RHEL 9.3 had 600 MiB /boot, see RHEL-7999
-		bootSize = 600 * common.MebiByte
+		bootSize = 600 * datasizes.MebiByte
 	default:
 		// RHEL >= 9.4 needs to have even a bigger /boot, see COMPOSER-2155
-		bootSize = 1 * common.GibiByte
+		bootSize = 1 * datasizes.GibiByte
 	}
 
 	switch t.Arch().Name() {
@@ -28,13 +29,13 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
-					Size:     1 * common.MebiByte,
+					Size:     1 * datasizes.MebiByte,
 					Bootable: true,
 					Type:     disk.BIOSBootPartitionGUID,
 					UUID:     disk.BIOSBootPartitionUUID,
 				},
 				{
-					Size: 200 * common.MebiByte,
+					Size: 200 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -61,7 +62,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 2 * common.GibiByte,
+					Size: 2 * datasizes.GibiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.RootPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -81,7 +82,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "gpt",
 			Partitions: []disk.Partition{
 				{
-					Size: 200 * common.MebiByte,
+					Size: 200 * datasizes.MebiByte,
 					Type: disk.EFISystemPartitionGUID,
 					UUID: disk.EFISystemPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -108,7 +109,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 2 * common.GibiByte,
+					Size: 2 * datasizes.GibiByte,
 					Type: disk.FilesystemDataGUID,
 					UUID: disk.RootPartitionUUID,
 					Payload: &disk.Filesystem{
@@ -128,7 +129,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Type: "dos",
 			Partitions: []disk.Partition{
 				{
-					Size:     4 * common.MebiByte,
+					Size:     4 * datasizes.MebiByte,
 					Type:     "41",
 					Bootable: true,
 				},
@@ -144,7 +145,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size: 2 * common.GibiByte,
+					Size: 2 * datasizes.GibiByte,
 					Payload: &disk.Filesystem{
 						Type:         "xfs",
 						Mountpoint:   "/",
@@ -173,7 +174,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 					},
 				},
 				{
-					Size:     2 * common.GibiByte,
+					Size:     2 * datasizes.GibiByte,
 					Bootable: true,
 					Payload: &disk.Filesystem{
 						Type:         "xfs",

--- a/pkg/distro/rhel/rhel9/qcow2.go
+++ b/pkg/distro/rhel/rhel9/qcow2.go
@@ -3,6 +3,7 @@ package rhel9
 import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/customizations/subscription"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -24,7 +25,7 @@ func mkQcow2ImgType(d *rhel.Distribution) *rhel.ImageType {
 
 	it.DefaultImageConfig = qcowImageConfig(d)
 	it.KernelOptions = "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -47,7 +48,7 @@ func mkOCIImgType(d *rhel.Distribution) *rhel.ImageType {
 
 	it.DefaultImageConfig = qcowImageConfig(d)
 	it.KernelOptions = "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
-	it.DefaultSize = 10 * common.GibiByte
+	it.DefaultSize = 10 * datasizes.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -72,7 +73,7 @@ func mkOpenstackImgType() *rhel.ImageType {
 		Locale: common.ToPtr("en_US.UTF-8"),
 	}
 	it.KernelOptions = "ro net.ifnames=0"
-	it.DefaultSize = 4 * common.GibiByte
+	it.DefaultSize = 4 * datasizes.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
 

--- a/pkg/distro/rhel/rhel9/vmdk.go
+++ b/pkg/distro/rhel/rhel9/vmdk.go
@@ -2,6 +2,7 @@ package rhel9
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -28,7 +29,7 @@ func mkVMDKImgType() *rhel.ImageType {
 	}
 	it.KernelOptions = vmdkKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 4 * common.GibiByte
+	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -53,7 +54,7 @@ func mkOVAImgType() *rhel.ImageType {
 	}
 	it.KernelOptions = vmdkKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 4 * common.GibiByte
+	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/artifact"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
@@ -99,7 +99,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers
 
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)
-	rootfsImagePipeline.Size = 4 * common.GibiByte
+	rootfsImagePipeline.Size = 4 * datasizes.GibiByte
 
 	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
 	bootTreePipeline.Platform = img.Platform

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/environment"
 	"github.com/osbuild/images/internal/workload"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/artifact"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -71,7 +71,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	livePipeline.Checkpoint()
 
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, livePipeline)
-	rootfsImagePipeline.Size = 8 * common.GibiByte
+	rootfsImagePipeline.Size = 8 * datasizes.GibiByte
 
 	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
 	bootTreePipeline.Platform = img.Platform

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/artifact"
 	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
 	"github.com/osbuild/images/pkg/customizations/subscription"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
@@ -102,7 +102,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers
 
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)
-	rootfsImagePipeline.Size = 4 * common.GibiByte
+	rootfsImagePipeline.Size = 4 * datasizes.GibiByte
 
 	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
 	bootTreePipeline.Platform = img.Platform

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -5,13 +5,13 @@ import (
 	"math/rand"
 	"path/filepath"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/environment"
 	"github.com/osbuild/images/internal/workload"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/artifact"
 	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -21,7 +21,7 @@ import (
 )
 
 func efiBootPartitionTable(rng *rand.Rand) *disk.PartitionTable {
-	var efibootImageSize uint64 = 20 * common.MebiByte
+	var efibootImageSize uint64 = 20 * datasizes.MebiByte
 	return &disk.PartitionTable{
 		Size: efibootImageSize,
 		Partitions: []disk.Partition{
@@ -154,7 +154,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline.Checkpoint()
 
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)
-	rootfsImagePipeline.Size = 5 * common.GibiByte
+	rootfsImagePipeline.Size = 5 * datasizes.GibiByte
 
 	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
 	bootTreePipeline.Platform = img.Platform

--- a/pkg/manifest/anaconda_installer_iso_tree_test.go
+++ b/pkg/manifest/anaconda_installer_iso_tree_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
@@ -50,7 +51,7 @@ func newTestAnacondaISOTree() *AnacondaInstallerISOTree {
 
 	pipeline := NewAnacondaInstallerISOTree(build, anacondaPipeline, rootfsImagePipeline, bootTreePipeline)
 	// copy of the default in pkg/image - will be moved to the pipeline
-	var efibootImageSize uint64 = 20 * common.MebiByte
+	var efibootImageSize uint64 = 20 * datasizes.MebiByte
 	pipeline.PartitionTable = &disk.PartitionTable{
 		Size: efibootImageSize,
 		Partitions: []disk.Partition{

--- a/pkg/osbuild/bootupd_stage_test.go
+++ b/pkg/osbuild/bootupd_stage_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/testdisk"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
@@ -203,13 +204,13 @@ var fakePt = &disk.PartitionTable{
 	Type: "gpt",
 	Partitions: []disk.Partition{
 		{
-			Size:     1 * common.MebiByte,
+			Size:     1 * datasizes.MebiByte,
 			Bootable: true,
 			Type:     disk.BIOSBootPartitionGUID,
 			UUID:     disk.BIOSBootPartitionUUID,
 		},
 		{
-			Size: 501 * common.MebiByte,
+			Size: 501 * datasizes.MebiByte,
 			Type: disk.EFISystemPartitionGUID,
 			UUID: disk.EFISystemPartitionUUID,
 			Payload: &disk.Filesystem{
@@ -223,7 +224,7 @@ var fakePt = &disk.PartitionTable{
 			},
 		},
 		{
-			Size: 1 * common.GibiByte,
+			Size: 1 * datasizes.GibiByte,
 			Type: disk.FilesystemDataGUID,
 			UUID: disk.FilesystemDataUUID,
 			Payload: &disk.Filesystem{
@@ -236,7 +237,7 @@ var fakePt = &disk.PartitionTable{
 			},
 		},
 		{
-			Size: 2 * common.GibiByte,
+			Size: 2 * datasizes.GibiByte,
 			Type: disk.FilesystemDataGUID,
 			UUID: disk.RootPartitionUUID,
 			Payload: &disk.Filesystem{

--- a/pkg/osbuild/device_test.go
+++ b/pkg/osbuild/device_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/testdisk"
 	"github.com/osbuild/images/pkg/blueprint"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 )
 
@@ -238,15 +238,15 @@ func TestMountsDeviceFromBrfs(t *testing.T) {
 			Type: "org.osbuild.loopback",
 			Options: &LoopbackDeviceOptions{
 				Filename: "fake-disk.img",
-				Size:     1 * common.GiB / 512,
+				Size:     1 * datasizes.GiB / 512,
 			},
 		},
 		"btrfs-6264": {
 			Type: "org.osbuild.loopback",
 			Options: &LoopbackDeviceOptions{
 				Filename: "fake-disk.img",
-				Start:    1 * common.GiB / 512,
-				Size:     9 * common.GiB / 512,
+				Start:    1 * datasizes.GiB / 512,
+				Size:     9 * datasizes.GiB / 512,
 			},
 		},
 	}, devices)

--- a/pkg/osbuild/disk_test.go
+++ b/pkg/osbuild/disk_test.go
@@ -5,10 +5,9 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/testdisk"
-
 	"github.com/osbuild/images/pkg/blueprint"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/stretchr/testify/assert"
 )
@@ -65,7 +64,7 @@ func TestGenImagePrepareStages(t *testing.T) {
 			Type: "org.osbuild.truncate",
 			Options: &TruncateStageOptions{
 				Filename: filename,
-				Size:     fmt.Sprintf("%d", 10*common.GiB),
+				Size:     fmt.Sprintf("%d", 10*datasizes.GiB),
 			},
 		},
 		{
@@ -74,11 +73,11 @@ func TestGenImagePrepareStages(t *testing.T) {
 				Label: "gpt",
 				Partitions: []SfdiskPartition{
 					{
-						Size: 1 * common.GiB / 512,
+						Size: 1 * datasizes.GiB / 512,
 					},
 					{
-						Start: 1 * common.GiB / 512,
-						Size:  9 * common.GiB / 512,
+						Start: 1 * datasizes.GiB / 512,
+						Size:  9 * datasizes.GiB / 512,
 					},
 				},
 			},
@@ -100,7 +99,7 @@ func TestGenImagePrepareStages(t *testing.T) {
 					Options: &LoopbackDeviceOptions{
 						Filename: filename,
 						Start:    0,
-						Size:     1 * common.GiB / 512,
+						Size:     1 * datasizes.GiB / 512,
 						Lock:     true,
 					},
 				},
@@ -114,8 +113,8 @@ func TestGenImagePrepareStages(t *testing.T) {
 					Type: "org.osbuild.loopback",
 					Options: &LoopbackDeviceOptions{
 						Filename: filename,
-						Start:    1 * common.GiB / 512,
-						Size:     9 * common.GiB / 512,
+						Start:    1 * datasizes.GiB / 512,
+						Size:     9 * datasizes.GiB / 512,
 						Lock:     true,
 					},
 				},
@@ -131,8 +130,8 @@ func TestGenImagePrepareStages(t *testing.T) {
 					Type: "org.osbuild.loopback",
 					Options: &LoopbackDeviceOptions{
 						Filename: filename,
-						Start:    1 * common.GiB / 512,
-						Size:     9 * common.GiB / 512,
+						Start:    1 * datasizes.GiB / 512,
+						Size:     9 * datasizes.GiB / 512,
 						Lock:     false,
 					},
 				},

--- a/pkg/osbuild/mkfs_stages_test.go
+++ b/pkg/osbuild/mkfs_stages_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/testdisk"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 )
 
@@ -143,7 +144,7 @@ func TestGenMkfsStagesBtrfs(t *testing.T) {
 					Type: "org.osbuild.loopback",
 					Options: &LoopbackDeviceOptions{
 						Filename: "file.img",
-						Size:     common.GiB / disk.DefaultSectorSize,
+						Size:     datasizes.GiB / disk.DefaultSectorSize,
 						Lock:     true,
 					},
 				},
@@ -159,8 +160,8 @@ func TestGenMkfsStagesBtrfs(t *testing.T) {
 					Type: "org.osbuild.loopback",
 					Options: &LoopbackDeviceOptions{
 						Filename: "file.img",
-						Start:    common.GiB / disk.DefaultSectorSize,
-						Size:     100 * common.MiB / disk.DefaultSectorSize,
+						Start:    datasizes.GiB / disk.DefaultSectorSize,
+						Size:     100 * datasizes.MiB / disk.DefaultSectorSize,
 						Lock:     true,
 					},
 				},
@@ -176,8 +177,8 @@ func TestGenMkfsStagesBtrfs(t *testing.T) {
 					Type: "org.osbuild.loopback",
 					Options: &LoopbackDeviceOptions{
 						Filename: "file.img",
-						Start:    (common.GiB + 100*common.MiB) / disk.DefaultSectorSize,
-						Size:     9 * common.GiB / disk.DefaultSectorSize,
+						Start:    (datasizes.GiB + 100*datasizes.MiB) / disk.DefaultSectorSize,
+						Size:     9 * datasizes.GiB / disk.DefaultSectorSize,
 						Lock:     true,
 					},
 				},

--- a/pkg/upload/azure/azurestorage.go
+++ b/pkg/upload/azure/azurestorage.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 )
 
 // StorageClient is a client for the Azure Storage API,
@@ -60,7 +61,7 @@ const DefaultUploadThreads = 16
 
 // PageBlobMaxUploadPagesBytes defines how much bytes can we upload in a single UploadPages call.
 // See https://learn.microsoft.com/en-us/rest/api/storageservices/put-page
-const PageBlobMaxUploadPagesBytes = 4 * common.MiB
+const PageBlobMaxUploadPagesBytes = 4 * datasizes.MiB
 
 // allZerosSlice returns true if all values in the slice are equal to 0
 func allZerosSlice(slice []byte) bool {

--- a/pkg/upload/koji/koji.go
+++ b/pkg/upload/koji/koji.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/ubccr/kerby/khttp"
 
-	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -386,7 +386,7 @@ func (k *Koji) uploadChunk(chunk []byte, filepath, filename string, offset uint6
 // Upload uploads file to the temporary filepath on the kojiserver under the name filename
 // The md5sum and size of the file is returned on success.
 func (k *Koji) Upload(file io.Reader, filepath, filename string) (string, uint64, error) {
-	chunk := make([]byte, common.MiB) // upload a mebiByte at a time
+	chunk := make([]byte, datasizes.MiB) // upload a mebiByte at a time
 	offset := uint64(0)
 	// Koji uses MD5 hashes
 	/* #nosec G401 */


### PR DESCRIPTION
This commit extracts the `common.DataSizeToUint64()` helper as `datasizes.Parse` and the `common.MiB` to `datasizes.MiB` (etc).

This is required so that we can import the datasizes package in the upcoming blueprints git module.

This will be needed for https://github.com/mvo5/blueprints (well, the "osbuild/blueprints" of course - with this the "blueprints" package that consists of pkg/{blueprints,customizations} is self sufficient. We may still need to look closer as there is a bunch of logic and imports (like pathpolicy ) that we need to get rid of.