### PR TITLE
manifest,sources: add librepo support to Serialize/GenSources

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -82,7 +82,7 @@ func makeManifest(
 		return nil, fmt.Errorf("[ERROR] ostree commit resolution failed: %w", err)
 	}
 
-	mf, err := manifest.Serialize(packageSpecs, containerSpecs, commitSpecs, nil)
+	mf, err := manifest.Serialize(packageSpecs, containerSpecs, commitSpecs, repoConfigs, 0)
 	if err != nil {
 		return nil, fmt.Errorf("[ERROR] manifest serialization failed: %w", err)
 	}

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -81,7 +81,7 @@ func makeManifest(
 		return nil, fmt.Errorf("[ERROR] ostree commit resolution failed: %w", err)
 	}
 
-	mf, err := manifest.Serialize(depsolvedSets, containerSpecs, commitSpecs, 0)
+	mf, err := manifest.Serialize(depsolvedSets, containerSpecs, commitSpecs, nil)
 	if err != nil {
 		return nil, fmt.Errorf("[ERROR] manifest serialization failed: %w", err)
 	}

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -221,9 +221,11 @@ func makeManifestJob(
 				err = fmt.Errorf("[%s] depsolve failed: %s", filename, err.Error())
 				return
 			}
-			if depsolvedSets == nil {
-				err = fmt.Errorf("[%s] nil package specs", filename)
-				return
+			for plName, depsolved := range depsolvedSets {
+				if depsolved.Packages == nil {
+					err = fmt.Errorf("[%s] nil package specs in %v", filename, plName)
+					return
+				}
 			}
 		} else {
 			depsolvedSets = mockDepsolve(manifest.GetPackageSetChains(), repos, archName)

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -251,7 +251,7 @@ func makeManifestJob(
 			commitSpecs = mockResolveCommits(manifest.GetOSTreeSourceSpecs())
 		}
 
-		mf, err := manifest.Serialize(packageSpecs, containerSpecs, commitSpecs, repoConfigs)
+		mf, err := manifest.Serialize(packageSpecs, containerSpecs, commitSpecs, repoConfigs, 0)
 		if err != nil {
 			return fmt.Errorf("[%s] manifest serialization failed: %s", filename, err.Error())
 		}

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -249,7 +249,7 @@ func makeManifestJob(
 			commitSpecs = mockResolveCommits(manifest.GetOSTreeSourceSpecs())
 		}
 
-		mf, err := manifest.Serialize(depsolvedSets, containerSpecs, commitSpecs, 0)
+		mf, err := manifest.Serialize(depsolvedSets, containerSpecs, commitSpecs, nil)
 		if err != nil {
 			return fmt.Errorf("[%s] manifest serialization failed: %s", filename, err.Error())
 		}

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -49,7 +49,7 @@ func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos
 		fmt.Fprintf(os.Stderr, "could not clean dnf cache: %s", err.Error())
 	}
 
-	bytes, err := manifest.Serialize(depsolvedSets, nil, nil, 0)
+	bytes, err := manifest.Serialize(depsolvedSets, nil, nil, nil)
 	if err != nil {
 		panic("failed to serialize manifest: " + err.Error())
 	}

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -49,7 +49,7 @@ func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos
 		fmt.Fprintf(os.Stderr, "could not clean dnf cache: %s", err.Error())
 	}
 
-	bytes, err := manifest.Serialize(packageSpecs, nil, nil, nil)
+	bytes, err := manifest.Serialize(packageSpecs, nil, nil, nil, 0)
 	if err != nil {
 		panic("failed to serialize manifest: " + err.Error())
 	}

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -134,7 +134,7 @@ func TestImageTypePipelineNames(t *testing.T) {
 						}
 						commits[name] = commitSpecs
 					}
-					mf, err := m.Serialize(packageSets, containers, commits, repoSets)
+					mf, err := m.Serialize(packageSets, containers, commits, repoSets, 0)
 					assert.NoError(err)
 					pm := new(manifest)
 					err = json.Unmarshal(mf, pm)

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -136,7 +136,7 @@ func TestImageTypePipelineNames(t *testing.T) {
 						}
 						commits[name] = commitSpecs
 					}
-					mf, err := m.Serialize(depsolvedSets, containers, commits, 0)
+					mf, err := m.Serialize(depsolvedSets, containers, commits, nil)
 					assert.NoError(err)
 					pm := new(manifest)
 					err = json.Unmarshal(mf, pm)

--- a/pkg/image/bootc_disk_test.go
+++ b/pkg/image/bootc_disk_test.go
@@ -88,7 +88,7 @@ func makeBootcDiskImageOsbuildManifest(t *testing.T, opts *bootcDiskImageTestOpt
 		"image": []container.Spec{{Source: "other-src", Digest: makeFakeDigest(t), ImageID: makeFakeDigest(t)}},
 	}
 
-	osbuildManifest, err := m.Serialize(nil, fakeSourceSpecs, nil, nil)
+	osbuildManifest, err := m.Serialize(nil, fakeSourceSpecs, nil, nil, 0)
 	require.Nil(t, err)
 
 	return osbuildManifest

--- a/pkg/image/bootc_disk_test.go
+++ b/pkg/image/bootc_disk_test.go
@@ -88,7 +88,7 @@ func makeBootcDiskImageOsbuildManifest(t *testing.T, opts *bootcDiskImageTestOpt
 		"image": []container.Spec{{Source: "other-src", Digest: makeFakeDigest(t), ImageID: makeFakeDigest(t)}},
 	}
 
-	osbuildManifest, err := m.Serialize(nil, fakeSourceSpecs, nil, 0)
+	osbuildManifest, err := m.Serialize(nil, fakeSourceSpecs, nil, nil)
 	require.Nil(t, err)
 
 	return osbuildManifest

--- a/pkg/image/bootc_disk_test.go
+++ b/pkg/image/bootc_disk_test.go
@@ -88,7 +88,7 @@ func makeBootcDiskImageOsbuildManifest(t *testing.T, opts *bootcDiskImageTestOpt
 		"image": []container.Spec{{Source: "other-src", Digest: makeFakeDigest(t), ImageID: makeFakeDigest(t)}},
 	}
 
-	osbuildManifest, err := m.Serialize(nil, fakeSourceSpecs, nil, nil, 0)
+	osbuildManifest, err := m.Serialize(nil, fakeSourceSpecs, nil, 0)
 	require.Nil(t, err)
 
 	return osbuildManifest

--- a/pkg/image/installer_image_test.go
+++ b/pkg/image/installer_image_test.go
@@ -364,7 +364,7 @@ func instantiateAndSerialize(t *testing.T, img image.ImageKind, packages map[str
 	_, err := img.InstantiateManifest(&mf, nil, &runner.CentOS{Version: 9}, rng)
 	assert.NoError(t, err)
 
-	mfs, err := mf.Serialize(packages, containers, commits, nil)
+	mfs, err := mf.Serialize(packages, containers, commits, nil, 0)
 	assert.NoError(t, err)
 
 	return string(mfs)

--- a/pkg/image/installer_image_test.go
+++ b/pkg/image/installer_image_test.go
@@ -372,7 +372,7 @@ func instantiateAndSerialize(t *testing.T, img image.ImageKind, depsolved map[st
 	_, err := img.InstantiateManifest(&mf, nil, &runner.CentOS{Version: 9}, rng)
 	assert.NoError(t, err)
 
-	mfs, err := mf.Serialize(depsolved, containers, commits, 0)
+	mfs, err := mf.Serialize(depsolved, containers, commits, nil)
 	assert.NoError(t, err)
 
 	return string(mfs)

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -198,11 +198,11 @@ func (p *AnacondaInstaller) serializeStart(inputs Inputs) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
-	p.packageSpecs = inputs.Packages
+	p.packageSpecs = inputs.Depsolved.Packages
 	if p.kernelName != "" {
 		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.kernelName)
 	}
-	p.repos = append(p.repos, inputs.RpmRepos...)
+	p.repos = append(p.repos, inputs.Depsolved.Repos...)
 }
 
 func (p *AnacondaInstaller) serializeEnd() {

--- a/pkg/manifest/anaconda_installer_test.go
+++ b/pkg/manifest/anaconda_installer_test.go
@@ -3,12 +3,14 @@ package manifest
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/osbuild/images/pkg/customizations/anaconda"
+	"github.com/osbuild/images/pkg/dnfjson"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/runner"
-	"github.com/stretchr/testify/require"
 )
 
 func newAnacondaInstaller() *AnacondaInstaller {
@@ -105,7 +107,7 @@ func TestAnacondaInstallerModules(t *testing.T) {
 				installerPipeline.UseLegacyAnacondaConfig = legacy
 				installerPipeline.AdditionalAnacondaModules = tc.enable
 				installerPipeline.DisabledAnacondaModules = tc.disable
-				installerPipeline.serializeStart(Inputs{Packages: pkgs})
+				installerPipeline.serializeStart(Inputs{Depsolved: dnfjson.DepsolveResult{Packages: pkgs}})
 				pipeline := installerPipeline.serialize()
 
 				require := require.New(t)

--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -102,8 +102,8 @@ func (p *BuildrootFromPackages) serializeStart(inputs Inputs) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
-	p.packageSpecs = inputs.Packages
-	p.repos = append(p.repos, inputs.RpmRepos...)
+	p.packageSpecs = inputs.Depsolved.Packages
+	p.repos = append(p.repos, inputs.Depsolved.Repos...)
 }
 
 func (p *BuildrootFromPackages) serializeEnd() {

--- a/pkg/manifest/commit_server_tree.go
+++ b/pkg/manifest/commit_server_tree.go
@@ -82,8 +82,8 @@ func (p *OSTreeCommitServer) serializeStart(inputs Inputs) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
-	p.packageSpecs = inputs.Packages
-	p.repos = append(p.repos, inputs.RpmRepos...)
+	p.packageSpecs = inputs.Depsolved.Packages
+	p.repos = append(p.repos, inputs.Depsolved.Repos...)
 }
 
 func (p *OSTreeCommitServer) serializeEnd() {

--- a/pkg/manifest/coreos_installer.go
+++ b/pkg/manifest/coreos_installer.go
@@ -138,11 +138,11 @@ func (p *CoreOSInstaller) serializeStart(inputs Inputs) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
-	p.packageSpecs = inputs.Packages
+	p.packageSpecs = inputs.Depsolved.Packages
 	if p.kernelName != "" {
 		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.kernelName)
 	}
-	p.repos = append(p.repos, inputs.RpmRepos...)
+	p.repos = append(p.repos, inputs.Depsolved.Repos...)
 }
 
 func (p *CoreOSInstaller) getInline() []string {

--- a/pkg/manifest/empty.go
+++ b/pkg/manifest/empty.go
@@ -69,10 +69,10 @@ func (p *ContentTest) serializeStart(inputs Inputs) {
 	if p.serializing {
 		panic("double call to serializeStart()")
 	}
-	p.packageSpecs = inputs.Packages
+	p.packageSpecs = inputs.Depsolved.Packages
 	p.containerSpecs = inputs.Containers
 	p.commitSpecs = inputs.Commits
-	p.repos = inputs.RpmRepos
+	p.repos = inputs.Depsolved.Repos
 
 	p.serializing = true
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -141,7 +141,15 @@ func (m Manifest) GetOSTreeSourceSpecs() map[string][]ostree.SourceSpec {
 	return ostreeSpecs
 }
 
-func (m Manifest) Serialize(depsolvedSets map[string]dnfjson.DepsolveResult, containerSpecs map[string][]container.Spec, ostreeCommits map[string][]ostree.CommitSpec, rpmDownloader osbuild.RpmDownloader) (OSBuildManifest, error) {
+type SerializeOptions struct {
+	RpmDownloader osbuild.RpmDownloader
+}
+
+func (m Manifest) Serialize(depsolvedSets map[string]dnfjson.DepsolveResult, containerSpecs map[string][]container.Spec, ostreeCommits map[string][]ostree.CommitSpec, opts *SerializeOptions) (OSBuildManifest, error) {
+	if opts == nil {
+		opts = &SerializeOptions{}
+	}
+
 	for _, pipeline := range m.pipelines {
 		pipeline.serializeStart(Inputs{
 			Depsolved:  depsolvedSets[pipeline.Name()],
@@ -165,7 +173,7 @@ func (m Manifest) Serialize(depsolvedSets map[string]dnfjson.DepsolveResult, con
 		pipeline.serializeEnd()
 	}
 
-	sources, err := osbuild.GenSources(mergedInputs, rpmDownloader)
+	sources, err := osbuild.GenSources(mergedInputs, opts.RpmDownloader)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -381,7 +381,7 @@ func (p *OS) serializeStart(inputs Inputs) {
 		panic("double call to serializeStart()")
 	}
 
-	p.packageSpecs = inputs.Packages
+	p.packageSpecs = inputs.Depsolved.Packages
 	p.containerSpecs = inputs.Containers
 	if len(inputs.Commits) > 0 {
 		if len(inputs.Commits) > 1 {
@@ -394,7 +394,7 @@ func (p *OS) serializeStart(inputs Inputs) {
 		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.KernelName)
 	}
 
-	p.repos = append(p.repos, inputs.RpmRepos...)
+	p.repos = append(p.repos, inputs.Depsolved.Repos...)
 }
 
 func (p *OS) serializeEnd() {

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -4,17 +4,18 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/bootc"
 	"github.com/osbuild/images/pkg/customizations/subscription"
+	"github.com/osbuild/images/pkg/dnfjson"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/runner"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // NewTestOS returns a minimally populated OS struct for use in testing
@@ -34,7 +35,12 @@ func NewTestOS() *OS {
 	packages := []rpmmd.PackageSpec{
 		{Name: "pkg1", Checksum: "sha1:c02524e2bd19490f2a7167958f792262754c5f46"},
 	}
-	os.serializeStart(Inputs{Packages: packages, RpmRepos: repos})
+	os.serializeStart(Inputs{
+		Depsolved: dnfjson.DepsolveResult{
+			Packages: packages,
+			Repos:    repos,
+		},
+	})
 
 	return os
 }

--- a/pkg/osbuild/curl_source.go
+++ b/pkg/osbuild/curl_source.go
@@ -9,6 +9,8 @@ import (
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
+const SourceNameCurl = "org.osbuild.curl"
+
 var curlDigestPattern = regexp.MustCompile(`(md5|sha1|sha256|sha384|sha512):[0-9a-f]{32,128}`)
 
 type CurlSource struct {

--- a/pkg/osbuild/inline_source.go
+++ b/pkg/osbuild/inline_source.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 )
 
+const SourceNameInline = "org.osbuild.inline"
+
 type InlineSource struct {
 	Items map[string]InlineSourceItem `json:"items"`
 }

--- a/pkg/osbuild/librepo_source.go
+++ b/pkg/osbuild/librepo_source.go
@@ -6,6 +6,8 @@ import (
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
+const SourceNameLibrepo = "org.osbuild.librepo"
+
 // LibrepoSource wraps the org.osbuild.librepo osbuild source
 type LibrepoSource struct {
 	Items   map[string]*LibrepoSourceItem `json:"items"`

--- a/pkg/osbuild/ostree_source.go
+++ b/pkg/osbuild/ostree_source.go
@@ -2,6 +2,8 @@ package osbuild
 
 import "github.com/osbuild/images/pkg/ostree"
 
+const SourceNameOstree = "org.osbuild.ostree"
+
 // The commits to fetch indexed their checksum
 type OSTreeSource struct {
 	Items map[string]OSTreeSourceItem `json:"items"`

--- a/pkg/osbuild/source.go
+++ b/pkg/osbuild/source.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/dnfjson"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -23,10 +24,9 @@ const (
 // Note that for Packages/RpmRepos the depsolve resolved results
 // must be passed
 type SourceInputs struct {
-	Packages   []rpmmd.PackageSpec
+	Depsolved  dnfjson.DepsolveResult
 	Containers []container.Spec
 	Commits    []ostree.CommitSpec
-	RpmRepos   []rpmmd.RepoConfig
 	InlineData []string
 }
 
@@ -107,13 +107,13 @@ func GenSources(inputs SourceInputs, rpmDownloader RpmDownloader) (Sources, erro
 	sources := Sources{}
 
 	// collect rpm package sources
-	if len(inputs.Packages) > 0 {
+	if len(inputs.Depsolved.Packages) > 0 {
 		var err error
 		switch rpmDownloader {
 		case RpmDownloaderCurl:
-			err = sources.addPackagesCurl(inputs.Packages)
+			err = sources.addPackagesCurl(inputs.Depsolved.Packages)
 		case RpmDownloaderLibrepo:
-			err = sources.addPackagesLibrepo(inputs.Packages, inputs.RpmRepos)
+			err = sources.addPackagesLibrepo(inputs.Depsolved.Packages, inputs.Depsolved.Repos)
 		default:
 			err = fmt.Errorf("unknown rpm downloader %v", rpmDownloader)
 		}

--- a/pkg/osbuild/source.go
+++ b/pkg/osbuild/source.go
@@ -56,13 +56,13 @@ func (sources *Sources) UnmarshalJSON(data []byte) error {
 	for name, rawSource := range rawSources {
 		var source Source
 		switch name {
-		case "org.osbuild.curl":
+		case SourceNameCurl:
 			source = new(CurlSource)
-		case "org.osbuild.librepo":
+		case SourceNameLibrepo:
 			source = new(LibrepoSource)
-		case "org.osbuild.inline":
+		case SourceNameInline:
 			source = new(InlineSource)
-		case "org.osbuild.ostree":
+		case SourceNameOstree:
 			source = new(OSTreeSource)
 		default:
 			return errors.New("unexpected source name: " + name)
@@ -85,7 +85,7 @@ func (sources Sources) addPackagesCurl(packages []rpmmd.PackageSpec) error {
 			return err
 		}
 	}
-	sources["org.osbuild.curl"] = curl
+	sources[SourceNameCurl] = curl
 	return nil
 }
 
@@ -97,7 +97,7 @@ func (sources Sources) addPackagesLibrepo(packages []rpmmd.PackageSpec, rpmRepos
 			return err
 		}
 	}
-	sources["org.osbuild.librepo"] = librepo
+	sources[SourceNameLibrepo] = librepo
 	return nil
 }
 
@@ -129,7 +129,7 @@ func GenSources(inputs SourceInputs, rpmDownloader RpmDownloader) (Sources, erro
 			ostree.AddItem(commit)
 		}
 		if len(ostree.Items) > 0 {
-			sources["org.osbuild.ostree"] = ostree
+			sources[SourceNameOstree] = ostree
 		}
 	}
 
@@ -140,7 +140,7 @@ func GenSources(inputs SourceInputs, rpmDownloader RpmDownloader) (Sources, erro
 			ils.AddItem(data)
 		}
 
-		sources["org.osbuild.inline"] = ils
+		sources[SourceNameInline] = ils
 	}
 
 	// collect skopeo and local container sources

--- a/pkg/osbuild/source.go
+++ b/pkg/osbuild/source.go
@@ -3,11 +3,32 @@ package osbuild
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
+
+// RpmDownloader specifies what backend to use for rpm downloads
+// Note that the librepo backend requires a newer osbuild.
+type RpmDownloader uint64
+
+const (
+	RpmDownloaderCurl    = iota
+	RpmDownloaderLibrepo = iota
+)
+
+// SourceInputs contains the inputs to generate osbuild.Sources
+// Note that for Packages/RpmRepos the depsolve resolved results
+// must be passed
+type SourceInputs struct {
+	Packages   []rpmmd.PackageSpec
+	Containers []container.Spec
+	Commits    []ostree.CommitSpec
+	RpmRepos   []rpmmd.RepoConfig
+	InlineData []string
+}
 
 // A Sources map contains all the sources made available to an osbuild run
 type Sources map[string]Source
@@ -37,6 +58,8 @@ func (sources *Sources) UnmarshalJSON(data []byte) error {
 		switch name {
 		case "org.osbuild.curl":
 			source = new(CurlSource)
+		case "org.osbuild.librepo":
+			source = new(LibrepoSource)
 		case "org.osbuild.inline":
 			source = new(InlineSource)
 		case "org.osbuild.ostree":
@@ -54,25 +77,55 @@ func (sources *Sources) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func GenSources(packages []rpmmd.PackageSpec, ostreeCommits []ostree.CommitSpec, inlineData []string, containers []container.Spec) (Sources, error) {
+func (sources Sources) addPackagesCurl(packages []rpmmd.PackageSpec) error {
+	curl := NewCurlSource()
+	for _, pkg := range packages {
+		err := curl.AddPackage(pkg)
+		if err != nil {
+			return err
+		}
+	}
+	sources["org.osbuild.curl"] = curl
+	return nil
+}
+
+func (sources Sources) addPackagesLibrepo(packages []rpmmd.PackageSpec, rpmRepos []rpmmd.RepoConfig) error {
+	librepo := NewLibrepoSource()
+	for _, pkg := range packages {
+		err := librepo.AddPackage(pkg, rpmRepos)
+		if err != nil {
+			return err
+		}
+	}
+	sources["org.osbuild.librepo"] = librepo
+	return nil
+}
+
+// GenSources generates the Sources from the given inputs. Note that
+// the packages and rpmRepos need to come from the *resolved* set.
+func GenSources(inputs SourceInputs, rpmDownloader RpmDownloader) (Sources, error) {
 	sources := Sources{}
 
 	// collect rpm package sources
-	if len(packages) > 0 {
-		curl := NewCurlSource()
-		for _, pkg := range packages {
-			err := curl.AddPackage(pkg)
-			if err != nil {
-				return nil, err
-			}
+	if len(inputs.Packages) > 0 {
+		var err error
+		switch rpmDownloader {
+		case RpmDownloaderCurl:
+			err = sources.addPackagesCurl(inputs.Packages)
+		case RpmDownloaderLibrepo:
+			err = sources.addPackagesLibrepo(inputs.Packages, inputs.RpmRepos)
+		default:
+			err = fmt.Errorf("unknown rpm downloader %v", rpmDownloader)
 		}
-		sources["org.osbuild.curl"] = curl
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// collect ostree commit sources
-	if len(ostreeCommits) > 0 {
+	if len(inputs.Commits) > 0 {
 		ostree := NewOSTreeSource()
-		for _, commit := range ostreeCommits {
+		for _, commit := range inputs.Commits {
 			ostree.AddItem(commit)
 		}
 		if len(ostree.Items) > 0 {
@@ -81,9 +134,9 @@ func GenSources(packages []rpmmd.PackageSpec, ostreeCommits []ostree.CommitSpec,
 	}
 
 	// collect inline data sources
-	if len(inlineData) > 0 {
+	if len(inputs.InlineData) > 0 {
 		ils := NewInlineSource()
-		for _, data := range inlineData {
+		for _, data := range inputs.InlineData {
 			ils.AddItem(data)
 		}
 
@@ -91,11 +144,11 @@ func GenSources(packages []rpmmd.PackageSpec, ostreeCommits []ostree.CommitSpec,
 	}
 
 	// collect skopeo and local container sources
-	if len(containers) > 0 {
+	if len(inputs.Containers) > 0 {
 		skopeo := NewSkopeoSource()
 		skopeoIndex := NewSkopeoIndexSource()
 		localContainers := NewContainersStorageSource()
-		for _, c := range containers {
+		for _, c := range inputs.Containers {
 			if c.LocalStorage {
 				localContainers.AddItem(c.ImageID)
 			} else {

--- a/pkg/osbuild/source_test.go
+++ b/pkg/osbuild/source_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/dnfjson"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -259,8 +260,10 @@ var fakeRepos = []rpmmd.RepoConfig{
 
 func TestGenSourcesRpmDefaultRpmDownloaderIsCurl(t *testing.T) {
 	inputs := SourceInputs{
-		Packages: []rpmmd.PackageSpec{opensslPkg},
-		RpmRepos: fakeRepos,
+		Depsolved: dnfjson.DepsolveResult{
+			Packages: []rpmmd.PackageSpec{opensslPkg},
+			Repos:    fakeRepos,
+		},
 	}
 	var defaultRpmDownloader RpmDownloader
 	sources, err := GenSources(inputs, defaultRpmDownloader)
@@ -272,8 +275,10 @@ func TestGenSourcesRpmDefaultRpmDownloaderIsCurl(t *testing.T) {
 
 func TestGenSourcesRpmWithLibcurl(t *testing.T) {
 	inputs := SourceInputs{
-		Packages: []rpmmd.PackageSpec{opensslPkg},
-		RpmRepos: fakeRepos,
+		Depsolved: dnfjson.DepsolveResult{
+			Packages: []rpmmd.PackageSpec{opensslPkg},
+			Repos:    fakeRepos,
+		},
 	}
 	sources, err := GenSources(inputs, RpmDownloaderCurl)
 	assert.NoError(t, err)
@@ -293,8 +298,10 @@ func TestGenSourcesRpmWithLibcurl(t *testing.T) {
 
 func TestGenSourcesRpmWithLibrepo(t *testing.T) {
 	inputs := SourceInputs{
-		Packages: []rpmmd.PackageSpec{opensslPkg},
-		RpmRepos: fakeRepos,
+		Depsolved: dnfjson.DepsolveResult{
+			Packages: []rpmmd.PackageSpec{opensslPkg},
+			Repos:    fakeRepos,
+		},
 	}
 	sources, err := GenSources(inputs, RpmDownloaderLibrepo)
 	assert.NoError(t, err)
@@ -323,8 +330,10 @@ func TestGenSourcesRpmWithLibrepo(t *testing.T) {
 
 func TestGenSourcesRpmBad(t *testing.T) {
 	inputs := SourceInputs{
-		Packages: []rpmmd.PackageSpec{opensslPkg},
-		RpmRepos: fakeRepos,
+		Depsolved: dnfjson.DepsolveResult{
+			Packages: []rpmmd.PackageSpec{opensslPkg},
+			Repos:    fakeRepos,
+		},
 	}
 	_, err := GenSources(inputs, 99)
 	assert.EqualError(t, err, "unknown rpm downloader 99")


### PR DESCRIPTION
This commit enables librepo sources generation via a new
osbuild.RpmDownloader iota that is passed to to
`manifest.Serialize()` and `osbuild.GenSources()`.

We also need to pass the resolved repoConfig to `manifest.Serialize()`.
This is currently not type-safe, ideally we would look into how to do
this in a type-safe way. Serialize should also take less args
ideally.

Superseeds https://github.com/osbuild/images/pull/1132

With that we can enable `--use-librepo` in 
* https://github.com/osbuild/image-builder-cli/pull/51
* https://github.com/osbuild/bootc-image-builder/pull/786