### PR TITLE
datasize, blueprint: add new `datasizes.Size` type and use in blueprints

### DIFF
--- a/pkg/blueprint/blueprint_test.go
+++ b/pkg/blueprint/blueprint_test.go
@@ -65,9 +65,9 @@ minsize = "20 GiB"
 	assert.Equal(t, bp.Version, "0.0.0")
 	assert.Equal(t, bp.Packages, []Package{{Name: "httpd", Version: "2.4.*"}})
 	assert.Equal(t, "/var", bp.Customizations.Filesystem[0].Mountpoint)
-	assert.Equal(t, uint64(2147483648), bp.Customizations.Filesystem[0].MinSize)
+	assert.Equal(t, uint64(2147483648), bp.Customizations.Filesystem[0].MinSize.Uint64())
 	assert.Equal(t, "/opt", bp.Customizations.Filesystem[1].Mountpoint)
-	assert.Equal(t, uint64(20*datasizes.GiB), bp.Customizations.Filesystem[1].MinSize)
+	assert.Equal(t, uint64(20*datasizes.GiB), bp.Customizations.Filesystem[1].MinSize.Uint64())
 }
 
 func TestGetPackages(t *testing.T) {

--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -304,7 +304,7 @@ func (c *Customizations) GetFilesystemsMinSize() uint64 {
 	}
 	var agg uint64
 	for _, m := range c.Filesystem {
-		agg += m.MinSize
+		agg += m.MinSize.Uint64()
 	}
 	// This ensures that file system customization `size` is a multiple of
 	// sector size (512)

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -3,9 +3,10 @@ package blueprint
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/customizations/anaconda"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCheckAllowed(t *testing.T) {

--- a/pkg/blueprint/disk_customizations_test.go
+++ b/pkg/blueprint/disk_customizations_test.go
@@ -1264,7 +1264,7 @@ func TestPartitionCustomizationUnmarshalJSON(t *testing.T) {
 				"mountpoint": "/",
 				"fs_type": "xfs"
 			}`,
-			errorMsg: "JSON unmarshal: error decoding minsize for partition: cannot be negative",
+			errorMsg: "JSON unmarshal: error decoding partition with type \"plain\": error decoding JSON size: cannot be negative",
 		},
 		"wrong-type/btrfs-with-lvm": {
 			input: `{
@@ -1559,12 +1559,12 @@ func TestPartitionCustomizationUnmarshalTOML(t *testing.T) {
 			input:    `type = 5`,
 			errorMsg: `toml: line 0: TOML unmarshal: type must be a string, got "5" of type int64`,
 		},
-		"negative-size": {
+		"negative-size-2": {
 			input: `minsize = -10
 					mountpoint = "/"
 					fs_type = "xfs"
 					`,
-			errorMsg: "toml: line 0: TOML unmarshal: error decoding minsize for partition: cannot be negative",
+			errorMsg: "toml: line 0: TOML unmarshal: error decoding partition with type \"plain\": error decoding JSON size: cannot be negative",
 		},
 		"wrong-type/btrfs-with-lvm": {
 			input: `type = "btrfs"

--- a/pkg/blueprint/filesystem_customizations.go
+++ b/pkg/blueprint/filesystem_customizations.go
@@ -1,7 +1,6 @@
 package blueprint
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -10,50 +9,8 @@ import (
 )
 
 type FilesystemCustomization struct {
-	Mountpoint string `json:"mountpoint,omitempty" toml:"mountpoint,omitempty"`
-	MinSize    uint64 `json:"minsize,omitempty" toml:"minsize,omitempty"`
-}
-
-func (fsc *FilesystemCustomization) UnmarshalTOML(data interface{}) error {
-	d, ok := data.(map[string]interface{})
-	if !ok {
-		return fmt.Errorf("customizations.filesystem is not an object")
-	}
-
-	switch d["mountpoint"].(type) {
-	case string:
-		fsc.Mountpoint = d["mountpoint"].(string)
-	default:
-		return fmt.Errorf("TOML unmarshal: mountpoint must be string, got \"%v\" of type %T", d["mountpoint"], d["mountpoint"])
-	}
-	minSize, err := decodeSize(d["minsize"])
-	if err != nil {
-		return fmt.Errorf("TOML unmarshal: error decoding minsize value for mountpoint %q: %w", fsc.Mountpoint, err)
-	}
-	fsc.MinSize = minSize
-	return nil
-}
-
-func (fsc *FilesystemCustomization) UnmarshalJSON(data []byte) error {
-	var v interface{}
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	d, _ := v.(map[string]interface{})
-
-	switch d["mountpoint"].(type) {
-	case string:
-		fsc.Mountpoint = d["mountpoint"].(string)
-	default:
-		return fmt.Errorf("JSON unmarshal: mountpoint must be string, got \"%v\" of type %T", d["mountpoint"], d["mountpoint"])
-	}
-
-	minSize, err := decodeSize(d["minsize"])
-	if err != nil {
-		return fmt.Errorf("JSON unmarshal: error decoding minsize value for mountpoint %q: %w", fsc.Mountpoint, err)
-	}
-	fsc.MinSize = minSize
-	return nil
+	Mountpoint string         `json:"mountpoint,omitempty" toml:"mountpoint,omitempty"`
+	MinSize    datasizes.Size `json:"minsize,omitempty" toml:"minsize,omitempty"`
 }
 
 // CheckMountpointsPolicy checks if the mountpoints are allowed by the policy
@@ -70,28 +27,4 @@ func CheckMountpointsPolicy(mountpoints []FilesystemCustomization, mountpointAll
 	}
 
 	return nil
-}
-
-// decodeSize takes an integer or string representing a data size (with a data
-// suffix) and returns the uint64 representation.
-func decodeSize(size any) (uint64, error) {
-	switch s := size.(type) {
-	case string:
-		return datasizes.Parse(s)
-	case int64:
-		if s < 0 {
-			return 0, fmt.Errorf("cannot be negative")
-		}
-		return uint64(s), nil
-	case float64:
-		if s < 0 {
-			return 0, fmt.Errorf("cannot be negative")
-		}
-		// TODO: emit warning of possible truncation?
-		return uint64(s), nil
-	case uint64:
-		return s, nil
-	default:
-		return 0, fmt.Errorf("failed to convert value \"%v\" to number", size)
-	}
 }

--- a/pkg/blueprint/filesystem_customizations_test.go
+++ b/pkg/blueprint/filesystem_customizations_test.go
@@ -53,13 +53,13 @@ func TestFilesystemCustomizationUnmarshalTOMLUnhappy(t *testing.T) {
 			name: "minsize nor string nor int",
 			input: `mountpoint="/"
 			minsize = true`,
-			err: `toml: line 2 (last key "minsize"): TOML unmarshal: error decoding size: failed to convert value "true" to number`,
+			err: `toml: line 2 (last key "minsize"): error decoding TOML size: failed to convert value "true" to number`,
 		},
 		{
 			name: "minsize not parseable",
 			input: `mountpoint="/"
 			minsize = "20 KG"`,
-			err: `toml: line 2 (last key "minsize"): TOML unmarshal: error decoding size: unknown data size units in string: 20 KG`,
+			err: `toml: line 2 (last key "minsize"): error decoding TOML size: unknown data size units in string: 20 KG`,
 		},
 	}
 
@@ -81,17 +81,17 @@ func TestFilesystemCustomizationUnmarshalJSONUnhappy(t *testing.T) {
 		{
 			name:  "mountpoint not string",
 			input: `{"mountpoint": 42, "minsize": 42}`,
-			err:   `json: cannot unmarshal number into Go struct field FilesystemCustomization.mountpoint of type string`,
+			err:   `json: cannot unmarshal number into Go struct field filesystemCustomization.mountpoint of type string`,
 		},
 		{
 			name:  "minsize nor string nor int",
 			input: `{"mountpoint":"/", "minsize": true}`,
-			err:   `JSON unmarshal: error decoding size: failed to convert value "true" to number`,
+			err:   `JSON unmarshal: error decoding minsize value for mountpoint "/": error decoding JSON size: failed to convert value "true" to number`,
 		},
 		{
 			name:  "minsize not parseable",
 			input: `{ "mountpoint": "/", "minsize": "20 KG"}`,
-			err:   `JSON unmarshal: error decoding size: unknown data size units in string: 20 KG`,
+			err:   `JSON unmarshal: error decoding minsize value for mountpoint "/": error decoding JSON size: unknown data size units in string: 20 KG`,
 		},
 	}
 

--- a/pkg/datasizes/size.go
+++ b/pkg/datasizes/size.go
@@ -1,0 +1,66 @@
+package datasizes
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Size is a wrapper around uint64 with support for reading from string
+// yaml/toml, so {"size": 123}, {"size": "1234"}, {"size": "1 GiB"} are
+// all supported
+type Size uint64
+
+func (si *Size) UnmarshalTOML(data interface{}) error {
+	i, err := decodeSize(data)
+	if err != nil {
+		return fmt.Errorf("error decoding TOML size: %w", err)
+	}
+	*si = Size(i)
+	return nil
+}
+
+func (si *Size) UnmarshalJSON(data []byte) error {
+	dec := json.NewDecoder(bytes.NewBuffer(data))
+	dec.UseNumber()
+
+	var v interface{}
+	if err := dec.Decode(&v); err != nil {
+		return err
+	}
+	i, err := decodeSize(v)
+	if err != nil {
+		// if only we could do better here and include e.g. the field
+		// name where this happend but encoding/json does not
+		// support this, c.f. https://github.com/golang/go/issues/58655
+		return fmt.Errorf("error decoding JSON size: %w", err)
+	}
+	*si = Size(i)
+	return nil
+}
+
+// decodeSize takes an integer or string representing a data size (with a data
+// suffix) and returns the uint64 representation.
+func decodeSize(size any) (uint64, error) {
+	switch s := size.(type) {
+	case string:
+		return Parse(s)
+	case json.Number:
+		i, err := s.Int64()
+		if i < 0 {
+			return 0, fmt.Errorf("cannot be negative")
+		}
+		return uint64(i), err
+	case int64:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot be negative")
+		}
+		return uint64(s), nil
+	case uint64:
+		return s, nil
+	case float64, float32:
+		return 0, fmt.Errorf("cannot be float")
+	default:
+		return 0, fmt.Errorf("failed to convert value \"%v\" to number", size)
+	}
+}

--- a/pkg/datasizes/size.go
+++ b/pkg/datasizes/size.go
@@ -11,6 +11,12 @@ import (
 // all supported
 type Size uint64
 
+// Uint64 returns the size as uint64. This is a convenience functions,
+// it is strictly equivalent to uint64(Size(1))
+func (si Size) Uint64() uint64 {
+	return uint64(si)
+}
+
 func (si *Size) UnmarshalTOML(data interface{}) error {
 	i, err := decodeSize(data)
 	if err != nil {

--- a/pkg/datasizes/size_test.go
+++ b/pkg/datasizes/size_test.go
@@ -1,0 +1,122 @@
+package datasizes_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/datasizes"
+)
+
+func TestSizeUnmarshalTOMLUnhappy(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		err   string
+	}{
+		{
+			name:  "wrong datatype/bool",
+			input: `size = true`,
+			err:   `toml: line 1 (last key "size"): error decoding TOML size: failed to convert value "true" to number`,
+		},
+		{
+			name:  "wrong datatype/float",
+			input: `size = 3.14`,
+			err:   `toml: line 1 (last key "size"): error decoding TOML size: cannot be float`,
+		},
+		{
+			name:  "wrong unit",
+			input: `size = "20 KG"`,
+			err:   `toml: line 1 (last key "size"): error decoding TOML size: unknown data size units in string: 20 KG`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v struct {
+				Size datasizes.Size `toml:"size"`
+			}
+			err := toml.Unmarshal([]byte(tc.input), &v)
+			assert.EqualError(t, err, tc.err, tc.input)
+		})
+	}
+}
+
+func TestSizeUnmarshalJSONUnhappy(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		err   string
+	}{
+		{
+			name:  "misize nor string nor int",
+			input: `{"size": true}`,
+			err:   `error decoding JSON size: failed to convert value "true" to number`,
+		},
+		{
+			name:  "wrong datatype/float",
+			input: `{"size": 3.14}`,
+			err:   `error decoding JSON size: strconv.ParseInt: parsing "3.14": invalid syntax`,
+		},
+		{
+			name:  "misize not parseable",
+			input: `{"size": "20 KG"}`,
+			err:   `error decoding JSON size: unknown data size units in string: 20 KG`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v struct {
+				Size datasizes.Size `json:"size"`
+			}
+			err := json.Unmarshal([]byte(tc.input), &v)
+			assert.EqualError(t, err, tc.err, tc.input)
+		})
+	}
+}
+
+func TestSizeUnmarshalHappy(t *testing.T) {
+	cases := []struct {
+		name      string
+		inputJSON string
+		inputTOML string
+		expected  datasizes.Size
+	}{
+		{
+			name:      "int",
+			inputJSON: `{"size": 1234}`,
+			inputTOML: `size = 1234`,
+			expected:  1234,
+		},
+		{
+			name:      "str",
+			inputJSON: `{"size": "1234"}`,
+			inputTOML: `size = "1234"`,
+			expected:  1234,
+		},
+		{
+			name:      "str/with-unit",
+			inputJSON: `{"size": "1234 MiB"}`,
+			inputTOML: `size = "1234 MiB"`,
+			expected:  1234 * datasizes.MiB,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v struct {
+				Size datasizes.Size `json:"size" toml:"size"`
+			}
+			err := toml.Unmarshal([]byte(tc.inputTOML), &v)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, v.Size, tc.inputTOML)
+			err = json.Unmarshal([]byte(tc.inputJSON), &v)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, v.Size, tc.inputJSON)
+		})
+	}
+}

--- a/pkg/datasizes/size_test.go
+++ b/pkg/datasizes/size_test.go
@@ -2,7 +2,6 @@ package datasizes_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/BurntSushi/toml"

--- a/pkg/disk/disk_test.go
+++ b/pkg/disk/disk_test.go
@@ -146,7 +146,7 @@ func blueprintApplied(pt *disk.PartitionTable, bp []blueprint.FilesystemCustomiz
 		}
 		for idx, ent := range path {
 			if sz, ok := ent.(disk.Sizeable); ok {
-				if sz.GetSize() < mnt.MinSize {
+				if sz.GetSize() < mnt.MinSize.Uint64() {
 					return fmt.Errorf("entity %d in the path from %s is smaller (%d) than the requested minsize %d", idx, mnt.Mountpoint, sz.GetSize(), mnt.MinSize)
 				}
 			}
@@ -178,7 +178,7 @@ func TestCreatePartitionTable(t *testing.T) {
 
 	sumSizes := func(bp []blueprint.FilesystemCustomization) (sum uint64) {
 		for _, mnt := range bp {
-			sum += mnt.MinSize
+			sum += mnt.MinSize.Uint64()
 		}
 		return sum
 	}

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -158,7 +158,7 @@ func (t *imageType) getPartitionTable(
 		if options.Size > 0 {
 			// user specified a size on the command line, so let's override the
 			// customization with the calculated/rounded imageSize
-			partitioning.MinSize = imageSize
+			partitioning.MinSize = datasizes.Size(imageSize)
 		}
 
 		partOptions := &disk.CustomPartitionTableOptions{


### PR DESCRIPTION
This is split out from https://github.com/osbuild/images/pull/1041 and also includes a cleanup from https://github.com/osbuild/images/pull/951

The idea is to make simplify the filesystem customization decoding to only use primitive types (string and the new `datasizes.Size` type) which means simpler code (as the mountpoint to string conversion will be done automatically for us) and also that we can use `meta.Undecoded()` for the toml library.

The tradeoff is of couse that it's slightly ugly that we now need to cast MinSize to uint64, if that is considered too ugly I can close this again.