### PR TITLE
datasize, blueprint: add new datasizes.Size type and use in blueprints

### DIFF
--- a/pkg/blueprint/disk_customizations.go
+++ b/pkg/blueprint/disk_customizations.go
@@ -9,13 +9,35 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/pathpolicy"
 )
 
 type DiskCustomization struct {
 	// TODO: Add partition table type: gpt or dos
-	MinSize    uint64                   `json:"minsize,omitempty" toml:"minsize,omitempty"`
+	MinSize    uint64
+	Partitions []PartitionCustomization
+}
+
+type diskCustomizationMarshaler struct {
+	// TODO: Add partition table type: gpt or dos
+	MinSize    datasizes.Size           `json:"minsize,omitempty" toml:"minsize,omitempty"`
 	Partitions []PartitionCustomization `json:"partitions,omitempty" toml:"partitions,omitempty"`
+}
+
+func (dc *DiskCustomization) UnmarshalJSON(data []byte) error {
+	var dcm diskCustomizationMarshaler
+	if err := json.Unmarshal(data, &dcm); err != nil {
+		return err
+	}
+	dc.MinSize = dcm.MinSize.Uint64()
+	dc.Partitions = dcm.Partitions
+
+	return nil
+}
+
+func (dc *DiskCustomization) UnmarshalTOML(data any) error {
+	return unmarshalTOMLviaJSON(dc, data)
 }
 
 // PartitionCustomization defines a single partition on a disk. The Type

--- a/pkg/blueprint/disk_customizations_test.go
+++ b/pkg/blueprint/disk_customizations_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 
 	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/pathpolicy"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPartitioningValidation(t *testing.T) {
@@ -1645,6 +1647,65 @@ func TestPartitionCustomizationUnmarshalTOML(t *testing.T) {
 			} else {
 				assert.EqualError(err, tc.errorMsg)
 			}
+		})
+	}
+}
+
+func TestDiskCustomizationUnmarshalJSON(t *testing.T) {
+	type testCase struct {
+		inputJSON string
+		inputTOML string
+		expected  *blueprint.DiskCustomization
+	}
+
+	testCases := map[string]testCase{
+		"nothing": {
+			inputJSON: "{}",
+			inputTOML: "",
+			expected: &blueprint.DiskCustomization{
+				MinSize: 0,
+			},
+		},
+		"minsize/int": {
+			inputJSON: `{
+				"minsize": 1234
+			}`,
+			inputTOML: "minsize = 1234",
+			expected: &blueprint.DiskCustomization{
+				MinSize: 1234,
+			},
+		},
+		"minsize/str": {
+			inputJSON: `{
+				"minsize": "1234"
+			}`,
+			inputTOML: `minsize = "1234"`,
+			expected: &blueprint.DiskCustomization{
+				MinSize: 1234,
+			},
+		},
+		"minsize/str-with-unit": {
+			inputJSON: `{
+				"minsize": "1 GiB"
+			}`,
+			inputTOML: `minsize = "1 GiB"`,
+			expected: &blueprint.DiskCustomization{
+				MinSize: 1 * datasizes.GiB,
+			},
+		},
+	}
+
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
+			var dc blueprint.DiskCustomization
+
+			err := json.Unmarshal([]byte(tc.inputJSON), &dc)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, &dc)
+			err = toml.Unmarshal([]byte(tc.inputTOML), &dc)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, &dc)
 		})
 	}
 }

--- a/pkg/blueprint/filesystem_customizations.go
+++ b/pkg/blueprint/filesystem_customizations.go
@@ -19,23 +19,6 @@ type filesystemCustomizationMarshaling struct {
 	MinSize    datasizes.Size `json:"minsize,omitempty" toml:"minsize,omitempty"`
 }
 
-func (fsc *FilesystemCustomization) UnmarshalTOML(data any) error {
-	// This is the most efficient way to reuse code when unmarshaling
-	// structs in toml, it leaks json errors which is a bit sad but
-	// because the toml unmarshaler gives us not "[]byte" but an
-	// already pre-processed "any" we cannot just unmarshal into our
-	// "fooMarshaling" struct and reuse the result so we resort to
-	// this workaround (but toml will go away long term anyway).
-	dataJSON, err := json.Marshal(data)
-	if err != nil {
-		return fmt.Errorf("error unmarshaling TOML data %v: %w", data, err)
-	}
-	if err := fsc.UnmarshalJSON(dataJSON); err != nil {
-		return fmt.Errorf("error decoding TOML %v: %w", data, err)
-	}
-	return nil
-}
-
 func (fsc *FilesystemCustomization) UnmarshalJSON(data []byte) error {
 	var fc filesystemCustomizationMarshaling
 	if err := json.Unmarshal(data, &fc); err != nil {
@@ -48,6 +31,10 @@ func (fsc *FilesystemCustomization) UnmarshalJSON(data []byte) error {
 	fsc.MinSize = fc.MinSize.Uint64()
 
 	return nil
+}
+
+func (fsc *FilesystemCustomization) UnmarshalTOML(data any) error {
+	return unmarshalTOMLviaJSON(fsc, data)
 }
 
 // CheckMountpointsPolicy checks if the mountpoints are allowed by the policy

--- a/pkg/blueprint/filesystem_customizations_test.go
+++ b/pkg/blueprint/filesystem_customizations_test.go
@@ -47,19 +47,19 @@ func TestFilesystemCustomizationUnmarshalTOMLUnhappy(t *testing.T) {
 			name: "mountpoint not string",
 			input: `mountpoint = 42
 			minsize = 42`,
-			err: `toml: line 0: TOML unmarshal: mountpoint must be string, got "42" of type int64`,
+			err: `toml: line 0: error decoding TOML map[minsize:42 mountpoint:42]: json: cannot unmarshal number into Go struct field filesystemCustomizationMarshaling.mountpoint of type string`,
 		},
 		{
 			name: "minsize nor string nor int",
 			input: `mountpoint="/"
 			minsize = true`,
-			err: `toml: line 0: TOML unmarshal: error decoding minsize value for mountpoint "/": failed to convert value "true" to number`,
+			err: `toml: line 0: error decoding TOML map[minsize:true mountpoint:/]: error decoding size: failed to convert value "true" to number`,
 		},
 		{
 			name: "minsize not parseable",
 			input: `mountpoint="/"
 			minsize = "20 KG"`,
-			err: `toml: line 0: TOML unmarshal: error decoding minsize value for mountpoint "/": unknown data size units in string: 20 KG`,
+			err: `toml: line 0: error decoding TOML map[minsize:20 KG mountpoint:/]: error decoding size: unknown data size units in string: 20 KG`,
 		},
 	}
 
@@ -81,17 +81,17 @@ func TestFilesystemCustomizationUnmarshalJSONUnhappy(t *testing.T) {
 		{
 			name:  "mountpoint not string",
 			input: `{"mountpoint": 42, "minsize": 42}`,
-			err:   `JSON unmarshal: mountpoint must be string, got "42" of type float64`,
+			err:   `json: cannot unmarshal number into Go struct field filesystemCustomizationMarshaling.mountpoint of type string`,
 		},
 		{
 			name:  "minsize nor string nor int",
 			input: `{"mountpoint":"/", "minsize": true}`,
-			err:   `JSON unmarshal: error decoding minsize value for mountpoint "/": failed to convert value "true" to number`,
+			err:   `error decoding minsize value for mountpoint "/": error decoding size: failed to convert value "true" to number`,
 		},
 		{
 			name:  "minsize not parseable",
 			input: `{ "mountpoint": "/", "minsize": "20 KG"}`,
-			err:   `JSON unmarshal: error decoding minsize value for mountpoint "/": unknown data size units in string: 20 KG`,
+			err:   `error decoding minsize value for mountpoint "/": error decoding size: unknown data size units in string: 20 KG`,
 		},
 	}
 
@@ -115,7 +115,7 @@ func TestFilesystemCustomizationUnmarshalTOMLNotAnObject(t *testing.T) {
 			input: `
 [customizations]
 filesystem = ["hello"]`,
-			err: "toml: line 3 (last key \"customizations.filesystem\"): customizations.filesystem is not an object",
+			err: `toml: line 3 (last key "customizations.filesystem"): error decoding TOML hello: json: cannot unmarshal string into Go value of type blueprint.filesystemCustomizationMarshaling`,
 		},
 	}
 

--- a/pkg/blueprint/toml_json_bridge.go
+++ b/pkg/blueprint/toml_json_bridge.go
@@ -1,0 +1,24 @@
+package blueprint
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// XXX: move to interal/common ?
+func unmarshalTOMLviaJSON(u json.Unmarshaler, data any) error {
+	// This is the most efficient way to reuse code when unmarshaling
+	// structs in toml, it leaks json errors which is a bit sad but
+	// because the toml unmarshaler gives us not "[]byte" but an
+	// already pre-processed "any" we cannot just unmarshal into our
+	// "fooMarshaling" struct and reuse the result so we resort to
+	// this workaround (but toml will go away long term anyway).
+	dataJSON, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling TOML data %v: %w", data, err)
+	}
+	if err := u.UnmarshalJSON(dataJSON); err != nil {
+		return fmt.Errorf("error decoding TOML %v: %w", data, err)
+	}
+	return nil
+}

--- a/pkg/datasizes/size.go
+++ b/pkg/datasizes/size.go
@@ -1,0 +1,72 @@
+package datasizes
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Size is a wrapper around uint64 with support for reading from string
+// yaml/toml, so {"size": 123}, {"size": "1234"}, {"size": "1 GiB"} are
+// all supported
+type Size uint64
+
+// Uint64 returns the size as uint64. This is a convenience functions,
+// it is strictly equivalent to uint64(Size(1))
+func (si Size) Uint64() uint64 {
+	return uint64(si)
+}
+
+func (si *Size) UnmarshalTOML(data interface{}) error {
+	i, err := decodeSize(data)
+	if err != nil {
+		return fmt.Errorf("error decoding TOML size: %w", err)
+	}
+	*si = Size(i)
+	return nil
+}
+
+func (si *Size) UnmarshalJSON(data []byte) error {
+	dec := json.NewDecoder(bytes.NewBuffer(data))
+	dec.UseNumber()
+
+	var v interface{}
+	if err := dec.Decode(&v); err != nil {
+		return err
+	}
+	i, err := decodeSize(v)
+	if err != nil {
+		// if only we could do better here and include e.g. the field
+		// name where this happend but encoding/json does not
+		// support this, c.f. https://github.com/golang/go/issues/58655
+		return fmt.Errorf("error decoding size: %w", err)
+	}
+	*si = Size(i)
+	return nil
+}
+
+// decodeSize takes an integer or string representing a data size (with a data
+// suffix) and returns the uint64 representation.
+func decodeSize(size any) (uint64, error) {
+	switch s := size.(type) {
+	case string:
+		return Parse(s)
+	case json.Number:
+		i, err := s.Int64()
+		if i < 0 {
+			return 0, fmt.Errorf("cannot be negative")
+		}
+		return uint64(i), err
+	case int64:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot be negative")
+		}
+		return uint64(s), nil
+	case uint64:
+		return s, nil
+	case float64, float32:
+		return 0, fmt.Errorf("cannot be float")
+	default:
+		return 0, fmt.Errorf("failed to convert value \"%v\" to number", size)
+	}
+}

--- a/pkg/datasizes/size_test.go
+++ b/pkg/datasizes/size_test.go
@@ -1,0 +1,125 @@
+package datasizes_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/datasizes"
+)
+
+func TestSizeUnmarshalTOMLUnhappy(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		err   string
+	}{
+		{
+			name:  "wrong datatype/bool",
+			input: `size = true`,
+			err:   `toml: line 1 (last key "size"): error decoding TOML size: failed to convert value "true" to number`,
+		},
+		{
+			name:  "wrong datatype/float",
+			input: `size = 3.14`,
+			err:   `toml: line 1 (last key "size"): error decoding TOML size: cannot be float`,
+		},
+		{
+			name:  "wrong unit",
+			input: `size = "20 KG"`,
+			err:   `toml: line 1 (last key "size"): error decoding TOML size: unknown data size units in string: 20 KG`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v struct {
+				Size datasizes.Size `toml:"size"`
+			}
+			err := toml.Unmarshal([]byte(tc.input), &v)
+			assert.EqualError(t, err, tc.err, tc.input)
+		})
+	}
+}
+
+func TestSizeUnmarshalJSONUnhappy(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		err   string
+	}{
+		{
+			name:  "misize nor string nor int",
+			input: `{"size": true}`,
+			err:   `error decoding size: failed to convert value "true" to number`,
+		},
+		{
+			name:  "wrong datatype/float",
+			input: `{"size": 3.14}`,
+			err:   `error decoding size: strconv.ParseInt: parsing "3.14": invalid syntax`,
+		},
+		{
+			name:  "misize not parseable",
+			input: `{"size": "20 KG"}`,
+			err:   `error decoding size: unknown data size units in string: 20 KG`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v struct {
+				Size datasizes.Size `json:"size"`
+			}
+			err := json.Unmarshal([]byte(tc.input), &v)
+			assert.EqualError(t, err, tc.err, tc.input)
+		})
+	}
+}
+
+func TestSizeUnmarshalHappy(t *testing.T) {
+	cases := []struct {
+		name      string
+		inputJSON string
+		inputTOML string
+		expected  datasizes.Size
+	}{
+		{
+			name:      "int",
+			inputJSON: `{"size": 1234}`,
+			inputTOML: `size = 1234`,
+			expected:  1234,
+		},
+		{
+			name:      "str",
+			inputJSON: `{"size": "1234"}`,
+			inputTOML: `size = "1234"`,
+			expected:  1234,
+		},
+		{
+			name:      "str/with-unit",
+			inputJSON: `{"size": "1234 MiB"}`,
+			inputTOML: `size = "1234 MiB"`,
+			expected:  1234 * datasizes.MiB,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v struct {
+				Size datasizes.Size `json:"size" toml:"size"`
+			}
+			err := toml.Unmarshal([]byte(tc.inputTOML), &v)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, v.Size, tc.inputTOML)
+			err = json.Unmarshal([]byte(tc.inputJSON), &v)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, v.Size, tc.inputJSON)
+		})
+	}
+}
+
+func TestSizeUint64(t *testing.T) {
+	assert.Equal(t, datasizes.Size(1234).Uint64(), uint64(1234))
+}


### PR DESCRIPTION
This is an alternative implementation of the idea in https://github.com/osbuild/images/pull/1049 based on feedback from @thozza (thanks!). 

---

blueprint: decouple FilesystemCustomization from marshaling

This commit decouples the marshaling representation of the
`FilesystemCustomization` from the actual struct. This means that
we can reuse custom unmarshaling via datasizes.Size and also
have our external represenation "pure".

If we continue using this pattern is also means that we can rename
fields in the marshaling and provide compatbility easily.

Thanks to Thozza, c.f.
https://github.com/osbuild/images/pull/1049#issuecomment-2493261642
and
https://github.com/osbuild/images/pull/983

---

datasizes: add new `Size` type with json/toml decoding
 support

This commit adds a new `datasizes.Size` type that is an alias
for uint64 but has supports direct json/toml decoding. So sizes
can be specified as 123, "123" or "123 GiB" and this is transparently
handled.
