### PR TITLE
LoadAllRepositoriesFromFS: log only filenames of loaded repositories

### DIFF
--- a/pkg/reporegistry/repository.go
+++ b/pkg/reporegistry/repository.go
@@ -75,7 +75,7 @@ func LoadAllRepositoriesFromFS(confPaths []fs.FS) (rpmmd.DistrosRepoConfigs, err
 					return nil, err
 				}
 
-				logrus.Infof("Loaded repository configuration file: %s", configFile)
+				logrus.Infof("Loaded repository configuration file: %s", fileEntry.Name())
 
 				distrosRepoConfigs[distro] = distroRepos
 			}


### PR DESCRIPTION
After the rework done by PR#1038 [1], the `configFile` changed from the file path string to `fs.File` instance. As a result, logging it makes the output verbose, as it logs the whole content of the loaded file (repo URLs, GPG keys, etc.). Revert to the old behavior by logging `fileEntry.Name()` for the loaded repository.

[1] https://github.com/osbuild/images/pull/1038