### PR TITLE
blueprint: add map conversion check to fs customization unmarshaller

### DIFF
--- a/pkg/blueprint/filesystem_customizations.go
+++ b/pkg/blueprint/filesystem_customizations.go
@@ -15,7 +15,10 @@ type FilesystemCustomization struct {
 }
 
 func (fsc *FilesystemCustomization) UnmarshalTOML(data interface{}) error {
-	d, _ := data.(map[string]interface{})
+	d, ok := data.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("customizations.filesystem is not an object")
+	}
 
 	switch d["mountpoint"].(type) {
 	case string:

--- a/pkg/blueprint/filesystem_customizations_test.go
+++ b/pkg/blueprint/filesystem_customizations_test.go
@@ -104,6 +104,30 @@ func TestFilesystemCustomizationUnmarshalJSONUnhappy(t *testing.T) {
 	}
 }
 
+func TestFilesystemCustomizationUnmarshalTOMLNotAnObject(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		err   string
+	}{
+		{
+			name: "filesystem is not an object",
+			input: `
+[customizations]
+filesystem = ["hello"]`,
+			err: "toml: line 3 (last key \"customizations.filesystem\"): customizations.filesystem is not an object",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var bp blueprint.Blueprint
+			err := toml.Unmarshal([]byte(c.input), &bp)
+			assert.EqualError(t, err, c.err)
+		})
+	}
+}
+
 func TestCheckMountpointsPolicy(t *testing.T) {
 	policy := pathpolicy.NewPathPolicies(map[string]pathpolicy.PathPolicy{
 		"/": {Exact: true},


### PR DESCRIPTION
If an element in the `customizations.filesystem` array is not an object, the existing code would fail the conversion without an error, but would fail on the `d["mountpoint"].(type)` conversion, which produces an error message that isn't very useful:
```
  mountpoint must be string, got <nil> of type <nil>
```
The commit catches the conversion error and instead prints a more useful error message.