### PR TITLE
blueprint: fix cacerts name for TOML

### DIFF
--- a/cmd/otk/osbuild-resolve-ostree-commit/main_test.go
+++ b/cmd/otk/osbuild-resolve-ostree-commit/main_test.go
@@ -202,7 +202,13 @@ func TestMockResolve(t *testing.T) {
 {
   "tree": {
     "ref": "otk/ostree/test",
-    "url": "https://ostree.example.org/repo"
+    "url": "https://ostree.example.org/repo",
+    "mtls": {
+        "ca": "ca.crt",
+        "client_cert": "client.crt",
+        "client_key": "client.key"
+    },
+    "proxy": "proxy.example.com:8080"
   }
 }
 `

--- a/pkg/blueprint/ca_customizations.go
+++ b/pkg/blueprint/ca_customizations.go
@@ -1,5 +1,0 @@
-package blueprint
-
-type CACustomization struct {
-	PEMCerts []string `json:"pem_certs,omitempty" toml:"pem_certs,omitempty"`
-}

--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -33,7 +33,7 @@ type Customizations struct {
 	Installer          *InstallerCustomization        `json:"installer,omitempty" toml:"installer,omitempty"`
 	RPM                *RPMCustomization              `json:"rpm,omitempty" toml:"rpm,omitempty"`
 	RHSM               *RHSMCustomization             `json:"rhsm,omitempty" toml:"rhsm,omitempty"`
-	CACerts            *CACustomization               `json:"cacerts,omitempty" toml:"ca,omitempty"`
+	CACerts            *CACustomization               `json:"cacerts,omitempty" toml:"cacerts,omitempty"`
 }
 
 type IgnitionCustomization struct {
@@ -142,6 +142,10 @@ type OpenSCAPJSONTailoringCustomizations struct {
 type ContainerStorageCustomization struct {
 	// destination is always `containers-storage`, so we won't expose this
 	StoragePath *string `json:"destination-path,omitempty" toml:"destination-path,omitempty"`
+}
+
+type CACustomization struct {
+	PEMCerts []string `json:"pem_certs,omitempty" toml:"pem_certs,omitempty"`
 }
 
 type CustomizationError struct {
@@ -441,16 +445,14 @@ func (c *Customizations) GetRHSM() *RHSMCustomization {
 }
 
 func (c *Customizations) checkCACerts() error {
-	if c == nil {
+	if c == nil || c.CACerts == nil {
 		return nil
 	}
 
-	if c.CACerts != nil {
-		for _, bundle := range c.CACerts.PEMCerts {
-			_, err := cert.ParseCerts(bundle)
-			if err != nil {
-				return err
-			}
+	for _, bundle := range c.CACerts.PEMCerts {
+		_, err := cert.ParseCerts(bundle)
+		if err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
@avitova found some issues, I am going to address them.

To test the CA generation run this:

```
go run ./cmd/gen-manifests --arches x86_64 --distros fedora-41 --types qcow2 -config ./test/configs/all-customizations.json
```

It creates the following file in `test/data/manifests`:

```
...
         {
            "type": "org.osbuild.copy",
            "inputs": {
              "file-4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c": {
                "type": "org.osbuild.files",
                "origin": "org.osbuild.source",
                "references": [
                  {
                    "id": "sha256:4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c"
                  }
                ]
              }
            },
            "options": {
              "paths": [
                {
                  "from": "input://file-4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c/sha256:4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c",
                  "to": "tree:///etc/pki/ca-trust/source/anchors/27894af897dd2423607045716438a725f28a6d0b.pem",
                  "remove_destination": true
                }
              ]
            }
          },
          {
            "type": "org.osbuild.chown",
            "options": {
              "items": {
                "/etc/pki/ca-trust/source/anchors/27894af897dd2423607045716438a725f28a6d0b.pem": {
                  "user": "root",
                  "group": "root"
                }
              }
            }
          },
          {
            "type": "org.osbuild.pki.update-ca-trust"
          },
...
```

I think it works.