### PR TITLE
rpmmd,dnfjson: add `Path`, `RepoID` to PackageSpec for librepo

### DIFF
--- a/pkg/dnfjson/dnfjson.go
+++ b/pkg/dnfjson/dnfjson.go
@@ -586,6 +586,8 @@ func (result depsolveResult) toRPMMD(rhsm map[string]bool) ([]rpmmd.PackageSpec,
 		rpmDependencies[i].RemoteLocation = dep.RemoteLocation
 		rpmDependencies[i].Checksum = dep.Checksum
 		rpmDependencies[i].CheckGPG = repo.GPGCheck
+		rpmDependencies[i].RepoID = dep.RepoID
+		rpmDependencies[i].Path = dep.Path
 		if verify := repo.SSLVerify; verify != nil {
 			rpmDependencies[i].IgnoreSSL = !*verify
 		}

--- a/pkg/dnfjson/dnfjson_test.go
+++ b/pkg/dnfjson/dnfjson_test.go
@@ -134,7 +134,8 @@ func TestDepsolver(t *testing.T) {
 				require.NotNil(t, res)
 			}
 
-			assert.Equal(expectedResult(s.RepoConfig), res.Packages)
+			assert.Equal(len(res.Repos), 1)
+			assert.Equal(expectedResult(res.Repos[0]), res.Packages)
 
 			if tc.sbomType != sbom.StandardTypeNone {
 				require.NotNil(t, res.SBOM)
@@ -725,6 +726,8 @@ func expectedResult(repo rpmmd.RepoConfig) []rpmmd.PackageSpec {
 	for idx := range exp {
 		urlTemplate := exp[idx].RemoteLocation
 		exp[idx].RemoteLocation = fmt.Sprintf(urlTemplate, strings.Join(repo.BaseURLs, ","))
+		exp[idx].Path = strings.TrimPrefix(urlTemplate, "%s/")
+		exp[idx].RepoID = repo.Id
 	}
 	return exp
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -145,7 +145,10 @@ func (m Manifest) GetOSTreeSourceSpecs() map[string][]ostree.SourceSpec {
 	return ostreeSpecs
 }
 
-// TODO: change signature to map[string]Inputs
+// TODO: change signature to map[string]Inputs and/or ensure that
+// only depsolved PackageSpecs/RepoConfigs are passed so that we
+// have a valid mapping of pkg.RepoID<->repo.Id which will be important
+// for librepo
 func (m Manifest) Serialize(packageSets map[string][]rpmmd.PackageSpec, containerSpecs map[string][]container.Spec, ostreeCommits map[string][]ostree.CommitSpec, rpmRepos map[string][]rpmmd.RepoConfig) (OSBuildManifest, error) {
 	pipelines := make([]osbuild.Pipeline, 0)
 	packages := make([]rpmmd.PackageSpec, 0)

--- a/pkg/rpmmd/repository.go
+++ b/pkg/rpmmd/repository.go
@@ -165,6 +165,9 @@ type PackageSpec struct {
 	Secrets        string `json:"secrets,omitempty"`
 	CheckGPG       bool   `json:"check_gpg,omitempty"`
 	IgnoreSSL      bool   `json:"ignore_ssl,omitempty"`
+
+	Path   string `json:"path,omitempty"`
+	RepoID string `json:"repo_id,omitempty"`
 }
 
 type PackageSource struct {

--- a/pkg/rpmmd/repository_test.go
+++ b/pkg/rpmmd/repository_test.go
@@ -53,6 +53,46 @@ func TestPackageSpecGetNEVRA(t *testing.T) {
 
 func TestRepoConfigMarshalEmpty(t *testing.T) {
 	repoCfg := &RepoConfig{}
-	js, _ := json.Marshal(repoCfg)
+	js, err := json.Marshal(repoCfg)
+	assert.NoError(t, err)
 	assert.Equal(t, string(js), `{}`)
+}
+
+func TestPackageSpecEmptyJson(t *testing.T) {
+	pkg := &PackageSpec{Name: "pkg1"}
+	js, err := json.Marshal(pkg)
+	assert.NoError(t, err)
+	assert.Equal(t, string(js), `{"name":"pkg1","epoch":0}`)
+}
+
+func TestPackageSpecFull(t *testing.T) {
+	pkg := &PackageSpec{
+		Name:           "acl",
+		Epoch:          0,
+		Version:        "2.3.1",
+		Release:        "3.el9",
+		Arch:           "x86_64",
+		RemoteLocation: "http://example.com/repo/Packages/acl-2.3.1-3.el9.x86_64.rpm",
+		Checksum:       "sha256:986044c3837eddbc9231d7be5e5fc517e245296978b988a803bc9f9172fe84ea",
+		Secrets:        "",
+		CheckGPG:       false,
+		IgnoreSSL:      true,
+		Path:           "Packages/acl-2.3.1-3.el9.x86_64.rpm",
+		RepoID:         "813859d10fe28ff54dbde44655a18b071c8adbaa849a551ec23cc415f0f7f1b0",
+	}
+
+	js, err := json.MarshalIndent(pkg, "", " ")
+	assert.NoError(t, err)
+	assert.Equal(t, string(js), `{
+ "name": "acl",
+ "epoch": 0,
+ "version": "2.3.1",
+ "release": "3.el9",
+ "arch": "x86_64",
+ "remote_location": "http://example.com/repo/Packages/acl-2.3.1-3.el9.x86_64.rpm",
+ "checksum": "sha256:986044c3837eddbc9231d7be5e5fc517e245296978b988a803bc9f9172fe84ea",
+ "ignore_ssl": true,
+ "path": "Packages/acl-2.3.1-3.el9.x86_64.rpm",
+ "repo_id": "813859d10fe28ff54dbde44655a18b071c8adbaa849a551ec23cc415f0f7f1b0"
+}`)
 }


### PR DESCRIPTION
This commit adds the two new `Path` and `RepoID` fields to the rpmmd.PackageSpec so that librepo can use them as it needs to correlate a package to a repo to generate the right mirror id.

Ideally we would also make sure the inputs to manifest.Serialize() only accepts depsolved packageSets/repoConfigs via static type checking. There is a TODO for this now but it's not done in this commit as it requires some more thinking/discussion. But because of the strict requirement for matching packageSpec.RepoID and repoConfig.Id we should try to make this type safe. The repoConfig.Id is really only guranteed after the depsolve() run.

[split out from https://github.com/osbuild/images/pull/1132 with improved docs/tests]