### PR TITLE
crypt: provide non-cgo implementation of "crypt()" to be more cross-build friendly 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Run unit tests without CGO
         # keep tags in sync with BUILDTAGS_CROSS in https://github.com/containers/podman/blob/2981262215f563461d449b9841741339f4d9a894/Makefile#L85
-        run: CGO_ENABLED=0 go test -v -tags "containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_overlay" ./...
+        run: CGO_ENABLED=0 go test -tags "containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_overlay" ./...
 
       - name: Run depsolver tests with force-dnf to make sure it's not skipped for any reason
         run: go test -v -race ./pkg/dnfjson/... -force-dnf

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,6 +101,13 @@ jobs:
       - name: Run unit tests
         run: go test -v -race  ./...
 
+      - name: Install openssl for cgo test below
+        run: dnf -y install openssl
+
+      - name: Run unit tests without CGO
+        # keep tags in sync with BUILDTAGS_CROSS in https://github.com/containers/podman/blob/2981262215f563461d449b9841741339f4d9a894/Makefile#L85
+        run: CGO_ENABLED=0 go test -v -tags "containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_overlay" ./...
+
       - name: Run depsolver tests with force-dnf to make sure it's not skipped for any reason
         run: go test -v -race ./pkg/dnfjson/... -force-dnf
 

--- a/pkg/crypt/crypt.go
+++ b/pkg/crypt/crypt.go
@@ -18,6 +18,7 @@ func CryptSHA512(phrase string) (string, error) {
 		return "", nil
 	}
 
+	// Note: update "crypt_impl_non_cgo.go" if new hash types get added
 	hashSettings := "$6$" + salt
 	return crypt(phrase, hashSettings)
 }

--- a/pkg/crypt/crypt_impl_non_cgo.go
+++ b/pkg/crypt/crypt_impl_non_cgo.go
@@ -1,0 +1,34 @@
+//go:build !cgo
+
+//
+// fallback implementation of "crypt" for cross building
+
+package crypt
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func crypt(pass, salt string) (string, error) {
+	// we could extract the "hash-type" here and pass it to
+	// openssl instead of hardcoding -6 but lets do that once we
+	// actually move away from sha512crypt
+	if !strings.HasPrefix(salt, "$6$") {
+		return "", fmt.Errorf("only crypt type SHA512 supported, got %q", salt)
+	}
+	cmd := exec.Command(
+		"openssl", "passwd", "-6",
+		// strip the $6$
+		"-salt", salt[3:],
+		"-stdin",
+	)
+	cmd.Stdin = bytes.NewBufferString(pass)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("cannot generate password: %v, output:%s\n", err, string(output))
+	}
+	return strings.TrimSpace(string(output)), nil
+}

--- a/pkg/crypt/crypt_test.go
+++ b/pkg/crypt/crypt_test.go
@@ -62,3 +62,27 @@ func TestGenSalt(t *testing.T) {
 	retSaltSecond, _ := genSalt(length)
 	assert.NotEqual(t, retSaltFirst, retSaltSecond)
 }
+
+func TestCryptItself(t *testing.T) {
+	for _, tc := range []struct {
+		pass, salt string
+		expected   string
+	}{
+		// test vectors from upstream glibc, e.g.
+		// https://github.com/lattera/glibc/blob/master/crypt/sha512c-test.c#L12
+		{
+			"Hello world!",
+			"$6$saltstring",
+			"$6$saltstring$svn8UoSVapNtMuq1ukKS4tPQd8iKwSMHWjl/O817G3uBnIFNjnQJuesI68u4OTLiBFdcbYEdFCoEOfaS35inz1", // notsecret
+		},
+		{
+			"Hello world!",
+			"$6$rounds=10000$saltstringsaltstring",
+			"$6$rounds=10000$saltstringsaltst$OW1/O6BYHV6BcXZu8QVeXbDWra3Oeqh0sbHbbMCVNSnCM/UrjmM0Dp8vOuZeHBy/YTBmSK6H9qs/y3RnOaw5v.", // notsecret
+		},
+	} {
+		cryptedPass, err := crypt(tc.pass, tc.salt)
+		assert.NoError(t, err)
+		assert.Equal(t, tc.expected, cryptedPass)
+	}
+}

--- a/pkg/upload/koji/koji.go
+++ b/pkg/upload/koji/koji.go
@@ -1,3 +1,8 @@
+//go:build cgo
+
+// koji requires the khttp kerberos module which requires cgo so when
+// build without cgo kerberos uploads are currently not supported
+
 package koji
 
 import (


### PR DESCRIPTION
This PR tweaks the images library to work without "cgo" so that we can cross build. Thanks to @supakeen for raising this!

With the PR we can now do:
```
$ GOARCH=arm64 go build -o ibc-aarch64 -tags "containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper" ./cmd/image-builder
```
in the image-builder-cli source tree.