### PR TITLE
Add support for the new partitioning customizations to RHEL and CentOS

### DIFF
--- a/pkg/distro/fedora/distro_test.go
+++ b/pkg/distro/fedora/distro_test.go
@@ -1064,7 +1064,7 @@ func TestDistro_DiskCustomizationRunsValidateLayoutConstraints(t *testing.T) {
 					Size: imgType.Size(0),
 				}
 				_, _, err := imgType.Manifest(&bp, imgOpts, nil, 0)
-				assert.EqualError(t, err, "cannot use disk customization: multiple LVM volume groups are not yet supported")
+				assert.EqualError(t, err, "multiple LVM volume groups are not yet supported")
 			})
 		}
 	}

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -397,6 +397,9 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 	if err := blueprint.CheckDiskMountpointsPolicy(partitioning, policies.MountpointPolicies); err != nil {
 		return nil, err
 	}
+	if err := partitioning.ValidateLayoutConstraints(); err != nil {
+		return nil, err
+	}
 
 	if osc := customizations.GetOpenSCAP(); osc != nil {
 		supported := oscap.IsProfileAllowed(osc.ProfileID, oscapProfileAllowList)
@@ -469,14 +472,6 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 			(customizations.GetUsers() != nil || customizations.GetGroups() != nil) {
 			return nil, fmt.Errorf("iot-installer installer.kickstart.contents are not supported in combination with users or groups")
 		}
-	}
-
-	diskc, err := customizations.GetPartitioning()
-	if err != nil {
-		return nil, err
-	}
-	if err := diskc.ValidateLayoutConstraints(); err != nil {
-		return nil, fmt.Errorf("cannot use disk customization: %w", err)
 	}
 
 	return nil, nil

--- a/pkg/distro/rhel/distro_test.go
+++ b/pkg/distro/rhel/distro_test.go
@@ -29,7 +29,7 @@ func TestESP(t *testing.T) {
 
 	distro_test_common.TestESP(t, distros, func(i distro.ImageType) (*disk.PartitionTable, error) {
 		it := i.(*rhel.ImageType)
-		return it.GetPartitionTable([]blueprint.FilesystemCustomization{}, distro.ImageOptions{}, rng)
+		return it.GetPartitionTable(&blueprint.Customizations{}, distro.ImageOptions{}, rng)
 	})
 }
 

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -377,7 +377,7 @@ func DiskImage(workload workload.Workload,
 	img.Workload = workload
 	img.Compression = t.Compression
 	// TODO: move generation into LiveImage
-	pt, err := t.GetPartitionTable(customizations.GetFilesystems(), options, rng)
+	pt, err := t.GetPartitionTable(customizations, options, rng)
 	if err != nil {
 		return nil, err
 	}
@@ -567,7 +567,7 @@ func EdgeRawImage(workload workload.Workload,
 	img.OSName = "rhel-edge"
 
 	// TODO: move generation into LiveImage
-	pt, err := t.GetPartitionTable(customizations.GetFilesystems(), options, rng)
+	pt, err := t.GetPartitionTable(customizations, options, rng)
 	if err != nil {
 		return nil, err
 	}
@@ -609,7 +609,7 @@ func EdgeSimplifiedInstallerImage(workload workload.Workload,
 	rawImg.OSName = "rhel-edge"
 
 	// TODO: move generation into LiveImage
-	pt, err := t.GetPartitionTable(customizations.GetFilesystems(), options, rng)
+	pt, err := t.GetPartitionTable(customizations, options, rng)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distro/rhel/imagetype.go
+++ b/pkg/distro/rhel/imagetype.go
@@ -39,6 +39,12 @@ const (
 	BlueprintPkgsKey = "blueprint"
 )
 
+// Default directory size minimums for all image types.
+var requiredDirectorySizes = map[string]uint64{
+	"/":    1 * datasizes.GiB,
+	"/usr": 2 * datasizes.GiB,
+}
+
 type ImageFunc func(workload workload.Workload, t *ImageType, customizations *blueprint.Customizations, options distro.ImageOptions, packageSets map[string]rpmmd.PackageSet, containers []container.SourceSpec, rng *rand.Rand) (image.ImageKind, error)
 
 type PackageSetFunc func(t *ImageType) rpmmd.PackageSet
@@ -193,6 +199,27 @@ func (t *ImageType) GetPartitionTable(
 	}
 
 	imageSize := t.Size(options.Size)
+	partitioning, err := customizations.GetPartitioning()
+	if err != nil {
+		return nil, err
+	}
+	if partitioning != nil {
+		// Use the new custom partition table to create a PT fully based on the user's customizations.
+		// This overrides FilesystemCustomizations, but we should never have both defined.
+		if options.Size > 0 {
+			// user specified a size on the command line, so let's override the
+			// customization with the calculated/rounded imageSize
+			partitioning.MinSize = imageSize
+		}
+
+		partOptions := &disk.CustomPartitionTableOptions{
+			PartitionTableType: basePartitionTable.Type, // PT type is not customizable, it is determined by the base PT for an image type or architecture
+			BootMode:           t.BootMode(),
+			DefaultFSType:      disk.FS_XFS, // default fs type for RHEL
+			RequiredMinSizes:   requiredDirectorySizes,
+		}
+		return disk.NewCustomPartitionTable(partitioning, partOptions, rng)
+	}
 
 	return disk.NewPartitionTable(&basePartitionTable, customizations.GetFilesystems(), imageSize, options.PartitioningMode, nil, rng)
 }

--- a/pkg/distro/rhel/imagetype.go
+++ b/pkg/distro/rhel/imagetype.go
@@ -180,7 +180,7 @@ func (t *ImageType) BootMode() platform.BootMode {
 }
 
 func (t *ImageType) GetPartitionTable(
-	mountpoints []blueprint.FilesystemCustomization,
+	customizations *blueprint.Customizations,
 	options distro.ImageOptions,
 	rng *rand.Rand,
 ) (*disk.PartitionTable, error) {
@@ -194,7 +194,7 @@ func (t *ImageType) GetPartitionTable(
 
 	imageSize := t.Size(options.Size)
 
-	return disk.NewPartitionTable(&basePartitionTable, mountpoints, imageSize, options.PartitioningMode, nil, rng)
+	return disk.NewPartitionTable(&basePartitionTable, customizations.GetFilesystems(), imageSize, options.PartitioningMode, nil, rng)
 }
 
 func (t *ImageType) getDefaultImageConfig() *distro.ImageConfig {

--- a/pkg/distro/rhel/rhel10/distro_internal_test.go
+++ b/pkg/distro/rhel/rhel10/distro_internal_test.go
@@ -181,7 +181,7 @@ func TestRhel10_NoBootPartition(t *testing.T) {
 					// and we do not support /boot on LVM, so it must be on a separate partition.
 					continue
 				}
-				pt, err := it.GetPartitionTable([]blueprint.FilesystemCustomization{}, distro.ImageOptions{}, rng)
+				pt, err := it.GetPartitionTable(&blueprint.Customizations{}, distro.ImageOptions{}, rng)
 				assert.NoError(t, err)
 				_, err = pt.GetMountpointSize("/boot")
 				require.EqualError(t, err, "cannot find mountpoint /boot")

--- a/pkg/distro/rhel/rhel8/distro_internal_test.go
+++ b/pkg/distro/rhel/rhel8/distro_internal_test.go
@@ -59,7 +59,7 @@ func TestEC2Partitioning(t *testing.T) {
 					require.NoError(t, err)
 
 					it := i.(*rhel.ImageType)
-					pt, err := it.GetPartitionTable([]blueprint.FilesystemCustomization{}, distro.ImageOptions{}, rng)
+					pt, err := it.GetPartitionTable(&blueprint.Customizations{}, distro.ImageOptions{}, rng)
 					require.NoError(t, err)
 
 					// x86_64 is /boot-less, check that

--- a/pkg/distro/rhel/rhel9/distro_internal_test.go
+++ b/pkg/distro/rhel/rhel9/distro_internal_test.go
@@ -60,7 +60,7 @@ func TestEC2Partitioning(t *testing.T) {
 					require.NoError(t, err)
 
 					it := i.(*rhel.ImageType)
-					pt, err := it.GetPartitionTable([]blueprint.FilesystemCustomization{}, distro.ImageOptions{}, rng)
+					pt, err := it.GetPartitionTable(&blueprint.Customizations{}, distro.ImageOptions{}, rng)
 					require.NoError(t, err)
 
 					bootSize, err := pt.GetMountpointSize("/boot")

--- a/pkg/distro/rhel/rhel9/distro_test.go
+++ b/pkg/distro/rhel/rhel9/distro_test.go
@@ -671,7 +671,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
 			if imgTypeName == "edge-commit" || imgTypeName == "edge-container" {
-				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
+				assert.EqualError(t, err, "custom mountpoints and partitioning are not supported for ostree types")
 			} else if imgTypeName == "edge-installer" || imgTypeName == "edge-simplified-installer" || imgTypeName == "edge-raw-image" || imgTypeName == "edge-ami" || imgTypeName == "edge-vsphere" {
 				continue
 			} else {
@@ -699,7 +699,7 @@ func TestDistro_TestRootMountPoint(t *testing.T) {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
 			if imgTypeName == "edge-commit" || imgTypeName == "edge-container" {
-				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
+				assert.EqualError(t, err, "custom mountpoints and partitioning are not supported for ostree types")
 			} else if imgTypeName == "edge-installer" || imgTypeName == "edge-simplified-installer" || imgTypeName == "edge-raw-image" || imgTypeName == "edge-ami" || imgTypeName == "edge-vsphere" {
 				continue
 			} else {
@@ -829,12 +829,110 @@ func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
 			if imgTypeName == "edge-commit" || imgTypeName == "edge-container" {
-				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
+				assert.EqualError(t, err, "custom mountpoints and partitioning are not supported for ostree types")
 			} else if imgTypeName == "edge-installer" || imgTypeName == "edge-simplified-installer" || imgTypeName == "edge-raw-image" || imgTypeName == "edge-ami" || imgTypeName == "edge-vsphere" {
 				continue
 			} else {
 				assert.NoError(t, err)
 			}
+		}
+	}
+}
+
+func TestDiskAndFilesystemCustomizationsError(t *testing.T) {
+	// simple test that checks that disk customizations are allowed
+	r8distro := rhelFamilyDistros[0].distro
+	bp := blueprint.Blueprint{
+		Customizations: &blueprint.Customizations{
+			Filesystem: []blueprint.FilesystemCustomization{
+				{
+					MinSize:    1024,
+					Mountpoint: "/home",
+				},
+			},
+			Disk: &blueprint.DiskCustomization{
+				Partitions: []blueprint.PartitionCustomization{
+					{
+						Type: "plain",
+						FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+							Mountpoint: "/",
+							Label:      "root",
+							FSType:     "ext4",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// these produce error message and are tested elsewhere
+	skipTest := map[string]bool{
+		"edge-commit":               true,
+		"edge-container":            true,
+		"edge-installer":            true,
+		"edge-simplified-installer": true,
+		"azure-eap7-rhui":           true,
+		"edge-vsphere":              true,
+		"edge-raw-image":            true,
+		"edge-ami":                  true,
+	}
+
+	for _, archName := range r8distro.ListArches() {
+		arch, _ := r8distro.GetArch(archName)
+		for _, imgTypeName := range arch.ListImageTypes() {
+			imgType, _ := arch.GetImageType(imgTypeName)
+			options := distro.ImageOptions{}
+			_, _, err := imgType.Manifest(&bp, options, nil, 0)
+			if skipTest[imgTypeName] {
+				continue
+			}
+			assert.EqualError(t, err, "partitioning customizations cannot be used with custom filesystems (mountpoints)")
+		}
+	}
+}
+
+func TestNoDiskCustomizationsNoError(t *testing.T) {
+	// simple test that checks that disk customizations are allowed
+	r8distro := rhelFamilyDistros[0].distro
+	bp := blueprint.Blueprint{
+		Customizations: &blueprint.Customizations{
+			Disk: &blueprint.DiskCustomization{
+				Partitions: []blueprint.PartitionCustomization{
+					{
+						Type: "plain",
+						FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+							Mountpoint: "/",
+							Label:      "root",
+							FSType:     "ext4",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// these produce error message and are tested elsewhere
+	skipTest := map[string]bool{
+		"edge-commit":               true,
+		"edge-container":            true,
+		"edge-installer":            true,
+		"edge-simplified-installer": true,
+		"azure-eap7-rhui":           true,
+		"edge-vsphere":              true,
+		"edge-raw-image":            true,
+		"edge-ami":                  true,
+	}
+
+	for _, archName := range r8distro.ListArches() {
+		arch, _ := r8distro.GetArch(archName)
+		for _, imgTypeName := range arch.ListImageTypes() {
+			imgType, _ := arch.GetImageType(imgTypeName)
+			options := distro.ImageOptions{}
+			_, _, err := imgType.Manifest(&bp, options, nil, 0)
+			if skipTest[imgTypeName] {
+				continue
+			}
+			assert.NoError(t, err)
 		}
 	}
 }

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -338,7 +338,11 @@
       "ami"
     ],
     "distros": [
-      "fedora*"
+      "centos-10",
+      "centos-9",
+      "fedora*",
+      "rhel-10*",
+      "rhel-9*"
     ]
   },
   "./configs/partitioning-btrfs.json": {
@@ -354,7 +358,11 @@
       "ami"
     ],
     "distros": [
-      "fedora*"
+      "centos-10",
+      "centos-9",
+      "fedora*",
+      "rhel-10*",
+      "rhel-9*"
     ]
   }
 }


### PR DESCRIPTION
Enabling the new partitioning customizations for RHEL and CentOS.

I also found some duplication in Fedora that I cleaned up.