### PR TITLE
rpmmd: add NEVRA

### DIFF
--- a/pkg/rpmmd/repository.go
+++ b/pkg/rpmmd/repository.go
@@ -160,6 +160,7 @@ type PackageSpec struct {
 	Version        string `json:"version,omitempty"`
 	Release        string `json:"release,omitempty"`
 	Arch           string `json:"arch,omitempty"`
+	NEVRA          string `json:"nevra,omitempty"`
 	RemoteLocation string `json:"remote_location,omitempty"`
 	Checksum       string `json:"checksum,omitempty"`
 	Secrets        string `json:"secrets,omitempty"`


### PR DESCRIPTION
The depsolver has started returning a pre-formatted NEVRA in https://github.com/osbuild/osbuild/pull/1933. This breaks deserialization, this PR adds the field to the `PackageSpec` type.

I'd prefer to do this here instead of dropping the NEVRA from the depsolve response; the EVR part from the response comes directly from DNF.