### PR TITLE
ostree: allow passing any ostree source secrets

### DIFF
--- a/pkg/osbuild/ostree_source.go
+++ b/pkg/osbuild/ostree_source.go
@@ -36,9 +36,9 @@ func NewOSTreeSourceItem(commit ostree.CommitSpec) *OSTreeSourceItem {
 	item := new(OSTreeSourceItem)
 	item.Remote.URL = commit.URL
 	item.Remote.ContentURL = commit.ContentURL
-	if commit.Secrets == "org.osbuild.rhsm.consumer" {
+	if commit.Secrets != "" {
 		item.Remote.Secrets = &OSTreeSourceRemoteSecrets{
-			Name: "org.osbuild.rhsm.consumer",
+			Name: commit.Secrets,
 		}
 	}
 	return item


### PR DESCRIPTION
Need this for the newly added `org.osbuild.mtls` secret that is required for Pulp MTLS feature.