### PR TITLE
Test/imgtestlib/get_osbuild_commit(): consider only gitlab-ci-runner distro (HMS-5243)

### DIFF
--- a/test/scripts/build-image
+++ b/test/scripts/build-image
@@ -46,9 +46,7 @@ def main():
 
     osbuild_ver, _ = testlib.runcmd(["osbuild", "--version"])
 
-    osrelease = testlib.read_osrelease()
-    distro_version = osrelease["ID"] + "-" + osrelease["VERSION_ID"]
-    osbuild_commit = testlib.get_osbuild_commit(distro_version)
+    osbuild_commit = testlib.get_osbuild_commit()
     if osbuild_commit is None:
         osbuild_commit = "RELEASE"
 

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -393,15 +393,20 @@ def read_osrelease():
     return osrelease
 
 
-def get_osbuild_commit(distro_version):
+def get_osbuild_commit():
     """
-    Get the osbuild commit defined in the Schutzfile for the host distro.
-    If not set, returns None.
+    Get the osbuild commit defined in the Schutzfile for the 'gitlab-ci-runner'
+    distro.
+    If not set, raises a KeyError.
     """
     with open(SCHUTZFILE, encoding="utf-8") as schutzfile:
         data = json.load(schutzfile)
 
-    return data.get(distro_version, {}).get("dependencies", {}).get("osbuild", {}).get("commit", None)
+    gitlab_ci_runner_distro = get_common_ci_runner().split("/")[1]
+
+    if (commit := data.get(gitlab_ci_runner_distro, {}).get("dependencies", {}).get("osbuild", {}).get("commit", None)) is None:
+        raise KeyError(f"osbuild dependency commit not defined for {gitlab_ci_runner_distro} in {SCHUTZFILE}")
+    return commit
 
 
 def get_bib_ref():

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -371,28 +371,6 @@ def clargs():
     return parser
 
 
-def read_osrelease():
-    """Read Operating System Information from `os-release`
-
-    This creates a dictionary with information describing the running operating system. It reads the information from
-    the path array provided as `paths`.  The first available file takes precedence. It must be formatted according to
-    the rules in `os-release(5)`.
-    """
-    osrelease = {}
-
-    with open(OS_RELEASE_FILE, encoding="utf8") as orf:
-        for line in orf:
-            line = line.strip()
-            if not line:
-                continue
-            if line[0] == "#":
-                continue
-            key, value = line.split("=", 1)
-            osrelease[key] = value.strip('"')
-
-    return osrelease
-
-
 def get_osbuild_commit():
     """
     Get the osbuild commit defined in the Schutzfile for the 'gitlab-ci-runner'


### PR DESCRIPTION
Previously, the osbuild commit stored in image build `info.json` was based on the host distro. However, we always use the same distro for all image build jobs, which is defined in the Schutzfile.

Modify the `get_osbuild_commit()` function to not take the distro as an argument, but instead read the `gitlab-ci-runner` from the Schutzfile and determine the osbuild commit based on its distro.

This will make it much easier to determine the actual osbuild commit that was (supposed to be) used for the image builds on the checked out branch. Consistency of data in `image.info` and the reality will be ensured.

Make `get_osbuild_commit()` raise a KeyError in case there's no osbuild commit defined in Shutzfile for the gitlab-ci-runner distro, so that we do not accidentally miss it and use unknown osbuild version from the distro repos.


/jira-epic COMPOSER-2318

JIRA: [HMS-5243](https://issues.redhat.com/browse/HMS-5243)