### PR TITLE
disk: separate most tests from package

### DIFF
--- a/pkg/disk/disk_internal_test.go
+++ b/pkg/disk/disk_internal_test.go
@@ -1,0 +1,108 @@
+package disk
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenUniqueString(t *testing.T) {
+	type testCase struct {
+		base     string
+		existing map[string]bool
+		exp      string
+	}
+
+	testCases := map[string]testCase{
+		"simple": {
+			base: "root",
+			existing: map[string]bool{
+				"one": true,
+				"two": true,
+			},
+			exp: "root",
+		},
+		"collision": {
+			base: "root",
+			existing: map[string]bool{
+				"one":  true,
+				"two":  true,
+				"root": true,
+			},
+			exp: "root00",
+		},
+		"collision-2": {
+			base: "word",
+			existing: map[string]bool{
+				"word":   true,
+				"word00": true,
+				"word01": true,
+				"other":  true,
+			},
+			exp: "word02",
+		},
+	}
+
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			out, err := genUniqueString(tc.base, tc.existing)
+			assert.NoError(err)
+			assert.Equal(tc.exp, out)
+		})
+	}
+}
+
+func TestGenUniqueStringManyCollisions(t *testing.T) {
+	type testCase struct {
+		base        string
+		ncollisions int
+		exp         string
+		errmsg      string
+	}
+
+	testCases := map[string]testCase{
+		"baseword33": {
+			base:        "baseword",
+			ncollisions: 33,
+			exp:         "baseword33",
+		},
+		"somany99": {
+			base:        "somany",
+			ncollisions: 99,
+			exp:         "somany99",
+		},
+		"tk42102": {
+			base:        "tk421",
+			ncollisions: 2,
+			exp:         "tk42102",
+		},
+		"so-many-collisions": {
+			base:        "all-the-collisions",
+			ncollisions: 100,
+			errmsg:      `name collision: could not generate unique version of "all-the-collisions"`,
+		},
+	}
+
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			existing := map[string]bool{
+				tc.base: true,
+			}
+			for n := 0; n < tc.ncollisions; n++ {
+				existing[fmt.Sprintf("%s%02d", tc.base, n)] = true
+			}
+			out, err := genUniqueString(tc.base, existing)
+			if tc.errmsg == "" {
+				assert.NoError(err)
+				assert.Equal(tc.exp, out)
+			} else {
+				assert.EqualError(err, tc.errmsg)
+			}
+		})
+	}
+}

--- a/pkg/disk/export_test.go
+++ b/pkg/disk/export_test.go
@@ -1,3 +1,10 @@
 package disk
 
-var PayloadEntityMap = payloadEntityMap
+var (
+	PayloadEntityMap = payloadEntityMap
+	EntityPath       = entityPath
+)
+
+func FindDirectoryEntityPath(pt *PartitionTable, path string) []Entity {
+	return pt.findDirectoryEntityPath(path)
+}

--- a/pkg/disk/partition_table_internal_test.go
+++ b/pkg/disk/partition_table_internal_test.go
@@ -4,8 +4,300 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/stretchr/testify/assert"
 )
+
+const (
+	KiB = datasizes.KiB
+	MiB = datasizes.MiB
+	GiB = datasizes.GiB
+)
+
+var TestPartitionTables = map[string]PartitionTable{
+	"plain": {
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []Partition{
+			{
+				Size:     1 * MiB,
+				Bootable: true,
+				Type:     BIOSBootPartitionGUID,
+				UUID:     BIOSBootPartitionUUID,
+			},
+			{
+				Size: 200 * MiB,
+				Type: EFISystemPartitionGUID,
+				UUID: EFISystemPartitionUUID,
+				Payload: &Filesystem{
+					Type:         "vfat",
+					UUID:         EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					Label:        "EFI-SYSTEM",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 500 * MiB,
+				Type: FilesystemDataGUID,
+				UUID: FilesystemDataUUID,
+				Payload: &Filesystem{
+					Type:         "xfs",
+					Mountpoint:   "/boot",
+					Label:        "boot",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+			{
+				Type: FilesystemDataGUID,
+				UUID: RootPartitionUUID,
+				Payload: &Filesystem{
+					Type:         "xfs",
+					Label:        "root",
+					Mountpoint:   "/",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+		},
+	},
+
+	"plain-noboot": {
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []Partition{
+			{
+				Size:     1 * MiB,
+				Bootable: true,
+				Type:     BIOSBootPartitionGUID,
+				UUID:     BIOSBootPartitionUUID,
+			},
+			{
+				Size: 200 * MiB,
+				Type: EFISystemPartitionGUID,
+				UUID: EFISystemPartitionUUID,
+				Payload: &Filesystem{
+					Type:         "vfat",
+					UUID:         EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					Label:        "EFI-SYSTEM",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Type: FilesystemDataGUID,
+				UUID: RootPartitionUUID,
+				Payload: &Filesystem{
+					Type:         "xfs",
+					Label:        "root",
+					Mountpoint:   "/",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+		},
+	},
+
+	"luks": {
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []Partition{
+			{
+				Size:     1 * MiB,
+				Bootable: true,
+				Type:     BIOSBootPartitionGUID,
+				UUID:     BIOSBootPartitionUUID,
+			},
+			{
+				Size: 200 * MiB,
+				Type: EFISystemPartitionGUID,
+				UUID: EFISystemPartitionUUID,
+				Payload: &Filesystem{
+					Type:         "vfat",
+					UUID:         EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					Label:        "EFI-SYSTEM",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 500 * MiB,
+				Type: FilesystemDataGUID,
+				UUID: FilesystemDataUUID,
+				Payload: &Filesystem{
+					Type:         "xfs",
+					Mountpoint:   "/boot",
+					Label:        "boot",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+			{
+				Type: FilesystemDataGUID,
+				UUID: RootPartitionUUID,
+				Payload: &LUKSContainer{
+					UUID:  "",
+					Label: "crypt_root",
+					Payload: &Filesystem{
+						Type:         "xfs",
+						Label:        "root",
+						Mountpoint:   "/",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
+				},
+			},
+		},
+	},
+	"luks+lvm": {
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []Partition{
+			{
+				Size:     1 * MiB,
+				Bootable: true,
+				Type:     BIOSBootPartitionGUID,
+				UUID:     BIOSBootPartitionUUID,
+			},
+			{
+				Size: 200 * MiB,
+				Type: EFISystemPartitionGUID,
+				UUID: EFISystemPartitionUUID,
+				Payload: &Filesystem{
+					Type:         "vfat",
+					UUID:         EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					Label:        "EFI-SYSTEM",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 500 * MiB,
+				Type: FilesystemDataGUID,
+				UUID: FilesystemDataUUID,
+				Payload: &Filesystem{
+					Type:         "xfs",
+					Mountpoint:   "/boot",
+					Label:        "boot",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+			{
+				Type: FilesystemDataGUID,
+				UUID: RootPartitionUUID,
+				Size: 5 * GiB,
+				Payload: &LUKSContainer{
+					UUID: "",
+					Payload: &LVMVolumeGroup{
+						Name:        "",
+						Description: "",
+						LogicalVolumes: []LVMLogicalVolume{
+							{
+								Size: 2 * GiB,
+								Payload: &Filesystem{
+									Type:         "xfs",
+									Label:        "root",
+									Mountpoint:   "/",
+									FSTabOptions: "defaults",
+									FSTabFreq:    0,
+									FSTabPassNo:  0,
+								},
+							},
+							{
+								Size: 2 * GiB,
+								Payload: &Filesystem{
+									Type:         "xfs",
+									Label:        "root",
+									Mountpoint:   "/home",
+									FSTabOptions: "defaults",
+									FSTabFreq:    0,
+									FSTabPassNo:  0,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	"btrfs": {
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []Partition{
+			{
+				Size:     1 * MiB,
+				Bootable: true,
+				Type:     BIOSBootPartitionGUID,
+				UUID:     BIOSBootPartitionUUID,
+			},
+			{
+				Size: 200 * MiB,
+				Type: EFISystemPartitionGUID,
+				UUID: EFISystemPartitionUUID,
+				Payload: &Filesystem{
+					Type:         "vfat",
+					UUID:         EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					Label:        "EFI-SYSTEM",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 500 * MiB,
+				Type: FilesystemDataGUID,
+				UUID: FilesystemDataUUID,
+				Payload: &Filesystem{
+					Type:         "xfs",
+					Mountpoint:   "/boot",
+					Label:        "boot",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+			{
+				Type: FilesystemDataGUID,
+				UUID: RootPartitionUUID,
+				Size: 10 * GiB,
+				Payload: &Btrfs{
+					UUID:       "",
+					Label:      "",
+					Mountpoint: "",
+					Subvolumes: []BtrfsSubvolume{
+						{
+							Size:       0,
+							Mountpoint: "/",
+							GroupID:    0,
+						},
+						{
+							Size:       5 * GiB,
+							Mountpoint: "/var",
+							GroupID:    0,
+						},
+					},
+				},
+			},
+		},
+	},
+}
 
 func TestPartitionTableFeatures(t *testing.T) {
 	type testCase struct {
@@ -20,7 +312,7 @@ func TestPartitionTableFeatures(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		pt := testPartitionTables[tc.partitionType]
+		pt := TestPartitionTables[tc.partitionType]
 		assert.Equal(t, tc.expectedFeatures, pt.features())
 
 	}


### PR DESCRIPTION
Separate most disk tests into internal and external ones.

- disk_test.go: was internal (package disk) and is now external (package disk_test)
- Function `entityPath()` and method `PartitionTable.findDirectoryEntityPath()` are now exported for tests in export_test.go
- Test partition tables moved to partition_table_internal_test.go and exported.
- Unique string tests moved to new file: disk_internal_test.go