### PR TITLE
Unify locales and timezones in RHEL 10 disk images (HMS-5342)

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -93,6 +93,9 @@ var (
 			osPkgsKey:        minimalrpmPackageSet,
 			installerPkgsKey: imageInstallerPackageSet,
 		},
+		defaultImageConfig: &distro.ImageConfig{
+			Locale: common.ToPtr("en_US.UTF-8"),
+		},
 		bootable:  true,
 		bootISO:   true,
 		rpmOstree: false,
@@ -112,6 +115,9 @@ var (
 		mimeType:    "application/x-iso9660-image",
 		packageSets: map[string]packageSetFunc{
 			installerPkgsKey: liveInstallerPackageSet,
+		},
+		defaultImageConfig: &distro.ImageConfig{
+			Locale: common.ToPtr("en_US.UTF-8"),
 		},
 		bootable:               true,
 		bootISO:                true,

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -407,6 +407,10 @@ func liveInstallerImage(workload workload.Workload,
 		img.RootfsType = manifest.SquashfsRootfs
 	}
 
+	if locale := t.getDefaultImageConfig().Locale; locale != nil {
+		img.Locale = *locale
+	}
+
 	return img, nil
 }
 
@@ -423,6 +427,11 @@ func imageInstallerImage(workload workload.Workload,
 	img := image.NewAnacondaTarInstaller()
 
 	var err error
+	img.OSCustomizations, err = osCustomizations(t, packageSets[osPkgsKey], containers, bp.Customizations)
+	if err != nil {
+		return nil, err
+	}
+
 	img.Kickstart, err = kickstart.New(customizations)
 	if err != nil {
 		return nil, err
@@ -452,11 +461,6 @@ func imageInstallerImage(workload workload.Workload,
 
 	img.Platform = t.platform
 	img.Workload = workload
-
-	img.OSCustomizations, err = osCustomizations(t, packageSets[osPkgsKey], containers, bp.Customizations)
-	if err != nil {
-		return nil, err
-	}
 
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
 
@@ -683,6 +687,10 @@ func iotInstallerImage(workload workload.Workload,
 	img.RootfsCompression = "lz4"
 	if common.VersionGreaterThanOrEqual(img.OSVersion, VERSION_ROOTFS_SQUASHFS) {
 		img.RootfsType = manifest.SquashfsRootfs
+	}
+
+	if locale := t.getDefaultImageConfig().Locale; locale != nil {
+		img.Locale = *locale
 	}
 
 	return img, nil

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -537,6 +537,10 @@ func EdgeInstallerImage(workload workload.Workload,
 
 	img.Filename = t.Filename()
 
+	if locale := t.getDefaultImageConfig().Locale; locale != nil {
+		img.Locale = *locale
+	}
+
 	return img, nil
 }
 

--- a/pkg/distro/rhel/rhel10/ami.go
+++ b/pkg/distro/rhel/rhel10/ami.go
@@ -166,7 +166,7 @@ const (
 // default EC2 images config (common for all architectures)
 func defaultEc2ImageConfig() *distro.ImageConfig {
 	return &distro.ImageConfig{
-		Locale:   common.ToPtr("en_US.UTF-8"),
+		Locale:   common.ToPtr("C.UTF-8"),
 		Timezone: common.ToPtr("UTC"),
 		TimeSynchronization: &osbuild.ChronyStageOptions{
 			Servers: []osbuild.ChronyConfigServer{

--- a/pkg/distro/rhel/rhel10/ami.go
+++ b/pkg/distro/rhel/rhel10/ami.go
@@ -166,8 +166,6 @@ const (
 // default EC2 images config (common for all architectures)
 func defaultEc2ImageConfig() *distro.ImageConfig {
 	return &distro.ImageConfig{
-		Locale:   common.ToPtr("C.UTF-8"),
-		Timezone: common.ToPtr("UTC"),
 		TimeSynchronization: &osbuild.ChronyStageOptions{
 			Servers: []osbuild.ChronyConfigServer{
 				{

--- a/pkg/distro/rhel/rhel10/azure.go
+++ b/pkg/distro/rhel/rhel10/azure.go
@@ -406,7 +406,7 @@ const defaultAzureKernelOptions = "ro loglevel=3 console=tty1 console=ttyS0 earl
 // based on https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/deploying_rhel_9_on_microsoft_azure/assembly_deploying-a-rhel-image-as-a-virtual-machine-on-microsoft-azure_cloud-content-azure#making-configuration-changes_configure-the-image-azure
 func defaultAzureImageConfig(rd *rhel.Distribution) *distro.ImageConfig {
 	ic := &distro.ImageConfig{
-		Timezone: common.ToPtr("Etc/UTC"),
+		Timezone: common.ToPtr("UTC"),
 		Locale:   common.ToPtr("C.UTF-8"),
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",

--- a/pkg/distro/rhel/rhel10/azure.go
+++ b/pkg/distro/rhel/rhel10/azure.go
@@ -406,8 +406,6 @@ const defaultAzureKernelOptions = "ro loglevel=3 console=tty1 console=ttyS0 earl
 // based on https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/deploying_rhel_9_on_microsoft_azure/assembly_deploying-a-rhel-image-as-a-virtual-machine-on-microsoft-azure_cloud-content-azure#making-configuration-changes_configure-the-image-azure
 func defaultAzureImageConfig(rd *rhel.Distribution) *distro.ImageConfig {
 	ic := &distro.ImageConfig{
-		Timezone: common.ToPtr("UTC"),
-		Locale:   common.ToPtr("C.UTF-8"),
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",
 			X11Keymap: &osbuild.X11KeymapOptions{

--- a/pkg/distro/rhel/rhel10/azure.go
+++ b/pkg/distro/rhel/rhel10/azure.go
@@ -407,7 +407,7 @@ const defaultAzureKernelOptions = "ro loglevel=3 console=tty1 console=ttyS0 earl
 func defaultAzureImageConfig(rd *rhel.Distribution) *distro.ImageConfig {
 	ic := &distro.ImageConfig{
 		Timezone: common.ToPtr("Etc/UTC"),
-		Locale:   common.ToPtr("en_US.UTF-8"),
+		Locale:   common.ToPtr("C.UTF-8"),
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",
 			X11Keymap: &osbuild.X11KeymapOptions{

--- a/pkg/distro/rhel/rhel10/distro.go
+++ b/pkg/distro/rhel/rhel10/distro.go
@@ -51,7 +51,7 @@ func distroISOLabelFunc(t *rhel.ImageType) string {
 
 func defaultDistroImageConfig(d *rhel.Distribution) *distro.ImageConfig {
 	return &distro.ImageConfig{
-		Timezone: common.ToPtr("America/New_York"),
+		Timezone: common.ToPtr("UTC"),
 		Locale:   common.ToPtr("C.UTF-8"),
 		Sysconfig: []*osbuild.SysconfigStageOptions{
 			{

--- a/pkg/distro/rhel/rhel10/gce.go
+++ b/pkg/distro/rhel/rhel10/gce.go
@@ -59,7 +59,7 @@ func baseGCEImageConfig() *distro.ImageConfig {
 			"reboot.target",
 		},
 		DefaultTarget: common.ToPtr("multi-user.target"),
-		Locale:        common.ToPtr("en_US.UTF-8"),
+		Locale:        common.ToPtr("C.UTF-8"),
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",
 		},

--- a/pkg/distro/rhel/rhel10/gce.go
+++ b/pkg/distro/rhel/rhel10/gce.go
@@ -37,7 +37,6 @@ func mkGCEImageType() *rhel.ImageType {
 
 func baseGCEImageConfig() *distro.ImageConfig {
 	ic := &distro.ImageConfig{
-		Timezone: common.ToPtr("UTC"),
 		TimeSynchronization: &osbuild.ChronyStageOptions{
 			Servers: []osbuild.ChronyConfigServer{{Hostname: "metadata.google.internal"}},
 		},
@@ -59,7 +58,6 @@ func baseGCEImageConfig() *distro.ImageConfig {
 			"reboot.target",
 		},
 		DefaultTarget: common.ToPtr("multi-user.target"),
-		Locale:        common.ToPtr("C.UTF-8"),
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",
 		},

--- a/pkg/distro/rhel/rhel10/ubi.go
+++ b/pkg/distro/rhel/rhel10/ubi.go
@@ -23,7 +23,6 @@ func mkWSLImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = &distro.ImageConfig{
-		Locale:    common.ToPtr("C.UTF-8"),
 		NoSElinux: common.ToPtr(true),
 		WSLConfig: &osbuild.WSLConfStageOptions{
 			Boot: osbuild.WSLConfBootOptions{

--- a/pkg/distro/rhel/rhel10/ubi.go
+++ b/pkg/distro/rhel/rhel10/ubi.go
@@ -23,7 +23,7 @@ func mkWSLImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = &distro.ImageConfig{
-		Locale:    common.ToPtr("en_US.UTF-8"),
+		Locale:    common.ToPtr("C.UTF-8"),
 		NoSElinux: common.ToPtr(true),
 		WSLConfig: &osbuild.WSLConfStageOptions{
 			Boot: osbuild.WSLConfBootOptions{

--- a/pkg/distro/rhel/rhel10/vmdk.go
+++ b/pkg/distro/rhel/rhel10/vmdk.go
@@ -1,9 +1,7 @@
 package rhel10
 
 import (
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/datasizes"
-	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -24,9 +22,6 @@ func mkVMDKImgType() *rhel.ImageType {
 		[]string{"vmdk"},
 	)
 
-	it.DefaultImageConfig = &distro.ImageConfig{
-		Locale: common.ToPtr("C.UTF-8"),
-	}
 	it.KernelOptions = vmdkKernelOptions
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
@@ -49,9 +44,6 @@ func mkOVAImgType() *rhel.ImageType {
 		[]string{"archive"},
 	)
 
-	it.DefaultImageConfig = &distro.ImageConfig{
-		Locale: common.ToPtr("C.UTF-8"),
-	}
 	it.KernelOptions = vmdkKernelOptions
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte

--- a/pkg/distro/rhel/rhel10/vmdk.go
+++ b/pkg/distro/rhel/rhel10/vmdk.go
@@ -25,7 +25,7 @@ func mkVMDKImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = &distro.ImageConfig{
-		Locale: common.ToPtr("en_US.UTF-8"),
+		Locale: common.ToPtr("C.UTF-8"),
 	}
 	it.KernelOptions = vmdkKernelOptions
 	it.Bootable = true
@@ -50,7 +50,7 @@ func mkOVAImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = &distro.ImageConfig{
-		Locale: common.ToPtr("en_US.UTF-8"),
+		Locale: common.ToPtr("C.UTF-8"),
 	}
 	it.KernelOptions = vmdkKernelOptions
 	it.Bootable = true

--- a/pkg/distro/rhel/rhel9/bare_metal.go
+++ b/pkg/distro/rhel/rhel9/bare_metal.go
@@ -62,6 +62,10 @@ func mkImageInstallerImgType() *rhel.ImageType {
 		},
 	}
 
+	it.DefaultImageConfig = &distro.ImageConfig{
+		Locale: common.ToPtr("C.UTF-8"),
+	}
+
 	return it
 }
 

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -51,6 +51,10 @@ type AnacondaContainerInstaller struct {
 	// Uses the old, deprecated, Anaconda config option "kickstart-modules".
 	// Only for RHEL 8.
 	UseLegacyAnacondaConfig bool
+
+	// Locale for the installer. This should be set to the same locale as the
+	// ISO OS payload, if known.
+	Locale string
 }
 
 func NewAnacondaContainerInstaller(container container.SourceSpec, ref string) *AnacondaContainerInstaller {
@@ -98,6 +102,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 		)
 	}
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers
+	anacondaPipeline.Locale = img.Locale
 
 	var rootfsImagePipeline *manifest.ISORootfsImg
 	switch img.RootfsType {

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -36,6 +36,10 @@ type AnacondaLiveInstaller struct {
 	Filename string
 
 	AdditionalKernelOpts []string
+
+	// Locale for the installer. This should be set to the same locale as the
+	// ISO OS payload, if known.
+	Locale string
 }
 
 func NewAnacondaLiveInstaller() *AnacondaLiveInstaller {
@@ -67,6 +71,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	livePipeline.Variant = img.Variant
 	livePipeline.Biosdevname = (img.Platform.GetArch() == arch.ARCH_X86_64)
+	livePipeline.Locale = img.Locale
 
 	// The live installer has SElinux enabled and targeted
 	livePipeline.SElinux = "targeted"

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -51,6 +51,10 @@ type AnacondaOSTreeInstaller struct {
 	// Uses the old, deprecated, Anaconda config option "kickstart-modules".
 	// Only for RHEL 8.
 	UseLegacyAnacondaConfig bool
+
+	// Locale for the installer. This should be set to the same locale as the
+	// ISO OS payload, if known.
+	Locale string
 }
 
 func NewAnacondaOSTreeInstaller(commit ostree.SourceSpec) *AnacondaOSTreeInstaller {
@@ -101,6 +105,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	}
 	anacondaPipeline.DisabledAnacondaModules = img.DisabledAnacondaModules
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers
+	anacondaPipeline.Locale = img.Locale
 
 	var rootfsImagePipeline *manifest.ISORootfsImg
 	switch img.RootfsType {

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -144,6 +144,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline.DisabledAnacondaModules = img.DisabledAnacondaModules
 	anacondaPipeline.AdditionalDracutModules = img.AdditionalDracutModules
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers
+	anacondaPipeline.Locale = img.OSCustomizations.Language
 
 	tarPath := "/liveimg.tar.gz"
 

--- a/pkg/image/installer_image_test.go
+++ b/pkg/image/installer_image_test.go
@@ -88,23 +88,24 @@ const (
 
 func TestContainerInstallerUnsetKSOptions(t *testing.T) {
 	img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+	assert.NotNil(t, img)
+
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-
-	assert.NotNil(t, img)
 	img.Platform = testPlatform
+
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil)
 	assert.Contains(t, mfs, fmt.Sprintf(`"inst.ks=hd:LABEL=%s:/osbuild.ks"`, isolabel))
 }
 
 func TestContainerInstallerUnsetKSPath(t *testing.T) {
 	img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+	assert.NotNil(t, img)
+
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-
-	assert.NotNil(t, img)
 	img.Platform = testPlatform
 	// set empty kickstart options (no path)
 	img.Kickstart = &kickstart.Options{}
@@ -115,11 +116,11 @@ func TestContainerInstallerUnsetKSPath(t *testing.T) {
 
 func TestContainerInstallerSetKSPath(t *testing.T) {
 	img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+	assert.NotNil(t, img)
+
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-
-	assert.NotNil(t, img)
 	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{
 		Path: "/test.ks",
@@ -132,12 +133,13 @@ func TestContainerInstallerSetKSPath(t *testing.T) {
 
 func TestContainerInstallerExt4Rootfs(t *testing.T) {
 	img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+	assert.NotNil(t, img)
+
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-
-	assert.NotNil(t, img)
 	img.Platform = testPlatform
+
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil)
 
 	// Confirm that it includes the rootfs-image pipeline that makes the ext4 rootfs
@@ -147,13 +149,14 @@ func TestContainerInstallerExt4Rootfs(t *testing.T) {
 
 func TestContainerInstallerSquashfsRootfs(t *testing.T) {
 	img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+	assert.NotNil(t, img)
+
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
 	img.RootfsType = manifest.SquashfsRootfs
-
-	assert.NotNil(t, img)
 	img.Platform = testPlatform
+
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil)
 
 	// Confirm that it does not include rootfs-image pipeline
@@ -163,11 +166,11 @@ func TestContainerInstallerSquashfsRootfs(t *testing.T) {
 
 func TestOSTreeInstallerUnsetKSPath(t *testing.T) {
 	img := image.NewAnacondaOSTreeInstaller(ostree.SourceSpec{})
+	assert.NotNil(t, img)
+
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-
-	assert.NotNil(t, img)
 	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{
 		// the ostree options must be non-nil
@@ -180,11 +183,11 @@ func TestOSTreeInstallerUnsetKSPath(t *testing.T) {
 
 func TestOSTreeInstallerSetKSPath(t *testing.T) {
 	img := image.NewAnacondaOSTreeInstaller(ostree.SourceSpec{})
+	assert.NotNil(t, img)
+
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-
-	assert.NotNil(t, img)
 	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{
 		// the ostree options must be non-nil
@@ -199,11 +202,11 @@ func TestOSTreeInstallerSetKSPath(t *testing.T) {
 
 func TestOSTreeInstallerExt4Rootfs(t *testing.T) {
 	img := image.NewAnacondaOSTreeInstaller(ostree.SourceSpec{})
+	assert.NotNil(t, img)
+
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-
-	assert.NotNil(t, img)
 	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{
 		// the ostree options must be non-nil
@@ -219,12 +222,12 @@ func TestOSTreeInstallerExt4Rootfs(t *testing.T) {
 
 func TestOSTreeInstallerSquashfsRootfs(t *testing.T) {
 	img := image.NewAnacondaOSTreeInstaller(ostree.SourceSpec{})
+	assert.NotNil(t, img)
+
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
 	img.RootfsType = manifest.SquashfsRootfs
-
-	assert.NotNil(t, img)
 	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{
 		// the ostree options must be non-nil
@@ -240,11 +243,11 @@ func TestOSTreeInstallerSquashfsRootfs(t *testing.T) {
 
 func TestTarInstallerUnsetKSOptions(t *testing.T) {
 	img := image.NewAnacondaTarInstaller()
+	assert.NotNil(t, img)
+
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-
-	assert.NotNil(t, img)
 	img.Platform = testPlatform
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
@@ -258,11 +261,11 @@ func TestTarInstallerUnsetKSOptions(t *testing.T) {
 
 func TestTarInstallerUnsetKSPath(t *testing.T) {
 	img := image.NewAnacondaTarInstaller()
+	assert.NotNil(t, img)
+
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-
-	assert.NotNil(t, img)
 	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{}
 
@@ -283,11 +286,11 @@ func TestTarInstallerUnsetKSPath(t *testing.T) {
 
 func TestTarInstallerSetKSPath(t *testing.T) {
 	img := image.NewAnacondaTarInstaller()
+	assert.NotNil(t, img)
+
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-
-	assert.NotNil(t, img)
 	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{
 		Path: "/test.ks",
@@ -302,11 +305,11 @@ func TestTarInstallerSetKSPath(t *testing.T) {
 
 func TestTarInstallerExt4Rootfs(t *testing.T) {
 	img := image.NewAnacondaTarInstaller()
+	assert.NotNil(t, img)
+
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-
-	assert.NotNil(t, img)
 	img.Platform = testPlatform
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
@@ -317,12 +320,12 @@ func TestTarInstallerExt4Rootfs(t *testing.T) {
 
 func TestTarInstallerSquashfsRootfs(t *testing.T) {
 	img := image.NewAnacondaTarInstaller()
+	assert.NotNil(t, img)
+
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
 	img.RootfsType = manifest.SquashfsRootfs
-
-	assert.NotNil(t, img)
 	img.Platform = testPlatform
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
@@ -333,11 +336,11 @@ func TestTarInstallerSquashfsRootfs(t *testing.T) {
 
 func TestLiveInstallerExt4Rootfs(t *testing.T) {
 	img := image.NewAnacondaLiveInstaller()
+	assert.NotNil(t, img)
+
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-
-	assert.NotNil(t, img)
 	img.Platform = testPlatform
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
@@ -348,12 +351,12 @@ func TestLiveInstallerExt4Rootfs(t *testing.T) {
 
 func TestLiveInstallerSquashfsRootfs(t *testing.T) {
 	img := image.NewAnacondaLiveInstaller()
+	assert.NotNil(t, img)
+
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
 	img.RootfsType = manifest.SquashfsRootfs
-
-	assert.NotNil(t, img)
 	img.Platform = testPlatform
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -87,6 +87,10 @@ type AnacondaInstaller struct {
 	// tree with the selected profile and selects the required package
 	// for depsolving
 	SElinux string
+
+	// Locale for the installer. This should be set to the same locale as the
+	// ISO OS payload, if known.
+	Locale string
 }
 
 func NewAnacondaInstaller(installerType AnacondaInstallerType,
@@ -234,7 +238,13 @@ func (p *AnacondaInstaller) serialize() osbuild.Pipeline {
 		Version: p.version,
 		Final:   !p.preview,
 	}))
-	pipeline.AddStage(osbuild.NewLocaleStage(&osbuild.LocaleStageOptions{Language: "en_US.UTF-8"}))
+
+	locale := p.Locale
+	if locale == "" {
+		// default to C.UTF-8 if unset
+		locale = "C.UTF-8"
+	}
+	pipeline.AddStage(osbuild.NewLocaleStage(&osbuild.LocaleStageOptions{Language: locale}))
 
 	// Let's do a bunch of sanity checks that are dependent on the installer type
 	// being serialized


### PR DESCRIPTION
This PR primarily
- Sets the timezone for all RHEL 10 images to `UTC`.
- Sets the locale for all RHEL 10 images to `C.UTF-8`.

On top of that, it pushes the definition of locales for installer (Anaconda ISO) image types to the image definition (in each distro).  For image installers, since we build the payload for the ISO, we ensure that the same locale is used for both the image and the ISO itself.  This means that a customized locale for an image (tar) installer will also change the locale for the ISO.

JIRA: [HMS-5342](https://issues.redhat.com/browse/HMS-5342)