### PR TITLE
imagefilter: make `short` output format as unstable

### DIFF
--- a/pkg/imagefilter/formatter.go
+++ b/pkg/imagefilter/formatter.go
@@ -87,6 +87,12 @@ type textShortResultsFormatter struct{}
 func (*textShortResultsFormatter) Output(w io.Writer, all []Result) error {
 	var errs []error
 
+	// deliberately break the yaml until the feature is stable, there
+	// are open questions, e.g. how this relates to:
+	// https://github.com/osbuild/osbuild-composer/pull/4336
+	// which adds a similar but slightly different API
+	fmt.Fprint(w, "@WARNING - the output format is not stable yet and may change\n")
+
 	outputMap := make(map[string]map[string][]string)
 	for _, res := range all {
 		if _, ok := outputMap[res.Distro.Name()]; !ok {

--- a/pkg/imagefilter/formatter_test.go
+++ b/pkg/imagefilter/formatter_test.go
@@ -73,7 +73,7 @@ func TestResultsFormatter(t *testing.T) {
 		{
 			"short",
 			[]string{"test-distro-1:qcow2:test_arch3"},
-			"test-distro-1:\n  qcow2: [ test_arch3 ]\n",
+			"@WARNING - the output format is not stable yet and may change\ntest-distro-1:\n  qcow2: [ test_arch3 ]\n",
 		},
 		{
 			"short",
@@ -81,7 +81,7 @@ func TestResultsFormatter(t *testing.T) {
 				"test-distro-1:qcow2:test_arch3",
 				"test-distro-2:qcow2:test_arch3",
 			},
-			"test-distro-1:\n  qcow2: [ test_arch3 ]\ntest-distro-2:\n  qcow2: [ test_arch3 ]\n",
+			"@WARNING - the output format is not stable yet and may change\ntest-distro-1:\n  qcow2: [ test_arch3 ]\ntest-distro-2:\n  qcow2: [ test_arch3 ]\n",
 		},
 		{
 			"short",
@@ -89,7 +89,7 @@ func TestResultsFormatter(t *testing.T) {
 				"test-distro-1:test_type:test_arch",
 				"test-distro-1:test_type:test_arch2",
 			},
-			"test-distro-1:\n  test_type: [ test_arch, test_arch2 ]\n",
+			"@WARNING - the output format is not stable yet and may change\ntest-distro-1:\n  test_type: [ test_arch, test_arch2 ]\n",
 		},
 	} {
 		res := make([]imagefilter.Result, len(tc.fakeResults))


### PR DESCRIPTION
This commit changes the "short" output format so that it is marked as "unstable". There are some open questions about this format and how it relates to e.g.
https://github.com/osbuild/osbuild-composer/pull/4336 which adds very similar API is a slightly different format.

So to prevent users from relying on the API before that is resolved we need to at least make them aware that this may still change.