### PR TITLE
rhel8/azure: don't enable systemd-resolved (COMPOSER-2380)

### DIFF
--- a/pkg/distro/rhel/rhel8/azure.go
+++ b/pkg/distro/rhel/rhel8/azure.go
@@ -529,7 +529,6 @@ var defaultAzureImageConfig = &distro.ImageConfig{
 		"nm-cloud-setup.service",
 		"nm-cloud-setup.timer",
 		"sshd",
-		"systemd-resolved",
 		"waagent",
 	},
 	SshdConfig: &osbuild.SshdConfigStageOptions{


### PR DESCRIPTION
In RHEL 8 and RHEL 9, systemd-resolved is available but provided as a Technology Preview only [1].

systemd-resolved does not need to be enabled in Azure image types [2]. Removing it from the enabled services list leaves it up to the vendor preset to determine the state of the service.  The executable itself is part of the systemd package.  In RHEL 9, it is a separate package and is not installed in any of our images.

[1] https://access.redhat.com/solutions/5647181
[2] See COMPOSER-2380