### PR TITLE
many: use new `disk.PartitionTableType` instead of string

### DIFF
--- a/cmd/osbuild-playground/partitiontables.go
+++ b/cmd/osbuild-playground/partitiontables.go
@@ -4,7 +4,7 @@ import "github.com/osbuild/images/pkg/disk"
 
 var basePT = disk.PartitionTable{
 	UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-	Type: "gpt",
+	Type: disk.PT_GPT,
 	Partitions: []disk.Partition{
 		{
 			Size:     1048576, // 1MB

--- a/cmd/otk/osbuild-gen-partition-table/main.go
+++ b/cmd/otk/osbuild-gen-partition-table/main.go
@@ -126,9 +126,13 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 		}
 	}
 
+	partType, err := disk.NewPartitionTableType(string(input.Properties.Type))
+	if err != nil {
+		return nil, err
+	}
 	pt := &disk.PartitionTable{
 		UUID:        input.Properties.UUID,
-		Type:        string(input.Properties.Type),
+		Type:        partType,
 		SectorSize:  input.Properties.SectorSize,
 		StartOffset: startOffset,
 	}

--- a/cmd/otk/osbuild-gen-partition-table/main_test.go
+++ b/cmd/otk/osbuild-gen-partition-table/main_test.go
@@ -367,7 +367,7 @@ func TestGenPartitionTableIntegrationPPC(t *testing.T) {
 				PartitionTable: &disk.PartitionTable{
 					Size: 10742661120,
 					UUID: "0x14fc63d2",
-					Type: "dos",
+					Type: disk.PT_DOS,
 					Partitions: []disk.Partition{
 						{
 							Bootable: true,
@@ -423,7 +423,7 @@ func TestGenPartitionTableMinimal(t *testing.T) {
 				PartitionTable: &disk.PartitionTable{
 					Size: 10738466816,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-					Type: "dos",
+					Type: disk.PT_DOS,
 					Partitions: []disk.Partition{
 						{
 							Start: 1048576,
@@ -483,7 +483,7 @@ func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
 				PartitionTable: &disk.PartitionTable{
 					Size: 15893266432,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-					Type: "dos",
+					Type: disk.PT_DOS,
 					Partitions: []disk.Partition{
 						{
 							Start: 1048576,
@@ -572,7 +572,7 @@ func TestGenPartitionTableCustomizationExtraMpPlusModificationPartitionMode(t *t
 				PartitionTable: &disk.PartitionTable{
 					Size: 13739491328,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-					Type: "dos",
+					Type: disk.PT_DOS,
 					Partitions: []disk.Partition{
 						{
 							Start: 3002073088,
@@ -630,7 +630,7 @@ func TestGenPartitionTablePropertiesDefaultSize(t *testing.T) {
 				PartitionTable: &disk.PartitionTable{
 					Size: 16106127360,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-					Type: "dos",
+					Type: disk.PT_DOS,
 					Partitions: []disk.Partition{
 						{
 							Start: 1048576,
@@ -681,7 +681,7 @@ func TestGenPartitionTableModificationMinDiskSize(t *testing.T) {
 				PartitionTable: &disk.PartitionTable{
 					Size: 21474836480,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-					Type: "dos",
+					Type: disk.PT_DOS,
 					Partitions: []disk.Partition{
 						{
 							Start: 1048576,
@@ -731,7 +731,7 @@ func TestGenPartitionTableModificationFilename(t *testing.T) {
 				PartitionTable: &disk.PartitionTable{
 					Size: 10738466816,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-					Type: "dos",
+					Type: disk.PT_DOS,
 					Partitions: []disk.Partition{
 						{
 							Start: 1048576,
@@ -791,7 +791,7 @@ func TestGenPartitionCreateESPDos(t *testing.T) {
 			Internal: otkdisk.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 12885950464,
-					Type: "dos",
+					Type: disk.PT_DOS,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
 					Partitions: []disk.Partition{
 						{

--- a/cmd/otk/osbuild-make-grub2-inst-stage/main_test.go
+++ b/cmd/otk/osbuild-make-grub2-inst-stage/main_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var fakePt = &disk.PartitionTable{
-	Type: "gpt",
+	Type: disk.PT_GPT,
 	Partitions: []disk.Partition{
 		{
 			Size:     1 * datasizes.MiB,

--- a/cmd/otk/osbuild-make-partition-stages/main_test.go
+++ b/cmd/otk/osbuild-make-partition-stages/main_test.go
@@ -24,7 +24,7 @@ var minimalInputBase = makestages.Input{
 				PartitionTable: &disk.PartitionTable{
 					Size: 10738466816,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-					Type: "dos",
+					Type: disk.PT_DOS,
 					Partitions: []disk.Partition{
 						{
 							Start: 1048576,

--- a/internal/testdisk/partition.go
+++ b/internal/testdisk/partition.go
@@ -32,7 +32,7 @@ func MakeFakePartitionTable(mntPoints ...string) *disk.PartitionTable {
 
 	}
 	return &disk.PartitionTable{
-		Type:       "gpt",
+		Type:       disk.PT_GPT,
 		Partitions: partitions,
 	}
 }
@@ -42,7 +42,7 @@ func MakeFakePartitionTable(mntPoints ...string) *disk.PartitionTable {
 func MakeFakeBtrfsPartitionTable(mntPoints ...string) *disk.PartitionTable {
 	var subvolumes []disk.BtrfsSubvolume
 	pt := &disk.PartitionTable{
-		Type:       "gpt",
+		Type:       disk.PT_GPT,
 		Size:       10 * datasizes.GiB,
 		Partitions: []disk.Partition{},
 	}
@@ -107,7 +107,7 @@ func MakeFakeBtrfsPartitionTable(mntPoints ...string) *disk.PartitionTable {
 func MakeFakeLVMPartitionTable(mntPoints ...string) *disk.PartitionTable {
 	var lvs []disk.LVMLogicalVolume
 	pt := &disk.PartitionTable{
-		Type:       "gpt",
+		Type:       disk.PT_GPT,
 		Size:       10 * datasizes.GiB,
 		Partitions: []disk.Partition{},
 	}

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -19,6 +19,7 @@ package disk
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
@@ -139,6 +140,24 @@ func (t PartitionTableType) String() string {
 	default:
 		panic(fmt.Sprintf("unknown or unsupported partition table type with enum value %d", t))
 	}
+}
+
+func (t PartitionTableType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
+}
+
+func (t *PartitionTableType) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+
+	new, err := NewPartitionTableType(s)
+	if err != nil {
+		return err
+	}
+	*t = new
+	return nil
 }
 
 func NewPartitionTableType(s string) (PartitionTableType, error) {

--- a/pkg/disk/disk_test.go
+++ b/pkg/disk/disk_test.go
@@ -52,7 +52,7 @@ func TestDynamicallyResizePartitionTable(t *testing.T) {
 	}
 	pt := disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		Type: disk.PT_GPT,
 		Partitions: []disk.Partition{
 			{
 				Size:     2048,

--- a/pkg/disk/enums_test.go
+++ b/pkg/disk/enums_test.go
@@ -1,21 +1,24 @@
 package disk_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
-	"github.com/osbuild/images/pkg/disk"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/disk"
 )
 
-func TestEnumPartitionTableType(t *testing.T) {
-	enumMap := map[string]disk.PartitionTableType{
-		"":    disk.PT_NONE,
-		"dos": disk.PT_DOS,
-		"gpt": disk.PT_GPT,
-	}
+var partitionTypeEnumMap = map[string]disk.PartitionTableType{
+	"":    disk.PT_NONE,
+	"dos": disk.PT_DOS,
+	"gpt": disk.PT_GPT,
+}
 
+func TestEnumPartitionTableType(t *testing.T) {
 	assert := assert.New(t)
-	for name, num := range enumMap {
+	for name, num := range partitionTypeEnumMap {
 		ptt, err := disk.NewPartitionTableType(name)
 		expected := disk.PartitionTableType(num)
 
@@ -32,6 +35,24 @@ func TestEnumPartitionTableType(t *testing.T) {
 	// error test: bad name
 	_, err := disk.NewPartitionTableType("not-a-type")
 	assert.EqualError(err, "unknown or unsupported partition table type name: not-a-type")
+}
+
+func TestEnumPartitionTableTypeJSON(t *testing.T) {
+	for name, num := range partitionTypeEnumMap {
+		jsData, err := json.Marshal(num)
+		assert.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf(`"%s"`, name), string(jsData))
+
+		var unmarshaledNum disk.PartitionTableType
+		err = json.Unmarshal(jsData, &unmarshaledNum)
+		assert.NoError(t, err)
+		assert.Equal(t, unmarshaledNum, num)
+	}
+
+	// bad unmarshal
+	var unmarshaledNum disk.PartitionTableType
+	err := json.Unmarshal([]byte(`"bad"`), &unmarshaledNum)
+	assert.EqualError(t, err, `unknown or unsupported partition table type name: bad`)
 }
 
 func TestEnumFSType(t *testing.T) {

--- a/pkg/disk/partition_table_internal_test.go
+++ b/pkg/disk/partition_table_internal_test.go
@@ -17,7 +17,7 @@ const (
 var TestPartitionTables = map[string]PartitionTable{
 	"plain": {
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		Type: PT_GPT,
 		Partitions: []Partition{
 			{
 				Size:     1 * MiB,
@@ -69,7 +69,7 @@ var TestPartitionTables = map[string]PartitionTable{
 
 	"plain-noboot": {
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		Type: PT_GPT,
 		Partitions: []Partition{
 			{
 				Size:     1 * MiB,
@@ -108,7 +108,7 @@ var TestPartitionTables = map[string]PartitionTable{
 
 	"luks": {
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		Type: PT_GPT,
 		Partitions: []Partition{
 			{
 				Size:     1 * MiB,
@@ -163,7 +163,7 @@ var TestPartitionTables = map[string]PartitionTable{
 	},
 	"luks+lvm": {
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		Type: PT_GPT,
 		Partitions: []Partition{
 			{
 				Size:     1 * MiB,
@@ -238,7 +238,7 @@ var TestPartitionTables = map[string]PartitionTable{
 	},
 	"btrfs": {
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		Type: PT_GPT,
 		Partitions: []Partition{
 			{
 				Size:     1 * MiB,
@@ -544,7 +544,7 @@ func TestRelayout(t *testing.T) {
 	testCases := map[string]testCase{
 		"simple-dos": {
 			pt: &PartitionTable{
-				Type: "dos",
+				Type: PT_DOS,
 				Size: 100 * MiB,
 				Partitions: []Partition{
 					{
@@ -560,7 +560,7 @@ func TestRelayout(t *testing.T) {
 			},
 			size: 100 * MiB,
 			expected: &PartitionTable{
-				Type: "dos",
+				Type: PT_DOS,
 				Size: 100 * MiB,
 				Partitions: []Partition{
 					{
@@ -579,7 +579,7 @@ func TestRelayout(t *testing.T) {
 		},
 		"simple-gpt": {
 			pt: &PartitionTable{
-				Type: "gpt",
+				Type: PT_GPT,
 				Size: 100 * MiB,
 				Partitions: []Partition{
 					{
@@ -595,7 +595,7 @@ func TestRelayout(t *testing.T) {
 			},
 			size: 100 * MiB,
 			expected: &PartitionTable{
-				Type: "gpt",
+				Type: PT_GPT,
 				Size: 100 * MiB,
 				Partitions: []Partition{
 					{
@@ -614,7 +614,7 @@ func TestRelayout(t *testing.T) {
 		},
 		"simple-gpt-root-first": {
 			pt: &PartitionTable{
-				Type: "gpt",
+				Type: PT_GPT,
 				Size: 100 * MiB,
 				Partitions: []Partition{
 					{
@@ -633,7 +633,7 @@ func TestRelayout(t *testing.T) {
 			},
 			size: 100 * MiB,
 			expected: &PartitionTable{
-				Type: "gpt",
+				Type: PT_GPT,
 				Size: 100 * MiB,
 				Partitions: []Partition{
 					{
@@ -656,7 +656,7 @@ func TestRelayout(t *testing.T) {
 		},
 		"lvm-dos": {
 			pt: &PartitionTable{
-				Type: "dos",
+				Type: PT_DOS,
 				Size: 100 * MiB,
 				Partitions: []Partition{
 					{
@@ -678,7 +678,7 @@ func TestRelayout(t *testing.T) {
 			},
 			size: 100 * MiB,
 			expected: &PartitionTable{
-				Type: "dos",
+				Type: PT_DOS,
 				Size: 100 * MiB,
 				Partitions: []Partition{
 					{
@@ -703,7 +703,7 @@ func TestRelayout(t *testing.T) {
 		},
 		"lvm-gpt": {
 			pt: &PartitionTable{
-				Type: "gpt",
+				Type: PT_GPT,
 				Size: 100 * MiB,
 				Partitions: []Partition{
 					{
@@ -726,7 +726,7 @@ func TestRelayout(t *testing.T) {
 			},
 			size: 100 * MiB,
 			expected: &PartitionTable{
-				Type: "gpt",
+				Type: PT_GPT,
 				Size: 100 * MiB,
 				Partitions: []Partition{
 					{
@@ -752,7 +752,7 @@ func TestRelayout(t *testing.T) {
 		},
 		"lvm-gpt-multilv": {
 			pt: &PartitionTable{
-				Type: "gpt",
+				Type: PT_GPT,
 				Size: 100 * MiB,
 				Partitions: []Partition{
 					{
@@ -778,7 +778,7 @@ func TestRelayout(t *testing.T) {
 			},
 			size: 100 * MiB,
 			expected: &PartitionTable{
-				Type: "gpt",
+				Type: PT_GPT,
 				Size: 100 * MiB,
 				Partitions: []Partition{
 					{
@@ -807,7 +807,7 @@ func TestRelayout(t *testing.T) {
 		},
 		"btrfs": {
 			pt: &PartitionTable{
-				Type: "gpt",
+				Type: PT_GPT,
 				Size: 100 * MiB,
 				Partitions: []Partition{
 					{
@@ -831,7 +831,7 @@ func TestRelayout(t *testing.T) {
 			},
 			size: 100 * MiB,
 			expected: &PartitionTable{
-				Type: "gpt",
+				Type: PT_GPT,
 				Size: 100 * MiB,
 				Partitions: []Partition{
 					{
@@ -858,7 +858,7 @@ func TestRelayout(t *testing.T) {
 		},
 		"simple-dos-grow-pt": {
 			pt: &PartitionTable{
-				Type: "dos",
+				Type: PT_DOS,
 				Size: 100 * MiB,
 				Partitions: []Partition{
 					{
@@ -874,7 +874,7 @@ func TestRelayout(t *testing.T) {
 			},
 			size: 100 * MiB,
 			expected: &PartitionTable{
-				Type: "dos",
+				Type: PT_DOS,
 				Size: 211 * MiB, // grows to fit partitions and header
 				Partitions: []Partition{
 					{
@@ -893,7 +893,7 @@ func TestRelayout(t *testing.T) {
 		},
 		"simple-gpt-growpt": {
 			pt: &PartitionTable{
-				Type: "gpt",
+				Type: PT_GPT,
 				Size: 100 * MiB,
 				Partitions: []Partition{
 					{
@@ -909,7 +909,7 @@ func TestRelayout(t *testing.T) {
 			},
 			size: 42 * MiB,
 			expected: &PartitionTable{
-				Type: "gpt",
+				Type: PT_GPT,
 				Size: 512 * MiB, // grows to fit partitions, header, and footer
 				Partitions: []Partition{
 					{
@@ -928,7 +928,7 @@ func TestRelayout(t *testing.T) {
 		},
 		"lvm-gpt-grow": {
 			pt: &PartitionTable{
-				Type: "gpt",
+				Type: PT_GPT,
 				Size: 10 * MiB,
 				Partitions: []Partition{
 					{
@@ -954,7 +954,7 @@ func TestRelayout(t *testing.T) {
 			},
 			size: 100 * MiB,
 			expected: &PartitionTable{
-				Type: "gpt",
+				Type: PT_GPT,
 				Size: 702 * MiB,
 				Partitions: []Partition{
 					{
@@ -983,7 +983,7 @@ func TestRelayout(t *testing.T) {
 		},
 		"lvm-dos-grow-rootvg": {
 			pt: &PartitionTable{
-				Type: "dos",
+				Type: PT_DOS,
 				Size: 10 * MiB, // PT is smaller than the sum of Partitions
 				Partitions: []Partition{
 					{
@@ -1009,7 +1009,7 @@ func TestRelayout(t *testing.T) {
 			},
 			size: 99 * MiB,
 			expected: &PartitionTable{
-				Type: "dos",
+				Type: PT_DOS,
 				Size: 325 * MiB,
 				Partitions: []Partition{
 					{
@@ -1038,7 +1038,7 @@ func TestRelayout(t *testing.T) {
 		},
 		"lvm-gpt-grow-rootvg": {
 			pt: &PartitionTable{
-				Type: "gpt",
+				Type: PT_GPT,
 				Size: 10 * MiB,
 				Partitions: []Partition{
 					{
@@ -1064,7 +1064,7 @@ func TestRelayout(t *testing.T) {
 			},
 			size: 99 * MiB,
 			expected: &PartitionTable{
-				Type: "gpt",
+				Type: PT_GPT,
 				Size: 326 * MiB,
 				Partitions: []Partition{
 					{

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -31,7 +31,7 @@ func TestPartitionTable_GetMountpointSize(t *testing.T) {
 
 func TestPartitionTable_GenerateUUIDs(t *testing.T) {
 	pt := disk.PartitionTable{
-		Type: "gpt",
+		Type: disk.PT_GPT,
 		Partitions: []disk.Partition{
 			{
 				Size:     1 * datasizes.MebiByte,
@@ -85,7 +85,7 @@ func TestPartitionTable_GenerateUUIDs(t *testing.T) {
 
 func TestPartitionTable_GenerateUUIDs_VFAT(t *testing.T) {
 	pt := disk.PartitionTable{
-		Type: "dos",
+		Type: disk.PT_DOS,
 		Partitions: []disk.Partition{
 			{
 				Size: 2 * datasizes.GibiByte,
@@ -116,10 +116,10 @@ func TestEnsureRootFilesystem(t *testing.T) {
 
 	testCases := map[string]testCase{
 		"empty-plain-gpt": {
-			pt:            disk.PartitionTable{Type: "gpt"},
+			pt:            disk.PartitionTable{Type: disk.PT_GPT},
 			defaultFsType: disk.FS_EXT4,
 			expected: disk.PartitionTable{
-				Type: "gpt",
+				Type: disk.PT_GPT,
 				Partitions: []disk.Partition{
 					{
 						Start:    0,
@@ -138,10 +138,10 @@ func TestEnsureRootFilesystem(t *testing.T) {
 			},
 		},
 		"empty-plain-dos": {
-			pt:            disk.PartitionTable{Type: "dos"},
+			pt:            disk.PartitionTable{Type: disk.PT_DOS},
 			defaultFsType: disk.FS_EXT4,
 			expected: disk.PartitionTable{
-				Type: "dos",
+				Type: disk.PT_DOS,
 				Partitions: []disk.Partition{
 					{
 						Start:    0,
@@ -161,7 +161,7 @@ func TestEnsureRootFilesystem(t *testing.T) {
 		},
 		"simple-plain-gpt": {
 			pt: disk.PartitionTable{
-				Type: "gpt",
+				Type: disk.PT_GPT,
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -175,7 +175,7 @@ func TestEnsureRootFilesystem(t *testing.T) {
 			},
 			defaultFsType: disk.FS_EXT4,
 			expected: disk.PartitionTable{
-				Type: "gpt",
+				Type: disk.PT_GPT,
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -203,7 +203,7 @@ func TestEnsureRootFilesystem(t *testing.T) {
 		},
 		"simple-plain-dos": {
 			pt: disk.PartitionTable{
-				Type: "dos",
+				Type: disk.PT_DOS,
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -217,7 +217,7 @@ func TestEnsureRootFilesystem(t *testing.T) {
 			},
 			defaultFsType: disk.FS_EXT4,
 			expected: disk.PartitionTable{
-				Type: "dos",
+				Type: disk.PT_DOS,
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -462,7 +462,7 @@ func TestEnsureRootFilesystem(t *testing.T) {
 		},
 		"plain-collision": {
 			pt: disk.PartitionTable{
-				Type: "gpt",
+				Type: disk.PT_GPT,
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -476,7 +476,7 @@ func TestEnsureRootFilesystem(t *testing.T) {
 			},
 			defaultFsType: disk.FS_EXT4,
 			expected: disk.PartitionTable{
-				Type: "gpt",
+				Type: disk.PT_GPT,
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -504,7 +504,7 @@ func TestEnsureRootFilesystem(t *testing.T) {
 		},
 		"lvm-collision": {
 			pt: disk.PartitionTable{
-				Type: "gpt",
+				Type: disk.PT_GPT,
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.LVMVolumeGroup{
@@ -543,7 +543,7 @@ func TestEnsureRootFilesystem(t *testing.T) {
 			},
 			defaultFsType: disk.FS_XFS,
 			expected: disk.PartitionTable{
-				Type: "gpt",
+				Type: disk.PT_GPT,
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.LVMVolumeGroup{
@@ -732,10 +732,10 @@ func TestEnsureBootPartition(t *testing.T) {
 
 	testCases := map[string]testCase{
 		"empty-plain-gpt": {
-			pt:     disk.PartitionTable{Type: "gpt"},
+			pt:     disk.PartitionTable{Type: disk.PT_GPT},
 			fsType: disk.FS_EXT4,
 			expected: disk.PartitionTable{
-				Type: "gpt",
+				Type: disk.PT_GPT,
 				Partitions: []disk.Partition{
 					{
 						Start:    0,
@@ -754,10 +754,10 @@ func TestEnsureBootPartition(t *testing.T) {
 			},
 		},
 		"empty-plain-dos": {
-			pt:     disk.PartitionTable{Type: "dos"},
+			pt:     disk.PartitionTable{Type: disk.PT_DOS},
 			fsType: disk.FS_EXT4,
 			expected: disk.PartitionTable{
-				Type: "dos",
+				Type: disk.PT_DOS,
 				Partitions: []disk.Partition{
 					{
 						Start:    0,
@@ -777,7 +777,7 @@ func TestEnsureBootPartition(t *testing.T) {
 		},
 		"simple-plain-gpt": {
 			pt: disk.PartitionTable{
-				Type: "gpt",
+				Type: disk.PT_GPT,
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -791,7 +791,7 @@ func TestEnsureBootPartition(t *testing.T) {
 			},
 			fsType: disk.FS_EXT4,
 			expected: disk.PartitionTable{
-				Type: "gpt",
+				Type: disk.PT_GPT,
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -819,7 +819,7 @@ func TestEnsureBootPartition(t *testing.T) {
 		},
 		"simple-plain-dos": {
 			pt: disk.PartitionTable{
-				Type: "dos",
+				Type: disk.PT_DOS,
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -833,7 +833,7 @@ func TestEnsureBootPartition(t *testing.T) {
 			},
 			fsType: disk.FS_EXT4,
 			expected: disk.PartitionTable{
-				Type: "dos",
+				Type: disk.PT_DOS,
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -963,7 +963,7 @@ func TestEnsureBootPartition(t *testing.T) {
 		},
 		"label-collision": {
 			pt: disk.PartitionTable{
-				Type: "gpt",
+				Type: disk.PT_GPT,
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -977,7 +977,7 @@ func TestEnsureBootPartition(t *testing.T) {
 			},
 			fsType: disk.FS_EXT4,
 			expected: disk.PartitionTable{
-				Type: "gpt",
+				Type: disk.PT_GPT,
 				Partitions: []disk.Partition{
 					{
 						Payload: &disk.Filesystem{
@@ -1037,20 +1037,20 @@ func TestAddPartitionsForBootMode(t *testing.T) {
 		// the partition table type shouldn't matter when the boot mode is
 		// none, but let's test with both anyway
 		"none-gpt": {
-			pt:       disk.PartitionTable{Type: "gpt"},
+			pt:       disk.PartitionTable{Type: disk.PT_GPT},
 			bootMode: platform.BOOT_NONE,
-			expected: disk.PartitionTable{Type: "gpt"},
+			expected: disk.PartitionTable{Type: disk.PT_GPT},
 		},
 		"none-dos": {
-			pt:       disk.PartitionTable{Type: "dos"},
+			pt:       disk.PartitionTable{Type: disk.PT_DOS},
 			bootMode: platform.BOOT_NONE,
-			expected: disk.PartitionTable{Type: "dos"},
+			expected: disk.PartitionTable{Type: disk.PT_DOS},
 		},
 		"bios-gpt": {
-			pt:       disk.PartitionTable{Type: "gpt"},
+			pt:       disk.PartitionTable{Type: disk.PT_GPT},
 			bootMode: platform.BOOT_LEGACY,
 			expected: disk.PartitionTable{
-				Type: "gpt",
+				Type: disk.PT_GPT,
 				Partitions: []disk.Partition{
 					{
 						Bootable: true,
@@ -1063,10 +1063,10 @@ func TestAddPartitionsForBootMode(t *testing.T) {
 			},
 		},
 		"bios-dos": {
-			pt:       disk.PartitionTable{Type: "dos"},
+			pt:       disk.PartitionTable{Type: disk.PT_DOS},
 			bootMode: platform.BOOT_LEGACY,
 			expected: disk.PartitionTable{
-				Type: "dos",
+				Type: disk.PT_DOS,
 				Partitions: []disk.Partition{
 					{
 						Bootable: true,
@@ -1079,10 +1079,10 @@ func TestAddPartitionsForBootMode(t *testing.T) {
 			},
 		},
 		"uefi-gpt": {
-			pt:       disk.PartitionTable{Type: "gpt"},
+			pt:       disk.PartitionTable{Type: disk.PT_GPT},
 			bootMode: platform.BOOT_UEFI,
 			expected: disk.PartitionTable{
-				Type: "gpt",
+				Type: disk.PT_GPT,
 				Partitions: []disk.Partition{
 					{
 						Start: 0 * datasizes.MiB,
@@ -1103,10 +1103,10 @@ func TestAddPartitionsForBootMode(t *testing.T) {
 			},
 		},
 		"uefi-dos": {
-			pt:       disk.PartitionTable{Type: "dos"},
+			pt:       disk.PartitionTable{Type: disk.PT_DOS},
 			bootMode: platform.BOOT_UEFI,
 			expected: disk.PartitionTable{
-				Type: "dos",
+				Type: disk.PT_DOS,
 				Partitions: []disk.Partition{
 					{
 						Start: 0 * datasizes.MiB,
@@ -1127,10 +1127,10 @@ func TestAddPartitionsForBootMode(t *testing.T) {
 			},
 		},
 		"hybrid-gpt": {
-			pt:       disk.PartitionTable{Type: "gpt"},
+			pt:       disk.PartitionTable{Type: disk.PT_GPT},
 			bootMode: platform.BOOT_HYBRID,
 			expected: disk.PartitionTable{
-				Type: "gpt",
+				Type: disk.PT_GPT,
 				Partitions: []disk.Partition{
 					{
 						Size:     1 * datasizes.MiB,
@@ -1156,10 +1156,10 @@ func TestAddPartitionsForBootMode(t *testing.T) {
 			},
 		},
 		"hybrid-dos": {
-			pt:       disk.PartitionTable{Type: "dos"},
+			pt:       disk.PartitionTable{Type: disk.PT_DOS},
 			bootMode: platform.BOOT_HYBRID,
 			expected: disk.PartitionTable{
-				Type: "dos",
+				Type: disk.PT_DOS,
 				Partitions: []disk.Partition{
 					{
 						Size:     1 * datasizes.MiB,
@@ -1185,22 +1185,22 @@ func TestAddPartitionsForBootMode(t *testing.T) {
 			},
 		},
 		"bad-pttype-bios": {
-			pt:       disk.PartitionTable{Type: "super-gpt"},
+			pt:       disk.PartitionTable{Type: disk.PartitionTableType(911)},
 			bootMode: platform.BOOT_LEGACY,
-			errmsg:   "error creating BIOS boot partition: unknown or unsupported partition table type: super-gpt",
+			errmsg:   "error creating BIOS boot partition: unknown or unsupported partition table enum: 911",
 		},
 		"bad-pttype-uefi": {
-			pt:       disk.PartitionTable{Type: "super-gpt"},
+			pt:       disk.PartitionTable{Type: disk.PartitionTableType(911)},
 			bootMode: platform.BOOT_UEFI,
-			errmsg:   "error creating EFI system partition: unknown or unsupported partition table type: super-gpt",
+			errmsg:   "error creating EFI system partition: unknown or unsupported partition table enum: 911",
 		},
 		"bad-pttype-hybrid": {
-			pt:       disk.PartitionTable{Type: "super-gpt"},
+			pt:       disk.PartitionTable{Type: disk.PartitionTableType(911)},
 			bootMode: platform.BOOT_HYBRID,
-			errmsg:   "error creating BIOS boot partition: unknown or unsupported partition table type: super-gpt",
+			errmsg:   "error creating BIOS boot partition: unknown or unsupported partition table enum: 911",
 		},
 		"bad-bootmode": {
-			pt:       disk.PartitionTable{Type: "gpt"},
+			pt:       disk.PartitionTable{Type: disk.PT_GPT},
 			bootMode: 4,
 			errmsg:   "unknown or unsupported boot mode type with enum value 4",
 		},

--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -98,7 +98,7 @@ type ImageType interface {
 
 	// Returns the corresponding partion type ("gpt", "dos") or "" the image type
 	// has no partition table. Only support for RHEL 8.5+
-	PartitionType() string
+	PartitionType() disk.PartitionTableType
 
 	// Returns the corresponding boot mode ("legacy", "uefi", "hybrid") or "none"
 	BootMode() platform.BootMode

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -173,10 +173,10 @@ func (t *imageType) getDefaultImageConfig() *distro.ImageConfig {
 
 }
 
-func (t *imageType) PartitionType() string {
+func (t *imageType) PartitionType() disk.PartitionTableType {
 	basePartitionTable, exists := t.basePartitionTables[t.arch.Name()]
 	if !exists {
-		return ""
+		return disk.PT_NONE
 	}
 
 	return basePartitionTable.Type

--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -10,7 +10,7 @@ import (
 var defaultBasePartitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		Type: disk.PT_GPT,
 		Partitions: []disk.Partition{
 			{
 				Size:     1 * datasizes.MebiByte,
@@ -62,7 +62,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 	},
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		Type: disk.PT_GPT,
 		Partitions: []disk.Partition{
 			{
 				Size: 200 * datasizes.MebiByte,
@@ -108,7 +108,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 	},
 	arch.ARCH_PPC64LE.String(): disk.PartitionTable{
 		UUID: "0x14fc63d2",
-		Type: "dos",
+		Type: disk.PT_DOS,
 		Partitions: []disk.Partition{
 			{
 				Size:     4 * datasizes.MebiByte,
@@ -141,7 +141,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 
 	arch.ARCH_S390X.String(): disk.PartitionTable{
 		UUID: "0x14fc63d2",
-		Type: "dos",
+		Type: disk.PT_DOS,
 		Partitions: []disk.Partition{
 			{
 				Size: 500 * datasizes.MebiByte,
@@ -172,7 +172,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 var minimalrawPartitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type:        "gpt",
+		Type:        disk.PT_GPT,
 		StartOffset: 8 * datasizes.MebiByte,
 		Partitions: []disk.Partition{
 			{
@@ -219,7 +219,7 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 	},
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
 		UUID:        "0xc1748067",
-		Type:        "dos",
+		Type:        disk.PT_DOS,
 		StartOffset: 8 * datasizes.MebiByte,
 		Partitions: []disk.Partition{
 			{
@@ -267,7 +267,7 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 var iotBasePartitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type:        "gpt",
+		Type:        disk.PT_GPT,
 		StartOffset: 8 * datasizes.MebiByte,
 		Partitions: []disk.Partition{
 			{
@@ -314,7 +314,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 	},
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
 		UUID:        "0xc1748067",
-		Type:        "dos",
+		Type:        disk.PT_DOS,
 		StartOffset: 8 * datasizes.MebiByte,
 		Partitions: []disk.Partition{
 			{
@@ -362,7 +362,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 	arch.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		Type: disk.PT_GPT,
 		Partitions: []disk.Partition{
 			{
 				Size: 501 * datasizes.MebiByte,
@@ -432,7 +432,7 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 	},
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		Type: disk.PT_GPT,
 		Partitions: []disk.Partition{
 			{
 				Size: 501 * datasizes.MebiByte,

--- a/pkg/distro/rhel/images_test.go
+++ b/pkg/distro/rhel/images_test.go
@@ -3,15 +3,17 @@ package rhel
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/customizations/subscription"
+	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestOsCustomizationsRHSM(t *testing.T) {
@@ -441,5 +443,5 @@ func TestOsCustomizationsRHSM(t *testing.T) {
 
 func TestPartitionTypeNotCrashing(t *testing.T) {
 	it := &ImageType{}
-	assert.Equal(t, it.PartitionType(), "")
+	assert.Equal(t, it.PartitionType(), disk.PT_NONE)
 }

--- a/pkg/distro/rhel/imagetype.go
+++ b/pkg/distro/rhel/imagetype.go
@@ -215,14 +215,14 @@ func (t *ImageType) getDefaultInstallerConfig() (*distro.InstallerConfig, error)
 	return t.DefaultInstallerConfig, nil
 }
 
-func (t *ImageType) PartitionType() string {
+func (t *ImageType) PartitionType() disk.PartitionTableType {
 	if t.BasePartitionTables == nil {
-		return ""
+		return disk.PT_NONE
 	}
 
 	basePartitionTable, exists := t.BasePartitionTables(t)
 	if !exists {
-		return ""
+		return disk.PT_NONE
 	}
 
 	return basePartitionTable.Type

--- a/pkg/distro/rhel/rhel10/partition_tables.go
+++ b/pkg/distro/rhel/rhel10/partition_tables.go
@@ -12,7 +12,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Partitions: []disk.Partition{
 				{
 					Size:     1 * datasizes.MebiByte,
@@ -52,7 +52,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Partitions: []disk.Partition{
 				{
 					Size: 200 * datasizes.MebiByte,
@@ -86,7 +86,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_PPC64LE.String():
 		return disk.PartitionTable{
 			UUID: "0x14fc63d2",
-			Type: "dos",
+			Type: disk.PT_DOS,
 			Partitions: []disk.Partition{
 				{
 					Size:     4 * datasizes.MebiByte,
@@ -109,7 +109,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_S390X.String():
 		return disk.PartitionTable{
 			UUID: "0x14fc63d2",
-			Type: "dos",
+			Type: disk.PT_DOS,
 			Partitions: []disk.Partition{
 				{
 					Size:     2 * datasizes.GibiByte,

--- a/pkg/distro/rhel/rhel7/ami.go
+++ b/pkg/distro/rhel/rhel7/ami.go
@@ -259,7 +259,7 @@ func ec2PartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Size: 10 * datasizes.GibiByte,
 			Partitions: []disk.Partition{
 				{

--- a/pkg/distro/rhel/rhel7/azure.go
+++ b/pkg/distro/rhel/rhel7/azure.go
@@ -286,7 +286,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Size: 64 * datasizes.GibiByte,
 			Partitions: []disk.Partition{
 				{

--- a/pkg/distro/rhel/rhel7/partition_tables.go
+++ b/pkg/distro/rhel/rhel7/partition_tables.go
@@ -12,7 +12,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Partitions: []disk.Partition{
 				{
 					Size:     1 * datasizes.MebiByte,

--- a/pkg/distro/rhel/rhel8/azure.go
+++ b/pkg/distro/rhel/rhel8/azure.go
@@ -287,7 +287,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Size: 64 * datasizes.GibiByte,
 			Partitions: []disk.Partition{
 				{
@@ -397,7 +397,7 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Size: 64 * datasizes.GibiByte,
 			Partitions: []disk.Partition{
 				{

--- a/pkg/distro/rhel/rhel8/partition_tables.go
+++ b/pkg/distro/rhel/rhel8/partition_tables.go
@@ -13,7 +13,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Partitions: []disk.Partition{
 				{
 					Size:     1 * datasizes.MebiByte,
@@ -53,7 +53,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Partitions: []disk.Partition{
 				{
 					Size: 100 * datasizes.MebiByte,
@@ -87,7 +87,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_PPC64LE.String():
 		return disk.PartitionTable{
 			UUID: "0x14fc63d2",
-			Type: "dos",
+			Type: disk.PT_DOS,
 			Partitions: []disk.Partition{
 				{
 					Size:     4 * datasizes.MebiByte,
@@ -110,7 +110,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_S390X.String():
 		return disk.PartitionTable{
 			UUID: "0x14fc63d2",
-			Type: "dos",
+			Type: disk.PT_DOS,
 			Partitions: []disk.Partition{
 				{
 					Size:     2 * datasizes.GibiByte,
@@ -136,7 +136,7 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Partitions: []disk.Partition{
 				{
 					Size:     1 * datasizes.MebiByte,
@@ -205,7 +205,7 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Partitions: []disk.Partition{
 				{
 					Size: 127 * datasizes.MebiByte,
@@ -283,7 +283,7 @@ func ec2PartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 
 	x86PartitionTable := disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		Type: disk.PT_GPT,
 		Partitions: []disk.Partition{
 			{
 				Size:     1 * datasizes.MebiByte,
@@ -323,7 +323,7 @@ func ec2PartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	if common.VersionLessThan(t.Arch().Distro().OsVersion(), "8.9") && t.IsRHEL() {
 		x86PartitionTable = disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Partitions: []disk.Partition{
 				{
 					Size:     1 * datasizes.MebiByte,
@@ -355,7 +355,7 @@ func ec2PartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Partitions: []disk.Partition{
 				{
 					Size: 200 * datasizes.MebiByte,

--- a/pkg/distro/rhel/rhel9/azure.go
+++ b/pkg/distro/rhel/rhel9/azure.go
@@ -196,7 +196,7 @@ func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, b
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Size: 64 * datasizes.GibiByte,
 			Partitions: []disk.Partition{
 				{
@@ -305,7 +305,7 @@ func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, b
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Size: 64 * datasizes.GibiByte,
 			Partitions: []disk.Partition{
 				{

--- a/pkg/distro/rhel/rhel9/edge.go
+++ b/pkg/distro/rhel/rhel9/edge.go
@@ -373,7 +373,7 @@ func minimalrawPartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
 			UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type:        "gpt",
+			Type:        disk.PT_GPT,
 			StartOffset: 8 * datasizes.MebiByte,
 			Partitions: []disk.Partition{
 				{
@@ -421,7 +421,7 @@ func minimalrawPartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
 			UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type:        "gpt",
+			Type:        disk.PT_GPT,
 			StartOffset: 8 * datasizes.MebiByte,
 			Partitions: []disk.Partition{
 				{
@@ -476,7 +476,7 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Partitions: []disk.Partition{
 				{
 					Size:     1 * datasizes.MebiByte,
@@ -553,7 +553,7 @@ func edgeBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Partitions: []disk.Partition{
 				{
 					Size: 127 * datasizes.MebiByte,

--- a/pkg/distro/rhel/rhel9/partition_tables.go
+++ b/pkg/distro/rhel/rhel9/partition_tables.go
@@ -26,7 +26,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_X86_64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Partitions: []disk.Partition{
 				{
 					Size:     1 * datasizes.MebiByte,
@@ -79,7 +79,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_AARCH64.String():
 		return disk.PartitionTable{
 			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: "gpt",
+			Type: disk.PT_GPT,
 			Partitions: []disk.Partition{
 				{
 					Size: 200 * datasizes.MebiByte,
@@ -126,7 +126,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_PPC64LE.String():
 		return disk.PartitionTable{
 			UUID: "0x14fc63d2",
-			Type: "dos",
+			Type: disk.PT_DOS,
 			Partitions: []disk.Partition{
 				{
 					Size:     4 * datasizes.MebiByte,
@@ -160,7 +160,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 	case arch.ARCH_S390X.String():
 		return disk.PartitionTable{
 			UUID: "0x14fc63d2",
-			Type: "dos",
+			Type: disk.PT_DOS,
 			Partitions: []disk.Partition{
 				{
 					Size: bootSize,

--- a/pkg/distro/test_distro/distro.go
+++ b/pkg/distro/test_distro/distro.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/osbuild/images/pkg/blueprint"
+	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/ostree"
@@ -207,8 +208,8 @@ func (t *TestImageType) Size(size uint64) uint64 {
 	return size
 }
 
-func (t *TestImageType) PartitionType() string {
-	return ""
+func (t *TestImageType) PartitionType() disk.PartitionTableType {
+	return disk.PT_NONE
 }
 
 func (t *TestImageType) BootMode() platform.BootMode {

--- a/pkg/osbuild/bootupd_stage_test.go
+++ b/pkg/osbuild/bootupd_stage_test.go
@@ -201,7 +201,7 @@ func TestGenBootupdDevicesMountsUnexpectedEntity(t *testing.T) {
 
 var fakePt = &disk.PartitionTable{
 	UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-	Type: "gpt",
+	Type: disk.PT_GPT,
 	Partitions: []disk.Partition{
 		{
 			Size:     1 * datasizes.MebiByte,

--- a/pkg/osbuild/common_test.go
+++ b/pkg/osbuild/common_test.go
@@ -8,7 +8,7 @@ var testPartitionTables = map[string]disk.PartitionTable{
 
 	"plain": {
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		Type: disk.PT_GPT,
 		Partitions: []disk.Partition{
 			{
 				Size:     1048576, // 1MB
@@ -60,7 +60,7 @@ var testPartitionTables = map[string]disk.PartitionTable{
 
 	"luks": {
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		Type: disk.PT_GPT,
 		Partitions: []disk.Partition{
 			{
 				Size:     1048576, // 1MB
@@ -121,7 +121,7 @@ var testPartitionTables = map[string]disk.PartitionTable{
 
 	"luks+lvm": {
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		Type: disk.PT_GPT,
 		Partitions: []disk.Partition{
 			{
 				Size:     1048576, // 1MB
@@ -205,7 +205,7 @@ var testPartitionTables = map[string]disk.PartitionTable{
 
 	"luks+lvm+clevisBind": {
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		Type: disk.PT_GPT,
 		Partitions: []disk.Partition{
 			{
 				Size:     1048576, // 1MB
@@ -282,7 +282,7 @@ var testPartitionTables = map[string]disk.PartitionTable{
 
 	"btrfs": {
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
+		Type: disk.PT_GPT,
 		Partitions: []disk.Partition{
 			{
 				Size:     1048576, // 1MB

--- a/pkg/osbuild/disk.go
+++ b/pkg/osbuild/disk.go
@@ -22,7 +22,7 @@ func sfdiskStageOptions(pt *disk.PartitionTable) *SfdiskStageOptions {
 		}
 	}
 	stageOptions := &SfdiskStageOptions{
-		Label:      pt.Type,
+		Label:      pt.Type.String(),
 		UUID:       pt.UUID,
 		Partitions: partitions,
 	}

--- a/pkg/osbuild/grub2_inst_stage.go
+++ b/pkg/osbuild/grub2_inst_stage.go
@@ -143,13 +143,13 @@ func NewGrub2InstStageOption(filename string, pt *disk.PartitionTable, platform 
 	}
 	core := CoreMkImage{
 		Type:       "mkimage",
-		PartLabel:  pt.Type,
+		PartLabel:  pt.Type.String(),
 		Filesystem: bootPayload.GetFSType(),
 	}
 
 	prefix := PrefixPartition{
 		Type:      "partition",
-		PartLabel: pt.Type,
+		PartLabel: pt.Type.String(),
 		// bootidx can't be negative after check with rootIdx above:
 		// nolint:gosec
 		Number: uint(bootIdx),

--- a/pkg/osbuild/mkfs_stages_test.go
+++ b/pkg/osbuild/mkfs_stages_test.go
@@ -189,7 +189,7 @@ func TestGenMkfsStagesBtrfs(t *testing.T) {
 
 func TestGenMkfsStagesUnhappy(t *testing.T) {
 	pt := &disk.PartitionTable{
-		Type: "gpt",
+		Type: disk.PT_GPT,
 		Partitions: []disk.Partition{
 			{
 				Payload: &disk.Filesystem{


### PR DESCRIPTION
This commit makes use of the new `disk.PartitionTableType instead of just using an untyped string (thanks to Achilleas for adding the new type and to Tomáš for suggesting to use it more).

---

disk: add json marshal/unmarshal to `PartitionTableType`

This commit adds json marshal/unmarshal to `PartitionTableType`
The reason is that the `otk` utils serialize this type
as a JSON. While the json is strictly internal and we make no
gurantees about it is still nicer to serialize as strings because
otherwise the diff in the json looks something like:
```json
@@ -147,7 +147,7 @@ func TestUnmarshalOutput(t *testing.T) {
       "partition-table": {
         "Size": 911,
         "UUID": "",
-        "Type": "gpt",
+        "Type": 2,
         "Partitions": [
           {
             "Start": 0,
```
and it is also nicer for general debug-ability.
