### PR TITLE
Test/scripts: move shared code to `imgtestlib` (HMS-5242)

### DIFF
--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -148,12 +148,6 @@ def boot_container(distro, arch, image_type, image_path, manifest_id):
             cmd_boot_aws(arch, image_name, privkey_file, pubkey_file, raw_image_path, [BASE_TEST_SCRIPT])
 
 
-def read_build_info(path):
-    info_file_path = os.path.join(path, "info.json")
-    with open(info_file_path, encoding="utf-8") as info_fp:
-        return json.load(info_fp)
-
-
 def main():
     desc = "Boot an image in the cloud environment it is built for and validate the configuration"
     parser = argparse.ArgumentParser(description=desc)
@@ -169,7 +163,7 @@ def main():
     search_path = args.image_search_path
 
     image_path = testlib.find_image_file(search_path)
-    build_info = read_build_info(search_path)
+    build_info = testlib.read_build_info(search_path)
     build_config_name = build_info["config"]
     build_config_path = f"test/configs/{build_config_name}.json"
 

--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -186,9 +186,7 @@ def main():
     # amend build info with boot success
     # search_path is the root of the build path (build/build_name)
     build_info["boot-success"] = True
-    info_file_path = os.path.join(search_path, "info.json")
-    with open(info_file_path, "w", encoding="utf-8") as info_fp:
-        json.dump(build_info, info_fp, indent=2)
+    testlib.write_build_info(search_path, build_info)
     if bib_image_id:
         # write a separate file with the bib image ID as filename to mark the boot success with that image
         bib_id_file = os.path.join(search_path, f"bib-{bib_image_id}")

--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -148,29 +148,6 @@ def boot_container(distro, arch, image_type, image_path, manifest_id):
             cmd_boot_aws(arch, image_name, privkey_file, pubkey_file, raw_image_path, [BASE_TEST_SCRIPT])
 
 
-def find_image_file(build_path: str) -> str:
-    """
-    Find the path to the image by reading the manifest to get the name of the last pipeline and searching for the file
-    under the directory named after the pipeline. Raises RuntimeError if no or multiple files are found in the expected
-    path.
-    """
-    manifest_file = os.path.join(build_path, "manifest.json")
-    with open(manifest_file, encoding="utf-8") as manifest:
-        data = json.load(manifest)
-
-    last_pipeline = data["pipelines"][-1]["name"]
-    files = os.listdir(os.path.join(build_path, last_pipeline))
-    if len(files) > 1:
-        error = "Multiple files found in build path while searching for image file"
-        error += "\n".join(files)
-        raise RuntimeError(error)
-
-    if len(files) == 0:
-        raise RuntimeError("No found in build path while searching for image file")
-
-    return os.path.join(build_path, last_pipeline, files[0])
-
-
 def read_build_info(path):
     info_file_path = os.path.join(path, "info.json")
     with open(info_file_path, encoding="utf-8") as info_fp:
@@ -191,7 +168,7 @@ def main():
     image_type = args.image_type
     search_path = args.image_search_path
 
-    image_path = find_image_file(search_path)
+    image_path = testlib.find_image_file(search_path)
     build_info = read_build_info(search_path)
     build_config_name = build_info["config"]
     build_config_path = f"test/configs/{build_config_name}.json"

--- a/test/scripts/build-image
+++ b/test/scripts/build-image
@@ -62,9 +62,7 @@ def main():
         "osbuild-commit": osbuild_commit,
         "commit": os.environ.get("CI_COMMIT_SHA", "N/A")
     }
-    info_file_path = os.path.join(build_dir, "info.json")
-    with open(info_file_path, "w", encoding="utf-8") as info_fp:
-        json.dump(build_info, info_fp, indent=2)
+    testlib.write_build_info(build_dir, build_info)
 
 
 if __name__ == "__main__":

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -513,3 +513,26 @@ def get_common_ci_runner():
         raise KeyError(f"gitlab-ci-runner not defined in {SCHUTZFILE}")
 
     return runner
+
+
+def find_image_file(build_path: str) -> str:
+    """
+    Find the path to the image by reading the manifest to get the name of the last pipeline and searching for the file
+    under the directory named after the pipeline. Raises RuntimeError if no or multiple files are found in the expected
+    path.
+    """
+    manifest_file = os.path.join(build_path, "manifest.json")
+    with open(manifest_file, encoding="utf-8") as manifest:
+        data = json.load(manifest)
+
+    last_pipeline = data["pipelines"][-1]["name"]
+    files = os.listdir(os.path.join(build_path, last_pipeline))
+    if len(files) > 1:
+        error = "Multiple files found in build path while searching for image file"
+        error += "\n".join(files)
+        raise RuntimeError(error)
+
+    if len(files) == 0:
+        raise RuntimeError("No found in build path while searching for image file")
+
+    return os.path.join(build_path, last_pipeline, files[0])

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -546,3 +546,12 @@ def read_build_info(build_path: str) -> Dict:
     info_file_path = os.path.join(build_path, "info.json")
     with open(info_file_path, encoding="utf-8") as info_fp:
         return json.load(info_fp)
+
+
+def write_build_info(build_path: str, data: Dict):
+    """
+    Write the data to the info.json file in the build directory.
+    """
+    info_file_path = os.path.join(build_path, "info.json")
+    with open(info_file_path, "w", encoding="utf-8") as info_fp:
+        json.dump(data, info_fp, indent=2)

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -536,3 +536,9 @@ def find_image_file(build_path: str) -> str:
         raise RuntimeError("No found in build path while searching for image file")
 
     return os.path.join(build_path, last_pipeline, files[0])
+
+
+def read_build_info(path):
+    info_file_path = os.path.join(path, "info.json")
+    with open(info_file_path, encoding="utf-8") as info_fp:
+        return json.load(info_fp)

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -5,6 +5,7 @@ import pathlib
 import subprocess as sp
 import sys
 from glob import glob
+from typing import Dict
 
 TEST_CACHE_ROOT = ".cache/osbuild-images"
 CONFIGS_PATH = "./test/configs"
@@ -538,7 +539,10 @@ def find_image_file(build_path: str) -> str:
     return os.path.join(build_path, last_pipeline, files[0])
 
 
-def read_build_info(path):
-    info_file_path = os.path.join(path, "info.json")
+def read_build_info(build_path: str) -> Dict:
+    """
+    Read the info.json file from the build directory and return the data as a dictionary.
+    """
+    info_file_path = os.path.join(build_path, "info.json")
     with open(info_file_path, encoding="utf-8") as info_fp:
         return json.load(info_fp)

--- a/test/scripts/upload-results
+++ b/test/scripts/upload-results
@@ -33,13 +33,10 @@ def main():
 
     # add the PR number (gitlab branch name) to the info.json if available
     if pr_number := os.environ.get("CI_COMMIT_BRANCH"):
-        info_path = os.path.join(build_dir, "info.json")
-        with open(info_path, "r", encoding="utf-8") as info_fp:
-            build_info = json.load(info_fp)
+        build_info = testlib.read_build_info(build_dir)
         # strip the PR prefix
         build_info["pr"] = pr_number.removeprefix("PR-")
-        with open(info_path, "w", encoding="utf-8") as info_fp:
-            json.dump(build_info, info_fp, indent=2)
+        testlib.write_build_info(build_dir, build_info)
 
     s3url = testlib.gen_build_info_s3(distro, arch, manifest_id)
 


### PR DESCRIPTION
- Move `find_image_file()` from boot-image to `imgtestlib` so that a new script generating the image-info report can use it later.
- Define common `{read,write}_build_info()` functions in `imgtestlib` to read/write build `info.json` and use them everywhere.

/jira-epic COMPOSER-2318

JIRA: [HMS-5242](https://issues.redhat.com/browse/HMS-5242)