### PR TITLE
blueprint: fix DiskCustomization.MinSize with existing  pattern

### DIFF
--- a/pkg/blueprint/disk_customizations.go
+++ b/pkg/blueprint/disk_customizations.go
@@ -18,6 +18,27 @@ type DiskCustomization struct {
 	Partitions []PartitionCustomization `json:"partitions,omitempty" toml:"partitions,omitempty"`
 }
 
+func (dc *DiskCustomization) UnmarshalJSON(data []byte) error {
+	var dcAnySize struct {
+		MinSize    any                      `json:"minsize,omitempty" toml:"minsize,omitempty"`
+		Partitions []PartitionCustomization `json:"partitions,omitempty" toml:"partitions,omitempty"`
+	}
+	if err := json.Unmarshal(data, &dcAnySize); err != nil {
+		return err
+	}
+
+	dc.Partitions = dcAnySize.Partitions
+
+	if dcAnySize.MinSize != nil {
+		size, err := decodeSize(dcAnySize.MinSize)
+		if err != nil {
+			return err
+		}
+		dc.MinSize = size
+	}
+	return nil
+}
+
 // PartitionCustomization defines a single partition on a disk. The Type
 // defines the kind of "payload" for the partition: plain, lvm, or btrfs.
 //   - plain: the payload will be a filesystem on a partition (e.g. xfs, ext4).


### PR DESCRIPTION
This commit fixes the issue that minsize cannot be a string
by using the existing pattern.

See https://github.com/osbuild/images/pull/1049 for alternative
ideas.

----

The disk customizations min-size setting is not accepting strings
or strings with units. This commit adds a failing test that will
validate the fix.


[this was found as part of the work in bib, https://github.com/osbuild/bootc-image-builder/pull/721]