### PR TITLE
cloud: allow to call S3 cleanup via defer

### DIFF
--- a/pkg/cloud/awscloud/awscloud.go
+++ b/pkg/cloud/awscloud/awscloud.go
@@ -294,10 +294,7 @@ func (a *AWS) Register(name, bucket, key string, shareWith []string, rpmArch str
 
 	// we no longer need the object in s3, let's just delete it
 	logrus.Infof("[AWS] 🧹 Deleting image from S3: %s/%s", bucket, key)
-	_, err = a.s3.DeleteObject(&s3.DeleteObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
-	})
+	err = a.Cleanup(name, bucket, key)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -386,6 +383,18 @@ func (a *AWS) Register(name, bucket, key string, shareWith []string, rpmArch str
 	}
 
 	return registerOutput.ImageId, snapshotID, nil
+}
+
+// Cleanup removes any temporary resources created during the image registration process.
+// Make sure to call this function via defer to ensure cleanup is always performed.
+// It will return an error if resources no longer exist or if there was an error deleting them.
+func (a *AWS) Cleanup(name, bucket, key string) error {
+	_, err := a.s3.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+
+	return err
 }
 
 // target region is determined by the region configured in the aws session

--- a/pkg/cloud/gcp/compute.go
+++ b/pkg/cloud/gcp/compute.go
@@ -77,6 +77,7 @@ func GuestOsFeaturesByDistro(distroName string) []*computepb.GuestOsFeature {
 // The image must be RAW image named 'disk.raw' inside a gzip-ed tarball.
 //
 // To delete the Storage object (image) used for the image import, use StorageObjectDelete().
+// Make sure to use defer in order to delete objects when error occurs.
 //
 // bucket - Google storage bucket name with the uploaded image archive
 // object - Google storage object name of the uploaded image


### PR DESCRIPTION
I noticed when upload or registration of AMI fails, the image is left on the S3 bucket forever. To fix this, we need to be able to use `defer` to delete the object even if an error occurs. Therefore new Cleanup function is introduced doing exactly that. The process still cleans the S3 bucket, but we can do this in composer/bib now:

```
// call cleanup and ignore possible error
defer a.Cleanup(name, key, bucket)

// do upload and processing
```