### PR TITLE
go.mod: update to go v1.22

### DIFF
--- a/.github/workflows/gitlab-helper.yml
+++ b/.github/workflows/gitlab-helper.yml
@@ -22,10 +22,10 @@ jobs:
       GOPROXY: "https://proxy.golang.org|direct"
     steps:
 
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,10 +64,10 @@ jobs:
       GOPROXY: "https://proxy.golang.org|direct"
 
     steps:
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
         id: go
 
       - name: Check out code into the Go module directory
@@ -148,10 +148,10 @@ jobs:
       # (go.opencensus.io/trace)
       GOPROXY: "https://proxy.golang.org|direct"
     steps:
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
         id: go
 
       - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/images
 
-go 1.21.0
+go 1.22.0
 
 toolchain go1.22.5
 

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -4,7 +4,7 @@ set -eux
 
 # Go version must be consistent with image-builder which uses UBI
 # container that is typically few months behind
-GO_VERSION=1.21.13
+GO_VERSION=1.22.9
 GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
 
 # this is the official way to get a different version of golang


### PR DESCRIPTION
- Update the go.mod to use v1.22
- Update all test workflows to install v1.22
- Edit and run tools/prepare-source.sh