### PR TITLE
[RFC] blueprint: make `minsize` required for `disk.Customizations`

### DIFF
--- a/pkg/blueprint/disk_customizations.go
+++ b/pkg/blueprint/disk_customizations.go
@@ -113,13 +113,15 @@ func (lv *LVCustomization) UnmarshalJSON(data []byte) error {
 	lv.Name = lvAnySize.Name
 	lv.FilesystemTypedCustomization = lvAnySize.FilesystemTypedCustomization
 
-	if lvAnySize.MinSize != nil {
-		size, err := decodeSize(lvAnySize.MinSize)
-		if err != nil {
-			return err
-		}
-		lv.MinSize = size
+	if lvAnySize.MinSize == nil {
+		return fmt.Errorf("minsize is required")
 	}
+	size, err := decodeSize(lvAnySize.MinSize)
+	if err != nil {
+		return err
+	}
+	lv.MinSize = size
+
 	return nil
 }
 
@@ -177,13 +179,15 @@ func (v *PartitionCustomization) UnmarshalJSON(data []byte) error {
 
 	v.Type = partType
 
-	if typeSniffer.MinSize != nil {
-		minsize, err := decodeSize(typeSniffer.MinSize)
-		if err != nil {
-			return fmt.Errorf("%s error decoding minsize for partition: %w", errPrefix, err)
-		}
-		v.MinSize = minsize
+	if typeSniffer.MinSize == nil {
+		return fmt.Errorf("minsize is required")
 	}
+
+	minsize, err := decodeSize(typeSniffer.MinSize)
+	if err != nil {
+		return fmt.Errorf("%s error decoding minsize for partition: %w", errPrefix, err)
+	}
+	v.MinSize = minsize
 
 	return nil
 }
@@ -301,13 +305,15 @@ func (v *PartitionCustomization) UnmarshalTOML(data any) error {
 
 	v.Type = partType
 
-	if minsizeField, ok := d["minsize"]; ok {
-		minsize, err := decodeSize(minsizeField)
-		if err != nil {
-			return fmt.Errorf("%s error decoding minsize for partition: %w", errPrefix, err)
-		}
-		v.MinSize = minsize
+	minsizeField, ok := d["minsize"]
+	if !ok {
+		return fmt.Errorf("minsize is required")
 	}
+	minsize, err := decodeSize(minsizeField)
+	if err != nil {
+		return fmt.Errorf("%s error decoding minsize for partition: %w", errPrefix, err)
+	}
+	v.MinSize = minsize
 
 	return nil
 }

--- a/pkg/blueprint/disk_customizations_test.go
+++ b/pkg/blueprint/disk_customizations_test.go
@@ -1035,16 +1035,8 @@ func TestPartitionCustomizationUnmarshalJSON(t *testing.T) {
 
 	testCases := map[string]testCase{
 		"nothing": {
-			input: "{}",
-			expected: &blueprint.PartitionCustomization{
-				Type:    "plain",
-				MinSize: 0,
-				FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
-					Mountpoint: "",
-					Label:      "",
-					FSType:     "",
-				},
-			},
+			input:    "{}",
+			errorMsg: "minsize is required",
 		},
 		"plain": {
 			input: `{
@@ -1346,16 +1338,8 @@ func TestPartitionCustomizationUnmarshalTOML(t *testing.T) {
 
 	testCases := map[string]testCase{
 		"nothing": {
-			input: "",
-			expected: &blueprint.PartitionCustomization{
-				Type:    "plain",
-				MinSize: 0,
-				FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
-					Mountpoint: "",
-					Label:      "",
-					FSType:     "",
-				},
-			},
+			input:    "",
+			errorMsg: "toml: line 0: minsize is required",
 		},
 		"plain": {
 			input: `type = "plain"
@@ -1647,13 +1631,6 @@ func TestDiskCustomizationUnmarshalJSON(t *testing.T) {
 	}
 
 	testCases := map[string]testCase{
-		"nothing": {
-			inputJSON: "{}",
-			inputTOML: "",
-			expected: &blueprint.DiskCustomization{
-				MinSize: 0,
-			},
-		},
 		"minsize/int": {
 			inputJSON: `{
 				"minsize": 1234


### PR DESCRIPTION
This commit enforces the use of "minsize" for disk customizations. Without this the `disk` code will create zero sized partitions when `minsize` is omited which then later yields a strange error from osbuild:
```
Building manifest-qcow2-raw-vmdk-vhd-gce.json
<stdin> has errors:

.pipelines[1].stages[2].options.volumes[0].size:
  '0B' does not match '[1-9][0-9]*[bBsSkKmMgGtTpPeE]?'

2024/11/25 09:35:42 error: cannot run osbuild: running osbuild failed: exit status 2
```

We could also attempt to fix this by making guesses about minsize (which is what the existing filesystem customizations do). But that seems less appropriate here as this is about finer control and an arbitrary size of e.g. `1 GiB` seems unexpected. Another alternative would be to infere from the parent container size and split equally. But we can always do this later and relax the rules (and even add things like `minsize: 50%` which would imply the parent container).


[edit: one wart of this is that for partitions with requiedMinsize data this should not be required but at this level we have no way of knowing :(]