### PR TITLE
imagefilter: use `distrosort` to sort the distro names

### DIFF
--- a/pkg/imagefilter/formatter.go
+++ b/pkg/imagefilter/formatter.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"sort"
 	"strings"
+
+	"github.com/osbuild/images/pkg/distrosort"
 )
 
 // OutputFormat contains the valid output formats for formatting results
@@ -106,7 +108,9 @@ func (*textShortResultsFormatter) Output(w io.Writer, all []Result) error {
 	for distro := range outputMap {
 		distros = append(distros, distro)
 	}
-	sort.Strings(distros)
+	if err := distrosort.Names(distros); err != nil {
+		return fmt.Errorf("cannot sort distro names %q: %w", distros, err)
+	}
 
 	for _, distro := range distros {
 		var types []string

--- a/pkg/imagefilter/formatter_test.go
+++ b/pkg/imagefilter/formatter_test.go
@@ -78,10 +78,10 @@ func TestResultsFormatter(t *testing.T) {
 		{
 			"short",
 			[]string{
-				"test-distro-1:qcow2:test_arch3",
-				"test-distro-2:qcow2:test_arch3",
+				"test-distro-9:qcow2:test_arch3",
+				"test-distro-10:qcow2:test_arch3",
 			},
-			"@WARNING - the output format is not stable yet and may change\ntest-distro-1:\n  qcow2: [ test_arch3 ]\ntest-distro-2:\n  qcow2: [ test_arch3 ]\n",
+			"@WARNING - the output format is not stable yet and may change\ntest-distro-9:\n  qcow2: [ test_arch3 ]\ntest-distro-10:\n  qcow2: [ test_arch3 ]\n",
 		},
 		{
 			"short",


### PR DESCRIPTION
[build on top of https://github.com/osbuild/images/pull/1173]

This commit uses the `distrosort` package to sort the distro names
by their name/version. This means that the output of centos is sorted
by low to high version like this:
```console
$ ./image-builder list-images --output=short --filter distro:centos*
centos-9:
  ami: [ aarch64, x86_64 ]
  ...
centos-10:
  ami: [ aarch64, x86_64 ]
  ...
```

with the regular "string" search this was:
```console
$ ./image-builder list-images --output=short --filter distro:centos*
centos-10:
  ami: [ aarch64, x86_64 ]
  ...
centos-9:
  ami: [ aarch64, x86_64 ]
  ...
```
(this is also quite visible with rhel).
