### PR TITLE
Add support for selecting a partition table type

### DIFF
--- a/cmd/otk/osbuild-gen-partition-table/main_test.go
+++ b/cmd/otk/osbuild-gen-partition-table/main_test.go
@@ -343,7 +343,7 @@ func TestGenPartitionTableIntegrationPPC(t *testing.T) {
 				Name:     "ppc-boot",
 				Bootable: true,
 				Size:     "4 MiB",
-				PartType: "41",
+				PartType: disk.DosPRePID,
 				PartUUID: "",
 			},
 			{
@@ -373,7 +373,7 @@ func TestGenPartitionTableIntegrationPPC(t *testing.T) {
 							Bootable: true,
 							Start:    1048576,
 							Size:     4194304,
-							Type:     "41",
+							Type:     disk.DosPRePID,
 						},
 						{
 							Start: 5242880,

--- a/pkg/blueprint/disk_customizations.go
+++ b/pkg/blueprint/disk_customizations.go
@@ -349,7 +349,16 @@ func (p *DiskCustomization) Validate() error {
 	}
 
 	switch p.Type {
-	case "gpt", "dos", "":
+	case "gpt", "":
+	case "dos":
+		// dos/mbr only supports 4 partitions
+		// Unfortunately, at this stage it's unknown whether we will need extra
+		// partitions (bios boot, root, esp), so this check is just to catch
+		// obvious invalid customizations early. The final partition table is
+		// checked after it's created.
+		if len(p.Partitions) > 4 {
+			return fmt.Errorf("invalid partitioning customizations: \"dos\" partition table type only supports up to 4 partitions: got %d", len(p.Partitions))
+		}
 	default:
 		return fmt.Errorf("unknown partition table type: %s (valid: gpt, dos)", p.Type)
 	}

--- a/pkg/blueprint/disk_customizations_test.go
+++ b/pkg/blueprint/disk_customizations_test.go
@@ -904,6 +904,22 @@ func TestPartitioningValidation(t *testing.T) {
 			},
 			expectedMsg: "invalid partitioning customizations:\nmountpoint for swap logical volume with name \"swappylv\" in volume group \"badvg\" must be empty",
 		},
+		"gpt": {
+			partitioning: &blueprint.DiskCustomization{
+				Type: "gpt",
+			},
+		},
+		"dos": {
+			partitioning: &blueprint.DiskCustomization{
+				Type: "dos",
+			},
+		},
+		"unhappy-badtype": {
+			partitioning: &blueprint.DiskCustomization{
+				Type: "toucan",
+			},
+			expectedMsg: "unknown partition table type: toucan (valid: gpt, dos)",
+		},
 	}
 
 	for name := range testCases {
@@ -1735,6 +1751,15 @@ func TestDiskCustomizationUnmarshalJSON(t *testing.T) {
 			inputTOML: `minsize = "1 GiB"`,
 			expected: &blueprint.DiskCustomization{
 				MinSize: 1 * datasizes.GiB,
+			},
+		},
+		"type": {
+			inputJSON: `{
+				"type": "gpt"
+			}`,
+			inputTOML: `type = "gpt"`,
+			expected: &blueprint.DiskCustomization{
+				Type: "gpt",
 			},
 		},
 	}

--- a/pkg/blueprint/disk_customizations_test.go
+++ b/pkg/blueprint/disk_customizations_test.go
@@ -920,6 +920,56 @@ func TestPartitioningValidation(t *testing.T) {
 			},
 			expectedMsg: "unknown partition table type: toucan (valid: gpt, dos)",
 		},
+		"unhappy-too-many-parts": {
+			partitioning: &blueprint.DiskCustomization{
+				Type: "dos",
+				Partitions: []blueprint.PartitionCustomization{
+					{
+						Type: "plain",
+						FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+							FSType:     "xfs",
+							Mountpoint: "/1",
+						},
+					},
+					{
+						Type: "plain",
+						FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+							FSType:     "xfs",
+							Mountpoint: "/2",
+						},
+					},
+					{
+						Type: "plain",
+						FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+							FSType:     "xfs",
+							Mountpoint: "/3",
+						},
+					},
+					{
+						Type: "plain",
+						FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+							FSType:     "ext4",
+							Mountpoint: "/4",
+						},
+					},
+					{
+						Type: "plain",
+						FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+							FSType:     "ext4",
+							Mountpoint: "/5",
+						},
+					},
+					{
+						Type: "plain",
+						FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+							FSType:     "ext4",
+							Mountpoint: "/6",
+						},
+					},
+				},
+			},
+			expectedMsg: `invalid partitioning customizations: "dos" partition table type only supports up to 4 partitions: got 6`,
+		},
 	}
 
 	for name := range testCases {

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -67,11 +67,17 @@ const (
 	// Partition type ID for any native Linux filesystem on dos
 	DosLinuxTypeID = "83"
 
-	// Partition type ID for BIOS boot partition on dos
-	DosBIOSBootID = "ef02"
+	// Partition type ID for LVM on dos
+	DosLVMTypeID = "8e"
+
+	// Partition type ID for BIOS boot partition on dos.
+	// Type ID is for 'empty'.
+	// TODO: drop this completely when we convert the bios BOOT space to a
+	// partitionless gap/offset.
+	DosBIOSBootID = "00"
 
 	// Partition type ID for ESP on dos
-	DosESPID = "ef00"
+	DosESPID = "ef"
 
 	// Partition type ID for swap
 	DosSwapID = "82"
@@ -87,7 +93,7 @@ var idMap = map[PartitionTableType]map[string]string{
 		"boot": DosLinuxTypeID,
 		"data": DosLinuxTypeID,
 		"esp":  DosESPID,
-		"lvm":  DosLinuxTypeID,
+		"lvm":  DosLVMTypeID,
 		"swap": DosSwapID,
 	},
 	PT_GPT: {

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -75,6 +75,9 @@ const (
 
 	// Partition type ID for swap
 	DosSwapID = "82"
+
+	// Partition type ID for PRep on dos
+	DosPRePID = "41"
 )
 
 // pt type -> type -> ID mapping for convenience

--- a/pkg/disk/partition.go
+++ b/pkg/disk/partition.go
@@ -87,7 +87,7 @@ func (p *Partition) IsBIOSBoot() bool {
 		return false
 	}
 
-	return p.Type == BIOSBootPartitionGUID
+	return p.Type == BIOSBootPartitionGUID || p.Type == DosBIOSBootID
 }
 
 func (p *Partition) IsPReP() bool {

--- a/pkg/disk/partition.go
+++ b/pkg/disk/partition.go
@@ -95,7 +95,7 @@ func (p *Partition) IsPReP() bool {
 		return false
 	}
 
-	return p.Type == "41" || p.Type == PRePartitionGUID
+	return p.Type == DosPRePID || p.Type == PRePartitionGUID
 }
 
 func (p *Partition) MarshalJSON() ([]byte, error) {

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -1232,15 +1232,24 @@ func NewCustomPartitionTable(customizations *blueprint.DiskCustomization, option
 
 	pt := &PartitionTable{}
 
-	// TODO: Handle partition table type in customizations
-	switch options.PartitionTableType {
-	case PT_GPT, PT_DOS:
-		pt.Type = options.PartitionTableType
-	case PT_NONE:
-		// default to "gpt"
+	switch customizations.Type {
+	case "dos":
+		pt.Type = PT_DOS
+	case "gpt":
 		pt.Type = PT_GPT
+	case "":
+		// partition table type not specified, determine the default
+		switch options.PartitionTableType {
+		case PT_GPT, PT_DOS:
+			pt.Type = options.PartitionTableType
+		case PT_NONE:
+			// default to "gpt"
+			pt.Type = PT_GPT
+		default:
+			return nil, fmt.Errorf("%s invalid partition table type enum value: %d", errPrefix, options.PartitionTableType)
+		}
 	default:
-		return nil, fmt.Errorf("%s invalid partition table type enum value: %d", errPrefix, options.PartitionTableType)
+		return nil, fmt.Errorf("%s invalid partition table type: %s", errPrefix, customizations.Type)
 	}
 
 	// add any partition(s) that are needed for booting (like /boot/efi)

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -1292,6 +1292,16 @@ func NewCustomPartitionTable(customizations *blueprint.DiskCustomization, option
 	pt.relayout(customizations.MinSize)
 	pt.GenerateUUIDs(rng)
 
+	// One thing not caught by the customization validation is if a final "dos"
+	// partition table has more than 4 partitions. This is not possible to
+	// predict with customizations alone because it depends on the boot type
+	// (which comes from the image type) which controls automatic partition
+	// creation. We should therefore always check the final partition table for
+	// this rule.
+	if pt.Type == PT_DOS && len(pt.Partitions) > 4 {
+		return nil, fmt.Errorf("%s invalid partition table: \"dos\" partition table type only supports up to 4 partitions: got %d after creating the partition table with all necessary partitions", errPrefix, len(pt.Partitions))
+	}
+
 	return pt, nil
 }
 

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -1131,11 +1131,13 @@ func TestNewCustomPartitionTable(t *testing.T) {
 
 	testCases := map[string]testCase{
 		"dos-hybrid": {
-			customizations: nil,
+			customizations: &blueprint.DiskCustomization{
+				Type: "dos", // overrides the default option
+			},
 			options: &disk.CustomPartitionTableOptions{
 				DefaultFSType:      disk.FS_XFS,
 				BootMode:           platform.BOOT_HYBRID,
-				PartitionTableType: disk.PT_DOS,
+				PartitionTableType: disk.PT_GPT,
 			},
 			expected: &disk.PartitionTable{
 				Type: disk.PT_DOS,
@@ -1580,6 +1582,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 		},
 		"plain+": {
 			customizations: &blueprint.DiskCustomization{
+				Type: "gpt", // overrides the default option
 				Partitions: []blueprint.PartitionCustomization{
 					{
 						MinSize: 50 * datasizes.MiB,
@@ -1609,7 +1612,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 			options: &disk.CustomPartitionTableOptions{
 				DefaultFSType:      disk.FS_EXT4,
 				BootMode:           platform.BOOT_HYBRID,
-				PartitionTableType: disk.PT_GPT,
+				PartitionTableType: disk.PT_DOS,
 				RequiredMinSizes:   map[string]uint64{"/": 3 * datasizes.GiB},
 			},
 			expected: &disk.PartitionTable{
@@ -2266,6 +2269,12 @@ func TestNewCustomPartitionTableErrors(t *testing.T) {
 				PartitionTableType: 100,
 			},
 			errmsg: `error generating partition table: invalid partition table type enum value: 100`,
+		},
+		"bad-pt-type-in-customizations": {
+			customizations: &blueprint.DiskCustomization{
+				Type: "toucan",
+			},
+			errmsg: `error generating partition table: unknown partition table type: toucan (valid: gpt, dos)`,
 		},
 	}
 

--- a/pkg/disk/partition_test.go
+++ b/pkg/disk/partition_test.go
@@ -105,3 +105,44 @@ func TestImplementsInterfacesCompileTimeCheckPartition(t *testing.T) {
 	var _ = disk.Container(&disk.Partition{})
 	var _ = disk.Sizeable(&disk.Partition{})
 }
+func TestIsBIOSBoot(t *testing.T) {
+	tests := []struct {
+		name      string
+		partition *disk.Partition
+		expected  bool
+	}{
+		{
+			name:      "nil",
+			partition: nil,
+			expected:  false,
+		},
+		{
+			name: "gpt-bios-boot",
+			partition: &disk.Partition{
+				Type: disk.BIOSBootPartitionGUID,
+			},
+			expected: true,
+		},
+		{
+			name: "dos-bios-boot",
+			partition: &disk.Partition{
+				Type: disk.DosBIOSBootID,
+			},
+			expected: true,
+		},
+		{
+			name: "non-bios-boot",
+			partition: &disk.Partition{
+				Type: disk.EFISystemPartitionGUID,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.partition.IsBIOSBoot()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -112,7 +112,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Partitions: []disk.Partition{
 			{
 				Size:     4 * datasizes.MebiByte,
-				Type:     "41",
+				Type:     disk.DosPRePID,
 				Bootable: true,
 			},
 			{

--- a/pkg/distro/rhel/rhel10/partition_tables.go
+++ b/pkg/distro/rhel/rhel10/partition_tables.go
@@ -90,7 +90,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Partitions: []disk.Partition{
 				{
 					Size:     4 * datasizes.MebiByte,
-					Type:     "41",
+					Type:     disk.DosPRePID,
 					Bootable: true,
 				},
 				{

--- a/pkg/distro/rhel/rhel8/partition_tables.go
+++ b/pkg/distro/rhel/rhel8/partition_tables.go
@@ -91,7 +91,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Partitions: []disk.Partition{
 				{
 					Size:     4 * datasizes.MebiByte,
-					Type:     "41",
+					Type:     disk.DosPRePID,
 					Bootable: true,
 				},
 				{

--- a/pkg/distro/rhel/rhel9/partition_tables.go
+++ b/pkg/distro/rhel/rhel9/partition_tables.go
@@ -173,7 +173,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Partitions: []disk.Partition{
 				{
 					Size:     4 * datasizes.MebiByte,
-					Type:     "41",
+					Type:     disk.DosPRePID,
 					Bootable: true,
 				},
 				{

--- a/pkg/osbuild/sfdisk_stage.go
+++ b/pkg/osbuild/sfdisk_stage.go
@@ -1,5 +1,11 @@
 package osbuild
 
+import (
+	"fmt"
+
+	"github.com/osbuild/images/pkg/disk"
+)
+
 // Partition a target using sfdisk(8)
 
 type SfdiskStageOptions struct {
@@ -36,7 +42,18 @@ type SfdiskPartition struct {
 	UUID string `json:"uuid,omitempty"`
 }
 
+func (o SfdiskStageOptions) validate() error {
+	if o.Label == disk.PT_DOS.String() && len(o.Partitions) > 4 {
+		return fmt.Errorf("sfdisk stage creation failed: \"dos\" partition table only supports up to 4 partitions: got %d", len(o.Partitions))
+	}
+	return nil
+}
+
 func NewSfdiskStage(options *SfdiskStageOptions, device *Device) *Stage {
+	if err := options.validate(); err != nil {
+		panic(err)
+	}
+
 	return &Stage{
 		Type:    "org.osbuild.sfdisk",
 		Options: options,

--- a/pkg/osbuild/sfdisk_stage_test.go
+++ b/pkg/osbuild/sfdisk_stage_test.go
@@ -41,3 +41,22 @@ func TestNewSfdiskStage(t *testing.T) {
 	actualStageDOS := NewSfdiskStage(&options, device)
 	assert.Equal(t, expectedStage, actualStageDOS)
 }
+
+func TestNewSfdiskStageInvalid(t *testing.T) {
+
+	partition := SfdiskPartition{
+		// doesn't really matter
+	}
+
+	options := SfdiskStageOptions{
+		Label:      "dos",
+		UUID:       "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Partitions: []SfdiskPartition{partition, partition, partition, partition, partition}, // 5 partitions
+	}
+
+	device := NewLoopbackDevice(&LoopbackDeviceOptions{Filename: "disk.raw"})
+
+	assert.Panics(t, func() {
+		NewSfdiskStage(&options, device)
+	})
+}

--- a/pkg/osbuild/sfdisk_stage_test.go
+++ b/pkg/osbuild/sfdisk_stage_test.go
@@ -18,7 +18,6 @@ func TestNewSfdiskStage(t *testing.T) {
 	}
 
 	options := SfdiskStageOptions{
-		Label:      "gpt",
 		UUID:       "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Partitions: []SfdiskPartition{partition},
 	}
@@ -32,6 +31,13 @@ func TestNewSfdiskStage(t *testing.T) {
 		Devices: devices,
 	}
 
-	actualStage := NewSfdiskStage(&options, device)
-	assert.Equal(t, expectedStage, actualStage)
+	// test with gpt
+	options.Label = "gpt"
+	actualStageGPT := NewSfdiskStage(&options, device)
+	assert.Equal(t, expectedStage, actualStageGPT)
+
+	// test again with dos
+	options.Label = "dos"
+	actualStageDOS := NewSfdiskStage(&options, device)
+	assert.Equal(t, expectedStage, actualStageDOS)
 }

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -364,5 +364,14 @@
       "rhel-10*",
       "rhel-9*"
     ]
+  },
+  "./configs/partitioning-dos-lvm.json": {
+    "image-types": [
+      "ami"
+    ],
+    "distros": [
+      "centos-10",
+      "centos-9"
+    ]
   }
 }

--- a/test/configs/partitioning-dos-lvm.json
+++ b/test/configs/partitioning-dos-lvm.json
@@ -1,16 +1,10 @@
 {
-  "name": "partitioning-lvm",
+  "name": "partitioning-dos-lvm",
   "blueprint": {
     "customizations": {
       "disk": {
-        "type": "gpt",
+        "type": "dos",
         "partitions": [
-          {
-            "mountpoint": "/data",
-            "minsize": "1 GiB",
-            "label": "data",
-            "fs_type": "ext4"
-          },
           {
             "type": "lvm",
             "name": "testvg",


### PR DESCRIPTION
Users need to have control over the partition table type in certain cases. Most prominently, they need a dos-style partition table for single-board computers.
    
Let's add a simple customizations for it.