### PR TITLE
dnfjson: support redirecting dnfjsons `stderr`

### DIFF
--- a/pkg/dnfjson/dnfjson_test.go
+++ b/pkg/dnfjson/dnfjson_test.go
@@ -858,7 +858,7 @@ exit 1
 	err := os.WriteFile(fakeDnfJsonPath, []byte(fakeDnfJsonNoOutput), 0o755)
 	assert.NoError(t, err)
 
-	_, err = run([]string{fakeDnfJsonPath}, &Request{})
+	_, err = run([]string{fakeDnfJsonPath}, &Request{}, nil)
 	assert.EqualError(t, err, `DNF error occurred: InternalError: dnf-json output was empty`)
 }
 
@@ -867,16 +867,20 @@ func TestSolverRunWithSolverNoError(t *testing.T) {
 	fakeSolver := `#!/bin/sh -e
 cat - > "$0".stdin
 echo '{"solver": "zypper"}'
+>&2 echo "output-on-stderr" 
 `
 	fakeSolverPath := filepath.Join(tmpdir, "fake-solver")
 	err := os.WriteFile(fakeSolverPath, []byte(fakeSolver), 0755) //nolint:gosec
 	assert.NoError(t, err)
 
+	var capturedStderr bytes.Buffer
 	solver := NewSolver("platform:f38", "38", "x86_64", "fedora-38", "/tmp/cache")
+	solver.Stderr = &capturedStderr
 	solver.dnfJsonCmd = []string{fakeSolverPath}
 	res, err := solver.Depsolve(nil, sbom.StandardTypeNone)
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
+	assert.Equal(t, "output-on-stderr\n", capturedStderr.String())
 
 	// prerequisite check, i.e. ensure our fake was called in the right way
 	stdin, err := os.ReadFile(fakeSolverPath + ".stdin")


### PR DESCRIPTION
This commit tweaks the dnfjson.Solver to also have a `Stderr` attribute. This is a minimal change to prevent `image-builder-cli` from showing:
```console
image-builder build qcow2 --distro centos-9 --progress=verbose
Manifest generation step
Building manifest for qcow2-centos-9
No match for group package "iwl5150-firmware"
No match for group package "iwl6050-firmware"
No match for group package "firewalld"
No match for group package "iwl7260-firmware"
No match for group package "dracut-config-rescue"
No match for group package "iwl105-firmware"
No match for group package "iwl2000-firmware"
No match for group package "iwl100-firmware"
No match for group package "iwl6000g2a-firmware"
No match for group package "iwl1000-firmware"
No match for group package "iwl3160-firmware"
No match for group package "iwl135-firmware"
No match for group package "iwl2030-firmware"
No match for group package "iwl5000-firmware"
...
```
which seems to be resulting from the "exclude" directive of the transaction. When qcow2 in centos-9 is build it contains the following:
```go
	ps := rpmmd.PackageSet{
		Include: []string{
			"@core",
			...
		},
		Exclude: []string{
			...
			"firewalld",
			"iwl7260-firmware",
			...
		},
```
and each package that is both in @core and in the exclude seems to trigger a message like the above, e.g.:
```
No match for group package "firewalld"
```
This is just confusing for our users so image-builder-cli will just discard this stderr output from dnfjson.

I'm not sure if there is a better way to handle this though, ideas (very) welcome.