### PR TITLE
many: extract newGCETarPipelineForImg() helper

### DIFF
--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -3,9 +3,7 @@ package image
 import (
 	"fmt"
 	"math/rand"
-	"regexp"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/disk"
@@ -92,15 +90,7 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 		fmt.Sprintf("%s.vhd", fileBasename),
 	}
 
-	// XXX: copied from https://github.com/osbuild/images/blob/v0.85.0/pkg/image/disk.go#L102
-	gcePipeline := manifest.NewTar(buildPipeline, rawImage, "gce")
-	gcePipeline.Format = osbuild.TarArchiveFormatOldgnu
-	gcePipeline.RootNode = osbuild.TarRootNodeOmit
-	// these are required to successfully import the image to GCP
-	gcePipeline.ACLs = common.ToPtr(false)
-	gcePipeline.SELinux = common.ToPtr(false)
-	gcePipeline.Xattrs = common.ToPtr(false)
-	gcePipeline.Transform = fmt.Sprintf(`s/%s/disk.raw/`, regexp.QuoteMeta(rawImage.Filename()))
+	gcePipeline := newGCETarPipelineForImg(buildPipeline, rawImage, "gce")
 	gcePipeline.SetFilename("image.tar.gz")
 
 	return nil

--- a/pkg/image/disk.go
+++ b/pkg/image/disk.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/environment"
 	"github.com/osbuild/images/internal/workload"
 	"github.com/osbuild/images/pkg/artifact"
@@ -103,13 +102,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 		// NOTE(akoutsou): temporary workaround; filename required for GCP
 		// TODO: define internal raw filename on image type
 		rawImagePipeline.SetFilename("disk.raw")
-		tarPipeline := manifest.NewTar(buildPipeline, rawImagePipeline, "archive")
-		tarPipeline.Format = osbuild.TarArchiveFormatOldgnu
-		tarPipeline.RootNode = osbuild.TarRootNodeOmit
-		// these are required to successfully import the image to GCP
-		tarPipeline.ACLs = common.ToPtr(false)
-		tarPipeline.SELinux = common.ToPtr(false)
-		tarPipeline.Xattrs = common.ToPtr(false)
+		tarPipeline := newGCETarPipelineForImg(buildPipeline, rawImagePipeline, "archive")
 		tarPipeline.SetFilename(img.Filename) // filename extension will determine compression
 		imagePipeline = tarPipeline
 	default:

--- a/pkg/image/gce.go
+++ b/pkg/image/gce.go
@@ -1,0 +1,24 @@
+package image
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+func newGCETarPipelineForImg(buildPipeline manifest.Build, inputPipeline manifest.FilePipeline, pipelinename string) *manifest.Tar {
+	tarPipeline := manifest.NewTar(buildPipeline, inputPipeline, pipelinename)
+	tarPipeline.Format = osbuild.TarArchiveFormatOldgnu
+	tarPipeline.RootNode = osbuild.TarRootNodeOmit
+	// these are required to successfully import the image to GCP
+	tarPipeline.ACLs = common.ToPtr(false)
+	tarPipeline.SELinux = common.ToPtr(false)
+	tarPipeline.Xattrs = common.ToPtr(false)
+	if inputPipeline.Filename() != "disk.raw" {
+		tarPipeline.Transform = fmt.Sprintf(`s/%s/disk.raw/`, regexp.QuoteMeta(inputPipeline.Filename()))
+	}
+	return tarPipeline
+}

--- a/pkg/image/gce_test.go
+++ b/pkg/image/gce_test.go
@@ -1,0 +1,42 @@
+package image
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/osbuild"
+	"github.com/osbuild/images/pkg/rpmmd"
+	"github.com/osbuild/images/pkg/runner"
+)
+
+func TestNewGCETarPipeline(t *testing.T) {
+	for _, tc := range []struct {
+		imgFilename       string
+		expectedTransform string
+	}{
+		{"disk.raw", ""},
+		{"foo.img", `s/foo\.img/disk.raw/`},
+	} {
+		var repos []rpmmd.RepoConfig
+		m := &manifest.Manifest{}
+		runner := &runner.Fedora{}
+
+		buildPipeline := manifest.NewBuild(m, runner, repos, nil)
+		buildPipeline.Checkpoint()
+
+		imgPipeline := manifest.NewRawImage(buildPipeline, nil)
+		imgPipeline.SetFilename(tc.imgFilename)
+
+		tar := newGCETarPipelineForImg(buildPipeline, imgPipeline, "my-test")
+		assert.NotNil(t, tar)
+		assert.Equal(t, tar.Format, osbuild.TarArchiveFormatOldgnu)
+		assert.Equal(t, tar.RootNode, osbuild.TarRootNodeOmit)
+		assert.Equal(t, *tar.ACLs, false)
+		assert.Equal(t, *tar.SELinux, false)
+		assert.Equal(t, *tar.Xattrs, false)
+		assert.Equal(t, tar.Transform, tc.expectedTransform)
+
+	}
+}


### PR DESCRIPTION
This commit extracts a common helper to setup the right tar options for the GCE tar file generation. The options that need to be passed to tar for GCE need to be exactly right so let's make sure we only have a single place where they are set.