### PR TITLE
distro: add SortNames helper

### DIFF
--- a/pkg/distro/sort.go
+++ b/pkg/distro/sort.go
@@ -1,0 +1,61 @@
+package distro
+
+import (
+	"errors"
+	"regexp"
+	"sort"
+
+	"github.com/hashicorp/go-version"
+)
+
+var nameVerRe = regexp.MustCompile(`-[0-9]+`)
+
+// SortNames sorts the given list of distro names by name, version
+// taking version semantics into account (i.e. sorting 8.1 lower then
+// 8.10). Full semantic versioning is supported (see semver.org).
+//
+// Invalid version numbers will create errors but the sorting continue
+// and invalid numbers are sorted lower than anything else (so the
+// result is still usable in a {G,T}UI).
+func SortNames(distros []string) error {
+	var errs []error
+
+	sort.Slice(distros, func(i, j int) bool {
+		var name1, ver1, name2, ver2 string
+
+		nameVer1 := distros[i]
+		nameVer2 := distros[j]
+		sep1 := nameVerRe.FindStringIndex(nameVer1)
+		if sep1 == nil {
+			name1 = nameVer1
+		} else {
+			name1 = nameVer1[:sep1[0]]
+			ver1 = nameVer1[sep1[0]+1:]
+		}
+		sep2 := nameVerRe.FindStringIndex(nameVer2)
+		if sep2 == nil {
+			name2 = nameVer2
+		} else {
+			name2 = nameVer2[:sep2[0]]
+			ver2 = nameVer2[sep2[0]+1:]
+		}
+
+		if name1 != name2 {
+			return name1 < name2
+		}
+		// similar to common/distro.go:VersionLessThan but without
+		// the panic on invalid numbers
+		aV, err := version.NewVersion(ver1)
+		if err != nil {
+			errs = append(errs, err)
+			return true
+		}
+		bV, err := version.NewVersion(ver2)
+		if err != nil {
+			errs = append(errs, err)
+			return true
+		}
+		return aV.LessThan(bV)
+	})
+	return errors.Join(errs...)
+}

--- a/pkg/distro/sort_test.go
+++ b/pkg/distro/sort_test.go
@@ -1,0 +1,48 @@
+package distro_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/distro"
+)
+
+func TestSortNames(t *testing.T) {
+	for _, tc := range []struct {
+		in     []string
+		sorted []string
+	}{
+		{
+			// distro names are sorted by first
+			[]string{"foo-2", "bar-1", "foo-1"},
+			[]string{"bar-1", "foo-1", "foo-2"},
+		}, {
+			// 1.4 is smaller than 1.10, sort.Strings will get this
+			// wrong
+			[]string{"foo-1.10", "foo-1.4"},
+			[]string{"foo-1.4", "foo-1.10"},
+		}, {
+			// multiple "-" are ok
+			[]string{"foo-bar-2", "bar-foo-1", "foo-bar-1"},
+			[]string{"bar-foo-1", "foo-bar-1", "foo-bar-2"},
+		}, {
+			// missing "-" is ok
+			[]string{"foo", "bar-1"},
+			[]string{"bar-1", "foo"},
+		}, {
+			// foo-bar-1.4-beta is "lower" than foo-bar-1.4
+			[]string{"foo-bar-1.4", "foo-bar-1.4-beta", "foo-bar-1.0"},
+			[]string{"foo-bar-1.0", "foo-bar-1.4-beta", "foo-bar-1.4"},
+		},
+	} {
+		err := distro.SortNames(tc.in)
+		assert.NoError(t, err)
+		assert.Equal(t, tc.sorted, tc.in)
+	}
+}
+
+func TestSortNamesInvalidVersion(t *testing.T) {
+	err := distro.SortNames([]string{"foo-1.x", "foo-2"})
+	assert.EqualError(t, err, `Malformed version: 1.x`)
+}


### PR DESCRIPTION
This commit adds a new `distro.SortNames()` helper that can be used sort sort distro names. It will take version numbers of the distro into account and sort by semantic version. This is useful in e.g. user-interfaces where we want to present the version in a nicely sorted way.