### PR TITLE
rhel: fix crash when PartitionType() is requested

### DIFF
--- a/pkg/distro/rhel/images_test.go
+++ b/pkg/distro/rhel/images_test.go
@@ -438,3 +438,8 @@ func TestOsCustomizationsRHSM(t *testing.T) {
 		})
 	}
 }
+
+func TestPartitionTypeNotCrashing(t *testing.T) {
+	it := &ImageType{}
+	assert.Equal(t, it.PartitionType(), "")
+}

--- a/pkg/distro/rhel/imagetype.go
+++ b/pkg/distro/rhel/imagetype.go
@@ -216,6 +216,10 @@ func (t *ImageType) getDefaultInstallerConfig() (*distro.InstallerConfig, error)
 }
 
 func (t *ImageType) PartitionType() string {
+	if t.BasePartitionTables == nil {
+		return ""
+	}
+
 	basePartitionTable, exists := t.BasePartitionTables(t)
 	if !exists {
 		return ""


### PR DESCRIPTION
This commit fixes a crash in when the rhel ImageType.PartitionType() is called, here the BasePartitionTables function pointer is sometimes not initialized (e.g. in the `centos9/edge-commit` image type).