### PR TITLE
disk: rename all DOS type ID consts to match GUIDs

### DIFF
--- a/cmd/otk/osbuild-gen-partition-table/main.go
+++ b/cmd/otk/osbuild-gen-partition-table/main.go
@@ -175,7 +175,7 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 				part.UUID = disk.EFISystemPartitionUUID
 			case otkdisk.PartTypeDOS:
 				part.Bootable = true
-				part.Type = disk.DosFat16B
+				part.Type = disk.FAT16BDOSID
 			default:
 				return nil, fmt.Errorf("unsupported partition type: %v", input)
 			}

--- a/cmd/otk/osbuild-gen-partition-table/main_test.go
+++ b/cmd/otk/osbuild-gen-partition-table/main_test.go
@@ -343,7 +343,7 @@ func TestGenPartitionTableIntegrationPPC(t *testing.T) {
 				Name:     "ppc-boot",
 				Bootable: true,
 				Size:     "4 MiB",
-				PartType: disk.DosPRePID,
+				PartType: disk.PRepPartitionDOSID,
 				PartUUID: "",
 			},
 			{
@@ -373,7 +373,7 @@ func TestGenPartitionTableIntegrationPPC(t *testing.T) {
 							Bootable: true,
 							Start:    1048576,
 							Size:     4194304,
-							Type:     disk.DosPRePID,
+							Type:     disk.PRepPartitionDOSID,
 						},
 						{
 							Start: 5242880,
@@ -497,7 +497,7 @@ func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
 						{
 							Start: 2148532224,
 							Size:  13744734208,
-							Type:  disk.DosLVMTypeID,
+							Type:  disk.LVMPartitionDOSID,
 							Payload: &disk.LVMVolumeGroup{
 								Name:        "rootvg",
 								Description: "created via lvm2 and osbuild",

--- a/cmd/otk/osbuild-gen-partition-table/main_test.go
+++ b/cmd/otk/osbuild-gen-partition-table/main_test.go
@@ -497,7 +497,7 @@ func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
 						{
 							Start: 2148532224,
 							Size:  13744734208,
-							Type:  "8e",
+							Type:  disk.DosLVMTypeID,
 							Payload: &disk.LVMVolumeGroup{
 								Name:        "rootvg",
 								Description: "created via lvm2 and osbuild",

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -40,7 +40,7 @@ const (
 	// rounded to the next MiB.
 	DefaultGrainBytes = uint64(1048576) // 1 MiB
 
-	// UUIDs
+	// UUIDs for GPT disks
 	BIOSBootPartitionGUID = "21686148-6449-6E6F-744E-656564454649"
 	BIOSBootPartitionUUID = "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
 
@@ -61,40 +61,42 @@ const (
 	// Extended Boot Loader Partition
 	XBootLDRPartitionGUID = "BC13C2FF-59E6-4262-A352-B275FD6F7172"
 
-	// DosFat16B used for the ESP-System partition
-	DosFat16B = "06"
-
-	// Partition type ID for any native Linux filesystem on dos
-	DosLinuxTypeID = "83"
-
-	// Partition type ID for LVM on dos
-	DosLVMTypeID = "8e"
+	// Partition type IDs for DOS disks
 
 	// Partition type ID for BIOS boot partition on dos.
 	// Type ID is for 'empty'.
 	// TODO: drop this completely when we convert the bios BOOT space to a
 	// partitionless gap/offset.
-	DosBIOSBootID = "00"
+	BIOSBootPartitionDOSID = "00"
+
+	// Partition type ID for any native Linux filesystem on dos
+	FilesystemLinuxDOSID = "83"
+
+	// FAT16BDOSID used for the ESP-System partition
+	FAT16BDOSID = "06"
+
+	// Partition type ID for LVM on dos
+	LVMPartitionDOSID = "8e"
 
 	// Partition type ID for ESP on dos
-	DosESPID = "ef"
+	EFISystemPartitionDOSID = "ef"
 
 	// Partition type ID for swap
-	DosSwapID = "82"
+	SwapPartitionDOSID = "82"
 
 	// Partition type ID for PRep on dos
-	DosPRePID = "41"
+	PRepPartitionDOSID = "41"
 )
 
 // pt type -> type -> ID mapping for convenience
 var idMap = map[PartitionTableType]map[string]string{
 	PT_DOS: {
-		"bios": DosBIOSBootID,
-		"boot": DosLinuxTypeID,
-		"data": DosLinuxTypeID,
-		"esp":  DosESPID,
-		"lvm":  DosLVMTypeID,
-		"swap": DosSwapID,
+		"bios": BIOSBootPartitionDOSID,
+		"boot": FilesystemLinuxDOSID,
+		"data": FilesystemLinuxDOSID,
+		"esp":  EFISystemPartitionDOSID,
+		"lvm":  LVMPartitionDOSID,
+		"swap": SwapPartitionDOSID,
 	},
 	PT_GPT: {
 		"bios": BIOSBootPartitionGUID,

--- a/pkg/disk/partition.go
+++ b/pkg/disk/partition.go
@@ -87,7 +87,7 @@ func (p *Partition) IsBIOSBoot() bool {
 		return false
 	}
 
-	return p.Type == BIOSBootPartitionGUID || p.Type == DosBIOSBootID
+	return p.Type == BIOSBootPartitionGUID || p.Type == BIOSBootPartitionDOSID
 }
 
 func (p *Partition) IsPReP() bool {
@@ -95,7 +95,7 @@ func (p *Partition) IsPReP() bool {
 		return false
 	}
 
-	return p.Type == DosPRePID || p.Type == PRePartitionGUID
+	return p.Type == PRepPartitionDOSID || p.Type == PRePartitionGUID
 }
 
 func (p *Partition) MarshalJSON() ([]byte, error) {

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -755,7 +755,7 @@ func (pt *PartitionTable) ensureLVM() error {
 		if pt.Type == PT_GPT {
 			part.Type = LVMPartitionGUID
 		} else {
-			part.Type = DosLVMTypeID
+			part.Type = LVMPartitionDOSID
 		}
 
 	} else {

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -755,7 +755,7 @@ func (pt *PartitionTable) ensureLVM() error {
 		if pt.Type == PT_GPT {
 			part.Type = LVMPartitionGUID
 		} else {
-			part.Type = "8e"
+			part.Type = DosLVMTypeID
 		}
 
 	} else {

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -148,7 +148,7 @@ func TestEnsureRootFilesystem(t *testing.T) {
 					{
 						Start:    0,
 						Size:     0,
-						Type:     disk.DosLinuxTypeID,
+						Type:     disk.FilesystemLinuxDOSID,
 						Bootable: false,
 						UUID:     "",
 						Payload: &disk.Filesystem{
@@ -232,7 +232,7 @@ func TestEnsureRootFilesystem(t *testing.T) {
 					{
 						Start:    0,
 						Size:     0,
-						Type:     disk.DosLinuxTypeID,
+						Type:     disk.FilesystemLinuxDOSID,
 						Bootable: false,
 						UUID:     "",
 						Payload: &disk.Filesystem{
@@ -764,7 +764,7 @@ func TestAddBootPartition(t *testing.T) {
 					{
 						Start:    0,
 						Size:     512 * datasizes.MiB,
-						Type:     disk.DosLinuxTypeID,
+						Type:     disk.FilesystemLinuxDOSID,
 						Bootable: false,
 						UUID:     "",
 						Payload: &disk.Filesystem{
@@ -848,7 +848,7 @@ func TestAddBootPartition(t *testing.T) {
 					{
 						Start:    0,
 						Size:     512 * datasizes.MiB,
-						Type:     disk.DosLinuxTypeID,
+						Type:     disk.FilesystemLinuxDOSID,
 						Bootable: false,
 						UUID:     "",
 						Payload: &disk.Filesystem{
@@ -972,7 +972,7 @@ func TestAddPartitionsForBootMode(t *testing.T) {
 						Bootable: true,
 						Start:    0,
 						Size:     1 * datasizes.MiB,
-						Type:     disk.DosBIOSBootID,
+						Type:     disk.BIOSBootPartitionDOSID,
 						UUID:     disk.BIOSBootPartitionUUID,
 					},
 				},
@@ -1011,7 +1011,7 @@ func TestAddPartitionsForBootMode(t *testing.T) {
 					{
 						Start: 0 * datasizes.MiB,
 						Size:  200 * datasizes.MiB,
-						Type:  disk.DosESPID,
+						Type:  disk.EFISystemPartitionDOSID,
 						UUID:  disk.EFISystemPartitionUUID,
 						Payload: &disk.Filesystem{
 							Type:         "vfat",
@@ -1064,12 +1064,12 @@ func TestAddPartitionsForBootMode(t *testing.T) {
 					{
 						Size:     1 * datasizes.MiB,
 						Bootable: true,
-						Type:     disk.DosBIOSBootID,
+						Type:     disk.BIOSBootPartitionDOSID,
 						UUID:     disk.BIOSBootPartitionUUID,
 					},
 					{
 						Size: 200 * datasizes.MiB,
-						Type: disk.DosESPID,
+						Type: disk.EFISystemPartitionDOSID,
 						UUID: disk.EFISystemPartitionUUID,
 						Payload: &disk.Filesystem{
 							Type:         "vfat",
@@ -1148,13 +1148,13 @@ func TestNewCustomPartitionTable(t *testing.T) {
 						Start:    1 * datasizes.MiB, // header
 						Bootable: true,
 						Size:     1 * datasizes.MiB,
-						Type:     disk.DosBIOSBootID,
+						Type:     disk.BIOSBootPartitionDOSID,
 						UUID:     disk.BIOSBootPartitionUUID,
 					},
 					{
 						Start: 2 * datasizes.MiB,
 						Size:  200 * datasizes.MiB,
-						Type:  disk.DosESPID,
+						Type:  disk.EFISystemPartitionDOSID,
 						UUID:  disk.EFISystemPartitionUUID,
 						Payload: &disk.Filesystem{
 							Type:         "vfat",
@@ -1169,7 +1169,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 					{
 						Start:    202 * datasizes.MiB,
 						Size:     0,
-						Type:     disk.DosLinuxTypeID,
+						Type:     disk.FilesystemLinuxDOSID,
 						Bootable: false,
 						Payload: &disk.Filesystem{
 							Type:         "xfs",
@@ -1209,13 +1209,13 @@ func TestNewCustomPartitionTable(t *testing.T) {
 						Start:    1 * datasizes.MiB, // header
 						Size:     1 * datasizes.MiB,
 						Bootable: true,
-						Type:     disk.DosBIOSBootID,
+						Type:     disk.BIOSBootPartitionDOSID,
 						UUID:     disk.BIOSBootPartitionUUID,
 					},
 					{
 						Start: 2 * datasizes.MiB,
 						Size:  200 * datasizes.MiB,
-						Type:  disk.DosESPID,
+						Type:  disk.EFISystemPartitionDOSID,
 						UUID:  disk.EFISystemPartitionUUID,
 						Payload: &disk.Filesystem{
 							Type:         "vfat",
@@ -1230,7 +1230,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 					{
 						Start:    202 * datasizes.MiB,
 						Size:     20 * datasizes.MiB,
-						Type:     disk.DosLinuxTypeID,
+						Type:     disk.FilesystemLinuxDOSID,
 						Bootable: false,
 						UUID:     "", // partitions on dos PTs don't have UUIDs
 						Payload: &disk.Filesystem{
@@ -1246,7 +1246,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 					{
 						Start:    222 * datasizes.MiB,
 						Size:     0,
-						Type:     disk.DosLinuxTypeID,
+						Type:     disk.FilesystemLinuxDOSID,
 						UUID:     "", // partitions on dos PTs don't have UUIDs
 						Bootable: false,
 						Payload: &disk.Filesystem{
@@ -1468,13 +1468,13 @@ func TestNewCustomPartitionTable(t *testing.T) {
 						Start:    1 * datasizes.MiB, // header
 						Size:     1 * datasizes.MiB,
 						Bootable: true,
-						Type:     disk.DosBIOSBootID,
+						Type:     disk.BIOSBootPartitionDOSID,
 						UUID:     disk.BIOSBootPartitionUUID,
 					},
 					{
 						Start:    2 * datasizes.MiB,
 						Size:     20 * datasizes.MiB,
-						Type:     disk.DosLinuxTypeID,
+						Type:     disk.FilesystemLinuxDOSID,
 						Bootable: false,
 						UUID:     "", // partitions on dos PTs don't have UUIDs
 						Payload: &disk.Filesystem{
@@ -1490,7 +1490,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 					{
 						Start:    22 * datasizes.MiB,
 						Size:     0,
-						Type:     disk.DosLinuxTypeID,
+						Type:     disk.FilesystemLinuxDOSID,
 						UUID:     "", // partitions on dos PTs don't have UUIDs
 						Bootable: false,
 						Payload: &disk.Filesystem{
@@ -1532,7 +1532,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 					{
 						Start: 1 * datasizes.MiB,
 						Size:  200 * datasizes.MiB,
-						Type:  disk.DosESPID,
+						Type:  disk.EFISystemPartitionDOSID,
 						UUID:  disk.EFISystemPartitionUUID,
 						Payload: &disk.Filesystem{
 							Type:         "vfat",
@@ -1547,7 +1547,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 					{
 						Start:    201 * datasizes.MiB,
 						Size:     20 * datasizes.MiB,
-						Type:     disk.DosLinuxTypeID,
+						Type:     disk.FilesystemLinuxDOSID,
 						Bootable: false,
 						UUID:     "", // partitions on dos PTs don't have UUIDs
 						Payload: &disk.Filesystem{
@@ -1563,7 +1563,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 					{
 						Start:    221 * datasizes.MiB,
 						Size:     0,
-						Type:     disk.DosLinuxTypeID,
+						Type:     disk.FilesystemLinuxDOSID,
 						UUID:     "", // partitions on dos PTs don't have UUIDs
 						Bootable: false,
 						Payload: &disk.Filesystem{
@@ -1607,13 +1607,13 @@ func TestNewCustomPartitionTable(t *testing.T) {
 						Start:    1 * datasizes.MiB, // header
 						Size:     1 * datasizes.MiB,
 						Bootable: true,
-						Type:     disk.DosBIOSBootID,
+						Type:     disk.BIOSBootPartitionDOSID,
 						UUID:     disk.BIOSBootPartitionUUID,
 					},
 					{
 						Start: 2 * datasizes.MiB,
 						Size:  200 * datasizes.MiB,
-						Type:  disk.DosESPID,
+						Type:  disk.EFISystemPartitionDOSID,
 						UUID:  disk.EFISystemPartitionUUID,
 						Payload: &disk.Filesystem{
 							Type:         "vfat",
@@ -1628,7 +1628,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 					{
 						Start:    202 * datasizes.MiB,
 						Size:     20 * datasizes.MiB,
-						Type:     disk.DosLinuxTypeID,
+						Type:     disk.FilesystemLinuxDOSID,
 						Bootable: false,
 						UUID:     "", // partitions on dos PTs don't have UUIDs
 						Payload: &disk.Filesystem{
@@ -1644,7 +1644,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 					{
 						Start:    222 * datasizes.MiB,
 						Size:     3 * datasizes.GiB,
-						Type:     disk.DosLinuxTypeID,
+						Type:     disk.FilesystemLinuxDOSID,
 						UUID:     "", // partitions on dos PTs don't have UUIDs
 						Bootable: false,
 						Payload: &disk.Filesystem{
@@ -1832,13 +1832,13 @@ func TestNewCustomPartitionTable(t *testing.T) {
 						Start:    1 * datasizes.MiB, // header
 						Size:     1 * datasizes.MiB,
 						Bootable: true,
-						Type:     disk.DosBIOSBootID,
+						Type:     disk.BIOSBootPartitionDOSID,
 						UUID:     disk.BIOSBootPartitionUUID,
 					},
 					{
 						Start: 2 * datasizes.MiB,
 						Size:  200 * datasizes.MiB,
-						Type:  disk.DosESPID,
+						Type:  disk.EFISystemPartitionDOSID,
 						UUID:  disk.EFISystemPartitionUUID,
 						Payload: &disk.Filesystem{
 							Type:         "vfat",
@@ -1853,7 +1853,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 					{
 						Start:    202 * datasizes.MiB,
 						Size:     512 * datasizes.MiB,
-						Type:     disk.DosLinuxTypeID,
+						Type:     disk.FilesystemLinuxDOSID,
 						UUID:     "",
 						Bootable: false,
 						Payload: &disk.Filesystem{
@@ -1869,7 +1869,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 					{
 						Start:    714 * datasizes.MiB,
 						Size:     200 * datasizes.MiB, // the sum of the LVs (rounded to the next 4 MiB extent)
-						Type:     disk.DosLVMTypeID,
+						Type:     disk.LVMPartitionDOSID,
 						UUID:     "",
 						Bootable: false,
 						Payload: &disk.LVMVolumeGroup{
@@ -2267,13 +2267,13 @@ func TestNewCustomPartitionTable(t *testing.T) {
 						Start:    1 * datasizes.MiB, // header
 						Size:     1 * datasizes.MiB,
 						Bootable: true,
-						Type:     disk.DosBIOSBootID,
+						Type:     disk.BIOSBootPartitionDOSID,
 						UUID:     disk.BIOSBootPartitionUUID,
 					},
 					{
 						Start: 2 * datasizes.MiB, // header
 						Size:  200 * datasizes.MiB,
-						Type:  disk.DosESPID,
+						Type:  disk.EFISystemPartitionDOSID,
 						UUID:  disk.EFISystemPartitionUUID,
 						Payload: &disk.Filesystem{
 							Type:         "vfat",
@@ -2288,7 +2288,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 					{
 						Start:    202 * datasizes.MiB,
 						Size:     512 * datasizes.MiB,
-						Type:     disk.DosLinuxTypeID,
+						Type:     disk.FilesystemLinuxDOSID,
 						UUID:     "",
 						Bootable: false,
 						Payload: &disk.Filesystem{
@@ -2304,7 +2304,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 					{
 						Start: 714 * datasizes.MiB,
 						Size:  230 * datasizes.MiB,
-						Type:  disk.DosLinuxTypeID,
+						Type:  disk.FilesystemLinuxDOSID,
 						UUID:  "",
 						Payload: &disk.Btrfs{
 							UUID: "fb180daf-48a7-4ee0-b10d-394651850fd4",

--- a/pkg/disk/partition_test.go
+++ b/pkg/disk/partition_test.go
@@ -126,7 +126,7 @@ func TestIsBIOSBoot(t *testing.T) {
 		{
 			name: "dos-bios-boot",
 			partition: &disk.Partition{
-				Type: disk.DosBIOSBootID,
+				Type: disk.BIOSBootPartitionDOSID,
 			},
 			expected: true,
 		},

--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -112,7 +112,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Partitions: []disk.Partition{
 			{
 				Size:     4 * datasizes.MebiByte,
-				Type:     disk.DosPRePID,
+				Type:     disk.PRepPartitionDOSID,
 				Bootable: true,
 			},
 			{
@@ -224,7 +224,7 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 		Partitions: []disk.Partition{
 			{
 				Size:     200 * datasizes.MebiByte,
-				Type:     disk.DosFat16B,
+				Type:     disk.FAT16BDOSID,
 				Bootable: true,
 				Payload: &disk.Filesystem{
 					Type:         "vfat",
@@ -238,7 +238,7 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 			},
 			{
 				Size: 1 * datasizes.GibiByte,
-				Type: disk.DosLinuxTypeID,
+				Type: disk.FilesystemLinuxDOSID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
@@ -250,7 +250,7 @@ var minimalrawPartitionTables = distro.BasePartitionTableMap{
 			},
 			{
 				Size: 2 * datasizes.GibiByte,
-				Type: disk.DosLinuxTypeID,
+				Type: disk.FilesystemLinuxDOSID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Label:        "root",
@@ -319,7 +319,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 		Partitions: []disk.Partition{
 			{
 				Size:     501 * datasizes.MebiByte,
-				Type:     disk.DosFat16B,
+				Type:     disk.FAT16BDOSID,
 				Bootable: true,
 				Payload: &disk.Filesystem{
 					Type:         "vfat",
@@ -333,7 +333,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 			},
 			{
 				Size: 1 * datasizes.GibiByte,
-				Type: disk.DosLinuxTypeID,
+				Type: disk.FilesystemLinuxDOSID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Mountpoint:   "/boot",
@@ -345,7 +345,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 			},
 			{
 				Size: 2569 * datasizes.MebiByte,
-				Type: disk.DosLinuxTypeID,
+				Type: disk.FilesystemLinuxDOSID,
 				Payload: &disk.Filesystem{
 					Type:         "ext4",
 					Label:        "root",

--- a/pkg/distro/rhel/rhel10/partition_tables.go
+++ b/pkg/distro/rhel/rhel10/partition_tables.go
@@ -90,7 +90,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Partitions: []disk.Partition{
 				{
 					Size:     4 * datasizes.MebiByte,
-					Type:     disk.DosPRePID,
+					Type:     disk.PRepPartitionDOSID,
 					Bootable: true,
 				},
 				{

--- a/pkg/distro/rhel/rhel8/partition_tables.go
+++ b/pkg/distro/rhel/rhel8/partition_tables.go
@@ -91,7 +91,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Partitions: []disk.Partition{
 				{
 					Size:     4 * datasizes.MebiByte,
-					Type:     disk.DosPRePID,
+					Type:     disk.PRepPartitionDOSID,
 					Bootable: true,
 				},
 				{

--- a/pkg/distro/rhel/rhel9/partition_tables.go
+++ b/pkg/distro/rhel/rhel9/partition_tables.go
@@ -173,7 +173,7 @@ func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
 			Partitions: []disk.Partition{
 				{
 					Size:     4 * datasizes.MebiByte,
-					Type:     disk.DosPRePID,
+					Type:     disk.PRepPartitionDOSID,
 					Bootable: true,
 				},
 				{


### PR DESCRIPTION
**disk,otk: use disk.DosLVMTypeID constant**


---

**disk: rename all DOS type ID consts to match GUIDs**

Rename the global constants to follow the same convention as the GPT
GUIDs and UUIDs.

---
