### PR TITLE
GH/test-osbuild-composer-integration: don't set env.pr_head

### DIFF
--- a/.github/workflows/test-osbuild-composer-integration.yml
+++ b/.github/workflows/test-osbuild-composer-integration.yml
@@ -104,8 +104,6 @@ jobs:
           fi
 
       - name: Update the osbuild/images reference to the PR HEAD
-        env:
-          pr_head: ${{ github.event.pull_request.hase.sha }}
         # if the base tests failed, there's no need to run the PR HEAD tests
         if: steps.tests-base.outputs.base_test == 1
         # Restore and clean the checkout and replace the dependency again using


### PR DESCRIPTION
The `pr_head` env variable set by the step was always empty, because there was a typo in the source variable "hase" vs. "head" / "base". I was not able to find any actual use of the `pr_head` variable, so let's delete it altogether from the action step.