### PR TITLE
rhel: On RHEL10 use erofs to compress the root filesystem of the Anaconda ISO

### DIFF
--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -495,9 +495,12 @@ func EdgeInstallerImage(workload workload.Workload,
 	// kickstart though kickstart does support setting them
 	img.Kickstart.Timezone, _ = customizations.GetTimezoneSettings()
 
-	img.RootfsCompression = "xz"
 	if t.Arch().Distro().Releasever() == "10" {
-		img.RootfsType = manifest.SquashfsRootfs
+		// On RHEL10 use erofs and lzma compression for the iso root filesystem
+		img.RootfsCompression = "lzma"
+		img.RootfsType = manifest.ErofsRootfs
+	} else {
+		img.RootfsCompression = "xz"
 	}
 
 	installerConfig, err := t.getDefaultInstallerConfig()
@@ -720,9 +723,12 @@ func ImageInstallerImage(workload workload.Workload,
 	}
 	img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, anaconda.ModuleUsers)
 
-	img.RootfsCompression = "xz"
 	if t.Arch().Distro().Releasever() == "10" {
-		img.RootfsType = manifest.SquashfsRootfs
+		// On RHEL10 use erofs and lzma compression for the iso root filesystem
+		img.RootfsCompression = "lzma"
+		img.RootfsType = manifest.ErofsRootfs
+	} else {
+		img.RootfsCompression = "xz"
 	}
 
 	// put the kickstart file in the root of the iso


### PR DESCRIPTION
This will use lzma compression with 128k blocks and the dedupe and all-fragments erofs options (see the manpage for mkfs.erofs for details).

Resolves: RHEL-75932