### PR TITLE
Add a blocking container resolver

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,9 +48,10 @@ jobs:
         run: git config --global --add safe.directory "$(pwd)"
 
       - name: Run unit tests
-        # skip the TestResolverLocalManifest test. It is tested separately
+        # skip the TestResolverLocalManifest and
+        # TestBlockingResolverLocalManifest tests. They are tested separately
         # (see below: requires root)
-        run: go test -race ./... -test.skip TestResolverLocalManifest
+        run: go test -race ./... -test.skip 'TestBlockingResolverLocalManifest|TestResolverLocalManifest'
 
       - name: Run depsolver tests with force-dnf to make sure it's not skipped
         run: go test -race ./pkg/dnfjson/... -force-dnf

--- a/pkg/container/blocking_resolver_test.go
+++ b/pkg/container/blocking_resolver_test.go
@@ -1,0 +1,200 @@
+package container_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/testregistry"
+	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/pkg/container"
+)
+
+func TestBlockingResolver(t *testing.T) {
+	registry := testregistry.New()
+	defer registry.Close()
+	repo := registry.AddRepo("library/osbuild")
+	ref := registry.GetRef("library/osbuild")
+
+	refs := make([]string, 10)
+	for i := 0; i < len(refs); i++ {
+		checksum := repo.AddImage(
+			[]testregistry.Blob{testregistry.NewDataBlobFromBase64(testregistry.RootLayer)},
+			[]string{"amd64", "ppc64le"},
+			fmt.Sprintf("image %d", i),
+			time.Time{})
+
+		tag := fmt.Sprintf("%d", i)
+		repo.AddTag(checksum, tag)
+		refs[i] = fmt.Sprintf("%s:%s", ref, tag)
+	}
+
+	resolver := container.NewBlockingResolver("amd64")
+
+	for _, r := range refs {
+		resolver.Add(container.SourceSpec{
+			Source:    r,
+			Name:      "",
+			Digest:    common.ToPtr(""),
+			TLSVerify: common.ToPtr(false),
+			Local:     false,
+		})
+	}
+
+	have, err := resolver.Finish()
+	assert.NoError(t, err)
+	assert.NotNil(t, have)
+
+	assert.Len(t, have, len(refs))
+
+	want := make([]container.Spec, len(refs))
+	for i, r := range refs {
+		spec, err := registry.Resolve(r, arch.ARCH_X86_64)
+		assert.NoError(t, err)
+		want[i] = spec
+	}
+
+	assert.ElementsMatch(t, have, want)
+}
+
+func TestBlockingResolverFail(t *testing.T) {
+	resolver := container.NewBlockingResolver("amd64")
+
+	resolver.Add(container.SourceSpec{
+		Source:    "invalid-reference@${IMAGE_DIGEST}",
+		Name:      "",
+		Digest:    common.ToPtr(""),
+		TLSVerify: common.ToPtr(false),
+		Local:     false,
+	})
+	specs, err := resolver.Finish()
+	assert.Error(t, err)
+	assert.Len(t, specs, 0)
+
+	registry := testregistry.New()
+	defer registry.Close()
+
+	resolver.Add(container.SourceSpec{
+		Source:    registry.GetRef("repo"),
+		Name:      "",
+		Digest:    common.ToPtr(""),
+		TLSVerify: common.ToPtr(false),
+		Local:     false,
+	})
+	specs, err = resolver.Finish()
+	assert.Error(t, err)
+	assert.Len(t, specs, 0)
+
+	resolver.Add(container.SourceSpec{
+		Source:    registry.GetRef("repo"),
+		Name:      "",
+		Digest:    common.ToPtr(""),
+		TLSVerify: common.ToPtr(false),
+		Local:     false,
+	})
+	specs, err = resolver.Finish()
+	assert.Error(t, err)
+	assert.Len(t, specs, 0)
+
+	resolver.Add(container.SourceSpec{
+		Source:    registry.GetRef("repo"),
+		Name:      "",
+		Digest:    common.ToPtr(""),
+		TLSVerify: common.ToPtr(false),
+		Local:     false,
+	})
+	specs, err = resolver.Finish()
+	assert.Error(t, err)
+	assert.Len(t, specs, 0)
+}
+
+func TestBlockingResolverLocalManifest(t *testing.T) {
+	currentUser, err := user.Current()
+	assert.NoError(t, err)
+
+	if !*forceLocal {
+		// local resolver tests aren't forced, so we can skip
+		// them if the user is not root or the podman executable
+		// is not installed
+		if currentUser.Uid != "0" {
+			t.Skip("User is not root, skipping test")
+		}
+
+		_, err = exec.LookPath("podman")
+		if err != nil {
+			t.Skip("Podman not available, skipping test")
+		}
+	}
+
+	containerFile, err := os.CreateTemp(t.TempDir(), "Containerfile")
+	assert.NoError(t, err)
+
+	tmpStorage := t.TempDir()
+
+	_, err = containerFile.Write([]byte("FROM scratch"))
+	assert.NoError(t, err)
+
+	cmd := exec.Command( //nolint:gosec
+		"podman",
+		"--root", tmpStorage, // don't dirty the default store
+		"build",
+		"--platform", "linux/amd64,linux/arm64",
+		"--manifest", "multi-arch",
+		"-f", containerFile.Name(),
+		".",
+	)
+	// cleanup the containers
+	defer func() {
+		cmd := exec.Command("podman", "--root", tmpStorage, "system", "prune", "-f")
+		err := cmd.Run()
+		assert.NoError(t, err)
+	}()
+
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+
+	err = cmd.Run()
+	assert.NoError(t, err)
+
+	// try resolve an x86_64 container using a local manifest list
+	resolver := container.NewBlockingResolverWithTestClient("amd64", func(target string) (*container.Client, error) {
+		return container.NewClientWithTestStorage(target, tmpStorage)
+	})
+
+	resolver.Add(container.SourceSpec{
+		Source:    "localhost/multi-arch",
+		Name:      "",
+		Digest:    common.ToPtr(""),
+		TLSVerify: common.ToPtr(false),
+		Local:     true,
+	})
+	specs, err := resolver.Finish()
+	assert.NoError(t, err)
+	assert.Len(t, specs, 1)
+	assert.Equal(t, specs[0].LocalName, "localhost/multi-arch:latest")
+	assert.Equal(t, specs[0].Arch.String(), arch.ARCH_X86_64.String())
+
+	// try resolve an  aarch64 container using a local manifest list
+	resolver = container.NewBlockingResolverWithTestClient("arm64", func(target string) (*container.Client, error) {
+		return container.NewClientWithTestStorage(target, tmpStorage)
+	})
+
+	resolver.Add(container.SourceSpec{
+		Source:    "localhost/multi-arch",
+		Name:      "",
+		Digest:    common.ToPtr(""),
+		TLSVerify: common.ToPtr(false),
+		Local:     true,
+	})
+	specs, err = resolver.Finish()
+	assert.NoError(t, err)
+	assert.Len(t, specs, 1)
+	assert.Equal(t, specs[0].LocalName, "localhost/multi-arch:latest")
+	assert.Equal(t, specs[0].Arch.String(), arch.ARCH_AARCH64.String())
+}

--- a/pkg/container/export_test.go
+++ b/pkg/container/export_test.go
@@ -11,3 +11,9 @@ func NewClientWithTestStorage(target, storage string) (*Client, error) {
 	client.store = storage
 	return client, err
 }
+
+func NewBlockingResolverWithTestClient(arch string, f func(string) (*Client, error)) Resolver {
+	resolver := NewBlockingResolver(arch)
+	resolver.(*blockingResolver).newClient = f
+	return resolver
+}

--- a/pkg/container/export_test.go
+++ b/pkg/container/export_test.go
@@ -1,6 +1,6 @@
 package container
 
-func NewResolverWithTestClient(arch string, f func(string) (*Client, error)) *Resolver {
+func NewResolverWithTestClient(arch string, f func(string) (*Client, error)) *asyncResolver {
 	resolver := NewResolver(arch)
 	resolver.newClient = f
 	return resolver

--- a/pkg/manifestgen/manifestgen.go
+++ b/pkg/manifestgen/manifestgen.go
@@ -223,7 +223,7 @@ func DefaultDepsolver(cacheDir string, packageSets map[string][]rpmmd.PackageSet
 }
 
 func resolveContainers(containers []container.SourceSpec, archName string) ([]container.Spec, error) {
-	resolver := container.NewResolver(archName)
+	resolver := container.NewBlockingResolver(archName)
 
 	for _, c := range containers {
 		resolver.Add(c)


### PR DESCRIPTION
This is a follow-up to #1153 and part of a bigger refactor meant to distribute some of the resolver conveniences from the new `manifestgen` package to the packages that implement the resolvers themselves.

This PR converts the `container.Resolver` from a concrete type to an interface with two implementations:
- `asyncResolver`: the old resolver that resolves container refs asynchronously and blocks on `Finish()`.
- `blockingResolver`: a new resolver that resolves container refs synchronously, blocking on each call to `Add()`.

The blockingResolver implements the Resolver interface but resolves containers synchronously, blocking execution on the resolve process inside the Add() method.  **This will become the only implementation in the near future.**  For now we will support both to make the transition easier for osbuild-composer.  This change is made so that the container resolver behaves in the same way as the other content resolvers (packages and ostree commits) for consistency.