### PR TITLE
fix: install anaconda-install-img-deps package in anaconda installers.

### DIFF
--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -354,7 +354,7 @@ func anacondaPackageSet(t *imageType) rpmmd.PackageSet {
 			"alsa-tools-firmware",
 			"anaconda",
 			"anaconda-dracut",
-			"anaconda-install-env-deps",
+			"anaconda-install-img-deps",
 			"anaconda-widgets",
 			"atheros-firmware",
 			"audit",


### PR DESCRIPTION
According to the anaconda team we should be using the `anaconda-install-img-deps`
metapackage to install all the boot.iso image dependencies.

Relates: fedora-iot/iot-distro#66
Signed-off-by: Miguel Martín <mmartinv@redhat.com>
