### PR TITLE
.github/workflows/update-osbuild: extend PR commit message

### DIFF
--- a/.github/workflows/update-osbuild.yml
+++ b/.github/workflows/update-osbuild.yml
@@ -25,6 +25,7 @@ jobs:
         working-directory: ./images
         env:
           GITHUB_TOKEN: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+        # this also creates github_pr_body.txt
         run: |
           ./test/scripts/update-schutzfile-osbuild
 
@@ -42,10 +43,9 @@ jobs:
           git add Schutzfile
           git commit -m "schutzfile: Update osbuild dependency commit ID"
           git push -f https://"$GITHUB_TOKEN"@github.com/schutzbot/images.git
-          echo "Updating osbuild dependency commit IDs to current `main`" > body
           gh pr create \
             -t "Update osbuild dependency commit ID to latest" \
-            -F "body" \
+            -F "github_pr_body.txt" \
             --repo "osbuild/images" \
             --base "main" \
             --head "schutzbot:${branch}"

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dictionary.dic
 
 *~
 container_built*.info
+github_pr_body.txt

--- a/test/scripts/update-schutzfile-osbuild
+++ b/test/scripts/update-schutzfile-osbuild
@@ -29,14 +29,25 @@ def update_osbuild_commit_ids(new):
     with open(testlib.SCHUTZFILE, encoding="utf-8") as schutzfile:
         data = json.load(schutzfile)
 
+    unique_changes = []
+
     for distro in data.keys():
         if distro == "common":
             continue
 
+        old = data[distro].get("dependencies", {}).get("osbuild", {}).get("commit", "main")
+        change = f"Changes: https://github.com/osbuild/osbuild/compare/{old}...{new}"
+        if change not in unique_changes:
+            unique_changes.append(change)
         data[distro].setdefault("dependencies", {}).setdefault("osbuild", {})["commit"] = new
 
     with open(testlib.SCHUTZFILE, encoding="utf-8", mode="w") as schutzfile:
         json.dump(data, schutzfile, indent="  ")
+
+    with open("github_pr_body.txt", encoding="utf-8", mode="w") as pr_body:
+        pr_body.write("Updating osbuild dependency commit IDs to current `main`\n\n")
+        pr_body.write("\n".join(unique_changes))
+        pr_body.write("\n")
 
 
 def main():


### PR DESCRIPTION
Extends the "update dependency PR" commit message to also contain a link to the exact changes for easier review.

e.g. the Message of https://github.com/osbuild/images/pull/1169 would be

```
Updating osbuild dependency commit IDs to current `main`

Changes: https://github.com/osbuild/osbuild/compare/55d53f58fdbe6f328581f12c4548efb80aa5ca19...e4333f87ba14f85ba3d9aa5b070190d82d06a297
```

similar change could be done with `./test/scripts/update-schutzfile-bib` in a separate PR