### PR TITLE
Remove dnsmasq from iot package sets

### DIFF
--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -97,7 +97,6 @@ func iotCommitPackageSet(t *imageType) rpmmd.PackageSet {
 			"cryptsetup",
 			"curl",
 			"dbus-parsec",
-			"dnsmasq",
 			"dosfstools",
 			"dracut-config-generic",
 			"dracut-network",
@@ -180,6 +179,13 @@ func iotCommitPackageSet(t *imageType) rpmmd.PackageSet {
 			Include: []string{
 				"passwd",         // provided by shadow-utils in F40+
 				"podman-plugins", // deprecated in podman 5
+			},
+		})
+	}
+	if common.VersionLessThan(t.arch.distro.osVersion, "41") {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"dnsmasq", // deprecated for F41+
 			},
 		})
 	}
@@ -653,7 +659,6 @@ func iotSimplifiedInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 			"coreos-installer-dracut",
 			"coreutils",
 			"device-mapper-multipath",
-			"dnsmasq",
 			"dosfstools",
 			"dracut-live",
 			"e2fsprogs",
@@ -694,6 +699,13 @@ func iotSimplifiedInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"passwd",
+			},
+		})
+	}
+	if common.VersionLessThan(t.arch.distro.osVersion, "41") {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"dnsmasq", // deprecated for F41+
 			},
 		})
 	}


### PR DESCRIPTION
Removes the `dnsmasq` package from iot package sets to bring package list in line with current iot package list here: https://pagure.io/fedora-iot/ostree/blob/main/f/fedora-iot-base.yaml

Also see the original PR that removed `dnsmasq` here: https://pagure.io/fedora-iot/ostree/c/176b0add790ece0b16b41337569b9170b0514117?branch=main