### PR TITLE
dnfjson: skip sbom tests with dnf5

### DIFF
--- a/pkg/dnfjson/dnfjson.go
+++ b/pkg/dnfjson/dnfjson.go
@@ -161,6 +161,7 @@ type DepsolveResult struct {
 	Packages []rpmmd.PackageSpec
 	Repos    []rpmmd.RepoConfig
 	SBOM     *sbom.Document
+	Solver   string
 }
 
 // Create a new Solver with the given configuration. Initialising a Solver also loads system subscription information.
@@ -244,6 +245,7 @@ func (s *Solver) Depsolve(pkgSets []rpmmd.PackageSet, sbomType sbom.StandardType
 		Packages: packages,
 		Repos:    repos,
 		SBOM:     sbomDoc,
+		Solver:   result.Solver,
 	}, nil
 }
 

--- a/pkg/dnfjson/dnfjson_test.go
+++ b/pkg/dnfjson/dnfjson_test.go
@@ -19,6 +19,24 @@ import (
 
 var forceDNF = flag.Bool("force-dnf", false, "force dnf testing, making them fail instead of skip if dnf isn't installed")
 
+// sniffSolverVersion performs a quick depsolve with the given solver to get
+// the value of the underlying library name and version from the 'solver' field
+// in the result.
+func sniffSolverVersion(solver *Solver, repo rpmmd.RepoConfig) string {
+	pkgsets := []rpmmd.PackageSet{
+		{
+			Include:      []string{"filesystem"},
+			Repositories: []rpmmd.RepoConfig{repo},
+		},
+	}
+	res, err := solver.Depsolve(pkgsets, sbom.StandardTypeNone)
+	if err != nil {
+		panic(fmt.Sprintf("sniffSolverVersion: the sniffer failed: %s", err))
+	}
+
+	return res.Solver
+}
+
 func TestDepsolver(t *testing.T) {
 	if !*forceDNF {
 		// dnf tests aren't forced: skip them if the dnf sniff check fails
@@ -114,10 +132,14 @@ func TestDepsolver(t *testing.T) {
 		},
 	}
 
+	solverIsDnf5 := sniffSolverVersion(solver, s.RepoConfig) == "dnf5"
 	for tcName := range testCases {
 		t.Run(tcName, func(t *testing.T) {
 			assert := assert.New(t)
 			tc := testCases[tcName]
+			if tc.sbomType != sbom.StandardTypeNone && solverIsDnf5 {
+				t.Skip("Skipping sbom test with dnf5: unsupported")
+			}
 			pkgsets := make([]rpmmd.PackageSet, len(tc.packages))
 			for idx := range tc.packages {
 				pkgsets[idx] = rpmmd.PackageSet{Include: tc.packages[idx], Repositories: tc.repos, InstallWeakDeps: true}


### PR DESCRIPTION
**dnfjson: add Solver string to DepsolveResult**

The solver string is returned from the depsolver with the response and
identifies the solver library that was used.  Currently, it is either
dnf or dnf5.

Returning it with the DepsolveResult can be useful for reproducibility
and troubleshooting.

---

**dnfjson: skip sbom tests with dnf5**

SBOMs are not yet supported when using the dnf5 solver in
osbuild-depsolve-dnf.  Running the test on Fedora 41, which uses dnf5 by
default, makes the test fail.

Sniff the solver used using a quick, simple depsolve to get the result,
and skip any SBOM tests if the solver is dnf5.

---
