### PR TITLE
blueprint: clarify filesystem type customization name

### DIFF
--- a/pkg/blueprint/disk_customizations.go
+++ b/pkg/blueprint/disk_customizations.go
@@ -470,7 +470,7 @@ func (p *PartitionCustomization) validatePlain(mountpoints map[string]bool) erro
 	}
 	// TODO: allow empty fstype with default from distro
 	if !slices.Contains(validPlainFSTypes, p.FSType) {
-		return fmt.Errorf("unknown or invalid filesystem type for mountpoint %q: %s", p.Mountpoint, p.FSType)
+		return fmt.Errorf("unknown or invalid filesystem type (fs_type) for mountpoint %q: %s", p.Mountpoint, p.FSType)
 	}
 	if err := validateFilesystemType(p.Mountpoint, p.FSType); err != nil {
 		return err
@@ -523,7 +523,7 @@ func (p *PartitionCustomization) validateLVM(mountpoints, vgnames map[string]boo
 
 		// TODO: allow empty fstype with default from distro
 		if !slices.Contains(validPlainFSTypes, lv.FSType) {
-			return fmt.Errorf("unknown or invalid filesystem type for logical volume with mountpoint %q: %s", lv.Mountpoint, lv.FSType)
+			return fmt.Errorf("unknown or invalid filesystem type (fs_type) for logical volume with mountpoint %q: %s", lv.Mountpoint, lv.FSType)
 		}
 	}
 	return nil

--- a/pkg/blueprint/disk_customizations_test.go
+++ b/pkg/blueprint/disk_customizations_test.go
@@ -212,7 +212,7 @@ func TestPartitioningValidation(t *testing.T) {
 					},
 				},
 			},
-			expectedMsg: "invalid partitioning customizations:\nunknown or invalid filesystem type for mountpoint \"/home\": ntfs",
+			expectedMsg: "invalid partitioning customizations:\nunknown or invalid filesystem type (fs_type) for mountpoint \"/home\": ntfs",
 		},
 		"unhappy-plain-badfstype-boot": {
 			partitioning: &blueprint.DiskCustomization{
@@ -243,7 +243,7 @@ func TestPartitioningValidation(t *testing.T) {
 					},
 				},
 			},
-			expectedMsg: "invalid partitioning customizations:\nunknown or invalid filesystem type for mountpoint \"/boot\": zfs",
+			expectedMsg: "invalid partitioning customizations:\nunknown or invalid filesystem type (fs_type) for mountpoint \"/boot\": zfs",
 		},
 		"unhappy-plain-badfstype-efi": {
 			partitioning: &blueprint.DiskCustomization{
@@ -823,7 +823,7 @@ func TestPartitioningValidation(t *testing.T) {
 					},
 				},
 			},
-			expectedMsg: "invalid partitioning customizations:\nunknown or invalid filesystem type for logical volume with mountpoint \"/var/log\": btrfs",
+			expectedMsg: "invalid partitioning customizations:\nunknown or invalid filesystem type (fs_type) for logical volume with mountpoint \"/var/log\": btrfs",
 		},
 		"unhappy-lv-notype": {
 			partitioning: &blueprint.DiskCustomization{
@@ -842,7 +842,7 @@ func TestPartitioningValidation(t *testing.T) {
 					},
 				},
 			},
-			expectedMsg: "invalid partitioning customizations:\nunknown or invalid filesystem type for logical volume with mountpoint \"/var/log\": ",
+			expectedMsg: "invalid partitioning customizations:\nunknown or invalid filesystem type (fs_type) for logical volume with mountpoint \"/var/log\": ",
 		},
 		"unhappy-bad-part-type": {
 			partitioning: &blueprint.DiskCustomization{

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -2235,7 +2235,7 @@ func TestNewCustomPartitionTableErrors(t *testing.T) {
 			options: nil,
 			// NOTE: this error message will change when we allow empty fs_type
 			// in customizations but with a requirement to define a default
-			errmsg: "error generating partition table: invalid partitioning customizations:\nunknown or invalid filesystem type for mountpoint \"/\": ",
+			errmsg: "error generating partition table: invalid partitioning customizations:\nunknown or invalid filesystem type (fs_type) for mountpoint \"/\": ",
 		},
 		"lvm-notype-nodefault": {
 			customizations: &blueprint.DiskCustomization{
@@ -2259,7 +2259,7 @@ func TestNewCustomPartitionTableErrors(t *testing.T) {
 			options: nil,
 			// NOTE: this error message will change when we allow empty fs_type
 			// in customizations but with a requirement to define a default
-			errmsg: "error generating partition table: invalid partitioning customizations:\nunknown or invalid filesystem type for logical volume with mountpoint \"/\": ",
+			errmsg: "error generating partition table: invalid partitioning customizations:\nunknown or invalid filesystem type (fs_type) for logical volume with mountpoint \"/\": ",
 		},
 		"bad-pt-type": {
 			options: &disk.CustomPartitionTableOptions{


### PR DESCRIPTION
When the fs_type field value is invalid, we refer to it as the 'filesystem type'.  Add a parenthetical mention to 'fs_type' as well to make it clear which option the error refers to.