### PR TITLE
test/scripts/imgtestlib.py: don't use walrus operator (HMS-5377)

### DIFF
--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -545,7 +545,8 @@ def get_common_ci_runner():
     with open(SCHUTZFILE, encoding="utf-8") as schutzfile:
         data = json.load(schutzfile)
 
-    if (runner := data.get("common", {}).get("gitlab-ci-runner")) is None:
+    runner = data.get("common", {}).get("gitlab-ci-runner")
+    if runner is None:
         raise KeyError(f"gitlab-ci-runner not defined in {SCHUTZFILE}")
 
     return runner


### PR DESCRIPTION
Don't use the walrus operator in the library to ensure Python 3.6 compatibility on RHEL-8.

/jira-epic COMPOSER-2318

JIRA: [HMS-5377](https://issues.redhat.com/browse/HMS-5377)