### PR TITLE
pkg: add new `manifestgen` package

### DIFF
--- a/pkg/manifestgen/manifestgen.go
+++ b/pkg/manifestgen/manifestgen.go
@@ -115,6 +115,10 @@ type Options struct {
 	// filename contains the suggest filename string and the
 	// content can be read
 	SBOMWriter SBOMWriterFunc
+
+	// CustomSeed overrides the default rng seed, this is mostly
+	// useful for testing
+	CustomSeed *int64
 }
 
 // Generator can generate an osbuild manifest from a given repository
@@ -131,6 +135,8 @@ type Generator struct {
 	reporegistry *reporegistry.RepoRegistry
 
 	rpmDownloader osbuild.RpmDownloader
+
+	customSeed *int64
 }
 
 // New will create a new manifest generator
@@ -148,6 +154,7 @@ func New(reporegistry *reporegistry.RepoRegistry, opts *Options) (*Generator, er
 		commitResolver:    opts.CommitResolver,
 		rpmDownloader:     opts.RpmDownloader,
 		sbomWriter:        opts.SBOMWriter,
+		customSeed:        opts.CustomSeed,
 	}
 	if mg.out == nil {
 		mg.out = os.Stdout
@@ -180,7 +187,7 @@ func (mg *Generator) Generate(bp *blueprint.Blueprint, dist distro.Distro, imgTy
 	// will have to be added to the repos with
 	// <repo_item>.PackageSets set to the "payload" pipeline names
 	// for the given image type, see e.g. distro/rhel/imagetype.go:Manifest()
-	preManifest, warnings, err := imgType.Manifest(bp, *imgOpts, repos, nil)
+	preManifest, warnings, err := imgType.Manifest(bp, *imgOpts, repos, mg.customSeed)
 	if err != nil {
 		return err
 	}

--- a/pkg/manifestgen/manifestgen.go
+++ b/pkg/manifestgen/manifestgen.go
@@ -1,0 +1,180 @@
+package manifestgen
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/osbuild/images/pkg/blueprint"
+	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/dnfjson"
+	"github.com/osbuild/images/pkg/ostree"
+	"github.com/osbuild/images/pkg/reporegistry"
+	"github.com/osbuild/images/pkg/rpmmd"
+	"github.com/osbuild/images/pkg/sbom"
+)
+
+// XXX: all of the helpers below are duplicated from
+// cmd/build/main.go:depsolve (and probably more places) should go
+// into a common helper in "images" or images should do this on its
+// own
+func defaultDepsolver(cacheDir string, packageSets map[string][]rpmmd.PackageSet, d distro.Distro, arch string) (map[string]dnfjson.DepsolveResult, error) {
+	solver := dnfjson.NewSolver(d.ModulePlatformID(), d.Releasever(), arch, d.Name(), cacheDir)
+	depsolvedSets := make(map[string]dnfjson.DepsolveResult)
+	for name, pkgSet := range packageSets {
+		res, err := solver.Depsolve(pkgSet, sbom.StandardTypeNone)
+		if err != nil {
+			return nil, fmt.Errorf("error depsolving: %w", err)
+		}
+		depsolvedSets[name] = *res
+	}
+	return depsolvedSets, nil
+}
+
+func resolveContainers(containers []container.SourceSpec, archName string) ([]container.Spec, error) {
+	resolver := container.NewResolver(archName)
+
+	for _, c := range containers {
+		resolver.Add(c)
+	}
+
+	return resolver.Finish()
+}
+
+func defaultContainerResolver(containerSources map[string][]container.SourceSpec, archName string) (map[string][]container.Spec, error) {
+	containerSpecs := make(map[string][]container.Spec, len(containerSources))
+	for plName, sourceSpecs := range containerSources {
+		specs, err := resolveContainers(sourceSpecs, archName)
+		if err != nil {
+			return nil, fmt.Errorf("error container resolving: %w", err)
+		}
+		containerSpecs[plName] = specs
+	}
+	return containerSpecs, nil
+}
+
+func defaultCommitResolver(commitSources map[string][]ostree.SourceSpec) (map[string][]ostree.CommitSpec, error) {
+	commits := make(map[string][]ostree.CommitSpec, len(commitSources))
+	for name, commitSources := range commitSources {
+		commitSpecs := make([]ostree.CommitSpec, len(commitSources))
+		for idx, commitSource := range commitSources {
+			var err error
+			commitSpecs[idx], err = ostree.Resolve(commitSource)
+			if err != nil {
+				return nil, fmt.Errorf("error ostree commit resolving: %w", err)
+			}
+		}
+		commits[name] = commitSpecs
+	}
+	return commits, nil
+}
+
+type (
+	DepsolveFunc func(cacheDir string, packageSets map[string][]rpmmd.PackageSet, d distro.Distro, arch string) (map[string]dnfjson.DepsolveResult, error)
+
+	ContainerResolverFunc func(containerSources map[string][]container.SourceSpec, archName string) (map[string][]container.Spec, error)
+
+	CommitResolverFunc func(commitSources map[string][]ostree.SourceSpec) (map[string][]ostree.CommitSpec, error)
+)
+
+// Options contains the optional settings for the manifest generation.
+// For unset values defaults will be used.
+type Options struct {
+	Cachedir string
+	// Output is the writer that the generated osbuild manifest will
+	// written to.
+	Output            io.Writer
+	Depsolver         DepsolveFunc
+	ContainerResolver ContainerResolverFunc
+	CommitResolver    CommitResolverFunc
+}
+
+// Generator can generate an osbuild manifest from a given repository
+// and options.
+type Generator struct {
+	cacheDir string
+	out      io.Writer
+
+	depsolver         DepsolveFunc
+	containerResolver ContainerResolverFunc
+	commitResolver    CommitResolverFunc
+
+	reporegistry *reporegistry.RepoRegistry
+}
+
+// New will create a new manifest generator
+func New(reporegistry *reporegistry.RepoRegistry, opts *Options) (*Generator, error) {
+	if opts == nil {
+		opts = &Options{}
+	}
+	mg := &Generator{
+		reporegistry: reporegistry,
+
+		cacheDir:          opts.Cachedir,
+		out:               opts.Output,
+		depsolver:         opts.Depsolver,
+		containerResolver: opts.ContainerResolver,
+		commitResolver:    opts.CommitResolver,
+	}
+	if mg.out == nil {
+		mg.out = os.Stdout
+	}
+	if mg.depsolver == nil {
+		mg.depsolver = defaultDepsolver
+	}
+	if mg.containerResolver == nil {
+		mg.containerResolver = defaultContainerResolver
+	}
+	if mg.commitResolver == nil {
+		mg.commitResolver = defaultCommitResolver
+	}
+
+	return mg, nil
+}
+
+// Generate will generate a new manifest for the given distro/imageType/arch
+// combination.
+func (mg *Generator) Generate(bp *blueprint.Blueprint, dist distro.Distro, imgType distro.ImageType, a distro.Arch, imgOpts *distro.ImageOptions) error {
+	if imgOpts == nil {
+		imgOpts = &distro.ImageOptions{}
+	}
+
+	repos, err := mg.reporegistry.ReposByImageTypeName(dist.Name(), a.Name(), imgType.Name())
+	if err != nil {
+		return err
+	}
+	// To support "user" a.k.a. "3rd party" repositories, these
+	// will have to be added to the repos with
+	// <repo_item>.PackageSets set to the "payload" pipeline names
+	// for the given image type, see e.g. distro/rhel/imagetype.go:Manifest()
+	preManifest, warnings, err := imgType.Manifest(bp, *imgOpts, repos, nil)
+	if err != nil {
+		return err
+	}
+	if len(warnings) > 0 {
+		// XXX: what can we do here? for things like json output?
+		// what are these warnings?
+		return fmt.Errorf("warnings during manifest creation: %v", strings.Join(warnings, "\n"))
+	}
+	depsolved, err := mg.depsolver(mg.cacheDir, preManifest.GetPackageSetChains(), dist, a.Name())
+	if err != nil {
+		return err
+	}
+	containerSpecs, err := mg.containerResolver(preManifest.GetContainerSourceSpecs(), a.Name())
+	if err != nil {
+		return err
+	}
+	commitSpecs, err := mg.commitResolver(preManifest.GetOSTreeSourceSpecs())
+	if err != nil {
+		return err
+	}
+	mf, err := preManifest.Serialize(depsolved, containerSpecs, commitSpecs, nil)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(mg.out, "%s\n", mf)
+
+	return nil
+}

--- a/pkg/manifestgen/manifestgen.go
+++ b/pkg/manifestgen/manifestgen.go
@@ -21,6 +21,15 @@ import (
 // into a common helper in "images" or images should do this on its
 // own
 func defaultDepsolver(cacheDir string, packageSets map[string][]rpmmd.PackageSet, d distro.Distro, arch string) (map[string]dnfjson.DepsolveResult, error) {
+	if cacheDir == "" {
+		var err error
+		cacheDir, err = os.MkdirTemp("", "manifestgen")
+		if err != nil {
+			return nil, fmt.Errorf("cannot create temporary directory: %w", err)
+		}
+		defer os.RemoveAll(cacheDir)
+	}
+
 	solver := dnfjson.NewSolver(d.ModulePlatformID(), d.Releasever(), arch, d.Name(), cacheDir)
 	depsolvedSets := make(map[string]dnfjson.DepsolveResult)
 	for name, pkgSet := range packageSets {

--- a/pkg/manifestgen/manifestgen_test.go
+++ b/pkg/manifestgen/manifestgen_test.go
@@ -3,7 +3,9 @@ package manifestgen_test
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -22,6 +24,7 @@ import (
 	"github.com/osbuild/images/pkg/osbuild/manifesttest"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/rpmmd"
+	"github.com/osbuild/images/pkg/sbom"
 	testrepos "github.com/osbuild/images/test/data/repositories"
 )
 
@@ -150,6 +153,11 @@ func fakeDepsolve(cacheDir string, packageSets map[string][]rpmmd.PackageSet, d 
 					Id:       repoId,
 					Metalink: "https://example.com/metalink",
 				})
+				doc, err := sbom.NewDocument(sbom.StandardTypeSpdx, json.RawMessage(fmt.Sprintf(`{"sbom-for":"%s"}`, name)))
+				if err != nil {
+					return nil, err
+				}
+				resolvedSet.SBOM = doc
 			}
 		}
 		depsolvedSets[name] = resolvedSet
@@ -237,4 +245,48 @@ func TestManifestGeneratorContainers(t *testing.T) {
 
 	// container is included
 	assert.Contains(t, osbuildManifest.String(), "resolved-cnt-"+fakeContainerSource)
+}
+
+func TestManifestGeneratorDepsolveWithSbomWriter(t *testing.T) {
+	repos, err := testrepos.New()
+	assert.NoError(t, err)
+	fac := distrofactory.NewDefault()
+
+	filter, err := imagefilter.New(fac, repos)
+	assert.NoError(t, err)
+	res, err := filter.Filter("distro:centos-9", "type:qcow2", "arch:x86_64")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(res))
+
+	var osbuildManifest bytes.Buffer
+	generatedSboms := map[string]string{}
+	opts := &manifestgen.Options{
+		Output:            &osbuildManifest,
+		Depsolver:         fakeDepsolve,
+		CommitResolver:    panicCommitResolver,
+		ContainerResolver: panicContainerResolver,
+
+		SBOMWriter: func(filename string, content io.Reader, docType sbom.StandardType) error {
+			assert.Equal(t, sbom.StandardTypeSpdx, docType)
+
+			b, err := io.ReadAll(content)
+			assert.NoError(t, err)
+			generatedSboms[filename] = strings.TrimSpace(string(b))
+			return nil
+		},
+	}
+	mg, err := manifestgen.New(repos, opts)
+	assert.NoError(t, err)
+	assert.NotNil(t, mg)
+	var bp blueprint.Blueprint
+	err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+	require.NoError(t, err)
+
+	assert.Contains(t, generatedSboms, "centos-9-qcow2-x86_64.buildroot-build.spdx.json")
+	assert.Contains(t, generatedSboms, "centos-9-qcow2-x86_64.image-os.spdx.json")
+	expected := map[string]string{
+		"centos-9-qcow2-x86_64.buildroot-build.spdx.json": `{"sbom-for":"build"}`,
+		"centos-9-qcow2-x86_64.image-os.spdx.json":        `{"sbom-for":"os"}`,
+	}
+	assert.Equal(t, expected, generatedSboms)
 }

--- a/pkg/manifestgen/manifestgen_test.go
+++ b/pkg/manifestgen/manifestgen_test.go
@@ -1,0 +1,219 @@
+package manifestgen_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/blueprint"
+	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distrofactory"
+	"github.com/osbuild/images/pkg/dnfjson"
+	"github.com/osbuild/images/pkg/imagefilter"
+	"github.com/osbuild/images/pkg/manifestgen"
+	"github.com/osbuild/images/pkg/osbuild/manifesttest"
+	"github.com/osbuild/images/pkg/ostree"
+	"github.com/osbuild/images/pkg/rpmmd"
+	testrepos "github.com/osbuild/images/test/data/repositories"
+)
+
+func init() {
+	// silence logrus by default, it is quite verbose
+	logrus.SetLevel(logrus.WarnLevel)
+}
+
+func sha256For(s string) string {
+	h := sha256.New()
+	h.Write([]byte(s))
+	bs := h.Sum(nil)
+	return fmt.Sprintf("sha256:%x", bs)
+}
+
+func TestManifestGeneratorDepsolve(t *testing.T) {
+	repos, err := testrepos.New()
+	assert.NoError(t, err)
+	fac := distrofactory.NewDefault()
+
+	filter, err := imagefilter.New(fac, repos)
+	assert.NoError(t, err)
+	res, err := filter.Filter("distro:centos-9", "type:qcow2", "arch:x86_64")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(res))
+
+	var osbuildManifest bytes.Buffer
+	opts := &manifestgen.Options{
+		Output:            &osbuildManifest,
+		Depsolver:         fakeDepsolve,
+		CommitResolver:    panicCommitResolver,
+		ContainerResolver: panicContainerResolver,
+	}
+	mg, err := manifestgen.New(repos, opts)
+	assert.NoError(t, err)
+	assert.NotNil(t, mg)
+	var bp blueprint.Blueprint
+	err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+	assert.NoError(t, err)
+
+	pipelineNames, err := manifesttest.PipelineNamesFrom(osbuildManifest.Bytes())
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"build", "os", "image", "qcow2"}, pipelineNames)
+
+	// we expect at least a "kernel" package in the manifest,
+	// sadly the test distro does not really generate much here so we
+	// need to use this as a canary that resolving happend
+	// XXX: add testhelper to manifesttest for this
+	expectedSha256 := sha256For("kernel")
+	assert.Contains(t, osbuildManifest.String(), expectedSha256)
+}
+
+func TestManifestGeneratorWithOstreeCommit(t *testing.T) {
+	var osbuildManifest bytes.Buffer
+
+	repos, err := testrepos.New()
+	assert.NoError(t, err)
+
+	fac := distrofactory.NewDefault()
+	filter, err := imagefilter.New(fac, repos)
+	assert.NoError(t, err)
+	res, err := filter.Filter("distro:centos-9", "type:edge-ami", "arch:x86_64")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(res))
+
+	opts := &manifestgen.Options{
+		Output:            &osbuildManifest,
+		Depsolver:         fakeDepsolve,
+		CommitResolver:    fakeCommitResolver,
+		ContainerResolver: panicContainerResolver,
+	}
+	imageOpts := &distro.ImageOptions{
+		OSTree: &ostree.ImageOptions{
+			//ImageRef: "latest/1/x86_64/edge",
+			URL: "http://example.com/",
+		},
+	}
+	mg, err := manifestgen.New(repos, opts)
+	assert.NoError(t, err)
+	assert.NotNil(t, mg)
+	var bp blueprint.Blueprint
+	err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, imageOpts)
+	assert.NoError(t, err)
+
+	pipelineNames, err := manifesttest.PipelineNamesFrom(osbuildManifest.Bytes())
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"build", "ostree-deployment", "image"}, pipelineNames)
+
+	// XXX: add testhelper to manifesttest for this
+	assert.Contains(t, osbuildManifest.String(), `{"url":"resolved-url-for-centos/9/x86_64/edge"}`)
+	// we expect at least a "glibc" package in the manifest,
+	// sadly the test distro does not really generate much here so we
+	// need to use this as a canary that resolving happend
+	// XXX: add testhelper to manifesttest for this
+	expectedSha256 := sha256For("glibc")
+	assert.Contains(t, osbuildManifest.String(), expectedSha256)
+}
+
+func fakeDepsolve(cacheDir string, packageSets map[string][]rpmmd.PackageSet, d distro.Distro, arch string) (map[string]dnfjson.DepsolveResult, error) {
+	depsolvedSets := make(map[string]dnfjson.DepsolveResult)
+	for name, pkgSets := range packageSets {
+		var resolvedSet dnfjson.DepsolveResult
+		for _, pkgSet := range pkgSets {
+			for _, pkgName := range pkgSet.Include {
+				resolvedSet.Packages = append(resolvedSet.Packages, rpmmd.PackageSpec{
+					Name:     pkgName,
+					Checksum: sha256For(pkgName),
+				})
+				resolvedSet.Repos = append(resolvedSet.Repos, rpmmd.RepoConfig{
+					Metalink: "https://example.com/metalink",
+				})
+			}
+		}
+		depsolvedSets[name] = resolvedSet
+	}
+	return depsolvedSets, nil
+}
+
+func fakeCommitResolver(commitSources map[string][]ostree.SourceSpec) (map[string][]ostree.CommitSpec, error) {
+	commits := make(map[string][]ostree.CommitSpec, len(commitSources))
+	for name, commitSources := range commitSources {
+		commitSpecs := make([]ostree.CommitSpec, len(commitSources))
+		for idx, commitSource := range commitSources {
+			commitSpecs[idx] = ostree.CommitSpec{
+				URL: fmt.Sprintf("resolved-url-for-%s", commitSource.Ref),
+			}
+		}
+		commits[name] = commitSpecs
+	}
+	return commits, nil
+
+}
+
+func panicCommitResolver(commitSources map[string][]ostree.SourceSpec) (map[string][]ostree.CommitSpec, error) {
+	if len(commitSources) > 0 {
+		panic("panicCommitResolver")
+	}
+	return nil, nil
+}
+
+func fakeContainerResolver(containerSources map[string][]container.SourceSpec, archName string) (map[string][]container.Spec, error) {
+	containerSpecs := make(map[string][]container.Spec, len(containerSources))
+	for plName, sourceSpecs := range containerSources {
+		var containers []container.Spec
+		for _, spec := range sourceSpecs {
+			containers = append(containers, container.Spec{
+				Source:  fmt.Sprintf("resolved-cnt-%s", spec.Source),
+				Digest:  "sha256:" + sha256For("digest:"+spec.Source),
+				ImageID: "sha256:" + sha256For("id:"+spec.Source),
+			})
+		}
+		containerSpecs[plName] = containers
+	}
+	return containerSpecs, nil
+}
+
+func panicContainerResolver(containerSources map[string][]container.SourceSpec, archName string) (map[string][]container.Spec, error) {
+	if len(containerSources) > 0 {
+		panic("panicContainerResolver")
+	}
+	return nil, nil
+}
+
+func TestManifestGeneratorContainers(t *testing.T) {
+	repos, err := testrepos.New()
+	assert.NoError(t, err)
+	fac := distrofactory.NewDefault()
+
+	filter, err := imagefilter.New(fac, repos)
+	assert.NoError(t, err)
+	res, err := filter.Filter("distro:centos-9", "type:qcow2", "arch:x86_64")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(res))
+
+	var osbuildManifest bytes.Buffer
+	opts := &manifestgen.Options{
+		Output:            &osbuildManifest,
+		Depsolver:         fakeDepsolve,
+		CommitResolver:    panicCommitResolver,
+		ContainerResolver: fakeContainerResolver,
+	}
+	mg, err := manifestgen.New(repos, opts)
+	assert.NoError(t, err)
+	assert.NotNil(t, mg)
+	fakeContainerSource := "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+	bp := blueprint.Blueprint{
+		Containers: []blueprint.Container{
+			{
+				Source: fakeContainerSource,
+			},
+		},
+	}
+	err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+	assert.NoError(t, err)
+
+	// container is included
+	assert.Contains(t, osbuildManifest.String(), "resolved-cnt-"+fakeContainerSource)
+}

--- a/pkg/osbuild/manifesttest/manifesttest.go
+++ b/pkg/osbuild/manifesttest/manifesttest.go
@@ -1,0 +1,25 @@
+package manifesttest
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// PipelineNamesFrom will return all pipeline names from an osbuild
+// json manifest. It will error on missing pipelines.
+func PipelineNamesFrom(osbuildManifest []byte) ([]string, error) {
+	var manifest map[string]interface{}
+
+	if err := json.Unmarshal(osbuildManifest, &manifest); err != nil {
+		return nil, fmt.Errorf("cannot unmarshal manifest: %w", err)
+	}
+	if manifest["pipelines"] == nil {
+		return nil, fmt.Errorf("cannot find any pipelines in %v", manifest)
+	}
+	pipelines := manifest["pipelines"].([]interface{})
+	pipelineNames := make([]string, len(pipelines))
+	for idx, pi := range pipelines {
+		pipelineNames[idx] = pi.(map[string]interface{})["name"].(string)
+	}
+	return pipelineNames, nil
+}

--- a/pkg/osbuild/manifesttest/manifesttest_test.go
+++ b/pkg/osbuild/manifesttest/manifesttest_test.go
@@ -1,0 +1,35 @@
+package manifesttest_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/osbuild/manifesttest"
+)
+
+var fakeOsbuildManifest = `{
+  "version": "2",
+  "pipelines": [
+    {
+       "name": "noop"
+    },
+    {
+       "name": "noop2"
+    }
+  ]
+}`
+
+func TestPipelineNamesFrom(t *testing.T) {
+	names, err := manifesttest.PipelineNamesFrom([]byte(fakeOsbuildManifest))
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"noop", "noop2"}, names)
+}
+
+func TestPipelineNamesFromSad(t *testing.T) {
+	_, err := manifesttest.PipelineNamesFrom([]byte("bad-json"))
+	assert.ErrorContains(t, err, "cannot unmarshal manifest: invalid char")
+
+	_, err = manifesttest.PipelineNamesFrom([]byte("{}"))
+	assert.ErrorContains(t, err, "cannot find any pipelines in map[]")
+}


### PR DESCRIPTION
This commit adds a new generic `manifestgen` package that can be
used to generate osbuild manifests. It works on a higher level
then the low-level `manifest` package from `images` and provides
plugable resolvers and a streamlined API.

The rational is that we currently have duplicated implementations
of e.g. `depsolve`, `containerResolver`, `ostreeCommitResolver`.
This helper provides default implementations for the common case
but also provide the ability to override the defaults.

This is a cleaned up version of https://github.com/osbuild/image-builder-cli/tree/main/internal/manifestgen

It is used in image-builder-cli like this: https://github.com/osbuild/image-builder-cli/blob/main/cmd/image-builder/manifest.go#L39

I did not include the full port of the "cmd/build" in this PR but I did do it in https://github.com/osbuild/images/compare/main...mvo5:new-pkg-manifestgen-used-in-build?expand=1 - this is what build would looks like https://github.com/mvo5/images/blob/30aa2cf16355d2ba5f4289b70c4ff4b15eed0a9e/cmd/build/main.go#L119 (still some warts and it will increase the size of this PR even more but I could pull it in here).