### PR TITLE
reporegistry: add new `LoadAllRepositoriesFromFS` and use in tests

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -28,10 +28,10 @@ import (
 	"github.com/osbuild/images/pkg/dnfjson"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/ostree"
-	"github.com/osbuild/images/pkg/reporegistry"
 	"github.com/osbuild/images/pkg/rhsm/facts"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/sbom"
+	testrepos "github.com/osbuild/images/test/data/repositories"
 )
 
 type buildRequest struct {
@@ -513,7 +513,7 @@ func main() {
 
 	flag.Parse()
 
-	testedRepoRegistry, err := reporegistry.NewTestedDefault()
+	testedRepoRegistry, err := testrepos.New()
 	if err != nil {
 		panic(fmt.Sprintf("failed to create repo registry with tested distros: %v", err))
 	}

--- a/cmd/list-images/main.go
+++ b/cmd/list-images/main.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gobwas/glob"
 	"github.com/osbuild/images/pkg/distrofactory"
-	"github.com/osbuild/images/pkg/reporegistry"
+	testrepos "github.com/osbuild/images/test/data/repositories"
 )
 
 type multiValue []string
@@ -75,7 +75,7 @@ func main() {
 	flag.BoolVar(&json, "json", false, "print configs as json")
 	flag.Parse()
 
-	testedRepoRegistry, err := reporegistry.NewTestedDefault()
+	testedRepoRegistry, err := testrepos.New()
 	if err != nil {
 		panic(fmt.Sprintf("failed to create repo registry with tested distros: %v", err))
 	}

--- a/cmd/osbuild-composer-image-definitions/main.go
+++ b/cmd/osbuild-composer-image-definitions/main.go
@@ -6,14 +6,14 @@ import (
 	"os"
 
 	"github.com/osbuild/images/pkg/distrofactory"
-	"github.com/osbuild/images/pkg/reporegistry"
+	testrepos "github.com/osbuild/images/test/data/repositories"
 )
 
 func main() {
 	definitions := map[string]map[string][]string{}
 	distroFac := distrofactory.NewDefault()
 
-	testedRepoRegistry, err := reporegistry.NewTestedDefault()
+	testedRepoRegistry, err := testrepos.New()
 	if err != nil {
 		panic(fmt.Sprintf("failed to create repo registry with tested distros: %v", err))
 	}

--- a/pkg/distro/distro_test_common/distro_test_common.go
+++ b/pkg/distro/distro_test_common/distro_test_common.go
@@ -11,7 +11,7 @@ import (
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/ostree"
-	"github.com/osbuild/images/pkg/reporegistry"
+	testrepos "github.com/osbuild/images/test/data/repositories"
 )
 
 const RandomTestSeed = 0
@@ -463,7 +463,7 @@ func TestDistro_OSTreeOptions(t *testing.T, d distro.Distro) {
 
 // ListTestedDistros returns a list of distro names that are explicitly tested
 func ListTestedDistros(t *testing.T) []string {
-	testRepoRegistry, err := reporegistry.NewTestedDefault()
+	testRepoRegistry, err := testrepos.New()
 	require.Nil(t, err)
 	require.NotEmpty(t, testRepoRegistry)
 	distros := testRepoRegistry.ListDistros()

--- a/pkg/imagefilter/imagefilter_test.go
+++ b/pkg/imagefilter/imagefilter_test.go
@@ -10,14 +10,14 @@ import (
 
 	"github.com/osbuild/images/pkg/distrofactory"
 	"github.com/osbuild/images/pkg/imagefilter"
-	"github.com/osbuild/images/pkg/reporegistry"
+	testrepos "github.com/osbuild/images/test/data/repositories"
 )
 
 func TestImageFilterSmoke(t *testing.T) {
 	logrus.SetLevel(logrus.WarnLevel)
 
 	fac := distrofactory.NewDefault()
-	repos, err := reporegistry.NewTestedDefault()
+	repos, err := testrepos.New()
 	require.NoError(t, err)
 
 	imgFilter, err := imagefilter.New(fac, repos)
@@ -29,7 +29,7 @@ func TestImageFilterSmoke(t *testing.T) {
 
 func TestImageFilterFilter(t *testing.T) {
 	fac := distrofactory.NewDefault()
-	repos, err := reporegistry.NewTestedDefault()
+	repos, err := testrepos.New()
 	require.NoError(t, err)
 
 	imgFilter, err := imagefilter.New(fac, repos)

--- a/pkg/reporegistry/reporegistry.go
+++ b/pkg/reporegistry/reporegistry.go
@@ -2,8 +2,6 @@ package reporegistry
 
 import (
 	"fmt"
-	"path/filepath"
-	"runtime"
 
 	"github.com/osbuild/images/pkg/distroidparser"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -25,19 +23,6 @@ func New(repoConfigPaths []string) (*RepoRegistry, error) {
 	}
 
 	return &RepoRegistry{repositories}, nil
-}
-
-// NewTestedDefault returns a new RepoRegistry instance with the data
-// loaded from the default test repositories
-func NewTestedDefault() (*RepoRegistry, error) {
-	_, callerSrc, _, ok := runtime.Caller(0)
-	var testReposPath []string
-	if !ok {
-		testReposPath = append(testReposPath, "../../test/data")
-	} else {
-		testReposPath = append(testReposPath, filepath.Join(filepath.Dir(callerSrc), "../../test/data"))
-	}
-	return New(testReposPath)
 }
 
 func NewFromDistrosRepoConfigs(distrosRepoConfigs rpmmd.DistrosRepoConfigs) *RepoRegistry {

--- a/pkg/reporegistry/reporegistry_test.go
+++ b/pkg/reporegistry/reporegistry_test.go
@@ -4,10 +4,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/test_distro"
 	"github.com/osbuild/images/pkg/rpmmd"
-	"github.com/stretchr/testify/assert"
 )
 
 func getTestingRepoRegistry() *RepoRegistry {
@@ -369,11 +370,4 @@ func TestInvalidReposByArchName(t *testing.T) {
 			assert.True(t, tt.want(got, err))
 		})
 	}
-}
-
-func Test_NewTestedDefault(t *testing.T) {
-	rr, err := NewTestedDefault()
-	assert.Nil(t, err)
-	assert.NotNil(t, rr)
-	assert.NotEmpty(t, rr.ListDistros())
 }

--- a/pkg/rpmmd/repository.go
+++ b/pkg/rpmmd/repository.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -232,10 +233,14 @@ func LoadRepositoriesFromFile(filename string) (map[string][]RepoConfig, error) 
 	}
 	defer f.Close()
 
+	return LoadRepositoriesFromReader(f)
+}
+
+func LoadRepositoriesFromReader(r io.Reader) (map[string][]RepoConfig, error) {
 	var reposMap map[string][]repository
 	repoConfigs := make(map[string][]RepoConfig)
 
-	err = json.NewDecoder(f).Decode(&reposMap)
+	err := json.NewDecoder(r).Decode(&reposMap)
 	if err != nil {
 		return nil, err
 	}

--- a/test/data/repositories/testrepos.go
+++ b/test/data/repositories/testrepos.go
@@ -1,0 +1,19 @@
+package testrepos
+
+import (
+	"embed"
+	"io/fs"
+
+	"github.com/osbuild/images/pkg/reporegistry"
+)
+
+//go:embed *.json
+var FS embed.FS
+
+func New() (*reporegistry.RepoRegistry, error) {
+	repositories, err := reporegistry.LoadAllRepositoriesFromFS([]fs.FS{FS})
+	if err != nil {
+		return nil, err
+	}
+	return reporegistry.NewFromDistrosRepoConfigs(repositories), nil
+}


### PR DESCRIPTION
This commit is a (hopefully) less controversial version of: https://github.com/osbuild/images/pull/1037

Here only a new helper to load repository information from an `fs.FS` is added and only used for loading the test repositories.

This will help to have a single test repository that can be embedded accross osbuild-composer, image-builder and images.

It also removes the public "NewTestedDefault()" in favor of a new `testrepos.New()` helper so that the `reporegistry` only has non-test API left.

[*maybe* this should be split into two commits actually]

This will allow me to use the test repos in the new `image-builder-cli` repo without the need to copy/import files from another git repo.