### PR TITLE
Add short output

### DIFF
--- a/docs/image-types/rhel8/google-gce.md
+++ b/docs/image-types/rhel8/google-gce.md
@@ -132,14 +132,14 @@ The high-level description of the workflow used to build RHEL Guest Images is as
 4. Delete all created resources.
 
 RHEL Guest Images are imported with the following Guest OS features set:
-* UEFI_COMPATIBLE
-* VIRTIO_SCSI_MULTIQUEUE
-* SEV_CAPABLE
-* SEV_SNP_CAPABLE
-* SEV_LIVE_MIGRATABLE
-* SEV_LIVE_MIGRATABLE_V2
-* GVNIC
-* IDPF
+* `UEFI_COMPATIBLE`
+* `VIRTIO_SCSI_MULTIQUEUE`
+* `SEV_CAPABLE`
+* `SEV_SNP_CAPABLE`
+* `SEV_LIVE_MIGRATABLE`
+* `SEV_LIVE_MIGRATABLE_V2`
+* `GVNIC`
+* `IDPF`
 
 
 [daisy-tool]: https://github.com/GoogleCloudPlatform/compute-image-tools/tree/master/daisy

--- a/pkg/imagefilter/formatter_test.go
+++ b/pkg/imagefilter/formatter_test.go
@@ -70,6 +70,27 @@ func TestResultsFormatter(t *testing.T) {
 			[]string{"test-distro-1:qcow2:test_arch3"},
 			"qcow2 --distro test-distro-1 --arch test_arch3\n",
 		},
+		{
+			"short",
+			[]string{"test-distro-1:qcow2:test_arch3"},
+			"test-distro-1:\n  qcow2: [ test_arch3 ]\n",
+		},
+		{
+			"short",
+			[]string{
+				"test-distro-1:qcow2:test_arch3",
+				"test-distro-2:qcow2:test_arch3",
+			},
+			"test-distro-1:\n  qcow2: [ test_arch3 ]\ntest-distro-2:\n  qcow2: [ test_arch3 ]\n",
+		},
+		{
+			"short",
+			[]string{
+				"test-distro-1:test_type:test_arch",
+				"test-distro-1:test_type:test_arch2",
+			},
+			"test-distro-1:\n  test_type: [ test_arch, test_arch2 ]\n",
+		},
 	} {
 		res := make([]imagefilter.Result, len(tc.fakeResults))
 		for i, resultSpec := range tc.fakeResults {


### PR DESCRIPTION
Add `short` output
which looks like
```
rhel-9.5:
  ami: [ aarch64, x86_64 ]
  azure-rhui: [ aarch64, x86_64 ]
  azure-sap-rhui: [ x86_64 ]
  ec2: [ aarch64, x86_64 ]
…
rhel-9.6:
  ami: [ aarch64, x86_64 ]
  azure-rhui: [ aarch64, x86_64 ]
  azure-sap-rhui: [ x86_64 ]
  ec2: [ aarch64, x86_64 ]
  ec2-ha: [ x86_64 ]
  ec2-sap: [ x86_64 ]
```

(this is based on #1166 )