### PR TITLE
pkg/{distro,platform}: move BootMode to platform

### DIFF
--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -6,35 +6,15 @@ import (
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/ostree"
+	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rhsm/facts"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-type BootMode uint64
-
 const (
-	BOOT_NONE BootMode = iota
-	BOOT_LEGACY
-	BOOT_UEFI
-	BOOT_HYBRID
 	UnsupportedCustomizationError = "unsupported blueprint customizations found for image type %q: (allowed: %s)"
 	NoCustomizationsAllowedError  = "image type %q does not support customizations"
 )
-
-func (m BootMode) String() string {
-	switch m {
-	case BOOT_NONE:
-		return "none"
-	case BOOT_LEGACY:
-		return "legacy"
-	case BOOT_UEFI:
-		return "uefi"
-	case BOOT_HYBRID:
-		return "hybrid"
-	default:
-		panic("invalid boot mode")
-	}
-}
 
 // A Distro represents composer's notion of what a given distribution is.
 type Distro interface {
@@ -121,7 +101,7 @@ type ImageType interface {
 	PartitionType() string
 
 	// Returns the corresponding boot mode ("legacy", "uefi", "hybrid") or "none"
-	BootMode() BootMode
+	BootMode() platform.BootMode
 
 	// Returns the names of the pipelines that set up the build environment (buildroot).
 	BuildPipelines() []string

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -126,15 +126,15 @@ func (t *imageType) Exports() []string {
 	return []string{"assembler"}
 }
 
-func (t *imageType) BootMode() distro.BootMode {
+func (t *imageType) BootMode() platform.BootMode {
 	if t.platform.GetUEFIVendor() != "" && t.platform.GetBIOSPlatform() != "" {
-		return distro.BOOT_HYBRID
+		return platform.BOOT_HYBRID
 	} else if t.platform.GetUEFIVendor() != "" {
-		return distro.BOOT_UEFI
+		return platform.BOOT_UEFI
 	} else if t.platform.GetBIOSPlatform() != "" || t.platform.GetZiplSupport() {
-		return distro.BOOT_LEGACY
+		return platform.BOOT_LEGACY
 	}
-	return distro.BOOT_NONE
+	return platform.BOOT_NONE
 }
 
 func (t *imageType) getPartitionTable(

--- a/pkg/distro/rhel/imagetype.go
+++ b/pkg/distro/rhel/imagetype.go
@@ -168,15 +168,15 @@ func (t *ImageType) Exports() []string {
 	return []string{"assembler"}
 }
 
-func (t *ImageType) BootMode() distro.BootMode {
+func (t *ImageType) BootMode() platform.BootMode {
 	if t.platform.GetUEFIVendor() != "" && t.platform.GetBIOSPlatform() != "" {
-		return distro.BOOT_HYBRID
+		return platform.BOOT_HYBRID
 	} else if t.platform.GetUEFIVendor() != "" {
-		return distro.BOOT_UEFI
+		return platform.BOOT_UEFI
 	} else if t.platform.GetBIOSPlatform() != "" || t.platform.GetZiplSupport() {
-		return distro.BOOT_LEGACY
+		return platform.BOOT_LEGACY
 	}
-	return distro.BOOT_NONE
+	return platform.BOOT_NONE
 }
 
 func (t *ImageType) GetPartitionTable(

--- a/pkg/distro/test_distro/distro.go
+++ b/pkg/distro/test_distro/distro.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/ostree"
+	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/policies"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -210,8 +211,8 @@ func (t *TestImageType) PartitionType() string {
 	return ""
 }
 
-func (t *TestImageType) BootMode() distro.BootMode {
-	return distro.BOOT_HYBRID
+func (t *TestImageType) BootMode() platform.BootMode {
+	return platform.BOOT_HYBRID
 }
 
 func (t *TestImageType) BuildPipelines() []string {

--- a/pkg/platform/bootmode.go
+++ b/pkg/platform/bootmode.go
@@ -1,0 +1,25 @@
+package platform
+
+type BootMode uint64
+
+const (
+	BOOT_NONE BootMode = iota
+	BOOT_LEGACY
+	BOOT_UEFI
+	BOOT_HYBRID
+)
+
+func (m BootMode) String() string {
+	switch m {
+	case BOOT_NONE:
+		return "none"
+	case BOOT_LEGACY:
+		return "legacy"
+	case BOOT_UEFI:
+		return "uefi"
+	case BOOT_HYBRID:
+		return "hybrid"
+	default:
+		panic("invalid boot mode")
+	}
+}


### PR DESCRIPTION
This is part of #926 which I'm slowly splitting into smaller, bite-sized PRs.

---

Move the BootMode enum from pkg/distro to pkg/platform.  We want to import BootMode to the disk package, which would create an import loop with distro.