### PR TITLE
github: prevent script injections via PR branch names

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Checkout branch
         id: pr_data
+        env:
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           PR_DATA=$(mktemp)
           # use uuid as a file terminator to avoid conflicts with data content
@@ -58,7 +60,7 @@ jobs:
             echo "pr_branch=PR-$PR" >> "$GITHUB_OUTPUT"
             git checkout -b PR-$PR
           else
-            git checkout ${{ github.event.workflow_run.head_branch }}
+            git checkout "${BRANCH}"
           fi
 
       - name: Push to GitLab


### PR DESCRIPTION
Prior this commit, ${{ github.event.workflow_run.head_branch }} got expanded in the bash script. A malicious actor could inject an arbitrary shell script. Since this action has access to a token with write rights the malicious actor can easily steal this token.

This commit moves the expansion into an env block where such an injection cannot happen. This is the preferred way according to the github docs:
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable

Note that we don't allow external contributors to run CI without our manual approval, so this could not actually be abused.