### PR TITLE
disk: AddPartitionsForBootMode() helper function 

### DIFF
--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -63,6 +63,12 @@ const (
 
 	// Partition type ID for any native Linux filesystem on dos
 	DosLinuxTypeID = "83"
+
+	// Partition type ID for BIOS boot partition on dos
+	DosBIOSBootID = "ef02"
+
+	// Partition type ID for ESP on dos
+	DosESPID = "ef00"
 )
 
 // FSType is the filesystem type enum.

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -1097,7 +1097,7 @@ func AddPartitionsForBootMode(pt *PartitionTable, bootMode platform.BootMode) er
 	case platform.BOOT_NONE:
 		return nil
 	default:
-		return fmt.Errorf("invalid boot mode specified: %s", bootMode)
+		return fmt.Errorf("unknown or unsupported boot mode type with enum value %d", bootMode)
 	}
 }
 

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/datasizes"
+	"github.com/osbuild/images/pkg/platform"
 )
 
 type PartitionTable struct {
@@ -1053,4 +1054,60 @@ func EnsureBootPartition(pt *PartitionTable, bootFsType FSType) error {
 	}
 	pt.Partitions = append(pt.Partitions, bootPart)
 	return nil
+}
+
+// AddPartitionsForBootMode creates partitions to satisfy the boot mode requirements:
+//   - BIOS/legacy: adds a 1 MiB BIOS boot partition.
+//   - UEFI: adds a 200 MiB EFI system partition.
+//   - Hybrid: adds both.
+//
+// The function will append the new partitions to the end of the existing
+// partition table therefore it is best to call this function early to put them
+// near the front (as is conventional).
+func AddPartitionsForBootMode(pt *PartitionTable, bootMode platform.BootMode) error {
+	switch bootMode {
+	case platform.BOOT_LEGACY:
+		// add BIOS boot partition
+		pt.Partitions = append(pt.Partitions, mkBIOSBoot())
+		return nil
+	case platform.BOOT_UEFI:
+		// add ESP
+		pt.Partitions = append(pt.Partitions, mkESP(200*datasizes.MiB))
+		return nil
+	case platform.BOOT_HYBRID:
+		// add both
+		pt.Partitions = append(pt.Partitions, mkBIOSBoot())
+		pt.Partitions = append(pt.Partitions, mkESP(200*datasizes.MiB))
+		return nil
+	case platform.BOOT_NONE:
+		return nil
+	default:
+		return fmt.Errorf("invalid boot mode specified: %s", bootMode)
+	}
+}
+
+func mkBIOSBoot() Partition {
+	return Partition{
+		Size:     1 * datasizes.MiB,
+		Bootable: true,
+		Type:     BIOSBootPartitionGUID,
+		UUID:     BIOSBootPartitionUUID,
+	}
+}
+
+func mkESP(size uint64) Partition {
+	return Partition{
+		Size: size,
+		Type: EFISystemPartitionGUID,
+		UUID: EFISystemPartitionUUID,
+		Payload: &Filesystem{
+			Type:         "vfat",
+			UUID:         EFIFilesystemUUID,
+			Mountpoint:   "/boot/efi",
+			Label:        "EFI-SYSTEM",
+			FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+			FSTabFreq:    0,
+			FSTabPassNo:  2,
+		},
+	}
 }

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -1199,6 +1199,11 @@ func TestAddPartitionsForBootMode(t *testing.T) {
 			bootMode: platform.BOOT_HYBRID,
 			errmsg:   "error creating BIOS boot partition: unknown or unsupported partition table type: super-gpt",
 		},
+		"bad-bootmode": {
+			pt:       disk.PartitionTable{Type: "gpt"},
+			bootMode: 4,
+			errmsg:   "unknown or unsupported boot mode type with enum value 4",
+		},
 	}
 
 	for name := range testCases {


### PR DESCRIPTION
This is part of #926 which I'm slowly splitting into smaller, bite-sized PRs.

---

The PR introduces a helper function, `AddPartitionsForBootMode()`.  The function takes a partition table and boot mode and adds partitions to satisfy the boot mode requirements:
- BIOS/legacy: adds a 1 MiB BIOS boot partition.
- UEFI: adds a 200 MiB EFI system partition.
- Hybrid: adds both.