### PR TITLE
Test/scripts/build-info: include runner-distro in `info.json` (HMS-5350)

### DIFF
--- a/test/scripts/build-image
+++ b/test/scripts/build-image
@@ -59,7 +59,8 @@ def main():
         "manifest-checksum": manifest_id,
         "osbuild-version": osbuild_ver.decode().strip(),
         "osbuild-commit": osbuild_commit,
-        "commit": os.environ.get("CI_COMMIT_SHA", "N/A")
+        "commit": os.environ.get("CI_COMMIT_SHA", "N/A"),
+        "runner-distro": distro_version,
     }
     testlib.write_build_info(build_dir, build_info)
 


### PR DESCRIPTION
While working on replacing manifest-db with images build cache, I've run into a situation when the ability to download the image artifact after the downloading of build info metadata would be useful. Specifically when tests are run in batches, when one needs to first determine the full list of test cases and then download image artifacts only for the relevant test cases.

Due to the size of image artifacts, downloading all of them every time is not really feasible as it takes non-trivial amount of time.

The idea is to be able to download image artifact from S3 after build metadata have been already downloaded. The `info.json` already contains almost all information necessary to construct the S3 path to download, except for the runner distro.

Let's add the `runner-distro` property to `info.json`, so that we can have a script that reads `info.json` and is able to download the complete build cache for the specific build.

Lastly, we determine the need to rebuild image on the runner-distro, osbuild-ref and manifest-id values. Therefore it makes sense, that two builds done on different runner distro would have different `info.json`, which was not the case until now.

EDIT:
I understand that this change will not ensure that the current build cache `info.json` files will contain the new value. I'd update osbuild-ref once this gets merged to ensure it is there. Determining the runner distro from the `Schutzfile` can be still used as a reasonable fallback.

/jira-epic COMPOSER-2318

JIRA: [HMS-5350](https://issues.redhat.com/browse/HMS-5350)
