### PR TITLE
distro: use `rand.Int63` intead of `time.UnixNano()`

### DIFF
--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -1,7 +1,7 @@
 package distro
 
 import (
-	"time"
+	"math/rand"
 
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/customizations/subscription"
@@ -162,7 +162,8 @@ func PayloadPackageSets() []string {
 
 func SeedFrom(p *int64) int64 {
 	if p == nil {
-		return time.Now().UnixNano()
+		// #nosec G404
+		return rand.Int63()
 	}
 	return *p
 }


### PR DESCRIPTION
This is a slightly silly commit. Instead of using `time.UnixNano()` its much more sensible to use `rand.Int63` which is automatically seeded since go1.20 [0] and also gives us a wider range of possible seeds than UnixNano (which will always be of a preditable length).

None of this really matters in practise as we just need something "good enough" but using rand.Int63() is the correct thing to do.

[0] https://tip.golang.org/doc/go1.20#mathrandpkgmathrand