### PR TITLE
Revert "dnfjson: skip sbom tests with dnf5"

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -8,21 +8,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "dd16c2b769ee8fb666dbb3d4a5bbb579c455c024"
+        "commit": "68de4e850ddbeb96350189254d15a28d19999f25"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "dd16c2b769ee8fb666dbb3d4a5bbb579c455c024"
+        "commit": "68de4e850ddbeb96350189254d15a28d19999f25"
       }
     }
   },
   "fedora-39": {
     "dependencies": {
       "osbuild": {
-        "commit": "dd16c2b769ee8fb666dbb3d4a5bbb579c455c024"
+        "commit": "68de4e850ddbeb96350189254d15a28d19999f25"
       }
     },
     "repos": [
@@ -65,7 +65,7 @@
   "fedora-40": {
     "dependencies": {
       "osbuild": {
-        "commit": "dd16c2b769ee8fb666dbb3d4a5bbb579c455c024"
+        "commit": "68de4e850ddbeb96350189254d15a28d19999f25"
       }
     },
     "repos": [
@@ -108,7 +108,7 @@
   "fedora-41": {
     "dependencies": {
       "osbuild": {
-        "commit": "dd16c2b769ee8fb666dbb3d4a5bbb579c455c024"
+        "commit": "68de4e850ddbeb96350189254d15a28d19999f25"
       }
     },
     "repos": [


### PR DESCRIPTION
Remove the code that skips the sbom test with dnf5.  The
osbuild-depsolve-dnf package now depends on python3-dnf in Fedora 41 and
configures it to use it, so as far as images is concerned, the sboms
should always be supported by the depsolver.

This reverts commit https://github.com/osbuild/images/commit/5134c8b620d3ab24174603cfa8c827bb78db7c45 (PR #1017).