### PR TITLE
disk: align logical volumes up in EnsureSize()

### DIFF
--- a/pkg/disk/lvm.go
+++ b/pkg/disk/lvm.go
@@ -136,13 +136,16 @@ func (vg *LVMVolumeGroup) CreateLogicalVolume(lvName string, size uint64, payloa
 	return &vg.LogicalVolumes[len(vg.LogicalVolumes)-1], nil
 }
 
-func (vg *LVMVolumeGroup) AlignUp(size uint64) uint64 {
-
+func alignUp(size uint64) uint64 {
 	if size%LVMDefaultExtentSize != 0 {
 		size += LVMDefaultExtentSize - size%LVMDefaultExtentSize
 	}
 
 	return size
+}
+
+func (vg *LVMVolumeGroup) AlignUp(size uint64) uint64 {
+	return alignUp(size)
 }
 
 func (vg *LVMVolumeGroup) MetadataSize() uint64 {
@@ -214,7 +217,7 @@ func (lv *LVMLogicalVolume) EnsureSize(s uint64) bool {
 		panic("LVMLogicalVolume.EnsureSize: nil entity")
 	}
 	if s > lv.Size {
-		lv.Size = s
+		lv.Size = alignUp(s)
 		return true
 	}
 	return false

--- a/pkg/disk/lvm_test.go
+++ b/pkg/disk/lvm_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/datasizes"
 )
 
 func TestLVMVCreateMountpoint(t *testing.T) {
@@ -65,4 +67,13 @@ func TestLVMVCreateLogicalVolumeWrongType(t *testing.T) {
 func TestImplementsInterfacesCompileTimeCheckLVM(t *testing.T) {
 	var _ = Container(&LVMVolumeGroup{})
 	var _ = Sizeable(&LVMLogicalVolume{})
+}
+
+func TestLVMLogicalVolumeEnsureSize(t *testing.T) {
+	lv := &LVMLogicalVolume{
+		Size: 1024 * 1024,
+	}
+	resized := lv.EnsureSize(1024*1024 + 17)
+	assert.True(t, resized)
+	assert.Equal(t, uint64(4*datasizes.MiB), lv.Size)
 }


### PR DESCRIPTION
When creating an LV they need to be aligned up boundaries or lvcreate will fail. When a lv is create via CreateLogicalVolume() this hapens because the size is calculcated with `v.AlignUp()` but when a resize is required via `lv.EnsureSize()` this is not taken into account.

This fixes the failure in bib PR#750