### PR TITLE
depsolve: add `modules` support

### DIFF
--- a/pkg/dnfjson/dnfjson.go
+++ b/pkg/dnfjson/dnfjson.go
@@ -722,10 +722,12 @@ type transactionArgs struct {
 }
 
 type packageSpecs []PackageSpec
+type moduleSpecs map[string]ModuleSpec
 
 type depsolveResult struct {
 	Packages packageSpecs          `json:"packages"`
 	Repos    map[string]repoConfig `json:"repos"`
+	Modules  moduleSpecs           `json:"modules"`
 
 	// (optional) contains the solver used, e.g. "dnf5"
 	Solver string `json:"solver,omitempty"`
@@ -746,6 +748,29 @@ type PackageSpec struct {
 	RemoteLocation string `json:"remote_location,omitempty"`
 	Checksum       string `json:"checksum,omitempty"`
 	Secrets        string `json:"secrets,omitempty"`
+}
+
+// Module specification
+type ModuleSpec struct {
+	ModuleConfigFile ModuleConfigFile   `json:"module-file"`
+	FailsafeFile     ModuleFailsafeFile `json:"failsafe-file"`
+}
+
+type ModuleConfigFile struct {
+	Path string           `json:"path"`
+	Data ModuleConfigData `json:"data"`
+}
+
+type ModuleConfigData struct {
+	Name     string   `json:"name"`
+	Stream   string   `json:"stream"`
+	Profiles []string `json:"profiles"`
+	State    string   `json:"state"`
+}
+
+type ModuleFailsafeFile struct {
+	Path string `json:"path"`
+	Data string `json:"string"`
 }
 
 // dnf-json error structure

--- a/pkg/dnfjson/dnfjson_test.go
+++ b/pkg/dnfjson/dnfjson_test.go
@@ -1,6 +1,7 @@
 package dnfjson
 
 import (
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -886,4 +887,18 @@ echo '{"solver": "zypper"}'
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(res.Packages))
 	assert.Equal(t, 0, len(res.Repos))
+}
+
+func TestDepsolveResultWithModulesKey(t *testing.T) {
+	// quick test that verifies that `depsolveResult` understands JSON that contains
+	// a `modules` key
+	data := []byte(`{"modules": {}}`)
+
+	var result depsolveResult
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+
+	err := dec.Decode(&result)
+
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Since the modularity PR https://github.com/osbuild/osbuild/pull/1933 landed in `osbuild` the depsolve result now contains a `modules` key with data if modules were resolved.

Add the appropriate structures to the depsolve result, without propagating them into rpmmd for now.

Also adds a quick test for the internal `depsolveResult` type deserialization to ensure it understands some JSON serialized data that contains a `modules` key.

This PR will serve as the basis for #1095 where the types will be propagated to rpmmd and the stage will be implemented; but this one is important to unblock our CI as everything now fails on the unexpected field.

---

Note that, as opposed to the nevra field on packages which was a big red herring today; this field is actually *expected* to be added. Hence we can't just remove it from the depsolve response. This also means that the DNF JSON version *will* need to be bumped; even though we didn't want to do that (cc: @ondrejbudai). See https://github.com/osbuild/osbuild/pull/1992 for that bump.

---

When this commit is to be depended on by `osbuild-composer` and `image-builder-cli` we will likely need to depend on the new API version as well if I understand correctly (cc @thozza).