### PR TITLE
distro: add `OutputFilename` option to ImageOptions

### DIFF
--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -130,6 +130,15 @@ type ImageOptions struct {
 	Subscription     *subscription.ImageOptions `json:"subscription,omitempty"`
 	Facts            *facts.ImageOptions        `json:"facts,omitempty"`
 	PartitioningMode disk.PartitioningMode      `json:"partitioning-mode,omitempty"`
+
+	OutputFilename string `json:"output_filename"`
+}
+
+func (i *ImageOptions) Filename(imgType ImageType) string {
+	if i.OutputFilename != "" {
+		return i.OutputFilename
+	}
+	return imgType.Filename()
 }
 
 type BasePartitionTableMap map[string]disk.PartitionTable

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/distro_test_common"
+	"github.com/osbuild/images/pkg/distro/test_distro"
 	"github.com/osbuild/images/pkg/distrofactory"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -565,5 +566,22 @@ func TestDistro_ManifestFIPSWarning(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func TestDistro_ImageOptionsFilename(t *testing.T) {
+	imgType := &test_distro.TestImageType{}
+
+	for _, tc := range []struct {
+		outputFilename   string
+		expectedFilename string
+	}{
+		{"", "test.img"},
+		{"foo.img", "foo.img"},
+	} {
+		imgOpts := &distro.ImageOptions{
+			OutputFilename: tc.outputFilename,
+		}
+		assert.Equal(t, tc.expectedFilename, imgOpts.Filename(imgType))
 	}
 }

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -334,8 +334,7 @@ func diskImage(workload workload.Workload,
 		return nil, err
 	}
 	img.PartitionTable = pt
-
-	img.Filename = t.Filename()
+	img.Filename = options.Filename(t)
 
 	return img, nil
 }
@@ -359,8 +358,7 @@ func containerImage(workload workload.Workload,
 
 	img.Environment = t.environment
 	img.Workload = workload
-
-	img.Filename = t.Filename()
+	img.Filename = options.Filename(t)
 
 	return img, nil
 }
@@ -392,8 +390,7 @@ func liveInstallerImage(workload workload.Workload,
 	if err != nil {
 		return nil, err
 	}
-
-	img.Filename = t.Filename()
+	img.Filename = options.Filename(t)
 
 	return img, nil
 }
@@ -466,8 +463,7 @@ func imageInstallerImage(workload workload.Workload,
 	if err != nil {
 		return nil, err
 	}
-
-	img.Filename = t.Filename()
+	img.Filename = options.Filename(t)
 
 	return img, nil
 }
@@ -513,7 +509,8 @@ func iotCommitImage(workload workload.Workload,
 	img.Workload = workload
 	img.OSTreeParent = parentCommit
 	img.OSVersion = d.osVersion
-	img.Filename = t.Filename()
+	img.Filename = options.Filename(t)
+
 	img.InstallWeakDeps = false
 
 	return img, nil
@@ -544,7 +541,8 @@ func bootableContainerImage(workload workload.Workload,
 	img.Workload = workload
 	img.OSTreeParent = parentCommit
 	img.OSVersion = d.osVersion
-	img.Filename = t.Filename()
+	img.Filename = options.Filename(t)
+
 	img.InstallWeakDeps = false
 	img.BootContainer = true
 	img.BootcConfig = &bootc.Config{
@@ -596,7 +594,7 @@ func iotContainerImage(workload workload.Workload,
 	img.OSTreeParent = parentCommit
 	img.OSVersion = d.osVersion
 	img.ExtraContainerPackages = packageSets[containerPkgsKey]
-	img.Filename = t.Filename()
+	img.Filename = options.Filename(t)
 
 	return img, nil
 }
@@ -664,8 +662,7 @@ func iotInstallerImage(workload workload.Workload,
 	if err != nil {
 		return nil, err
 	}
-
-	img.Filename = t.Filename()
+	img.Filename = options.Filename(t)
 
 	return img, nil
 }
@@ -705,8 +702,8 @@ func iotImage(workload workload.Workload,
 		return nil, err
 	}
 	img.PartitionTable = pt
+	img.Filename = options.Filename(t)
 
-	img.Filename = t.Filename()
 	img.Compression = t.compression
 
 	return img, nil
@@ -747,13 +744,15 @@ func iotSimplifiedInstallerImage(workload workload.Workload,
 	}
 	rawImg.PartitionTable = pt
 
-	rawImg.Filename = t.Filename()
+	filename := options.Filename(t)
+	rawImg.Filename = filename
 
 	img := image.NewOSTreeSimplifiedInstaller(rawImg, customizations.InstallationDevice)
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
 	// img.Workload = workload
 	img.Platform = t.platform
-	img.Filename = t.Filename()
+	img.Filename = filename
+
 	if bpFDO := customizations.GetFDO(); bpFDO != nil {
 		img.FDO = fdo.FromBP(*bpFDO)
 	}

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -374,8 +374,7 @@ func DiskImage(workload workload.Workload,
 		return nil, err
 	}
 	img.PartitionTable = pt
-
-	img.Filename = t.Filename()
+	img.Filename = options.Filename(t)
 
 	img.VPCForceSize = t.DiskImageVPCForceSize
 
@@ -415,7 +414,7 @@ func EdgeCommitImage(workload workload.Workload,
 	img.Workload = workload
 	img.OSTreeParent = parentCommit
 	img.OSVersion = t.Arch().Distro().OsVersion()
-	img.Filename = t.Filename()
+	img.Filename = options.Filename(t)
 
 	return img, nil
 }
@@ -445,7 +444,7 @@ func EdgeContainerImage(workload workload.Workload,
 	img.OSTreeParent = parentCommit
 	img.OSVersion = t.Arch().Distro().OsVersion()
 	img.ExtraContainerPackages = packageSets[ContainerPkgsKey]
-	img.Filename = t.Filename()
+	img.Filename = options.Filename(t)
 
 	return img, nil
 }
@@ -523,8 +522,7 @@ func EdgeInstallerImage(workload workload.Workload,
 	img.OSVersion = t.Arch().Distro().OsVersion()
 	img.Release = fmt.Sprintf("%s %s", t.Arch().Distro().Product(), t.Arch().Distro().OsVersion())
 	img.FIPS = customizations.GetFIPS()
-
-	img.Filename = t.Filename()
+	img.Filename = options.Filename(t)
 
 	return img, nil
 }
@@ -564,8 +562,8 @@ func EdgeRawImage(workload workload.Workload,
 		return nil, err
 	}
 	img.PartitionTable = pt
+	img.Filename = options.Filename(t)
 
-	img.Filename = t.Filename()
 	img.Compression = t.Compression
 
 	return img, nil
@@ -607,13 +605,14 @@ func EdgeSimplifiedInstallerImage(workload workload.Workload,
 	}
 	rawImg.PartitionTable = pt
 
-	rawImg.Filename = t.Filename()
+	filename := options.Filename(t)
+	rawImg.Filename = filename
 
 	img := image.NewOSTreeSimplifiedInstaller(rawImg, customizations.InstallationDevice)
 	img.ExtraBasePackages = packageSets[InstallerPkgsKey]
 	// img.Workload = workload
 	img.Platform = t.platform
-	img.Filename = t.Filename()
+	img.Filename = filename
 	if bpFDO := customizations.GetFDO(); bpFDO != nil {
 		img.FDO = fdo.FromBP(*bpFDO)
 	}
@@ -719,8 +718,7 @@ func ImageInstallerImage(workload workload.Workload,
 	img.Product = d.product
 	img.OSVersion = d.osVersion
 	img.Release = fmt.Sprintf("%s %s", d.product, d.osVersion)
-
-	img.Filename = t.Filename()
+	img.Filename = options.Filename(t)
 
 	return img, nil
 }
@@ -744,8 +742,7 @@ func TarImage(workload workload.Workload,
 
 	img.Environment = t.Environment
 	img.Workload = workload
-
-	img.Filename = t.Filename()
+	img.Filename = options.Filename(t)
 
 	return img, nil
 


### PR DESCRIPTION
This commit allows to change the filename when creating a manifest from an image type. This is useful when doing a UI for users, e.g. this will allow us to support:
```
$ image-builder build rhel-9 type:qcow2 --output foo.img
```
(this will also be useful for bootc-image-builder).

Well, osbuild itself will still put it under a directory when doing main_cli.py:exports() but that is something orthogonal.

 I couldn't find a good way to test this end-to-end though (without doing a full manifest with depsolve) because the various `DiskImage()`, `EdgeCommitImage()` functions are assigned to `ImageType.method` so iterating over the image types will only give me the ability to run Manifest() which creates a manifest.Manifest but from there I cannot access any pipelines without producing a full osbuild manifest. Ideas welcome, I did test it via the "image-builder-cli" branch. Maybe I'm missing something but this area of the code might need some tweaks to make it more testable.

P.S. I also explored an alternative approach that would allow to set the filename on the image type in (in https://github.com/osbuild/images/compare/main...mvo5:make-target-filename-setable?expand=1) but this one here feels slightly cleaner.