### PR TITLE
feat: remove signatures in container deployments by default

### DIFF
--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -236,7 +236,9 @@ func (p *BuildrootFromContainer) serialize() osbuild.Pipeline {
 	pipeline.Runner = p.runner.String()
 
 	image := osbuild.NewContainersInputForSingleSource(p.containerSpecs[0])
-	stage, err := osbuild.NewContainerDeployStage(image, &osbuild.ContainerDeployOptions{})
+	// Make skopeo copy to remove the signatures of signed containers by default to workaround
+	// build failures until https://github.com/containers/image/issues/2599 is implemented
+	stage, err := osbuild.NewContainerDeployStage(image, &osbuild.ContainerDeployOptions{RemoveSignatures: true})
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/osbuild/container_deploy_stage.go
+++ b/pkg/osbuild/container_deploy_stage.go
@@ -9,7 +9,8 @@ type ContainerDeployInputs struct {
 func (ContainerDeployInputs) isStageInputs() {}
 
 type ContainerDeployOptions struct {
-	Exclude []string `json:"exclude,omitempty"`
+	Exclude          []string `json:"exclude,omitempty"`
+	RemoveSignatures bool     `json:"remove-signatures,omitempty"`
 }
 
 func (ContainerDeployOptions) isStageOptions() {}

--- a/pkg/osbuild/container_deploy_stage_test.go
+++ b/pkg/osbuild/container_deploy_stage_test.go
@@ -70,6 +70,18 @@ func TestContainersDeployStageOptionsJson(t *testing.T) {
 	assert.Equal(t, string(json), expectedJson)
 }
 
+func TestContainersDeployStageOptionsJsonRemoveSignatures(t *testing.T) {
+	expectedJson := `{
+        "remove-signatures": true
+}`
+	cdi := osbuild.ContainerDeployOptions{
+		RemoveSignatures: true,
+	}
+	json, err := json.MarshalIndent(cdi, "", "        ")
+	require.Nil(t, err)
+	assert.Equal(t, string(json), expectedJson)
+}
+
 func TestContainersDeployStageEmptyOptionsJson(t *testing.T) {
 	expectedJson := `{}`
 	cdi := osbuild.ContainerDeployOptions{}


### PR DESCRIPTION
Make `skopeo copy` to remove the signatures of signed containers by default to workaround build failures until containers/image#2599 is implemented.

Depends: osbuild/osbuild#1906
Resolves: osbuild/bootc-image-builder#681

Signed-off-by: Miguel Martín <mmartinv@redhat.com>
