### PR TITLE
disk: cover all entities in PartitionTable.features()

### DIFF
--- a/pkg/disk/disk_test.go
+++ b/pkg/disk/disk_test.go
@@ -987,22 +987,23 @@ func TestForEachFSTabEntity(t *testing.T) {
 	}
 
 	for name := range testdisk.TestPartitionTables {
-		t.Run(name, func(t *testing.T) {
-
+		// use a different name for the internal testing argument so we can
+		// refer to the global test by t.Name() in the error message
+		t.Run(name, func(ts *testing.T) {
 			var targets []string
 			targetCollectorCB := func(ent disk.FSTabEntity, _ []disk.Entity) error {
 				targets = append(targets, ent.GetFSFile())
 				return nil
 			}
 
-			require := require.New(t)
+			require := require.New(ts)
 			pt := testdisk.TestPartitionTables[name]
 
 			// print an informative failure message if a new test partition
 			// table is added and this test is not updated (instead of failing
 			// at the final Equal() check)
 			exp, ok := expectedEntityPaths[name]
-			require.True(ok, "expected options not defined for test partition table %q: please update the TestNewFSTabStageOptions test", name)
+			require.True(ok, "expected test result not defined for test partition table %q: please update the %s test", name, t.Name())
 
 			err := pt.ForEachFSTabEntity(targetCollectorCB)
 			// the callback never returns an error, but let's check it anyway

--- a/pkg/osbuild/fstab_stage_test.go
+++ b/pkg/osbuild/fstab_stage_test.go
@@ -104,8 +104,10 @@ func TestNewFSTabStageOptions(t *testing.T) {
 	}
 	// Use the test partition tables from the disk package.
 	for name := range testdisk.TestPartitionTables {
-		t.Run(name, func(t *testing.T) {
-			require := require.New(t)
+		// use a different name for the internal testing argument so we can
+		// refer to the global test by t.Name() in the error message
+		t.Run(name, func(ts *testing.T) {
+			require := require.New(ts)
 			pt := testdisk.TestPartitionTables[name]
 
 			// math/rand is good enough in this case
@@ -118,7 +120,7 @@ func TestNewFSTabStageOptions(t *testing.T) {
 			// table is added and this test is not updated (instead of failing
 			// at the final Equal() check)
 			exp, ok := expectedOptions[name]
-			require.True(ok, "expected options not defined for test partition table %q: please update the TestNewFSTabStageOptions test", name)
+			require.True(ok, "expected test result not defined for test partition table %q: please update the %s test", name, t.Name())
 
 			options, err := NewFSTabStageOptions(&pt)
 			require.NoError(err)


### PR DESCRIPTION
Follow-up from #1072 (https://github.com/osbuild/images/pull/1072#discussion_r1861786532)

---

Add a case for every entity type in the PartitionTable.features() callback.  More importantly, panic if any entity type is not covered by a case.  This ensures that when a new entity type is added, we need to consider whether it needs to be represented as a feature, added to an existing one, or ignored.

Co-authored-by: Michael Vogt <michael.vogt@gmail.com>
