### PR TITLE
awscloud: add import role parameter to AMI registration

### DIFF
--- a/cmd/boot-aws/main.go
+++ b/cmd/boot-aws/main.go
@@ -198,10 +198,8 @@ func doSetup(a *awscloud.AWS, filename string, flags *pflag.FlagSet, res *resour
 
 	fmt.Printf("file uploaded to %s\n", aws.StringValue(&uploadOutput.Location))
 
-	var bootModePtr *string
-	if bootMode, err := flags.GetString("boot-mode"); bootMode != "" {
-		bootModePtr = &bootMode
-	} else if err != nil {
+	bootMode, err := getOptionalStringFlag(flags, "boot-mode")
+	if err != nil {
 		return err
 	}
 
@@ -220,7 +218,7 @@ func doSetup(a *awscloud.AWS, filename string, flags *pflag.FlagSet, res *resour
 		return err
 	}
 
-	ami, snapshot, err := a.Register(imageName, bucketName, keyName, nil, arch, bootModePtr, importRole)
+	ami, snapshot, err := a.Register(imageName, bucketName, keyName, nil, arch, bootMode, importRole)
 	if err != nil {
 		return fmt.Errorf("Register(): %s", err.Error())
 	}

--- a/pkg/cloud/awscloud/awscloud.go
+++ b/pkg/cloud/awscloud/awscloud.go
@@ -240,8 +240,10 @@ func WaitUntilImportSnapshotTaskCompletedWithContext(c *ec2.EC2, ctx aws.Context
 // The caller can optionally specify the boot mode of the AMI. If the boot
 // mode is not specified, then the instances launched from this AMI use the
 // default boot mode value of the instance type.
+// The caller can also specify the name of the role used to do the import.
+// If nil is given, the default one from the SDK is used (vmimport).
 // Returns the image ID and the snapshot ID.
-func (a *AWS) Register(name, bucket, key string, shareWith []string, rpmArch string, bootMode *string) (*string, *string, error) {
+func (a *AWS) Register(name, bucket, key string, shareWith []string, rpmArch string, bootMode, importRole *string) (*string, *string, error) {
 	rpmArchToEC2Arch := map[string]string{
 		"x86_64":  "x86_64",
 		"aarch64": "arm64",
@@ -269,6 +271,7 @@ func (a *AWS) Register(name, bucket, key string, shareWith []string, rpmArch str
 					S3Key:    aws.String(key),
 				},
 			},
+			RoleName: importRole,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
We got a request for supporting custom role names, let's start by
adding support for it in the images library.