### PR TITLE
Refactor LVM LV name generation and extract unique name generator into helper

### DIFF
--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -211,6 +211,8 @@ func NewVolIDFromRand(r *rand.Rand) string {
 // the existing set. If the base itself does not exist, it is returned as is,
 // otherwise a two digit number is added and incremented until a unique string
 // is found.
+// This function is mimicking what blivet does for avoiding name collisions.
+// See blivet/blivet.py#L1060 commit 2eb4bd4
 func genUniqueString(base string, existing map[string]bool) (string, error) {
 	if !existing[base] {
 		return base, nil

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -19,6 +19,7 @@ package disk
 
 import (
 	"encoding/hex"
+	"fmt"
 	"io"
 	"math/rand"
 	"reflect"
@@ -204,4 +205,23 @@ func NewVolIDFromRand(r *rand.Rand) string {
 		panic("expected four random bytes")
 	}
 	return hex.EncodeToString(volid)
+}
+
+// genUniqueString returns a string based on base that does does not exist in
+// the existing set. If the base itself does not exist, it is returned as is,
+// otherwise a two digit number is added and incremented until a unique string
+// is found.
+func genUniqueString(base string, existing map[string]bool) (string, error) {
+	if !existing[base] {
+		return base, nil
+	}
+
+	for i := 0; i < 100; i++ {
+		uniq := fmt.Sprintf("%s%02d", base, i)
+		if !existing[uniq] {
+			return uniq, nil
+		}
+	}
+
+	return "", fmt.Errorf("name collision: could not generate unique version of %q", base)
 }

--- a/pkg/disk/disk_test.go
+++ b/pkg/disk/disk_test.go
@@ -1255,3 +1255,103 @@ func TestFSTabOptionsReadOnly(t *testing.T) {
 		})
 	}
 }
+
+func TestGenUniqueString(t *testing.T) {
+	type testCase struct {
+		base     string
+		existing map[string]bool
+		exp      string
+	}
+
+	testCases := map[string]testCase{
+		"simple": {
+			base: "root",
+			existing: map[string]bool{
+				"one": true,
+				"two": true,
+			},
+			exp: "root",
+		},
+		"collision": {
+			base: "root",
+			existing: map[string]bool{
+				"one":  true,
+				"two":  true,
+				"root": true,
+			},
+			exp: "root00",
+		},
+		"collision-2": {
+			base: "word",
+			existing: map[string]bool{
+				"word":   true,
+				"word00": true,
+				"word01": true,
+				"other":  true,
+			},
+			exp: "word02",
+		},
+	}
+
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			out, err := genUniqueString(tc.base, tc.existing)
+			assert.NoError(err)
+			assert.Equal(tc.exp, out)
+		})
+	}
+}
+
+func TestGenUniqueStringManyCollisions(t *testing.T) {
+	type testCase struct {
+		base        string
+		ncollisions int
+		exp         string
+		errmsg      string
+	}
+
+	testCases := map[string]testCase{
+		"baseword33": {
+			base:        "baseword",
+			ncollisions: 33,
+			exp:         "baseword33",
+		},
+		"somany99": {
+			base:        "somany",
+			ncollisions: 99,
+			exp:         "somany99",
+		},
+		"tk42102": {
+			base:        "tk421",
+			ncollisions: 2,
+			exp:         "tk42102",
+		},
+		"so-many-collisions": {
+			base:        "all-the-collisions",
+			ncollisions: 100,
+			errmsg:      `name collision: could not generate unique version of "all-the-collisions"`,
+		},
+	}
+
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			existing := map[string]bool{
+				tc.base: true,
+			}
+			for n := 0; n < tc.ncollisions; n++ {
+				existing[fmt.Sprintf("%s%02d", tc.base, n)] = true
+			}
+			out, err := genUniqueString(tc.base, existing)
+			if tc.errmsg == "" {
+				assert.NoError(err)
+				assert.Equal(tc.exp, out)
+			} else {
+				assert.EqualError(err, tc.errmsg)
+			}
+		})
+	}
+}

--- a/pkg/disk/lvm.go
+++ b/pkg/disk/lvm.go
@@ -95,25 +95,9 @@ func (vg *LVMVolumeGroup) genLVName(base string) (string, error) {
 
 	base = lvname(base) // if the mountpoint is used (i.e. if the base contains /), sanitize it and append 'lv'
 
-	var exists bool
-	name := base
-
-	// Make sure that we don't collide with an existing volume, e.g. 'home/test'
-	// and /home/test_test would collide. We try 100 times and then give up. This
-	// is mimicking what blivet does. See blivet/blivet.py#L1060 commit 2eb4bd4
-	for i := 0; i < 100; i++ {
-		exists = names[name]
-		if !exists {
-			break
-		}
-
-		name = fmt.Sprintf("%s%02d", base, i)
-	}
-
-	if exists {
-		return "", fmt.Errorf("could not create logical volume: name collision")
-	}
-	return name, nil
+	// Make sure that we don't collide with an existing volume, e.g.
+	// 'home/test' and /home_test would collide.
+	return genUniqueString(base, names)
 }
 
 // CreateLogicalVolume creates a new logical volume on the volume group. If a

--- a/pkg/disk/lvm_test.go
+++ b/pkg/disk/lvm_test.go
@@ -30,7 +30,7 @@ func TestLVMVCreateMountpoint(t *testing.T) {
 	assert.Equal("home_testlv00", dedup.Name)
 
 	// Lets collide it
-	for i := 0; i < 98; i++ {
+	for i := 0; i < 99; i++ {
 		_, err = vg.CreateMountpoint("/home/test", 0)
 		assert.NoError(err)
 	}

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -715,7 +715,7 @@ func (pt *PartitionTable) ensureLVM() error {
 
 		// create root logical volume on the new volume group with the same
 		// size and filesystem as the previous root partition
-		_, err := vg.CreateLogicalVolume("root", part.Size, filesystem)
+		_, err := vg.CreateLogicalVolume("rootlv", part.Size, filesystem)
 		if err != nil {
 			panic(fmt.Sprintf("Could not create LV: %v", err))
 		}


### PR DESCRIPTION
This is part of #926 which I'm slowly splitting into smaller, bite-sized PRs.

---

**disk: refactor LVM Logical Volume name generation**

The VolumeGroup.CreateLogicalVolume() function assumed that the given
name was a mountpoint and would automatically escape it, append 'lv',
and append numbers in case of collisions.  This made it impossible to
use the helper function for LV creation with desired names.

Refactor the function and modify all the calls so that now it uses the
provided name without validating, escaping, or checking for collisions,
and generates a name from the payload's mountpoint when one is not
provided.

The CreateMountpoint() function's functionality is not affected.

---

**disk: helper function for generating unique names**

The new genUniqueString() function follows the logic used when
generating logical volume names, which was based on the same
functionality in blivet.
It will be used to generate unique logical volume names, labels, and
btrfs volume names.

---

**disk: replace the lvm name generation with genUniqueString()**

Replace the heart of the lvm name generator with the new function.
Update the vg.CreateMountpoint() test, because the old implementation
was off by one and would fail when '99' was available.

---
