### PR TITLE
reporegistry: introduce new  `distro.aliases` file

### DIFF
--- a/pkg/reporegistry/repository.go
+++ b/pkg/reporegistry/repository.go
@@ -78,27 +78,13 @@ func LoadAllRepositories(confPaths []string) (rpmmd.DistrosRepoConfigs, error) {
 // encounter is preferred. For this reason, the order of paths in the passed list should
 // reflect the desired preference.
 func LoadRepositories(confPaths []string, distro string) (map[string][]rpmmd.RepoConfig, error) {
-	var repoConfigs map[string][]rpmmd.RepoConfig
-	path := "/repositories/" + distro + ".json"
-
-	for _, confPath := range confPaths {
-		var err error
-		repoConfigs, err = rpmmd.LoadRepositoriesFromFile(confPath + path)
-		if os.IsNotExist(err) {
-			continue
-		} else if err != nil {
-			return nil, err
-		}
-
-		// Found the distro repository configs in the current path
-		if repoConfigs != nil {
-			break
-		}
+	reposConfig, err := LoadAllRepositories(confPaths)
+	if err != nil {
+		return nil, err
 	}
-
-	if repoConfigs == nil {
+	if reposConfig[distro] == nil {
 		return nil, &NoReposLoadedError{confPaths}
 	}
 
-	return repoConfigs, nil
+	return reposConfig[distro], nil
 }

--- a/pkg/reporegistry/repository_test.go
+++ b/pkg/reporegistry/repository_test.go
@@ -85,7 +85,7 @@ func TestLoadRepositoriesNonExisting(t *testing.T) {
 	confPaths := getConfPaths(t)
 	repos, err := LoadRepositories(confPaths, "my-imaginary-distro")
 	assert.Nil(t, repos)
-	assert.NotNil(t, err)
+	assert.Equal(t, &NoReposLoadedError{confPaths}, err)
 }
 
 func Test_LoadAllRepositories(t *testing.T) {

--- a/pkg/reporegistry/repository_test.go
+++ b/pkg/reporegistry/repository_test.go
@@ -5,11 +5,17 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/distro/test_distro"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/stretchr/testify/assert"
 )
+
+func init() {
+	logrus.SetLevel(logrus.WarnLevel)
+}
 
 func getConfPaths(t *testing.T) []string {
 	confPaths := []string{
@@ -90,6 +96,36 @@ func TestLoadRepositoriesNonExisting(t *testing.T) {
 
 func Test_LoadAllRepositories(t *testing.T) {
 	expectedReposMap := rpmmd.DistrosRepoConfigs{
+		"alias-for-fedora-33": {
+			test_distro.TestArchName: {
+				{
+					Name:     "fedora-33-p1",
+					BaseURLs: []string{"https://example.com/fedora-33-p1/test_arch"},
+					GPGKeys:  []string{"FAKE-GPG-KEY"},
+					CheckGPG: common.ToPtr(true),
+				},
+				{
+					Name:     "updates-33-p1",
+					BaseURLs: []string{"https://example.com/updates-33-p1/test_arch"},
+					GPGKeys:  []string{"FAKE-GPG-KEY"},
+					CheckGPG: common.ToPtr(true),
+				},
+			},
+			test_distro.TestArch2Name: {
+				{
+					Name:     "fedora-33-p1",
+					BaseURLs: []string{"https://example.com/fedora-33-p1/test_arch2"},
+					GPGKeys:  []string{"FAKE-GPG-KEY"},
+					CheckGPG: common.ToPtr(true),
+				},
+				{
+					Name:     "updates-33-p1",
+					BaseURLs: []string{"https://example.com/updates-33-p1/test_arch2"},
+					GPGKeys:  []string{"FAKE-GPG-KEY"},
+					CheckGPG: common.ToPtr(true),
+				},
+			},
+		},
 		"fedora-33": {
 			test_distro.TestArchName: {
 				{
@@ -294,4 +330,20 @@ func Test_LoadAllRepositories(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLoadAllRepositoriesLoadsAlias(t *testing.T) {
+	confPaths := getConfPaths(t)
+
+	allRepos, err := LoadAllRepositories(confPaths)
+	assert.Nil(t, err)
+	assert.True(t, len(allRepos["alias-for-fedora-33"]) > 0)
+}
+
+func TestLoadRepositoriesLoadsAlias(t *testing.T) {
+	confPaths := getConfPaths(t)
+
+	repos, err := LoadRepositories(confPaths, "alias-for-fedora-33")
+	assert.Nil(t, err)
+	assert.True(t, len(repos) > 0)
 }

--- a/pkg/reporegistry/test/confpaths/priority1/repositories/distro.aliases
+++ b/pkg/reporegistry/test/confpaths/priority1/repositories/distro.aliases
@@ -1,0 +1,6 @@
+[
+  {
+	"name": "fedora-33",
+	"alias": "alias-for-fedora-33"
+  }
+]


### PR DESCRIPTION
This commit introduces a new `distro.aliases` file that replaces the
role of the existing symlinks to provide an alias name for a distro.
The reason is that when using `go:embed` symlinks are not supported
and we have currently `centos-9.json -> centos-stream-9.json` in
our `osbuild-comopser` distro definitions.

By moving them from symlinks to alias files we can start using
`go:embed` which is nice for the daemonless work, i.e. the
`image-builder` binary will be self-contained and one can do:
```
$ go run github.com/osbuild/image-builder/cmd/image-builder --list-images
```
directly without any further configuration. It also solves how to
keep the default repository configuration between `osbuild-composer` and
`image-builder-cli` in sync.

---

reporegistry: remove duplication in LoadRepositories()

This commit removes some directory traversal duplication from
LoadRepositories() on the expense of more "expensive" repo loading.
The new code will just always load all repos and return the one
matching the distro. The advantage of this approach is that when
aliases are introduced there is only a single code path that needs
changing.
