### PR TITLE
osbuild: Rename GCE output from .tgz to .tar.gz

### DIFF
--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -101,7 +101,7 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 	gcePipeline.SELinux = common.ToPtr(false)
 	gcePipeline.Xattrs = common.ToPtr(false)
 	gcePipeline.Transform = fmt.Sprintf(`s/%s/disk.raw/`, regexp.QuoteMeta(rawImage.Filename()))
-	gcePipeline.SetFilename("image.tgz")
+	gcePipeline.SetFilename("image.tar.gz")
 
 	return nil
 }


### PR DESCRIPTION
Import with `gcloud` cli requires the file to ends with `.tar.gz`, otherwise the command fails

```
gcloud compute images create --help
[...]
       --source-uri=SOURCE_URI
          The full Cloud Storage URI where the disk image is stored. This file
          must be a gzip-compressed tarball whose name ends in .tar.gz. For
          more information about Cloud Storage URIs, see
          https://cloud.google.com/storage/docs/request-endpoints#json-api.
```