### PR TITLE
imagefilter: add SupportedOutputFormats

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/ubccr/kerby v0.0.0-20230802201021-412be7bfaee5
 	github.com/vmware/govmomi v0.48.0
+	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/oauth2 v0.25.0
 	golang.org/x/sys v0.29.0
 	golang.org/x/tools v0.26.0
@@ -168,7 +169,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.32.0 // indirect
 	go.opentelemetry.io/otel/trace v1.32.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect

--- a/pkg/imagefilter/export_test.go
+++ b/pkg/imagefilter/export_test.go
@@ -1,0 +1,3 @@
+package imagefilter
+
+var SupportedFormatters = supportedFormatters

--- a/pkg/imagefilter/formatter_test.go
+++ b/pkg/imagefilter/formatter_test.go
@@ -116,3 +116,9 @@ func TestSupportedOutputFormats(t *testing.T) {
 	assert.Contains(t, formatters, "short")
 	assert.True(t, sort.StringsAreSorted(formatters))
 }
+
+func TestResultsFormatterError(t *testing.T) {
+	fmter, err := imagefilter.NewResultsFormatter(imagefilter.OutputFormat("unsupported"))
+	assert.Error(t, err)
+	assert.Nil(t, fmter)
+}

--- a/pkg/imagefilter/formatter_test.go
+++ b/pkg/imagefilter/formatter_test.go
@@ -2,6 +2,7 @@ package imagefilter_test
 
 import (
 	"bytes"
+	"sort"
 	"strings"
 	"testing"
 
@@ -104,4 +105,14 @@ func TestResultsFormatter(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, tc.expectsOutput, buf.String(), tc)
 	}
+}
+
+func TestSupportedOutputFormats(t *testing.T) {
+	formatters := imagefilter.SupportedOutputFormats()
+	assert.Len(t, formatters, len(imagefilter.SupportedFormatters))
+	assert.Contains(t, formatters, "text")
+	assert.Contains(t, formatters, "json")
+	assert.Contains(t, formatters, "shell")
+	assert.Contains(t, formatters, "short")
+	assert.True(t, sort.StringsAreSorted(formatters))
 }


### PR DESCRIPTION
Convenience function for concise help output

(This is based on #1166 and #1167)

The last commit could be split off, it's not directly related to the implementation of `SupportedOutputFormats` just extends the tests