### PR TITLE
Validate config map and fix bad Fedora IoT test config

### DIFF
--- a/.github/workflows/gitlab-helper.yml
+++ b/.github/workflows/gitlab-helper.yml
@@ -16,6 +16,10 @@ jobs:
   prepare:
     name: "🔍 Check source preparation and test configs"
     runs-on: ubuntu-latest
+    env:
+      # workaround for expired cert at source of indirect dependency
+      # (go.opencensus.io/trace)
+      GOPROXY: "https://proxy.golang.org|direct"
     steps:
 
       - name: Set up Go 1.21

--- a/.github/workflows/gitlab-helper.yml
+++ b/.github/workflows/gitlab-helper.yml
@@ -14,7 +14,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   prepare:
-    name: "🔍 Check source preparation"
+    name: "🔍 Check source preparation and test configs"
     runs-on: ubuntu-latest
     steps:
 
@@ -45,6 +45,11 @@ jobs:
           else
             exit "0"
           fi
+
+      - name: Check that the config-map is valid
+        run: |
+          ./test/scripts/validate-config-map
+
 
   gitlab-ci-helper:
     name: "Gitlab CI trigger helper"

--- a/.github/workflows/test-osbuild-composer-integration.yml
+++ b/.github/workflows/test-osbuild-composer-integration.yml
@@ -53,6 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/fedora:latest
+    env:
+      # workaround for expired cert at source of indirect dependency
+      # (go.opencensus.io/trace)
+      GOPROXY: "https://proxy.golang.org|direct"
     outputs:
       # Define job outputs
       # (see https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs#example-defining-outputs-for-a-job)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,9 @@ jobs:
         run: git config --global --add safe.directory "$(pwd)"
 
       - name: Run unit tests
-        run: go test -race ./...
+        # skip the TestResolverLocalManifest test. It is tested separately
+        # (see below: requires root)
+        run: go test -race ./... -test.skip TestResolverLocalManifest
 
       - name: Run depsolver tests with force-dnf to make sure it's not skipped
         run: go test -race ./pkg/dnfjson/... -force-dnf

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,21 +160,21 @@ jobs:
           SHELLCHECK_OPTS: -e SC1091 -e SC2002 -e SC2317
 
   python-test:
-    name: "🐍 pytest (imgtestlib)"
+    name: "🐍 pytest (imgtestlib and test scripts)"
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/fedora:latest
     steps:
 
       - name: Install build and test dependencies
-        run: dnf -y install python3-pytest podman skopeo
+        run: dnf -y install python3-pytest podman skopeo go btrfs-progs-devel device-mapper-devel gpgme-devel
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Testing imgtestlib
+      - name: Testing imgtestlib and test scripts
         run: |
           python3 -m pytest -v
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,19 +23,43 @@ jobs:
       fail-fast: false  # if one fails, keep the other(s) running
     name: "🛃 Unit tests (Fedora ${{ matrix.fedora_version }})"
     runs-on: ubuntu-latest
-
+    container: registry.fedoraproject.org/fedora:${{ matrix.fedora_version }}
+    env:
+      # workaround for expired cert at source of indirect dependency
+      # (go.opencensus.io/trace)
+      GOPROXY: "https://proxy.golang.org|direct"
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Install python3
+        # The Fedora 41 container doesn't have python3 installed by default
+        run: dnf -y install python3
+
+      - name: Set up repository for pinned osbuild commit
+        run: ./test/scripts/setup-osbuild-repo
+
+      - name: Install test dependencies
+        run: ./test/scripts/install-dependencies
+
+      - name: Mark the working directory as safe for git
+        run: git config --global --add safe.directory "$(pwd)"
+
       - name: Run unit tests
-        run: make BASE_CONTAINER_IMAGE_TAG=${{matrix.fedora_version}} gh-action-test
+        run: go test -race ./...
+
+      - name: Run depsolver tests with force-dnf to make sure it's not skipped
+        run: go test -race ./pkg/dnfjson/... -force-dnf
 
   container-resolver-tests:
     name: "🛃 Container resolver tests"
     runs-on: ubuntu-latest
+    env:
+      # workaround for expired cert at source of indirect dependency
+      # (go.opencensus.io/trace)
+      GOPROXY: "https://proxy.golang.org|direct"
 
     steps:
       - name: Set up Go 1.21
@@ -76,6 +100,9 @@ jobs:
       image: quay.io/centos/centos:${{ matrix.centos_stream.image_tag }}
     env:
       GOFLAGS: "-tags=exclude_graphdriver_btrfs"
+      # workaround for expired cert at source of indirect dependency
+      # (go.opencensus.io/trace)
+      GOPROXY: "https://proxy.golang.org|direct"
 
     steps:
       - name: Install dnf plugins
@@ -114,6 +141,10 @@ jobs:
   lint:
     name: "⌨ Lint"
     runs-on: ubuntu-latest
+    env:
+      # workaround for expired cert at source of indirect dependency
+      # (go.opencensus.io/trace)
+      GOPROXY: "https://proxy.golang.org|direct"
     steps:
       - name: Set up Go 1.21
         uses: actions/setup-go@v5
@@ -146,6 +177,10 @@ jobs:
   shellcheck:
     name: "🐚 Shellcheck"
     runs-on: ubuntu-latest
+    env:
+      # workaround for expired cert at source of indirect dependency
+      # (go.opencensus.io/trace)
+      GOPROXY: "https://proxy.golang.org|direct"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -162,6 +197,10 @@ jobs:
   python-test:
     name: "🐍 pytest (imgtestlib and test scripts)"
     runs-on: ubuntu-latest
+    env:
+      # workaround for expired cert at source of indirect dependency
+      # (go.opencensus.io/trace)
+      GOPROXY: "https://proxy.golang.org|direct"
     container:
       image: registry.fedoraproject.org/fedora:latest
     steps:
@@ -181,6 +220,10 @@ jobs:
   python-lint:
     name: "🐍 Lint (test scripts)"
     runs-on: ubuntu-latest
+    env:
+      # workaround for expired cert at source of indirect dependency
+      # (go.opencensus.io/trace)
+      GOPROXY: "https://proxy.golang.org|direct"
     container:
       image: registry.fedoraproject.org/fedora:latest
     steps:

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -168,7 +168,7 @@
   },
   "./configs/iot-ostree-pull-user.json": {
     "image-types": [
-      "iot-ami"
+      "iot-qcow2-image"
     ]
   },
   "./configs/kernel-debug.json": {

--- a/test/configs/edge-ostree-pull-user.json
+++ b/test/configs/edge-ostree-pull-user.json
@@ -8,7 +8,15 @@
             "wheel"
           ],
           "key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNebAh6SjpAn8wB53K4695cGnHGuCtl4RdaX3futZgJUultHyzeYHnzMO7d4++qnRL+Rworew62LKP560uvtncc= github.com/osbuild/images",
-          "name": "osbuild"
+          "name": "osbuild",
+          "uid": 1001,
+          "gid": 1002
+        }
+      ],
+      "group": [
+        {
+          "name": "osbuild",
+          "gid": 1002
         }
       ]
     }

--- a/test/scripts/install-dependencies
+++ b/test/scripts/install-dependencies
@@ -7,6 +7,7 @@ dnf -y install \
     gcc \
     go \
     gpgme-devel \
+    krb5-devel \
     osbuild \
     osbuild-depsolve-dnf \
     osbuild-luks2 \

--- a/test/scripts/test_validate_config_map.py
+++ b/test/scripts/test_validate_config_map.py
@@ -1,0 +1,190 @@
+import importlib
+from types import ModuleType
+
+import pytest
+
+
+def import_validator() -> ModuleType:
+    name = "validate_config_map"
+    path = "test/scripts/validate-config-map"
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    if spec is None:
+        raise ImportError(f"cannot import {name} from {path}, got None as the spec")
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+def write_configs(files, root):
+    for config_file in files:
+        config_path = root / config_file
+        config_path.parent.mkdir(exist_ok=True)
+        config_path.touch()
+
+
+@pytest.mark.parametrize("config_map,files,missing_files,invalid_cfgs", (
+    # valid
+    (
+        {
+            "everything.json": {
+                "distros": [
+                    "fedora*",
+                ],
+            },
+            "empty.json": {
+                "image-types": ["qcow2"],
+            },
+        },
+        ["everything.json", "empty.json"],
+        [],
+        [],
+    ),
+    (
+        {
+            "configs/cfg-1.json": {},
+            "configs/cfg-2.json": {
+                "distros": ["centos*"],
+                "arches": ["s390x"],
+                "image-types": ["qcow2"],
+            },
+        },
+        ["configs/cfg-1.json", "configs/cfg-2.json"],
+        [],
+        [],
+    ),
+    (
+        {
+            "configs/cfg-3.json": {
+                "distros": ["fedora*"],
+            },
+            "configs/cfg-4.json": {
+                "image-types": ["qcow2"],
+            },
+        },
+        ["configs/cfg-3.json", "configs/cfg-4.json"],
+        [],
+        [],
+    ),
+
+    # missing files
+    (
+        {
+            "everything.json": {
+                "distros": [
+                    "fedora*",
+                ],
+            },
+            "empty.json": {
+                "image-types": ["qcow2"],
+            },
+        },
+        ["everything.json"],
+        ["empty.json"],
+        [],
+    ),
+    (
+        {
+            "configs/cfg-1.json": {},
+            "configs/cfg-2.json": {
+                "distros": ["centos*"],
+                "arches": ["s390x"],
+                "image-types": ["qcow2"],
+            },
+        },
+        [],
+        ["configs/cfg-1.json", "configs/cfg-2.json"],
+        [],
+    ),
+    (
+        {
+            "configs/cfg-3.json": {
+                "distros": ["fedora*"],
+            },
+            "configs/cfg-4.json": {
+                "image-types": ["qcow2"],
+            },
+        },
+        ["configs/cfg-4.json"],
+        ["configs/cfg-3.json"],
+        [],
+    ),
+
+    # bad config
+    (
+        {
+            "everything.json": {
+                "distros": [
+                    "fedora*",
+                ],
+            },
+            "empty.json": {
+                "image-types": ["not-qcow2"],
+            },
+        },
+        ["everything.json", "empty.json"],
+        [],
+        [
+            (
+                "empty.json",
+                {
+                    "image-types": ["not-qcow2"],
+                },
+            )
+        ],
+    ),
+    (
+        {
+            "configs/cfg-1.json": {},
+            "configs/cfg-2.json": {
+                "distros": ["centos*"],
+                "arches": ["noarch"],
+                "image-types": ["qcow2"],
+            },
+        },
+        ["configs/cfg-1.json", "configs/cfg-2.json"],
+        [],
+        [
+            (
+                "configs/cfg-2.json",
+                {
+                    "distros": ["centos*"],
+                    "arches": ["noarch"],
+                    "image-types": ["qcow2"],
+                },
+            )
+        ],
+    ),
+    (
+        {
+            "configs/cfg-3.json": {
+                "distros": ["archlinux"],
+            },
+            "configs/cfg-4.json": {
+                "distros": ["ubuntu*"],
+            },
+        },
+        ["configs/cfg-3.json", "configs/cfg-4.json"],
+        [],
+        [
+            (
+                "configs/cfg-3.json",
+                {
+                    "distros": ["archlinux"],
+                },
+            ),
+            (
+                "configs/cfg-4.json",
+                {
+                    "distros": ["ubuntu*"],
+                },
+            ),
+        ],
+    ),
+))
+def test_valid_config_map(config_map, files, missing_files, invalid_cfgs, tmp_path):
+    validator = import_validator()
+    write_configs(files, tmp_path)
+
+    assert validator.validate_config_file_paths(config_map, tmp_path) == [tmp_path / mf for mf in missing_files]
+    assert validator.validate_build_config(config_map) == invalid_cfgs

--- a/test/scripts/validate-config-map
+++ b/test/scripts/validate-config-map
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Reads the config map and verifies that: 1. All listed config files exist, and 2. The combination of distros, arches, and
+image-types produces at least one valid build configuration for each config file.
+
+The config map is read as test/config-map.json relative to the repository root.
+"""
+import argparse
+import json
+import pathlib
+import sys
+
+import imgtestlib as testlib
+
+
+def read_config_map(root):
+    config_map_path = root / "test/config-map.json"
+    if not config_map_path.exists():
+        print(f"config map not found at {config_map_path}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Reading config map: {config_map_path}")
+    with config_map_path.open(encoding="utf-8") as config_map_fp:
+        return json.load(config_map_fp), config_map_path.parent
+
+
+def validate_config_file_paths(config_map, config_map_dir):
+    """
+    Validate that all paths used as keys in the config map exist. Paths must be relative to config_map_dir (the parent
+    directory of the config map).
+
+    Returns a list of paths found in the config map that were not found in the directory.
+    """
+    not_found = []
+    for path in config_map.keys():
+        config_path = config_map_dir / path
+        if not config_path.exists():
+            not_found.append(config_path)
+
+    return not_found
+
+
+def validate_build_config(config_map, root):
+    """
+    Validate that all build configurations (distros, arches, image types) match at least one valid, known configuration.
+
+    Returns a list of 2-tuples, each consisting of the config file path and the build configuration.
+    """
+    no_matches = []
+    for config, build_config in config_map.items():
+        distros = build_config.get("distros", ["*"])
+        arches = build_config.get("arches", ["*"])
+        image_types = build_config.get("image-types", ["*"])
+
+        matches = testlib.list_images(distros=distros, arches=arches, images=image_types, cmd_root=root)
+        if not matches:
+            no_matches.append((config, build_config))
+
+    return no_matches
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", default=".", nargs="?", help="path to repository root")
+    args = parser.parse_args()
+
+    root = pathlib.Path(args.path)
+
+    config_map, config_map_dir = read_config_map(root)
+
+    print("Validating config file paths")
+    not_found = validate_config_file_paths(config_map, config_map_dir)
+    if not_found:
+        print("  failed: the following config files were not found:", file=sys.stderr)
+        for idx, path in enumerate(not_found, start=1):
+            print(f"{idx}: {path}", file=sys.stderr)
+        sys.exit(len(not_found))
+    print("OK: All config files found")
+
+    print("Validating build configurations (distros, arches, image types)")
+    no_matches = validate_build_config(config_map, root)
+    if no_matches:
+        print("failed: the following configs do not match any known build configurations", file=sys.stderr)
+        for idx, (config, build_config) in enumerate(no_matches, start=1):
+            distros = ",".join(build_config.get("distros", ["*"]))
+            arches = ",".join(build_config.get("arches", ["*"]))
+            image_types = ",".join(build_config.get("image-types", ["*"]))
+            print(f"{idx} {config}:", file=sys.stderr)
+            print(f"  distros: {distros}", file=sys.stderr)
+            print(f"  arches: {arches}", file=sys.stderr)
+            print(f"  image types: {image_types}", file=sys.stderr)
+
+        sys.exit(len(no_matches))
+    print("OK: All test configs have at least one valid build configuration")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/scripts/validate-config-map
+++ b/test/scripts/validate-config-map
@@ -40,7 +40,7 @@ def validate_config_file_paths(config_map, config_map_dir):
     return not_found
 
 
-def validate_build_config(config_map, root):
+def validate_build_config(config_map):
     """
     Validate that all build configurations (distros, arches, image types) match at least one valid, known configuration.
 
@@ -52,7 +52,7 @@ def validate_build_config(config_map, root):
         arches = build_config.get("arches", ["*"])
         image_types = build_config.get("image-types", ["*"])
 
-        matches = testlib.list_images(distros=distros, arches=arches, images=image_types, cmd_root=root)
+        matches = testlib.list_images(distros=distros, arches=arches, images=image_types)
         if not matches:
             no_matches.append((config, build_config))
 
@@ -78,7 +78,7 @@ def main():
     print("OK: All config files found")
 
     print("Validating build configurations (distros, arches, image types)")
-    no_matches = validate_build_config(config_map, root)
+    no_matches = validate_build_config(config_map)
     if no_matches:
         print("failed: the following configs do not match any known build configurations", file=sys.stderr)
         for idx, (config, build_config) in enumerate(no_matches, start=1):


### PR DESCRIPTION
1. Follow-up from #1154 with the same change but for the edge-ami image type.
2. Add a new test script that validates the build configurations in the config map¹.
3. Change the `iot-ami` image type in the config map to `iot-qcow2-image`.  `iot-ami` is not a valid image type name.

¹ Note that the validation script does not catch all issues with the config map.  For
example, the following configuration is considered valid:
```json
{
  "./configs/some-config.json": {
    "distros": [
      "rhel-10*",
    ],
    "image-types": [
      "ami",
      "invalid-type-name"
    ]
  }
}
```

because it still produces (at least) one valid configuration:

    rhel-10.0, ami, any architecture

This is (somewhat) necessary because we also want the following to be
valid:
```json
{
  "./configs/some-config.json": {
    "distros": [
      "rhel-9*",
      "fedora*"
    ],
    "image-types": [
      "iot-commit",
      "edge-commit"
    ]
  }
}
```

where iot-commit is only valid for fedora* and edge-commit is only valid
for rhel-9*.