### PR TITLE
anaconda: Use erroronfail

### DIFF
--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -531,7 +531,8 @@ bootc switch --mutate-in-place --transport %s %s
 
 # used during automatic image testing as finished marker
 if [ -c /dev/ttyS0 ]; then
-    echo "Install finished" > /dev/ttyS0
+    # continue on errors here, because we used to omit --erroronfail
+    echo "Install finished" > /dev/ttyS0 || true
 fi
 %%end
 `, targetContainerTransport, p.containerSpec.LocalName)

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -526,7 +526,7 @@ reboot --eject
 `
 
 	// Workaround for lack of --target-imgref in Anaconda, xref https://github.com/osbuild/images/issues/380
-	hardcodedKickstartBits += fmt.Sprintf(`%%post
+	hardcodedKickstartBits += fmt.Sprintf(`%%post --erroronfail
 bootc switch --mutate-in-place --transport %s %s
 
 # used during automatic image testing as finished marker


### PR DESCRIPTION
Not doing this can silently mask errors.

xref https://github.com/containers/bootc/issues/931