### PR TITLE
image: add support for FIPS customization to `BootcDiskImage`

### DIFF
--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -25,6 +25,7 @@ type BootcDiskImage struct {
 
 	// Customizations
 	KernelOptionsAppend []string
+	FIPS                bool
 
 	// The users to put into the image, note that /etc/paswd (and friends)
 	// will become unmanaged state by bootc when used
@@ -61,6 +62,9 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 	rawImage.Groups = img.Groups
 	rawImage.KernelOptionsAppend = img.KernelOptionsAppend
 	rawImage.SELinux = img.SELinux
+	if img.FIPS {
+		rawImage.KernelOptionsAppend = append(rawImage.KernelOptionsAppend, "fips=1")
+	}
 
 	// In BIB, we export multiple images from the same pipeline so we use the
 	// filename as the basename for each export and set the extensions based on


### PR DESCRIPTION
[draft as I think we want to double check if this makes sense in the bootc world first]

This commit is a followup for
https://github.com/osbuild/bootc-image-builder/pull/709 and adds support for FIPS to the `BootcDiskImage` image type.

One open question is if this should be done at this level or if the container itself should set the kernel cmdline to FIPS and bib would not bother.