### PR TITLE
github/actions: Enable /jira-epic slash commands (HMS-5161)

### DIFF
--- a/.github/workflows/pr_best_practices.yml
+++ b/.github/workflows/pr_best_practices.yml
@@ -4,6 +4,9 @@ name: "Verify PR best practices"
 on:  # yamllint disable-line rule:truthy
   pull_request_target:
     branches: [main]
+    types: [opened, synchronize, reopened, edited]
+  issue_comment:
+    types: [created]
 
 jobs:
   pr-best-practices:
@@ -13,3 +16,4 @@ jobs:
         uses: osbuild/pr-best-practices@main
         with:
           token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+          jira_token: ${{ secrets.IMAGEBUILDER_BOT_JIRA_TOKEN }}


### PR DESCRIPTION
This change allows for using the command to create Jira Tasks under a given Epic both in a pull request comment or in the pull request description.