### PR TITLE
test/scripts: pylint: disable=too-many-positional-arguments

### DIFF
--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -64,7 +64,7 @@ def ensure_uncompressed(filepath):
 
 
 def cmd_boot_aws(arch, image_name, privkey, pubkey, image_path, script_cmd):
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     aws_config = get_aws_config()
     cmd = ["go", "run", "./cmd/boot-aws", "run",
            "--access-key-id", aws_config["key_id"],

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -200,7 +200,7 @@ def check_config_names():
 
 def gen_manifests(outputdir, config_map=None, distros=None, arches=None, images=None,
                   commits=False, skip_no_config=False):
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     cmd = ["go", "run", "./cmd/gen-manifests",
            "--cache", os.path.join(TEST_CACHE_ROOT, "rpmmd"),
            "--output", outputdir,


### PR DESCRIPTION
Pylint recently grew a new issue type 'too-many-positional-arguments', which is separate from the more general 'too-many-arguments'.  Our offending functions match both.