### PR TITLE
Changes to require pinned osbuild commit for the CI runners (HMS-5248)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,9 +30,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Set up repository for pinned osbuild commit
-        run: ./test/scripts/setup-osbuild-repo
-
       - name: Run unit tests
         run: make BASE_CONTAINER_IMAGE_TAG=${{matrix.fedora_version}} gh-action-test
 

--- a/Schutzfile
+++ b/Schutzfile
@@ -25,43 +25,7 @@
       "osbuild": {
         "commit": "fcb93bde01d4a027c67b5747c8f976ceb4fc8d80"
       }
-    },
-    "repos": [
-      {
-        "file": "/etc/yum.repos.d/fedora.repo",
-        "x86_64": [
-          {
-            "title": "fedora",
-            "name": "fedora",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-x86_64-fedora-20240514"
-          }
-        ],
-        "aarch64": [
-          {
-            "title": "fedora",
-            "name": "fedora",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-aarch64-fedora-20240514"
-          }
-        ]
-      },
-      {
-        "file": "/etc/yum.repos.d/fedora-updates.repo",
-        "x86_64": [
-          {
-            "title": "updates",
-            "name": "updates",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-x86_64-updates-released-20250101"
-          }
-        ],
-        "aarch64": [
-          {
-            "title": "updates",
-            "name": "updates",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-aarch64-updates-released-20250101"
-          }
-        ]
-      }
-    ]
+    }
   },
   "fedora-41": {
     "dependencies": {

--- a/Schutzfile
+++ b/Schutzfile
@@ -6,14 +6,14 @@
     },
     "gitlab-ci-runner": "aws/fedora-41"
   },
-  "centos-8": {
+  "centos-9": {
     "dependencies": {
       "osbuild": {
         "commit": "fcb93bde01d4a027c67b5747c8f976ceb4fc8d80"
       }
     }
   },
-  "centos-9": {
+  "centos-10": {
     "dependencies": {
       "osbuild": {
         "commit": "fcb93bde01d4a027c67b5747c8f976ceb4fc8d80"

--- a/test/scripts/setup-osbuild-repo
+++ b/test/scripts/setup-osbuild-repo
@@ -55,8 +55,8 @@ def main():
     distro_version = osrelease["ID"] + "-" + osrelease["VERSION_ID"]
     commit_id = testlib.get_osbuild_commit(distro_version)
     if not commit_id:
-        print("No commit ID defined for osbuild")
-        return
+        print(f"Error: {distro_version} does not have the osbuild commit ID defined in the Schutzfile")
+        sys.exit(1)
 
     write_repo(commit_id, distro_version)
 

--- a/test/scripts/update-schutzfile-osbuild
+++ b/test/scripts/update-schutzfile-osbuild
@@ -30,8 +30,10 @@ def update_osbuild_commit_ids(new):
         data = json.load(schutzfile)
 
     for distro in data.keys():
-        if data[distro].get("dependencies", {}).get("osbuild", {}).get("commit", {}):
-            data[distro]["dependencies"]["osbuild"]["commit"] = new
+        if distro == "common":
+            continue
+
+        data[distro].setdefault("dependencies", {}).setdefault("osbuild", {})["commit"] = new
 
     with open(testlib.SCHUTZFILE, encoding="utf-8", mode="w") as schutzfile:
         json.dump(data, schutzfile, indent="  ")


### PR DESCRIPTION
Ensure that we always use well-known osbuild version on CI workers by:

- `update-schutzfile-osbuild` script unconditionally defining the latest osbuild commit for all distros in the `Schutzfile`.
- `setup-osbuild-repo` script failing in case the host distro does not have the osbuild dependency commit defined.

Define the osbuild dependency commit for every distro we run in GH actions or in GitLab CI. Delete repo overrides for F40, since we no longer run F40 workers in GitLab.

/jira-epic COMPOSER-2318

JIRA: [HMS-5248](https://issues.redhat.com/browse/HMS-5248)