### PR TITLE
manifest: change the serializeStart() to take a new `Inputs` arg

### DIFF
--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -6,12 +6,10 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
-	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -196,15 +194,15 @@ func (p *AnacondaInstaller) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *AnacondaInstaller) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
+func (p *AnacondaInstaller) serializeStart(inputs Inputs) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
-	p.packageSpecs = packages
+	p.packageSpecs = inputs.Packages
 	if p.kernelName != "" {
 		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.kernelName)
 	}
-	p.repos = append(p.repos, rpmRepos...)
+	p.repos = append(p.repos, inputs.RpmRepos...)
 }
 
 func (p *AnacondaInstaller) serializeEnd() {

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -14,7 +14,6 @@ import (
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
-	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 type RootfsType uint64
@@ -227,25 +226,25 @@ func (p *AnacondaInstallerISOTree) NewErofsStage() *osbuild.Stage {
 	return osbuild.NewErofsStage(&erofsOptions, p.anacondaPipeline.Name())
 }
 
-func (p *AnacondaInstallerISOTree) serializeStart(_ []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec, _ []rpmmd.RepoConfig) {
+func (p *AnacondaInstallerISOTree) serializeStart(inputs Inputs) {
 	if p.ostreeCommitSpec != nil || p.containerSpec != nil {
 		panic("double call to serializeStart()")
 	}
 
-	if len(commits) > 1 {
+	if len(inputs.Commits) > 1 {
 		panic("pipeline supports at most one ostree commit")
 	}
 
-	if len(containers) > 1 {
+	if len(inputs.Containers) > 1 {
 		panic("pipeline supports at most one container")
 	}
 
-	if len(commits) > 0 {
-		p.ostreeCommitSpec = &commits[0]
+	if len(inputs.Commits) > 0 {
+		p.ostreeCommitSpec = &inputs.Commits[0]
 	}
 
-	if len(containers) > 0 {
-		p.containerSpec = &containers[0]
+	if len(inputs.Containers) > 0 {
+		p.containerSpec = &inputs.Containers[0]
 	}
 }
 

--- a/pkg/manifest/anaconda_installer_iso_tree_test.go
+++ b/pkg/manifest/anaconda_installer_iso_tree_test.go
@@ -285,11 +285,11 @@ func TestAnacondaISOTreePayloadsBad(t *testing.T) {
 
 	assert.PanicsWithValue(
 		"pipeline supports at most one ostree commit",
-		func() { pipeline.serializeStart(nil, nil, make([]ostree.CommitSpec, 2), nil) },
+		func() { pipeline.serializeStart(Inputs{Commits: make([]ostree.CommitSpec, 2)}) },
 	)
 	assert.PanicsWithValue(
 		"pipeline supports at most one container",
-		func() { pipeline.serializeStart(nil, make([]container.Spec, 2), nil, nil) },
+		func() { pipeline.serializeStart(Inputs{Containers: make([]container.Spec, 2)}) },
 	)
 }
 
@@ -309,7 +309,7 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 	t.Run("plain", func(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.OSPipeline = osPayload
-		pipeline.serializeStart(nil, nil, nil, nil)
+		pipeline.serializeStart(Inputs{})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, payloadStages,
@@ -322,7 +322,7 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.OSPipeline = osPayload
 		pipeline.Kickstart = &kickstart.Options{Path: testKsPath}
-		pipeline.serializeStart(nil, nil, nil, nil)
+		pipeline.serializeStart(Inputs{})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.kickstart"),
@@ -335,7 +335,7 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 		pipeline.OSPipeline = osPayload
 		pipeline.Kickstart = &kickstart.Options{Path: testKsPath}
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, nil, nil, nil)
+		pipeline.serializeStart(Inputs{})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux", "org.osbuild.kickstart"),
@@ -347,7 +347,7 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 		pipeline.OSPipeline = osPayload
 		pipeline.Kickstart = &kickstart.Options{Path: testKsPath, Unattended: true}
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, nil, nil, nil)
+		pipeline.serializeStart(Inputs{})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux", "org.osbuild.kickstart"),
@@ -364,7 +364,7 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 			SudoNopasswd: []string{`%wheel`, `%sudo`},
 		}
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, nil, nil, nil)
+		pipeline.serializeStart(Inputs{})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux", "org.osbuild.kickstart"),
@@ -384,7 +384,7 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 			},
 		}
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, nil, nil, nil)
+		pipeline.serializeStart(Inputs{})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux", "org.osbuild.kickstart"),
@@ -404,7 +404,7 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 			},
 		}
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, nil, nil, nil)
+		pipeline.serializeStart(Inputs{})
 		assert.Panics(t, func() { pipeline.serialize() })
 	})
 
@@ -420,7 +420,7 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 			},
 		}
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, nil, nil, nil)
+		pipeline.serializeStart(Inputs{})
 		assert.Panics(t, func() { pipeline.serialize() })
 	})
 
@@ -428,7 +428,7 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.OSPipeline = osPayload
 		pipeline.RootfsType = SquashfsRootfs
-		pipeline.serializeStart(nil, nil, nil, nil)
+		pipeline.serializeStart(Inputs{})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, payloadStages,
@@ -440,7 +440,7 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.OSPipeline = osPayload
 		pipeline.RootfsType = ErofsRootfs
-		pipeline.serializeStart(nil, nil, nil, nil)
+		pipeline.serializeStart(Inputs{})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages,
@@ -472,7 +472,7 @@ func TestAnacondaISOTreeSerializeWithOSTree(t *testing.T) {
 	t.Run("plain", func(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.Kickstart = &kickstart.Options{Path: testKsPath, OSTree: &kickstart.OSTree{}}
-		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit}, nil)
+		pipeline.serializeStart(Inputs{Commits: []ostree.CommitSpec{ostreeCommit}})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, payloadStages,
@@ -484,7 +484,7 @@ func TestAnacondaISOTreeSerializeWithOSTree(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.Kickstart = &kickstart.Options{Path: testKsPath, OSTree: &kickstart.OSTree{}}
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit}, nil)
+		pipeline.serializeStart(Inputs{Commits: []ostree.CommitSpec{ostreeCommit}})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux"), variantStages))
@@ -494,7 +494,7 @@ func TestAnacondaISOTreeSerializeWithOSTree(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.Kickstart = &kickstart.Options{Path: testKsPath, Unattended: true, OSTree: &kickstart.OSTree{}}
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit}, nil)
+		pipeline.serializeStart(Inputs{Commits: []ostree.CommitSpec{ostreeCommit}})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux"), variantStages))
@@ -510,7 +510,7 @@ func TestAnacondaISOTreeSerializeWithOSTree(t *testing.T) {
 			OSTree:       &kickstart.OSTree{},
 		}
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit}, nil)
+		pipeline.serializeStart(Inputs{Commits: []ostree.CommitSpec{ostreeCommit}})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux"), variantStages))
@@ -529,7 +529,7 @@ func TestAnacondaISOTreeSerializeWithOSTree(t *testing.T) {
 			OSTree: &kickstart.OSTree{},
 		}
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit}, nil)
+		pipeline.serializeStart(Inputs{Commits: []ostree.CommitSpec{ostreeCommit}})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux"), variantStages))
@@ -548,7 +548,7 @@ func TestAnacondaISOTreeSerializeWithOSTree(t *testing.T) {
 			OSTree: &kickstart.OSTree{},
 		}
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit}, nil)
+		pipeline.serializeStart(Inputs{Commits: []ostree.CommitSpec{ostreeCommit}})
 		assert.Panics(t, func() { pipeline.serialize() })
 	})
 
@@ -565,7 +565,7 @@ func TestAnacondaISOTreeSerializeWithOSTree(t *testing.T) {
 			OSTree:       &kickstart.OSTree{},
 		}
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit}, nil)
+		pipeline.serializeStart(Inputs{Commits: []ostree.CommitSpec{ostreeCommit}})
 		assert.Panics(t, func() { pipeline.serialize() })
 	})
 
@@ -573,7 +573,7 @@ func TestAnacondaISOTreeSerializeWithOSTree(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.RootfsType = SquashfsRootfs
 		pipeline.Kickstart = &kickstart.Options{Path: testKsPath, OSTree: &kickstart.OSTree{}}
-		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit}, nil)
+		pipeline.serializeStart(Inputs{Commits: []ostree.CommitSpec{ostreeCommit}})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, payloadStages,
@@ -585,7 +585,7 @@ func TestAnacondaISOTreeSerializeWithOSTree(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.RootfsType = ErofsRootfs
 		pipeline.Kickstart = &kickstart.Options{Path: testKsPath, OSTree: &kickstart.OSTree{}}
-		pipeline.serializeStart(nil, nil, []ostree.CommitSpec{ostreeCommit}, nil)
+		pipeline.serializeStart(Inputs{Commits: []ostree.CommitSpec{ostreeCommit}})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages,
@@ -621,7 +621,7 @@ func TestAnacondaISOTreeSerializeWithContainer(t *testing.T) {
 	t.Run("kspath", func(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.Kickstart = &kickstart.Options{Path: testKsPath}
-		pipeline.serializeStart(nil, []container.Spec{containerPayload}, nil, nil)
+		pipeline.serializeStart(Inputs{Containers: []container.Spec{containerPayload}})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, payloadStages,
@@ -633,7 +633,7 @@ func TestAnacondaISOTreeSerializeWithContainer(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.Kickstart = &kickstart.Options{Path: testKsPath}
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, []container.Spec{containerPayload}, nil, nil)
+		pipeline.serializeStart(Inputs{Containers: []container.Spec{containerPayload}})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux"), variantStages))
@@ -646,7 +646,7 @@ func TestAnacondaISOTreeSerializeWithContainer(t *testing.T) {
 			Unattended:          true,
 			KernelOptionsAppend: []string{"kernel.opt=1", "debug"},
 		}
-		pipeline.serializeStart(nil, []container.Spec{containerPayload}, nil, nil)
+		pipeline.serializeStart(Inputs{Containers: []container.Spec{containerPayload}})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		kickstartSt := findStage("org.osbuild.kickstart", sp.Stages)
@@ -658,7 +658,7 @@ func TestAnacondaISOTreeSerializeWithContainer(t *testing.T) {
 	t.Run("network-on-boot", func(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.Kickstart = &kickstart.Options{Path: testKsPath, NetworkOnBoot: true}
-		pipeline.serializeStart(nil, []container.Spec{containerPayload}, nil, nil)
+		pipeline.serializeStart(Inputs{Containers: []container.Spec{containerPayload}})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		kickstartSt := findStage("org.osbuild.kickstart", sp.Stages)
@@ -678,7 +678,7 @@ func TestAnacondaISOTreeSerializeWithContainer(t *testing.T) {
 			},
 		}
 		pipeline.ISOLinux = true
-		pipeline.serializeStart(nil, []container.Spec{containerPayload}, nil, nil)
+		pipeline.serializeStart(Inputs{Containers: []container.Spec{containerPayload}})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, append(payloadStages, "org.osbuild.isolinux"), variantStages))
@@ -689,7 +689,7 @@ func TestAnacondaISOTreeSerializeWithContainer(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.Kickstart = &kickstart.Options{Path: testKsPath}
 		pipeline.PayloadRemoveSignatures = true
-		pipeline.serializeStart(nil, []container.Spec{containerPayload}, nil, nil)
+		pipeline.serializeStart(Inputs{Containers: []container.Spec{containerPayload}})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		skopeoStage := findStage("org.osbuild.skopeo", sp.Stages)
@@ -701,7 +701,7 @@ func TestAnacondaISOTreeSerializeWithContainer(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.RootfsType = SquashfsRootfs
 		pipeline.Kickstart = &kickstart.Options{Path: testKsPath}
-		pipeline.serializeStart(nil, []container.Spec{containerPayload}, nil, nil)
+		pipeline.serializeStart(Inputs{Containers: []container.Spec{containerPayload}})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages, payloadStages,
@@ -713,7 +713,7 @@ func TestAnacondaISOTreeSerializeWithContainer(t *testing.T) {
 		pipeline := newTestAnacondaISOTree()
 		pipeline.RootfsType = ErofsRootfs
 		pipeline.Kickstart = &kickstart.Options{Path: testKsPath}
-		pipeline.serializeStart(nil, []container.Spec{containerPayload}, nil, nil)
+		pipeline.serializeStart(Inputs{Containers: []container.Spec{containerPayload}})
 		sp := pipeline.serialize()
 		pipeline.serializeEnd()
 		assert.NoError(t, checkISOTreeStages(sp.Stages,
@@ -745,7 +745,7 @@ restorecon -rvF /etc/sudoers.d
 
 func stagesFrom(pipeline Pipeline) []*osbuild.Stage {
 	containerPayload := makeFakeContainerPayload()
-	pipeline.serializeStart(nil, []container.Spec{containerPayload}, nil, nil)
+	pipeline.serializeStart(Inputs{Containers: []container.Spec{containerPayload}})
 	sp := pipeline.serialize()
 	pipeline.serializeEnd()
 	return sp.Stages

--- a/pkg/manifest/anaconda_installer_test.go
+++ b/pkg/manifest/anaconda_installer_test.go
@@ -105,7 +105,7 @@ func TestAnacondaInstallerModules(t *testing.T) {
 				installerPipeline.UseLegacyAnacondaConfig = legacy
 				installerPipeline.AdditionalAnacondaModules = tc.enable
 				installerPipeline.DisabledAnacondaModules = tc.disable
-				installerPipeline.serializeStart(pkgs, nil, nil, nil)
+				installerPipeline.serializeStart(Inputs{Packages: pkgs})
 				pipeline := installerPipeline.serialize()
 
 				require := require.New(t)

--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/runner"
 )
@@ -99,12 +98,12 @@ func (p *BuildrootFromPackages) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *BuildrootFromPackages) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
+func (p *BuildrootFromPackages) serializeStart(inputs Inputs) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
-	p.packageSpecs = packages
-	p.repos = append(p.repos, rpmRepos...)
+	p.packageSpecs = inputs.Packages
+	p.repos = append(p.repos, inputs.RpmRepos...)
 }
 
 func (p *BuildrootFromPackages) serializeEnd() {
@@ -199,11 +198,11 @@ func (p *BuildrootFromContainer) getContainerSpecs() []container.Spec {
 	return p.containerSpecs
 }
 
-func (p *BuildrootFromContainer) serializeStart(_ []rpmmd.PackageSpec, containerSpecs []container.Spec, _ []ostree.CommitSpec, _ []rpmmd.RepoConfig) {
+func (p *BuildrootFromContainer) serializeStart(inputs Inputs) {
 	if len(p.containerSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
-	p.containerSpecs = containerSpecs
+	p.containerSpecs = inputs.Containers
 }
 
 func (p *BuildrootFromContainer) serializeEnd() {

--- a/pkg/manifest/build_test.go
+++ b/pkg/manifest/build_test.go
@@ -109,7 +109,7 @@ func TestNewBuildFromContainerSpecs(t *testing.T) {
 	}
 	// containerSpecs is "nil" until serializeStart populates it
 	require.Nil(t, build.getContainerSpecs())
-	build.serializeStart(nil, fakeContainerSpecs, nil, nil)
+	build.serializeStart(Inputs{Containers: fakeContainerSpecs})
 	assert.Equal(t, build.getContainerSpecs(), fakeContainerSpecs)
 
 	osbuildPipeline := build.serialize()

--- a/pkg/manifest/commit_server_tree.go
+++ b/pkg/manifest/commit_server_tree.go
@@ -4,9 +4,7 @@ import (
 	"path/filepath"
 
 	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -80,12 +78,12 @@ func (p *OSTreeCommitServer) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *OSTreeCommitServer) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
+func (p *OSTreeCommitServer) serializeStart(inputs Inputs) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
-	p.packageSpecs = packages
-	p.repos = append(p.repos, rpmRepos...)
+	p.packageSpecs = inputs.Packages
+	p.repos = append(p.repos, inputs.RpmRepos...)
 }
 
 func (p *OSTreeCommitServer) serializeEnd() {

--- a/pkg/manifest/coreos_installer.go
+++ b/pkg/manifest/coreos_installer.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 
 	"github.com/osbuild/images/pkg/arch"
-	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/fdo"
 	"github.com/osbuild/images/pkg/customizations/ignition"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -136,15 +134,15 @@ func (p *CoreOSInstaller) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *CoreOSInstaller) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
+func (p *CoreOSInstaller) serializeStart(inputs Inputs) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
-	p.packageSpecs = packages
+	p.packageSpecs = inputs.Packages
 	if p.kernelName != "" {
 		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.kernelName)
 	}
-	p.repos = append(p.repos, rpmRepos...)
+	p.repos = append(p.repos, inputs.RpmRepos...)
 }
 
 func (p *CoreOSInstaller) getInline() []string {

--- a/pkg/manifest/empty.go
+++ b/pkg/manifest/empty.go
@@ -65,14 +65,14 @@ func (p *ContentTest) getOSTreeCommits() []ostree.CommitSpec {
 	return p.commitSpecs
 }
 
-func (p *ContentTest) serializeStart(pkgs []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
+func (p *ContentTest) serializeStart(inputs Inputs) {
 	if p.serializing {
 		panic("double call to serializeStart()")
 	}
-	p.packageSpecs = pkgs
-	p.containerSpecs = containers
-	p.commitSpecs = commits
-	p.repos = rpmRepos
+	p.packageSpecs = inputs.Packages
+	p.containerSpecs = inputs.Containers
+	p.commitSpecs = inputs.Commits
+	p.repos = inputs.RpmRepos
 
 	p.serializing = true
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -41,6 +41,13 @@ const (
 	DISTRO_FEDORA
 )
 
+type Inputs struct {
+	Packages   []rpmmd.PackageSpec
+	Containers []container.Spec
+	Commits    []ostree.CommitSpec
+	RpmRepos   []rpmmd.RepoConfig
+}
+
 // An OSBuildManifest is an opaque JSON object, which is a valid input to osbuild
 type OSBuildManifest []byte
 
@@ -138,6 +145,7 @@ func (m Manifest) GetOSTreeSourceSpecs() map[string][]ostree.SourceSpec {
 	return ostreeSpecs
 }
 
+// TODO: change signature to map[string]Inputs
 func (m Manifest) Serialize(packageSets map[string][]rpmmd.PackageSpec, containerSpecs map[string][]container.Spec, ostreeCommits map[string][]ostree.CommitSpec, rpmRepos map[string][]rpmmd.RepoConfig) (OSBuildManifest, error) {
 	pipelines := make([]osbuild.Pipeline, 0)
 	packages := make([]rpmmd.PackageSpec, 0)
@@ -145,7 +153,12 @@ func (m Manifest) Serialize(packageSets map[string][]rpmmd.PackageSpec, containe
 	inline := make([]string, 0)
 	containers := make([]container.Spec, 0)
 	for _, pipeline := range m.pipelines {
-		pipeline.serializeStart(packageSets[pipeline.Name()], containerSpecs[pipeline.Name()], ostreeCommits[pipeline.Name()], rpmRepos[pipeline.Name()])
+		pipeline.serializeStart(Inputs{
+			Packages:   packageSets[pipeline.Name()],
+			Containers: containerSpecs[pipeline.Name()],
+			Commits:    ostreeCommits[pipeline.Name()],
+			RpmRepos:   rpmRepos[pipeline.Name()],
+		})
 	}
 	for _, pipeline := range m.pipelines {
 		commits = append(commits, pipeline.getOSTreeCommits()...)

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -376,25 +376,25 @@ func (p *OS) getContainerSpecs() []container.Spec {
 	return p.containerSpecs
 }
 
-func (p *OS) serializeStart(packages []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
+func (p *OS) serializeStart(inputs Inputs) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
 
-	p.packageSpecs = packages
-	p.containerSpecs = containers
-	if len(commits) > 0 {
-		if len(commits) > 1 {
+	p.packageSpecs = inputs.Packages
+	p.containerSpecs = inputs.Containers
+	if len(inputs.Commits) > 0 {
+		if len(inputs.Commits) > 1 {
 			panic("pipeline supports at most one ostree commit")
 		}
-		p.ostreeParentSpec = &commits[0]
+		p.ostreeParentSpec = &inputs.Commits[0]
 	}
 
 	if p.KernelName != "" {
 		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.KernelName)
 	}
 
-	p.repos = append(p.repos, rpmRepos...)
+	p.repos = append(p.repos, inputs.RpmRepos...)
 }
 
 func (p *OS) serializeEnd() {

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -34,7 +34,7 @@ func NewTestOS() *OS {
 	packages := []rpmmd.PackageSpec{
 		{Name: "pkg1", Checksum: "sha1:c02524e2bd19490f2a7167958f792262754c5f46"},
 	}
-	os.serializeStart(packages, nil, nil, repos)
+	os.serializeStart(Inputs{Packages: packages, RpmRepos: repos})
 
 	return os
 }

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -13,7 +13,6 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
-	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 // OSTreeDeploymentCustomizations encapsulates all configuration applied to an
@@ -161,18 +160,18 @@ func (p *OSTreeDeployment) getContainerSources() []container.SourceSpec {
 	}
 }
 
-func (p *OSTreeDeployment) serializeStart(_ []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec, _ []rpmmd.RepoConfig) {
+func (p *OSTreeDeployment) serializeStart(inputs Inputs) {
 	if p.ostreeSpec != nil || p.containerSpec != nil {
 		panic("double call to serializeStart()")
 	}
 
 	switch {
-	case len(commits) == 1:
-		p.ostreeSpec = &commits[0]
-	case len(containers) == 1:
-		p.containerSpec = &containers[0]
+	case len(inputs.Commits) == 1:
+		p.ostreeSpec = &inputs.Commits[0]
+	case len(inputs.Containers) == 1:
+		p.containerSpec = &inputs.Containers[0]
 	default:
-		panic(fmt.Sprintf("pipeline %s requires exactly one ostree commit or one container (have commits: %v; containers: %v)", p.Name(), commits, containers))
+		panic(fmt.Sprintf("pipeline %s requires exactly one ostree commit or one container (have commits: %v; containers: %v)", p.Name(), inputs.Commits, inputs.Containers))
 	}
 }
 

--- a/pkg/manifest/pipeline.go
+++ b/pkg/manifest/pipeline.go
@@ -53,7 +53,7 @@ type Pipeline interface {
 	// its full Spec. See the ostree package for more details.
 	getOSTreeCommitSources() []ostree.SourceSpec
 
-	serializeStart([]rpmmd.PackageSpec, []container.Spec, []ostree.CommitSpec, []rpmmd.RepoConfig)
+	serializeStart(Inputs)
 	serializeEnd()
 	serialize() osbuild.Pipeline
 
@@ -166,7 +166,7 @@ func NewBase(name string, build Build) Base {
 
 // serializeStart must be called exactly once before each call
 // to serialize().
-func (p Base) serializeStart([]rpmmd.PackageSpec, []container.Spec, []ostree.CommitSpec, []rpmmd.RepoConfig) {
+func (p Base) serializeStart(inputs Inputs) {
 }
 
 // serializeEnd must be called exactly once after each call to

--- a/pkg/manifest/raw_bootc.go
+++ b/pkg/manifest/raw_bootc.go
@@ -10,9 +10,7 @@ import (
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
-	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 // A RawBootcImage represents a raw bootc image file which can be booted in a
@@ -71,11 +69,11 @@ func (p *RawBootcImage) getContainerSpecs() []container.Spec {
 	return p.containerSpecs
 }
 
-func (p *RawBootcImage) serializeStart(_ []rpmmd.PackageSpec, containerSpecs []container.Spec, _ []ostree.CommitSpec, _ []rpmmd.RepoConfig) {
+func (p *RawBootcImage) serializeStart(inputs Inputs) {
 	if len(p.containerSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
-	p.containerSpecs = containerSpecs
+	p.containerSpecs = inputs.Containers
 }
 
 func (p *RawBootcImage) serializeEnd() {

--- a/pkg/manifest/raw_bootc_export_test.go
+++ b/pkg/manifest/raw_bootc_export_test.go
@@ -1,10 +1,7 @@
 package manifest
 
 import (
-	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/ostree"
-	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 func (br *BuildrootFromContainer) Dependents() []Pipeline {
@@ -15,6 +12,6 @@ func (rbc *RawBootcImage) Serialize() osbuild.Pipeline {
 	return rbc.serialize()
 }
 
-func (rbc *RawBootcImage) SerializeStart(a []rpmmd.PackageSpec, b []container.Spec, c []ostree.CommitSpec, r []rpmmd.RepoConfig) {
-	rbc.serializeStart(a, b, c, r)
+func (rbc *RawBootcImage) SerializeStart(inputs Inputs) {
+	rbc.serializeStart(inputs)
 }

--- a/pkg/manifest/raw_bootc_test.go
+++ b/pkg/manifest/raw_bootc_test.go
@@ -61,7 +61,7 @@ func TestRawBootcImageSerialize(t *testing.T) {
 	rawBootcPipeline.Users = []users.User{{Name: "root", Key: common.ToPtr("some-ssh-key")}}
 	rawBootcPipeline.KernelOptionsAppend = []string{"karg1", "karg2"}
 
-	rawBootcPipeline.SerializeStart(nil, []container.Spec{{Source: "foo"}}, nil, nil)
+	rawBootcPipeline.SerializeStart(manifest.Inputs{Containers: []container.Spec{{Source: "foo"}}})
 	imagePipeline := rawBootcPipeline.Serialize()
 	assert.Equal(t, "image", imagePipeline.Name)
 
@@ -87,7 +87,7 @@ func TestRawBootcImageSerializeMountsValidated(t *testing.T) {
 	rawBootcPipeline := manifest.NewRawBootcImage(build, nil, pf)
 	// note that we create a partition table without /boot here
 	rawBootcPipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/missing-boot")
-	rawBootcPipeline.SerializeStart(nil, []container.Spec{{Source: "foo"}}, nil, nil)
+	rawBootcPipeline.SerializeStart(manifest.Inputs{Containers: []container.Spec{{Source: "foo"}}})
 	assert.PanicsWithError(t, `required mounts for bootupd stage [/boot/efi] missing`, func() {
 		rawBootcPipeline.Serialize()
 	})
@@ -112,7 +112,7 @@ func makeFakeRawBootcPipeline() *manifest.RawBootcImage {
 	build := manifest.NewBuildFromContainer(&mani, runner, nil, nil)
 	rawBootcPipeline := manifest.NewRawBootcImage(build, nil, pf)
 	rawBootcPipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
-	rawBootcPipeline.SerializeStart(nil, []container.Spec{{Source: "foo"}}, nil, nil)
+	rawBootcPipeline.SerializeStart(manifest.Inputs{Containers: []container.Spec{{Source: "foo"}}})
 
 	return rawBootcPipeline
 }


### PR DESCRIPTION
The signature of serializeStart() is a bit unwieldy and when adding librepo based sources this prompted for this proposed cleanup. The idea is to just pass a single "Inputs" struct to the serialization so that if we add field we don't need to change the signature all over the place. It also makes the calls easier to read (IMHO).

This contains only mechanical changes so the review shouldbe straightforward.

Unfortunately there will be conflicts with https://github.com/osbuild/images/pull/1095/files but after this is merged the other PR will be a lot smaller

We should merge this relatively soon as pretty much any PR will conflict with this one.

[edit: happy to discuss naming, I think `manifest.Inputs` makes sense in the context and `serializeStart(inputs)` too but open for ideas, some other possibilities:
- manifest.Sources
- manifest.SerializationInputs, SerialkzationSources
- manifest.Resources
- manifest.InputData
- ...
- ?