### PR TITLE
Partition table helper functions for adding root filesystem and boot partition

### DIFF
--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -60,6 +60,9 @@ const (
 
 	// DosFat16B used for the ESP-System partition
 	DosFat16B = "06"
+
+	// Partition type ID for any native Linux filesystem on dos
+	DosLinuxTypeID = "83"
 )
 
 // FSType is the filesystem type enum.

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -978,9 +978,8 @@ func EnsureRootFilesystem(pt *PartitionTable, defaultFsType FSType) error {
 		return fmt.Errorf("error creating root partition: %w", err)
 	}
 	rootpart := Partition{
-		Type:     FilesystemDataGUID,
-		Bootable: false,
-		Size:     0, // Set the size to 0 and it will be adjusted by EnsureDirectorySizes() and relayout()
+		Type: FilesystemDataGUID,
+		Size: 0, // Set the size to 0 and it will be adjusted by EnsureDirectorySizes() and relayout()
 		Payload: &Filesystem{
 			Type:         defaultFsType.String(),
 			Label:        rootLabel,

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -795,7 +795,7 @@ func (pt *PartitionTable) ensureBtrfs() error {
 		if pt.Type == "gpt" {
 			part.Type = FilesystemDataGUID
 		} else {
-			part.Type = "83"
+			part.Type = DosLinuxTypeID
 		}
 
 	} else {
@@ -977,8 +977,18 @@ func EnsureRootFilesystem(pt *PartitionTable, defaultFsType FSType) error {
 	if err != nil {
 		return fmt.Errorf("error creating root partition: %w", err)
 	}
+
+	var partType string
+	switch pt.Type {
+	case "dos":
+		partType = DosLinuxTypeID
+	case "gpt":
+		partType = FilesystemDataGUID
+	default:
+		return fmt.Errorf("error creating root partition: unknown or unsupported partition table type: %s", pt.Type)
+	}
 	rootpart := Partition{
-		Type: FilesystemDataGUID,
+		Type: partType,
 		Size: 0, // Set the size to 0 and it will be adjusted by EnsureDirectorySizes() and relayout()
 		Payload: &Filesystem{
 			Type:         defaultFsType.String(),
@@ -1021,8 +1031,18 @@ func EnsureBootPartition(pt *PartitionTable, bootFsType FSType) error {
 	if err != nil {
 		return fmt.Errorf("error creating boot partition: %w", err)
 	}
+
+	var partType string
+	switch pt.Type {
+	case "dos":
+		partType = DosLinuxTypeID
+	case "gpt":
+		partType = XBootLDRPartitionGUID
+	default:
+		return fmt.Errorf("error creating boot partition: unknown or unsupported partition table type: %s", pt.Type)
+	}
 	bootPart := Partition{
-		Type: XBootLDRPartitionGUID,
+		Type: partType,
 		Size: 512 * datasizes.MiB,
 		Payload: &Filesystem{
 			Type:         bootFsType.String(),

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -114,10 +114,11 @@ func TestEnsureRootFilesystem(t *testing.T) {
 	}
 
 	testCases := map[string]testCase{
-		"empty-plain": {
-			pt:            disk.PartitionTable{},
+		"empty-plain-gpt": {
+			pt:            disk.PartitionTable{Type: "gpt"},
 			defaultFsType: disk.FS_EXT4,
 			expected: disk.PartitionTable{
+				Type: "gpt",
 				Partitions: []disk.Partition{
 					{
 						Start:    0,
@@ -135,8 +136,31 @@ func TestEnsureRootFilesystem(t *testing.T) {
 				},
 			},
 		},
-		"simple-plain": {
+		"empty-plain-dos": {
+			pt:            disk.PartitionTable{Type: "dos"},
+			defaultFsType: disk.FS_EXT4,
+			expected: disk.PartitionTable{
+				Type: "dos",
+				Partitions: []disk.Partition{
+					{
+						Start:    0,
+						Size:     0,
+						Type:     disk.DosLinuxTypeID,
+						Bootable: false,
+						UUID:     "",
+						Payload: &disk.Filesystem{
+							Type:         "ext4",
+							Label:        "root",
+							Mountpoint:   "/",
+							FSTabOptions: "defaults",
+						},
+					},
+				},
+			},
+		},
+		"simple-plain-gpt": {
 			pt: disk.PartitionTable{
+				Type: "gpt",
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -150,6 +174,7 @@ func TestEnsureRootFilesystem(t *testing.T) {
 			},
 			defaultFsType: disk.FS_EXT4,
 			expected: disk.PartitionTable{
+				Type: "gpt",
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -163,6 +188,48 @@ func TestEnsureRootFilesystem(t *testing.T) {
 						Start:    0,
 						Size:     0,
 						Type:     disk.FilesystemDataGUID,
+						Bootable: false,
+						UUID:     "",
+						Payload: &disk.Filesystem{
+							Type:         "ext4",
+							Label:        "root",
+							Mountpoint:   "/",
+							FSTabOptions: "defaults",
+						},
+					},
+				},
+			},
+		},
+		"simple-plain-dos": {
+			pt: disk.PartitionTable{
+				Type: "dos",
+				Partitions: []disk.Partition{
+					{
+						Payload: &disk.Filesystem{
+							Type:         "ext4",
+							Label:        "home",
+							Mountpoint:   "/home",
+							FSTabOptions: "defaults",
+						},
+					},
+				},
+			},
+			defaultFsType: disk.FS_EXT4,
+			expected: disk.PartitionTable{
+				Type: "dos",
+				Partitions: []disk.Partition{
+					{
+						Payload: &disk.Filesystem{
+							Type:         "ext4",
+							Label:        "home",
+							Mountpoint:   "/home",
+							FSTabOptions: "defaults",
+						},
+					},
+					{
+						Start:    0,
+						Size:     0,
+						Type:     disk.DosLinuxTypeID,
 						Bootable: false,
 						UUID:     "",
 						Payload: &disk.Filesystem{
@@ -394,6 +461,7 @@ func TestEnsureRootFilesystem(t *testing.T) {
 		},
 		"plain-collision": {
 			pt: disk.PartitionTable{
+				Type: "gpt",
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -407,6 +475,7 @@ func TestEnsureRootFilesystem(t *testing.T) {
 			},
 			defaultFsType: disk.FS_EXT4,
 			expected: disk.PartitionTable{
+				Type: "gpt",
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -434,6 +503,7 @@ func TestEnsureRootFilesystem(t *testing.T) {
 		},
 		"lvm-collision": {
 			pt: disk.PartitionTable{
+				Type: "gpt",
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.LVMVolumeGroup{
@@ -472,6 +542,7 @@ func TestEnsureRootFilesystem(t *testing.T) {
 			},
 			defaultFsType: disk.FS_XFS,
 			expected: disk.PartitionTable{
+				Type: "gpt",
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.LVMVolumeGroup{
@@ -586,6 +657,11 @@ func TestEnsureRootFilesystemErrors(t *testing.T) {
 			pt:     disk.PartitionTable{},
 			errmsg: "error creating root partition: no default filesystem type",
 		},
+		"err-no-pt-type": {
+			pt:            disk.PartitionTable{},
+			defaultFsType: disk.FS_EXT4,
+			errmsg:        "error creating root partition: unknown or unsupported partition table type: ",
+		},
 		"err-plain": {
 			pt: disk.PartitionTable{
 				Partitions: []disk.Partition{
@@ -654,10 +730,11 @@ func TestEnsureBootPartition(t *testing.T) {
 	}
 
 	testCases := map[string]testCase{
-		"empty-plain": {
-			pt:     disk.PartitionTable{},
+		"empty-plain-gpt": {
+			pt:     disk.PartitionTable{Type: "gpt"},
 			fsType: disk.FS_EXT4,
 			expected: disk.PartitionTable{
+				Type: "gpt",
 				Partitions: []disk.Partition{
 					{
 						Start:    0,
@@ -675,8 +752,31 @@ func TestEnsureBootPartition(t *testing.T) {
 				},
 			},
 		},
-		"simple-plain": {
+		"empty-plain-dos": {
+			pt:     disk.PartitionTable{Type: "dos"},
+			fsType: disk.FS_EXT4,
+			expected: disk.PartitionTable{
+				Type: "dos",
+				Partitions: []disk.Partition{
+					{
+						Start:    0,
+						Size:     512 * datasizes.MiB,
+						Type:     disk.DosLinuxTypeID,
+						Bootable: false,
+						UUID:     "",
+						Payload: &disk.Filesystem{
+							Type:         "ext4",
+							Label:        "boot",
+							Mountpoint:   "/boot",
+							FSTabOptions: "defaults",
+						},
+					},
+				},
+			},
+		},
+		"simple-plain-gpt": {
 			pt: disk.PartitionTable{
+				Type: "gpt",
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -690,6 +790,7 @@ func TestEnsureBootPartition(t *testing.T) {
 			},
 			fsType: disk.FS_EXT4,
 			expected: disk.PartitionTable{
+				Type: "gpt",
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -703,6 +804,48 @@ func TestEnsureBootPartition(t *testing.T) {
 						Start:    0,
 						Size:     512 * datasizes.MiB,
 						Type:     disk.XBootLDRPartitionGUID,
+						Bootable: false,
+						UUID:     "",
+						Payload: &disk.Filesystem{
+							Type:         "ext4",
+							Label:        "boot",
+							Mountpoint:   "/boot",
+							FSTabOptions: "defaults",
+						},
+					},
+				},
+			},
+		},
+		"simple-plain-dos": {
+			pt: disk.PartitionTable{
+				Type: "dos",
+				Partitions: []disk.Partition{
+					{
+						Payload: &disk.Filesystem{
+							Type:         "ext4",
+							Label:        "home",
+							Mountpoint:   "/home",
+							FSTabOptions: "defaults",
+						},
+					},
+				},
+			},
+			fsType: disk.FS_EXT4,
+			expected: disk.PartitionTable{
+				Type: "dos",
+				Partitions: []disk.Partition{
+					{
+						Payload: &disk.Filesystem{
+							Type:         "ext4",
+							Label:        "home",
+							Mountpoint:   "/home",
+							FSTabOptions: "defaults",
+						},
+					},
+					{
+						Start:    0,
+						Size:     512 * datasizes.MiB,
+						Type:     disk.DosLinuxTypeID,
 						Bootable: false,
 						UUID:     "",
 						Payload: &disk.Filesystem{
@@ -819,6 +962,7 @@ func TestEnsureBootPartition(t *testing.T) {
 		},
 		"label-collision": {
 			pt: disk.PartitionTable{
+				Type: "gpt",
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -832,6 +976,7 @@ func TestEnsureBootPartition(t *testing.T) {
 			},
 			fsType: disk.FS_EXT4,
 			expected: disk.PartitionTable{
+				Type: "gpt",
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{

--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -238,7 +238,7 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 			},
 			{
 				Size: 1 * datasizes.GibiByte,
-				Type: "83",
+				Type: disk.DosLinuxTypeID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
@@ -250,7 +250,7 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 			},
 			{
 				Size: 2 * datasizes.GibiByte,
-				Type: "83",
+				Type: disk.DosLinuxTypeID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Label:        "root",
@@ -333,7 +333,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 			},
 			{
 				Size: 1 * datasizes.GibiByte,
-				Type: "83",
+				Type: disk.DosLinuxTypeID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
@@ -345,7 +345,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 			},
 			{
 				Size: 2569 * datasizes.MebiByte,
-				Type: "83",
+				Type: disk.DosLinuxTypeID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Label:        "root",


### PR DESCRIPTION
This is part of #926 which I'm slowly splitting into smaller, bite-sized PRs.

---

The PR introduces two helper functions, `EnsureRootFilesystem()` and `EnsureBootPartition()`.  These will add, respectively, a root filesystem and a boot partition to a partition table if they don't already exist.