### PR TITLE
reporegistry: do not prepend `repositories` in confPaths

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -93,12 +93,7 @@ func run() error {
 		}
 		overrideRepos = repoConfig[archName]
 	} else {
-		// HACK: reporegistry hardcodes adding the "repositories"
-		// dir to the "repoConfigPaths" but the interface of
-		// "images" does not expect this.
-		// XXX: should we fix this in reporegistry?
-		repositories = filepath.Join(repositories, "..")
-		reporeg, err = reporegistry.New([]string{repositories})
+		reporeg, err = reporegistry.New([]string{repositories}, nil)
 		if err != nil {
 			return fmt.Errorf("failed to load repositories from %q: %w", repositories, err)
 		}

--- a/pkg/reporegistry/error.go
+++ b/pkg/reporegistry/error.go
@@ -1,13 +1,17 @@
 package reporegistry
 
-import "fmt"
+import (
+	"fmt"
+	"io/fs"
+)
 
 // NoReposLoadedError is an error type that is returned when no repositories
 // are loaded from the given paths.
 type NoReposLoadedError struct {
 	Paths []string
+	FSes  []fs.FS
 }
 
 func (e *NoReposLoadedError) Error() string {
-	return fmt.Sprintf("no repositories found in the given paths: %v", e.Paths)
+	return fmt.Sprintf("no repositories found in the given paths: %v/%v", e.Paths, e.FSes)
 }

--- a/pkg/reporegistry/reporegistry.go
+++ b/pkg/reporegistry/reporegistry.go
@@ -17,7 +17,10 @@ type RepoRegistry struct {
 
 // New returns a new RepoRegistry instance with the data loaded from
 // the given repoConfigPaths and repoConfigFS instance. The order is
-// important here, first the paths are tried, then the FSes
+// important here, first the paths are tried, then the FSes.
+//
+// Note that the confPaths must point directly to the directory with
+// the json repo files.
 func New(repoConfigPaths []string, repoConfigFS []fs.FS) (*RepoRegistry, error) {
 	repositories, err := loadAllRepositories(repoConfigPaths, repoConfigFS)
 	if err != nil {

--- a/pkg/reporegistry/reporegistry.go
+++ b/pkg/reporegistry/reporegistry.go
@@ -2,6 +2,7 @@ package reporegistry
 
 import (
 	"fmt"
+	"io/fs"
 
 	"github.com/osbuild/images/pkg/distroidparser"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -14,10 +15,11 @@ type RepoRegistry struct {
 	repos rpmmd.DistrosRepoConfigs
 }
 
-// New returns a new RepoRegistry instance with the data
-// loaded from the given repoConfigPaths
-func New(repoConfigPaths []string) (*RepoRegistry, error) {
-	repositories, err := LoadAllRepositories(repoConfigPaths)
+// New returns a new RepoRegistry instance with the data loaded from
+// the given repoConfigPaths and repoConfigFS instance. The order is
+// important here, first the paths are tried, then the FSes
+func New(repoConfigPaths []string, repoConfigFS []fs.FS) (*RepoRegistry, error) {
+	repositories, err := loadAllRepositories(repoConfigPaths, repoConfigFS)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reporegistry/repository.go
+++ b/pkg/reporegistry/repository.go
@@ -18,7 +18,7 @@ func loadAllRepositories(confPaths []string, confFSes []fs.FS) (rpmmd.DistrosRep
 	var mergedFSes []fs.FS
 
 	for _, confPath := range confPaths {
-		mergedFSes = append(mergedFSes, os.DirFS(filepath.Join(confPath, "repositories")))
+		mergedFSes = append(mergedFSes, os.DirFS(confPath))
 	}
 	mergedFSes = append(mergedFSes, confFSes...)
 
@@ -90,9 +90,12 @@ func loadAllRepositoriesFromFS(confPaths []fs.FS) (rpmmd.DistrosRepoConfigs, err
 // If there are duplicate distro repositories definitions found in multiple paths, the first
 // encounter is preferred. For this reason, the order of paths in the passed list should
 // reflect the desired preference.
+//
+// Note that the confPaths must point directly to the directory with
+// the json repo files.
 func LoadRepositories(confPaths []string, distro string) (map[string][]rpmmd.RepoConfig, error) {
 	var repoConfigs map[string][]rpmmd.RepoConfig
-	path := "/repositories/" + distro + ".json"
+	path := distro + ".json"
 
 	for _, confPath := range confPaths {
 		var err error

--- a/pkg/reporegistry/repository_test.go
+++ b/pkg/reporegistry/repository_test.go
@@ -19,8 +19,8 @@ import (
 
 func getConfPaths(t *testing.T) []string {
 	confPaths := []string{
-		"./test/confpaths/priority1",
-		"./test/confpaths/priority2",
+		"./test/confpaths/priority1/repositories",
+		"./test/confpaths/priority2/repositories",
 	}
 	var absConfPaths []string
 

--- a/pkg/reporegistry/repository_test.go
+++ b/pkg/reporegistry/repository_test.go
@@ -280,7 +280,7 @@ func Test_LoadAllRepositories(t *testing.T) {
 
 	confPaths := getConfPaths(t)
 
-	distroReposMap, err := LoadAllRepositories(confPaths)
+	distroReposMap, err := loadAllRepositories(confPaths, nil)
 	assert.NotNil(t, distroReposMap)
 	assert.Nil(t, err)
 	assert.Equal(t, len(distroReposMap), len(expectedReposMap))
@@ -307,7 +307,7 @@ func TestLoadRepositoriesLogging(t *testing.T) {
 	logrus.AddHook(logHook)
 
 	confPaths := getConfPaths(t)
-	_, err := LoadAllRepositories(confPaths)
+	_, err := loadAllRepositories(confPaths, nil)
 	require.NoError(t, err)
 	needle := "Loaded repository configuration file: rhel-8.10.json"
 	assert.True(t, slices.ContainsFunc(logHook.AllEntries(), func(entry *logrus.Entry) bool {

--- a/test/data/repositories/testrepos.go
+++ b/test/data/repositories/testrepos.go
@@ -11,9 +11,5 @@ import (
 var FS embed.FS
 
 func New() (*reporegistry.RepoRegistry, error) {
-	repositories, err := reporegistry.LoadAllRepositoriesFromFS([]fs.FS{FS})
-	if err != nil {
-		return nil, err
-	}
-	return reporegistry.NewFromDistrosRepoConfigs(repositories), nil
+	return reporegistry.New(nil, []fs.FS{FS})
 }


### PR DESCRIPTION
This PR changes the API for reporegistry in two incompatible
ways. The important change is that we want to drop the
prepending of `repositories` when loading from confPaths.

Doing this on its own has the disadvantage of breaking
the API without breaking the builds. So this includes a
small tweak to allow adding repos via fs.FS directly
which will mean the code in ibcli will become simpler:
```go
diff --git a/cmd/image-builder/repos.go b/cmd/image-builder/repos.go
index bc238dc..5d16a95 100644
--- a/cmd/image-builder/repos.go
+++ b/cmd/image-builder/repos.go
@@ -2,8 +2,6 @@ package main
 
 import (
        "io/fs"
-       "os"
-       "path/filepath"
 
        "github.com/osbuild/images/data/repositories"
        "github.com/osbuild/images/pkg/reporegistry"
@@ -27,17 +25,6 @@ var newRepoRegistry = func(dataDir string) (*reporegistry.RepoRegistry, error) {
                dataDirs = defaultDataDirs
        }
 
-       // XXX: think about sharing this with reporegistry?
-       var fses []fs.FS
-       for _, d := range dataDirs {
-               fses = append(fses, os.DirFS(filepath.Join(d, "repositories")))
-       }
-       fses = append(fses, repos.FS)
-
        // XXX: should we support disabling the build-ins somehow?
-       conf, err := reporegistry.LoadAllRepositoriesFromFS(fses)
-       if err != nil {
-               return nil, err
-       }
-       return reporegistry.NewFromDistrosRepoConfigs(conf), nil
+       return reporegistry.New(dataDirs, []fs.FS{repos.FS})
 }
```
And for composer it will just be adding a `nil` to the New()
call.

Note that this also allows us to unexport the LoadAllRepositories
repository loading as this is only used by composer or ibcli.

---

reporegistry: do not prepend `repositories` in confPaths

This commit breaks the API by changing the confPaths loading
in reporegistry to stop prepending `repositories/`. This makes
it easier to use this interface in e.g. `cmd/build`.

Note that this requires changes in the upstream projecs, notably
osbuild-composer and image-builder-cli.

---

This commit changes `reporegistry.New()` to take a new parameter
`repoConfigFS []fs.FS`. With that we can unexport the public
`LoadAllRepositories{,FromFS}` as the only user for those is
`composer` and that can simply use `.New()`.
