### PR TITLE
Add erofs support 

### DIFF
--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -479,7 +479,7 @@ func imageInstallerImage(workload workload.Workload,
 
 	img.Filename = t.Filename()
 
-	img.SquashfsCompression = "lz4"
+	img.RootfsCompression = "lz4"
 	if common.VersionGreaterThanOrEqual(img.OSVersion, VERSION_ROOTFS_SQUASHFS) {
 		img.RootfsType = manifest.SquashfsRootfs
 	}
@@ -680,7 +680,7 @@ func iotInstallerImage(workload workload.Workload,
 
 	img.Filename = t.Filename()
 
-	img.SquashfsCompression = "lz4"
+	img.RootfsCompression = "lz4"
 	if common.VersionGreaterThanOrEqual(img.OSVersion, VERSION_ROOTFS_SQUASHFS) {
 		img.RootfsType = manifest.SquashfsRootfs
 	}

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -495,7 +495,7 @@ func EdgeInstallerImage(workload workload.Workload,
 	// kickstart though kickstart does support setting them
 	img.Kickstart.Timezone, _ = customizations.GetTimezoneSettings()
 
-	img.SquashfsCompression = "xz"
+	img.RootfsCompression = "xz"
 	if t.Arch().Distro().Releasever() == "10" {
 		img.RootfsType = manifest.SquashfsRootfs
 	}
@@ -716,7 +716,7 @@ func ImageInstallerImage(workload workload.Workload,
 	}
 	img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, anaconda.ModuleUsers)
 
-	img.SquashfsCompression = "xz"
+	img.RootfsCompression = "xz"
 	if t.Arch().Distro().Releasever() == "10" {
 		img.RootfsType = manifest.SquashfsRootfs
 	}

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -22,8 +22,8 @@ type AnacondaContainerInstaller struct {
 	Platform          platform.Platform
 	ExtraBasePackages rpmmd.PackageSet
 
-	SquashfsCompression string
-	RootfsType          manifest.RootfsType
+	RootfsCompression string
+	RootfsType        manifest.RootfsType
 
 	ISOLabel  string
 	Product   string
@@ -132,7 +132,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.Release = img.Release
 	isoTreePipeline.Kickstart = img.Kickstart
 
-	isoTreePipeline.SquashfsCompression = img.SquashfsCompression
+	isoTreePipeline.RootfsCompression = img.RootfsCompression
 
 	// For ostree installers, always put the kickstart file in the root of the ISO
 	isoTreePipeline.PayloadPath = "/container"

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -133,6 +133,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.Kickstart = img.Kickstart
 
 	isoTreePipeline.RootfsCompression = img.RootfsCompression
+	isoTreePipeline.RootfsType = img.RootfsType
 
 	// For ostree installers, always put the kickstart file in the root of the ISO
 	isoTreePipeline.PayloadPath = "/container"

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -108,6 +108,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.ISOLinux = isoLinuxEnabled
 
 	isoTreePipeline.RootfsCompression = img.RootfsCompression
+	isoTreePipeline.RootfsType = img.RootfsType
 
 	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, img.ISOLabel)
 	isoPipeline.SetFilename(img.Filename)

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -23,8 +23,8 @@ type AnacondaLiveInstaller struct {
 
 	ExtraBasePackages rpmmd.PackageSet
 
-	SquashfsCompression string
-	RootfsType          manifest.RootfsType
+	RootfsCompression string
+	RootfsType        manifest.RootfsType
 
 	ISOLabel  string
 	Product   string
@@ -107,7 +107,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.KernelOpts = kernelOpts
 	isoTreePipeline.ISOLinux = isoLinuxEnabled
 
-	isoTreePipeline.SquashfsCompression = img.SquashfsCompression
+	isoTreePipeline.RootfsCompression = img.RootfsCompression
 
 	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, img.ISOLabel)
 	isoPipeline.SetFilename(img.Filename)

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -28,8 +28,8 @@ type AnacondaOSTreeInstaller struct {
 	// Subscription options to include
 	Subscription *subscription.ImageOptions
 
-	SquashfsCompression string
-	RootfsType          manifest.RootfsType
+	RootfsCompression string
+	RootfsType        manifest.RootfsType
 
 	ISOLabel  string
 	Product   string
@@ -139,7 +139,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.PartitionTable = efiBootPartitionTable(rng)
 	isoTreePipeline.Release = img.Release
 	isoTreePipeline.Kickstart = img.Kickstart
-	isoTreePipeline.SquashfsCompression = img.SquashfsCompression
+	isoTreePipeline.RootfsCompression = img.RootfsCompression
 
 	isoTreePipeline.PayloadPath = "/ostree/repo"
 

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -140,6 +140,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.Release = img.Release
 	isoTreePipeline.Kickstart = img.Kickstart
 	isoTreePipeline.RootfsCompression = img.RootfsCompression
+	isoTreePipeline.RootfsType = img.RootfsType
 
 	isoTreePipeline.PayloadPath = "/ostree/repo"
 

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -56,8 +56,8 @@ type AnacondaTarInstaller struct {
 	ISORootKickstart bool
 	Kickstart        *kickstart.Options
 
-	SquashfsCompression string
-	RootfsType          manifest.RootfsType
+	RootfsCompression string
+	RootfsType        manifest.RootfsType
 
 	ISOLabel  string
 	Product   string
@@ -195,7 +195,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 		isoTreePipeline.Kickstart.Path = img.Kickstart.Path
 	}
 
-	isoTreePipeline.SquashfsCompression = img.SquashfsCompression
+	isoTreePipeline.RootfsCompression = img.RootfsCompression
 
 	isoTreePipeline.OSPipeline = osPipeline
 	isoTreePipeline.KernelOpts = img.AdditionalKernelOpts

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -196,6 +196,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	}
 
 	isoTreePipeline.RootfsCompression = img.RootfsCompression
+	isoTreePipeline.RootfsType = img.RootfsType
 
 	isoTreePipeline.OSPipeline = osPipeline
 	isoTreePipeline.KernelOpts = img.AdditionalKernelOpts

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -50,6 +50,7 @@ type AnacondaInstallerISOTree struct {
 	isoLabel string
 
 	RootfsCompression string
+	RootfsType        RootfsType
 
 	OSPipeline         *OS
 	OSTreeCommitSource *ostree.SourceSpec
@@ -289,7 +290,7 @@ func (p *AnacondaInstallerISOTree) serialize() osbuild.Pipeline {
 	// The iso's rootfs can either be an ext4 filesystem compressed with squashfs, or
 	// a squashfs of the plain directory tree
 	var squashfsStage *osbuild.Stage
-	if p.rootfsPipeline != nil {
+	if p.RootfsType == SquashfsExt4Rootfs {
 		squashfsStage = osbuild.NewSquashfsStage(&squashfsOptions, p.rootfsPipeline.Name())
 	} else {
 		squashfsStage = osbuild.NewSquashfsStage(&squashfsOptions, p.anacondaPipeline.Name())

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -49,7 +49,7 @@ type AnacondaInstallerISOTree struct {
 
 	isoLabel string
 
-	SquashfsCompression string
+	RootfsCompression string
 
 	OSPipeline         *OS
 	OSTreeCommitSource *ostree.SourceSpec
@@ -273,8 +273,8 @@ func (p *AnacondaInstallerISOTree) serialize() osbuild.Pipeline {
 		}
 	}
 
-	if p.SquashfsCompression != "" {
-		squashfsOptions.Compression.Method = p.SquashfsCompression
+	if p.RootfsCompression != "" {
+		squashfsOptions.Compression.Method = p.RootfsCompression
 	} else {
 		// default to xz if not specified
 		squashfsOptions.Compression.Method = "xz"

--- a/pkg/osbuild/erofs_stage.go
+++ b/pkg/osbuild/erofs_stage.go
@@ -1,0 +1,24 @@
+package osbuild
+
+type ErofsCompression struct {
+	Method string `json:"method"`
+	Level  *int   `json:"level,omitempty"`
+}
+
+type ErofsStageOptions struct {
+	Filename string `json:"filename"`
+
+	Compression     *ErofsCompression `json:"compression,omitempty"`
+	ExtendedOptions []string          `json:"options,omitempty"`
+	ClusterSize     *int              `json:"cluster-size,omitempty"`
+}
+
+func (ErofsStageOptions) isStageOptions() {}
+
+func NewErofsStage(options *ErofsStageOptions, inputPipeline string) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.erofs",
+		Options: options,
+		Inputs:  NewPipelineTreeInputs("tree", inputPipeline),
+	}
+}

--- a/pkg/osbuild/erofs_stage_test.go
+++ b/pkg/osbuild/erofs_stage_test.go
@@ -1,0 +1,83 @@
+package osbuild_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+func TestErofStageJsonMinimal(t *testing.T) {
+	expectedJson := `{
+        "type": "org.osbuild.erofs",
+        "inputs": {
+                "tree": {
+                        "type": "org.osbuild.tree",
+                        "origin": "org.osbuild.pipeline",
+                        "references": [
+                                "name:input-pipeline"
+                        ]
+                }
+        },
+        "options": {
+                "filename": "foo.ero"
+        }
+}`
+
+	opts := &osbuild.ErofsStageOptions{
+		Filename: "foo.ero",
+	}
+	stage := osbuild.NewErofsStage(opts, "input-pipeline")
+	require.NotNil(t, stage)
+
+	json, err := json.MarshalIndent(stage, "", "        ")
+	require.Nil(t, err)
+	assert.Equal(t, string(json), expectedJson)
+}
+
+func TestErofStageJsonFull(t *testing.T) {
+	expectedJson := `{
+        "type": "org.osbuild.erofs",
+        "inputs": {
+                "tree": {
+                        "type": "org.osbuild.tree",
+                        "origin": "org.osbuild.pipeline",
+                        "references": [
+                                "name:input-pipeline"
+                        ]
+                }
+        },
+        "options": {
+                "filename": "foo.ero",
+                "compression": {
+                        "method": "lz4hc",
+                        "level": 9
+                },
+                "options": [
+                        "all-fragments",
+                        "dedupe"
+                ],
+                "cluster-size": 131072
+        }
+}`
+
+	opts := &osbuild.ErofsStageOptions{
+		Filename: "foo.ero",
+		Compression: &osbuild.ErofsCompression{
+			Method: "lz4hc",
+			Level:  common.ToPtr(9),
+		},
+		ExtendedOptions: []string{"all-fragments", "dedupe"},
+		ClusterSize:     common.ToPtr(131072),
+	}
+	stage := osbuild.NewErofsStage(opts, "input-pipeline")
+	require.NotNil(t, stage)
+
+	json, err := json.MarshalIndent(stage, "", "        ")
+	require.Nil(t, err)
+	assert.Equal(t, string(json), expectedJson)
+}


### PR DESCRIPTION
Things that are needed:
* allow zstd compression in org.osbuild.erofs - https://github.com/osbuild/osbuild/pull/1969
* Add block size support to org.osbuild.erofs - also in https://github.com/osbuild/osbuild/pull/1969
* ~~RHEL 10 kernel needs to support erofs and zstd compression~~