### PR TITLE
disk: support automatic name generation for swap devices

### DIFF
--- a/pkg/disk/lvm.go
+++ b/pkg/disk/lvm.go
@@ -110,12 +110,15 @@ func (vg *LVMVolumeGroup) CreateLogicalVolume(lvName string, size uint64, payloa
 
 	if lvName == "" {
 		// generate a name based on the payload's mountpoint
-		mntble, ok := payload.(Mountable)
-		if !ok {
-			return nil, fmt.Errorf("could not create logical volume: no name provided and payload is not mountable")
+		switch ent := payload.(type) {
+		case Mountable:
+			lvName = ent.GetMountpoint()
+		case *Swap:
+			lvName = "swap"
+		default:
+			return nil, fmt.Errorf("could not create logical volume: no name provided and payload %T is not mountable or swap", payload)
 		}
-		mountpoint := mntble.GetMountpoint()
-		autoName, err := vg.genLVName(mountpoint)
+		autoName, err := vg.genLVName(lvName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/disk/lvm_test.go
+++ b/pkg/disk/lvm_test.go
@@ -39,6 +39,29 @@ func TestLVMVCreateMountpoint(t *testing.T) {
 	assert.Error(err)
 }
 
+func TestLVMVCreateLogicalVolumeSwap(t *testing.T) {
+	vg := &LVMVolumeGroup{
+		Name:        "root",
+		Description: "root volume group",
+	}
+	swap := &Swap{}
+	lv, err := vg.CreateLogicalVolume("", 12345, swap)
+	assert.NoError(t, err)
+	assert.Equal(t, "swaplv", lv.Name)
+	// one more
+	lv2, err := vg.CreateLogicalVolume("", 12345, swap)
+	assert.NoError(t, err)
+	assert.Equal(t, "swaplv00", lv2.Name)
+}
+
+func TestLVMVCreateLogicalVolumeWrongType(t *testing.T) {
+	vg := &LVMVolumeGroup{
+		Name: "root",
+	}
+	_, err := vg.CreateLogicalVolume("", 12345, &LUKSContainer{})
+	assert.EqualError(t, err, `could not create logical volume: no name provided and payload *disk.LUKSContainer is not mountable or swap`)
+}
+
 func TestImplementsInterfacesCompileTimeCheckLVM(t *testing.T) {
 	var _ = Container(&LVMVolumeGroup{})
 	var _ = Sizeable(&LVMLogicalVolume{})


### PR DESCRIPTION
This commit adds support for automatic geneation of names for an lv swap devices. This saves the users of advanced blueprints some typing.