### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence.
+*               @osbuild/osbuild-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
 *               @osbuild/osbuild-reviewers
+
+# Test scripts
+/test/scripts   @achilleas-k @thozza

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,8 @@
 # the repo. Unless a later match takes precedence.
 *               @osbuild/osbuild-reviewers
 
+# Package-specific reviewers
+/pkg/disk/      @achilleas-k
+
 # Test scripts
 /test/scripts   @achilleas-k @thozza


### PR DESCRIPTION
**github: add CODEOWNERS**

Add a CODEOWNERS file that makes PRs get automatically assigned to people base on the package path or file globs.

For now, I added the new osbuild-reviewers team as a global default and a couple of more specific rules for myself.

@thozza: I added you as a co-owner of the test/scripts/ directory as well since you're doing a lot of work understanding and updating the way CI works for the manifest-db changes.  Let me know if you want it removed.

See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file