### PR TITLE
distro: run `ValidateLayoutConstraints()` when using PartitionCustomizations

### DIFF
--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -468,5 +468,13 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		}
 	}
 
+	diskc, err := customizations.GetPartitioning()
+	if err != nil {
+		return nil, err
+	}
+	if err := diskc.ValidateLayoutConstraints(); err != nil {
+		return nil, fmt.Errorf("cannot use disk customization: %w", err)
+	}
+
 	return nil, nil
 }


### PR DESCRIPTION
This commit will run `ValidateLayoutConstraints()` when a `DiskCustomization` is used.

Fwiw, the fact that we have to implement this in every distro (and in bib) and must not forget about it makes me wonder if we shouldn't flip this around. Call it by default but return a distinct error type (ValidateLayoutConstraintsError) when it is violated that clients (like a potential low-level otk partitioner) could choose to ignore. Wdyt?