### PR TITLE
osbuild: add consts for more "sources" in sources.go

### DIFF
--- a/pkg/osbuild/containers_input.go
+++ b/pkg/osbuild/containers_input.go
@@ -29,7 +29,7 @@ func newContainersInputForSources(containers []container.Spec, forLocal bool) Co
 
 	var sourceType string
 	if forLocal {
-		sourceType = "org.osbuild.containers-storage"
+		sourceType = SourceNameContainersStorage
 	} else {
 		sourceType = "org.osbuild.containers"
 	}

--- a/pkg/osbuild/containers_storage_source.go
+++ b/pkg/osbuild/containers_storage_source.go
@@ -2,6 +2,8 @@ package osbuild
 
 import "fmt"
 
+const SourceNameContainersStorage = "org.osbuild.containers-storage"
+
 type ContainersStorageSource struct {
 	Items map[string]struct{} `json:"items"`
 }

--- a/pkg/osbuild/skopeo_index_source.go
+++ b/pkg/osbuild/skopeo_index_source.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 )
 
+const SourceNameSkopeoIndex = "org.osbuild.skopeo-index"
+
 type SkopeoIndexSource struct {
 	Items map[string]SkopeoIndexSourceItem `json:"items"`
 }

--- a/pkg/osbuild/skopeo_source.go
+++ b/pkg/osbuild/skopeo_source.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 )
 
+const SourceNameSkopeo = "org.osbuild.skopeo"
+
 var skopeoDigestPattern = regexp.MustCompile(`sha256:[0-9a-f]{64}`)
 
 const DockerTransport = "docker"

--- a/pkg/osbuild/skopeo_stage.go
+++ b/pkg/osbuild/skopeo_stage.go
@@ -41,7 +41,7 @@ func NewSkopeoStageWithContainersStorage(path string, images ContainersInput, ma
 	}
 
 	return &Stage{
-		Type: "org.osbuild.skopeo",
+		Type: SourceNameSkopeo,
 		Options: &SkopeoStageOptions{
 			Destination: SkopeoDestinationContainersStorage{
 				Type:        "containers-storage",
@@ -59,7 +59,7 @@ func NewSkopeoStageWithOCI(path string, images ContainersInput, manifests *Files
 	}
 
 	return &Stage{
-		Type: "org.osbuild.skopeo",
+		Type: SourceNameSkopeo,
 		Options: &SkopeoStageOptions{
 			Destination: &SkopeoDestinationOCI{
 				Type: "oci",

--- a/pkg/osbuild/source.go
+++ b/pkg/osbuild/source.go
@@ -160,13 +160,13 @@ func GenSources(inputs SourceInputs, rpmDownloader RpmDownloader) (Sources, erro
 			}
 		}
 		if len(skopeo.Items) > 0 {
-			sources["org.osbuild.skopeo"] = skopeo
+			sources[SourceNameSkopeo] = skopeo
 		}
 		if len(skopeoIndex.Items) > 0 {
-			sources["org.osbuild.skopeo-index"] = skopeoIndex
+			sources[SourceNameSkopeoIndex] = skopeoIndex
 		}
 		if len(localContainers.Items) > 0 {
-			sources["org.osbuild.containers-storage"] = localContainers
+			sources[SourceNameContainersStorage] = localContainers
 		}
 	}
 


### PR DESCRIPTION
This is a followup for the suggestion in PR#1142 to not use strings for defining sources but constants. This helps avoiding typos.

Note that this does not change the tests to ensure that we keep the API promises here. I.e. an accidental change of e.g. the `SourceNameSkopeoIndex` const should trigger a test failure.