### PR TITLE
disk: define PartitionTableType enum for partition table types

### DIFF
--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -110,6 +110,41 @@ func NewFSType(s string) (FSType, error) {
 	}
 }
 
+// PartitionTableType is the partition table type enum.
+type PartitionTableType uint64
+
+const (
+	PT_NONE PartitionTableType = iota
+	PT_DOS
+	PT_GPT
+)
+
+func (t PartitionTableType) String() string {
+	switch t {
+	case PT_NONE:
+		return ""
+	case PT_DOS:
+		return "dos"
+	case PT_GPT:
+		return "gpt"
+	default:
+		panic(fmt.Sprintf("unknown or unsupported partition table type with enum value %d", t))
+	}
+}
+
+func NewPartitionTableType(s string) (PartitionTableType, error) {
+	switch s {
+	case "":
+		return PT_NONE, nil
+	case "dos":
+		return PT_DOS, nil
+	case "gpt":
+		return PT_GPT, nil
+	default:
+		return PT_NONE, fmt.Errorf("unknown or unsupported partition table type name: %s", s)
+	}
+}
+
 // Entity is the base interface for all disk-related entities.
 type Entity interface {
 	// Clone returns a deep copy of the entity.

--- a/pkg/disk/enums_test.go
+++ b/pkg/disk/enums_test.go
@@ -1,0 +1,64 @@
+package disk_test
+
+import (
+	"testing"
+
+	"github.com/osbuild/images/pkg/disk"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnumPartitionTableType(t *testing.T) {
+	enumMap := map[string]disk.PartitionTableType{
+		"":    disk.PT_NONE,
+		"dos": disk.PT_DOS,
+		"gpt": disk.PT_GPT,
+	}
+
+	assert := assert.New(t)
+	for name, num := range enumMap {
+		ptt, err := disk.NewPartitionTableType(name)
+		expected := disk.PartitionTableType(num)
+
+		assert.NoError(err)
+		assert.Equal(expected, ptt)
+
+		assert.Equal(name, ptt.String())
+	}
+
+	// error test: bad value
+	badPtt := disk.PartitionTableType(3)
+	assert.PanicsWithValue("unknown or unsupported partition table type with enum value 3", func() { _ = badPtt.String() })
+
+	// error test: bad name
+	_, err := disk.NewPartitionTableType("not-a-type")
+	assert.EqualError(err, "unknown or unsupported partition table type name: not-a-type")
+}
+
+func TestEnumFSType(t *testing.T) {
+	enumMap := map[string]disk.FSType{
+		"":      disk.FS_NONE,
+		"vfat":  disk.FS_VFAT,
+		"ext4":  disk.FS_EXT4,
+		"xfs":   disk.FS_XFS,
+		"btrfs": disk.FS_BTRFS,
+	}
+
+	assert := assert.New(t)
+	for name, num := range enumMap {
+		fst, err := disk.NewFSType(name)
+		expected := disk.FSType(num)
+
+		assert.NoError(err)
+		assert.Equal(expected, fst)
+
+		assert.Equal(name, fst.String())
+	}
+
+	// error test: bad value
+	badFst := disk.FSType(5)
+	assert.PanicsWithValue("unknown or unsupported filesystem type with enum value 5", func() { _ = badFst.String() })
+
+	// error test: bad name
+	_, err := disk.NewFSType("not-a-type")
+	assert.EqualError(err, "unknown or unsupported filesystem type name: not-a-type")
+}


### PR DESCRIPTION
This is part of #926 which I'm slowly splitting into smaller, bite-sized PRs.

---

Add a new enum, PartitionTableType, for referring to the two partition table types, "dos" and "gpt".
This is currently not used but will be part of the new custom partition table generator.