### PR TITLE
distro/fedora: bump branched version

### DIFF
--- a/pkg/distro/fedora/version.go
+++ b/pkg/distro/fedora/version.go
@@ -1,4 +1,4 @@
 package fedora
 
-const VERSION_BRANCHED = "41"
+const VERSION_BRANCHED = "42"
 const VERSION_RAWHIDE = "42"


### PR DESCRIPTION
Fedora is currently building Release Candidates. Since we use the versions to determine if we turn on the preview notice we need to bump the version for branched to remove it.