### PR TITLE
reporegistry: support loading repos from fs.FS

### DIFF
--- a/pkg/reporegistry/reporegistry.go
+++ b/pkg/reporegistry/reporegistry.go
@@ -27,9 +27,22 @@ func New(repoConfigPaths []string) (*RepoRegistry, error) {
 	return &RepoRegistry{repositories}, nil
 }
 
+// TODO: add a `NewDefault(extraConfigPaths []string)` constructor
+// here similar that will
+//   repos, err := loadAllRepositories([]fs.FS{
+//       os.DirFS(extraConfigPaths...),
+//       testRepos.FS,
+//   })
+//   return &RepoRegistry{repos}, err
+// to avoid having to ship the default repos in every user of the library
+
 // NewTestedDefault returns a new RepoRegistry instance with the data
 // loaded from the default test repositories
 func NewTestedDefault() (*RepoRegistry, error) {
+	// we could use embedding here:
+	//   repos, err := loadAllRepositories([]fs.FS{testRepos.FS})
+	//   return &RepoRegistry{repos}, err
+	// but the downside would be that it increases the library size by 1mb
 	_, callerSrc, _, ok := runtime.Caller(0)
 	var testReposPath []string
 	if !ok {

--- a/pkg/reporegistry/repository.go
+++ b/pkg/reporegistry/repository.go
@@ -78,27 +78,13 @@ func LoadAllRepositories(confPaths []string) (rpmmd.DistrosRepoConfigs, error) {
 // encounter is preferred. For this reason, the order of paths in the passed list should
 // reflect the desired preference.
 func LoadRepositories(confPaths []string, distro string) (map[string][]rpmmd.RepoConfig, error) {
-	var repoConfigs map[string][]rpmmd.RepoConfig
-	path := "/repositories/" + distro + ".json"
-
-	for _, confPath := range confPaths {
-		var err error
-		repoConfigs, err = rpmmd.LoadRepositoriesFromFile(confPath + path)
-		if os.IsNotExist(err) {
-			continue
-		} else if err != nil {
-			return nil, err
-		}
-
-		// Found the distro repository configs in the current path
-		if repoConfigs != nil {
-			break
-		}
+	reposConfig, err := LoadAllRepositories(confPaths)
+	if err != nil {
+		return nil, err
 	}
-
-	if repoConfigs == nil {
+	if reposConfig[distro] == nil {
 		return nil, &NoReposLoadedError{confPaths}
 	}
 
-	return repoConfigs, nil
+	return reposConfig[distro], nil
 }

--- a/pkg/reporegistry/repository_test.go
+++ b/pkg/reporegistry/repository_test.go
@@ -85,7 +85,7 @@ func TestLoadRepositoriesNonExisting(t *testing.T) {
 	confPaths := getConfPaths(t)
 	repos, err := LoadRepositories(confPaths, "my-imaginary-distro")
 	assert.Nil(t, repos)
-	assert.NotNil(t, err)
+	assert.Equal(t, &NoReposLoadedError{confPaths}, err)
 }
 
 func Test_LoadAllRepositories(t *testing.T) {

--- a/pkg/reporegistry/repository_test.go
+++ b/pkg/reporegistry/repository_test.go
@@ -5,11 +5,17 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/distro/test_distro"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/stretchr/testify/assert"
 )
+
+func init() {
+	logrus.SetLevel(logrus.WarnLevel)
+}
 
 func getConfPaths(t *testing.T) []string {
 	confPaths := []string{
@@ -90,6 +96,36 @@ func TestLoadRepositoriesNonExisting(t *testing.T) {
 
 func Test_LoadAllRepositories(t *testing.T) {
 	expectedReposMap := rpmmd.DistrosRepoConfigs{
+		"alias-for-fedora-33": {
+			test_distro.TestArchName: {
+				{
+					Name:     "fedora-33-p1",
+					BaseURLs: []string{"https://example.com/fedora-33-p1/test_arch"},
+					GPGKeys:  []string{"FAKE-GPG-KEY"},
+					CheckGPG: common.ToPtr(true),
+				},
+				{
+					Name:     "updates-33-p1",
+					BaseURLs: []string{"https://example.com/updates-33-p1/test_arch"},
+					GPGKeys:  []string{"FAKE-GPG-KEY"},
+					CheckGPG: common.ToPtr(true),
+				},
+			},
+			test_distro.TestArch2Name: {
+				{
+					Name:     "fedora-33-p1",
+					BaseURLs: []string{"https://example.com/fedora-33-p1/test_arch2"},
+					GPGKeys:  []string{"FAKE-GPG-KEY"},
+					CheckGPG: common.ToPtr(true),
+				},
+				{
+					Name:     "updates-33-p1",
+					BaseURLs: []string{"https://example.com/updates-33-p1/test_arch2"},
+					GPGKeys:  []string{"FAKE-GPG-KEY"},
+					CheckGPG: common.ToPtr(true),
+				},
+			},
+		},
 		"fedora-33": {
 			test_distro.TestArchName: {
 				{
@@ -294,4 +330,20 @@ func Test_LoadAllRepositories(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLoadAllRepositoriesLoadsAlias(t *testing.T) {
+	confPaths := getConfPaths(t)
+
+	allRepos, err := LoadAllRepositories(confPaths)
+	assert.Nil(t, err)
+	assert.True(t, len(allRepos["alias-for-fedora-33"]) > 0)
+}
+
+func TestLoadRepositoriesLoadsAlias(t *testing.T) {
+	confPaths := getConfPaths(t)
+
+	repos, err := LoadRepositories(confPaths, "alias-for-fedora-33")
+	assert.Nil(t, err)
+	assert.True(t, len(repos) > 0)
 }

--- a/pkg/reporegistry/test/confpaths/priority1/repositories/distro.aliases
+++ b/pkg/reporegistry/test/confpaths/priority1/repositories/distro.aliases
@@ -1,0 +1,6 @@
+[
+  {
+	"name": "fedora-33",
+	"alias": "alias-for-fedora-33"
+  }
+]

--- a/pkg/rpmmd/repository.go
+++ b/pkg/rpmmd/repository.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -232,10 +233,14 @@ func LoadRepositoriesFromFile(filename string) (map[string][]RepoConfig, error) 
 	}
 	defer f.Close()
 
+	return LoadRepositoriesFromReader(f)
+}
+
+func LoadRepositoriesFromReader(r io.Reader) (map[string][]RepoConfig, error) {
 	var reposMap map[string][]repository
 	repoConfigs := make(map[string][]RepoConfig)
 
-	err = json.NewDecoder(f).Decode(&reposMap)
+	err := json.NewDecoder(r).Decode(&reposMap)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
[based on https://github.com/osbuild/images/pull/1036 and draft because it need 1036 and a tweak in osbuild-composer to make the repos there embeddable - mostly here so that people can see where this is heading]

reporegistry: support loading repos from fs.FS

This is a first step towards loading repositories via `go:embed`
and fully compatible with the old way of loading repos.

