### PR TITLE
rhel10: add `@hardware-support` to installed anaconda packages

### DIFF
--- a/pkg/distro/rhel/rhel10/bare_metal.go
+++ b/pkg/distro/rhel/rhel10/bare_metal.go
@@ -190,6 +190,7 @@ func anacondaPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 
 	ps = ps.Append(rpmmd.PackageSet{
 		Include: []string{
+			"@hardware-support",
 			"alsa-firmware",
 			"alsa-tools-firmware",
 			"anaconda",


### PR DESCRIPTION
This commit adds the @hardware-support group to the anaconda installer packages. This was originally requested for bootc-image-builder in https://github.com/osbuild/bootc-image-builder/issues/807 and implemented in
https://github.com/osbuild/bootc-image-builder/pull/808

But it seems a good idea to be consistent and add it here as well.

Thanks to Tomáš Hozza.