### PR TITLE
osbuild: update org.osbuild.systemd.unit.create stage

### DIFF
--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -513,13 +513,13 @@ func createMountpointService(serviceName string, mountpoints []string) *osbuild.
 	for _, mountpoint := range mountpoints {
 		conditionPathIsDirectory = append(conditionPathIsDirectory, "|!"+mountpoint)
 	}
-	unit := osbuild.Unit{
+	unit := osbuild.UnitSection{
 		Description:              "Ensure custom filesystem mountpoints exist",
 		DefaultDependencies:      common.ToPtr(false), // Default dependencies would interfere with our custom order (before mountpoints)
 		ConditionPathIsDirectory: conditionPathIsDirectory,
 		After:                    []string{"ostree-remount.service"},
 	}
-	service := osbuild.Service{
+	service := osbuild.ServiceSection{
 		Type:            osbuild.OneshotServiceType,
 		RemainAfterExit: false,
 		// compatibility with composefs, will require transient rootfs to be enabled too.
@@ -541,7 +541,7 @@ func createMountpointService(serviceName string, mountpoints []string) *osbuild.
 	}
 	unit.Before = befores
 
-	install := osbuild.Install{
+	install := osbuild.InstallSection{
 		WantedBy: []string{"local-fs.target"},
 	}
 	options := osbuild.SystemdUnitCreateStageOptions{

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -548,7 +548,7 @@ func createMountpointService(serviceName string, mountpoints []string) *osbuild.
 		Filename: serviceName,
 		UnitPath: osbuild.EtcUnitPath,
 		UnitType: osbuild.System,
-		Config: osbuild.SystemdServiceUnit{
+		Config: osbuild.SystemdUnit{
 			Unit:    &unit,
 			Service: &service,
 			Install: &install,

--- a/pkg/manifest/subscription.go
+++ b/pkg/manifest/subscription.go
@@ -157,19 +157,19 @@ func subscriptionService(subscriptionOptions subscription.ImageOptions, serviceO
 		UnitType: "system",
 		UnitPath: unitPath,
 		Config: osbuild.SystemdServiceUnit{
-			Unit: &osbuild.Unit{
+			Unit: &osbuild.UnitSection{
 				Description:         "First-boot service for registering with Red Hat subscription manager and/or insights",
 				ConditionPathExists: []string{subkeyFilepath},
 				Wants:               []string{"network-online.target"},
 				After:               []string{"network-online.target"},
 			},
-			Service: &osbuild.Service{
+			Service: &osbuild.ServiceSection{
 				Type:            osbuild.OneshotServiceType,
 				RemainAfterExit: false,
 				ExecStart:       commands,
 				EnvironmentFile: []string{subkeyFilepath},
 			},
-			Install: &osbuild.Install{
+			Install: &osbuild.InstallSection{
 				WantedBy: []string{"default.target"},
 			},
 		},

--- a/pkg/manifest/subscription.go
+++ b/pkg/manifest/subscription.go
@@ -156,7 +156,7 @@ func subscriptionService(subscriptionOptions subscription.ImageOptions, serviceO
 		Filename: subscribeServiceFile,
 		UnitType: "system",
 		UnitPath: unitPath,
-		Config: osbuild.SystemdServiceUnit{
+		Config: osbuild.SystemdUnit{
 			Unit: &osbuild.UnitSection{
 				Description:         "First-boot service for registering with Red Hat subscription manager and/or insights",
 				ConditionPathExists: []string{subkeyFilepath},

--- a/pkg/manifest/subscription_test.go
+++ b/pkg/manifest/subscription_test.go
@@ -51,7 +51,7 @@ func TestSubscriptionService(t *testing.T) {
 					Filename: serviceFilename,
 					UnitType: unitType,
 					UnitPath: osbuild.UsrUnitPath,
-					Config: osbuild.SystemdServiceUnit{
+					Config: osbuild.SystemdUnit{
 						Unit: &osbuild.UnitSection{
 							Description: serviceDescription,
 							ConditionPathExists: []string{
@@ -96,7 +96,7 @@ func TestSubscriptionService(t *testing.T) {
 					Filename: serviceFilename,
 					UnitType: unitType,
 					UnitPath: osbuild.UsrUnitPath,
-					Config: osbuild.SystemdServiceUnit{
+					Config: osbuild.SystemdUnit{
 						Unit: &osbuild.UnitSection{
 							Description: serviceDescription,
 							ConditionPathExists: []string{
@@ -143,7 +143,7 @@ func TestSubscriptionService(t *testing.T) {
 					Filename: serviceFilename,
 					UnitType: unitType,
 					UnitPath: osbuild.UsrUnitPath,
-					Config: osbuild.SystemdServiceUnit{
+					Config: osbuild.SystemdUnit{
 						Unit: &osbuild.UnitSection{
 							Description: serviceDescription,
 							ConditionPathExists: []string{
@@ -190,7 +190,7 @@ func TestSubscriptionService(t *testing.T) {
 					Filename: serviceFilename,
 					UnitType: unitType,
 					UnitPath: osbuild.UsrUnitPath,
-					Config: osbuild.SystemdServiceUnit{
+					Config: osbuild.SystemdUnit{
 						Unit: &osbuild.UnitSection{
 							Description: serviceDescription,
 							ConditionPathExists: []string{
@@ -239,7 +239,7 @@ func TestSubscriptionService(t *testing.T) {
 					Filename: serviceFilename,
 					UnitType: unitType,
 					UnitPath: osbuild.UsrUnitPath,
-					Config: osbuild.SystemdServiceUnit{
+					Config: osbuild.SystemdUnit{
 						Unit: &osbuild.UnitSection{
 							Description: serviceDescription,
 							ConditionPathExists: []string{
@@ -292,7 +292,7 @@ func TestSubscriptionService(t *testing.T) {
 					Filename: serviceFilename,
 					UnitType: unitType,
 					UnitPath: osbuild.EtcUnitPath,
-					Config: osbuild.SystemdServiceUnit{
+					Config: osbuild.SystemdUnit{
 						Unit: &osbuild.UnitSection{
 							Description: serviceDescription,
 							ConditionPathExists: []string{
@@ -342,7 +342,7 @@ func TestSubscriptionService(t *testing.T) {
 					Filename: serviceFilename,
 					UnitType: unitType,
 					UnitPath: osbuild.EtcUnitPath,
-					Config: osbuild.SystemdServiceUnit{
+					Config: osbuild.SystemdUnit{
 						Unit: &osbuild.UnitSection{
 							Description: serviceDescription,
 							ConditionPathExists: []string{

--- a/pkg/manifest/subscription_test.go
+++ b/pkg/manifest/subscription_test.go
@@ -52,7 +52,7 @@ func TestSubscriptionService(t *testing.T) {
 					UnitType: unitType,
 					UnitPath: osbuild.UsrUnitPath,
 					Config: osbuild.SystemdServiceUnit{
-						Unit: &osbuild.Unit{
+						Unit: &osbuild.UnitSection{
 							Description: serviceDescription,
 							ConditionPathExists: []string{
 								subkeyFilepath,
@@ -60,7 +60,7 @@ func TestSubscriptionService(t *testing.T) {
 							Wants: serviceWants,
 							After: serviceAfter,
 						},
-						Service: &osbuild.Service{
+						Service: &osbuild.ServiceSection{
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
 								"/usr/sbin/subscription-manager register --org=${ORG_ID} --activationkey=${ACTIVATION_KEY} --serverurl theserverurl --baseurl thebaseurl",
@@ -70,7 +70,7 @@ func TestSubscriptionService(t *testing.T) {
 								subkeyFilepath,
 							},
 						},
-						Install: &osbuild.Install{
+						Install: &osbuild.InstallSection{
 							WantedBy: serviceWantedBy,
 						},
 					},
@@ -97,7 +97,7 @@ func TestSubscriptionService(t *testing.T) {
 					UnitType: unitType,
 					UnitPath: osbuild.UsrUnitPath,
 					Config: osbuild.SystemdServiceUnit{
-						Unit: &osbuild.Unit{
+						Unit: &osbuild.UnitSection{
 							Description: serviceDescription,
 							ConditionPathExists: []string{
 								subkeyFilepath,
@@ -105,7 +105,7 @@ func TestSubscriptionService(t *testing.T) {
 							Wants: serviceWants,
 							After: serviceAfter,
 						},
-						Service: &osbuild.Service{
+						Service: &osbuild.ServiceSection{
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
 								"/usr/sbin/subscription-manager register --org=${ORG_ID} --activationkey=${ACTIVATION_KEY} --serverurl theserverurl-wi --baseurl thebaseurl-wi",
@@ -117,7 +117,7 @@ func TestSubscriptionService(t *testing.T) {
 								subkeyFilepath,
 							},
 						},
-						Install: &osbuild.Install{
+						Install: &osbuild.InstallSection{
 							WantedBy: serviceWantedBy,
 						},
 					},
@@ -144,7 +144,7 @@ func TestSubscriptionService(t *testing.T) {
 					UnitType: unitType,
 					UnitPath: osbuild.UsrUnitPath,
 					Config: osbuild.SystemdServiceUnit{
-						Unit: &osbuild.Unit{
+						Unit: &osbuild.UnitSection{
 							Description: serviceDescription,
 							ConditionPathExists: []string{
 								subkeyFilepath,
@@ -152,7 +152,7 @@ func TestSubscriptionService(t *testing.T) {
 							Wants: serviceWants,
 							After: serviceAfter,
 						},
-						Service: &osbuild.Service{
+						Service: &osbuild.ServiceSection{
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
 								"/usr/bin/rhc connect --organization=${ORG_ID} --activation-key=${ACTIVATION_KEY} --server theserverurl-wr",
@@ -164,7 +164,7 @@ func TestSubscriptionService(t *testing.T) {
 								subkeyFilepath,
 							},
 						},
-						Install: &osbuild.Install{
+						Install: &osbuild.InstallSection{
 							WantedBy: serviceWantedBy,
 						},
 					},
@@ -191,7 +191,7 @@ func TestSubscriptionService(t *testing.T) {
 					UnitType: unitType,
 					UnitPath: osbuild.UsrUnitPath,
 					Config: osbuild.SystemdServiceUnit{
-						Unit: &osbuild.Unit{
+						Unit: &osbuild.UnitSection{
 							Description: serviceDescription,
 							ConditionPathExists: []string{
 								subkeyFilepath,
@@ -199,7 +199,7 @@ func TestSubscriptionService(t *testing.T) {
 							Wants: serviceWants,
 							After: serviceAfter,
 						},
-						Service: &osbuild.Service{
+						Service: &osbuild.ServiceSection{
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
 								"/usr/bin/rhc connect --organization=${ORG_ID} --activation-key=${ACTIVATION_KEY} --server theserverurl-wir",
@@ -211,7 +211,7 @@ func TestSubscriptionService(t *testing.T) {
 								subkeyFilepath,
 							},
 						},
-						Install: &osbuild.Install{
+						Install: &osbuild.InstallSection{
 							WantedBy: serviceWantedBy,
 						},
 					},
@@ -240,7 +240,7 @@ func TestSubscriptionService(t *testing.T) {
 					UnitType: unitType,
 					UnitPath: osbuild.UsrUnitPath,
 					Config: osbuild.SystemdServiceUnit{
-						Unit: &osbuild.Unit{
+						Unit: &osbuild.UnitSection{
 							Description: serviceDescription,
 							ConditionPathExists: []string{
 								subkeyFilepath,
@@ -248,7 +248,7 @@ func TestSubscriptionService(t *testing.T) {
 							Wants: serviceWants,
 							After: serviceAfter,
 						},
-						Service: &osbuild.Service{
+						Service: &osbuild.ServiceSection{
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
 								"/usr/sbin/subscription-manager register --org=${ORG_ID} --activationkey=${ACTIVATION_KEY} --serverurl theserverurl-iob --baseurl thebaseurl-iob",
@@ -260,7 +260,7 @@ func TestSubscriptionService(t *testing.T) {
 								subkeyFilepath,
 							},
 						},
-						Install: &osbuild.Install{
+						Install: &osbuild.InstallSection{
 							WantedBy: serviceWantedBy,
 						},
 					},
@@ -293,7 +293,7 @@ func TestSubscriptionService(t *testing.T) {
 					UnitType: unitType,
 					UnitPath: osbuild.EtcUnitPath,
 					Config: osbuild.SystemdServiceUnit{
-						Unit: &osbuild.Unit{
+						Unit: &osbuild.UnitSection{
 							Description: serviceDescription,
 							ConditionPathExists: []string{
 								subkeyFilepath,
@@ -301,7 +301,7 @@ func TestSubscriptionService(t *testing.T) {
 							Wants: serviceWants,
 							After: serviceAfter,
 						},
-						Service: &osbuild.Service{
+						Service: &osbuild.ServiceSection{
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
 								"/usr/sbin/subscription-manager register --org=${ORG_ID} --activationkey=${ACTIVATION_KEY} --serverurl theserverurl-etc --baseurl thebaseurl-etc",
@@ -311,7 +311,7 @@ func TestSubscriptionService(t *testing.T) {
 								subkeyFilepath,
 							},
 						},
-						Install: &osbuild.Install{
+						Install: &osbuild.InstallSection{
 							WantedBy: serviceWantedBy,
 						},
 					},
@@ -343,7 +343,7 @@ func TestSubscriptionService(t *testing.T) {
 					UnitType: unitType,
 					UnitPath: osbuild.EtcUnitPath,
 					Config: osbuild.SystemdServiceUnit{
-						Unit: &osbuild.Unit{
+						Unit: &osbuild.UnitSection{
 							Description: serviceDescription,
 							ConditionPathExists: []string{
 								subkeyFilepath,
@@ -351,7 +351,7 @@ func TestSubscriptionService(t *testing.T) {
 							Wants: serviceWants,
 							After: serviceAfter,
 						},
-						Service: &osbuild.Service{
+						Service: &osbuild.ServiceSection{
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
 								"/usr/sbin/subscription-manager register --org=${ORG_ID} --activationkey=${ACTIVATION_KEY} --serverurl theserverurl-iob-etc --baseurl thebaseurl-iob-etc",
@@ -363,7 +363,7 @@ func TestSubscriptionService(t *testing.T) {
 								subkeyFilepath,
 							},
 						},
-						Install: &osbuild.Install{
+						Install: &osbuild.InstallSection{
 							WantedBy: serviceWantedBy,
 						},
 					},

--- a/pkg/osbuild/systemd_unit_create_stage.go
+++ b/pkg/osbuild/systemd_unit_create_stage.go
@@ -50,6 +50,21 @@ type MountSection struct {
 	Options string `json:"Options,omitempty"`
 }
 
+type SocketSection struct {
+	Service                string `json:"Service,omitempty"`
+	ListenStream           string `json:"ListenStream,omitempty"`
+	ListenDatagram         string `json:"ListenDatagram,omitempty"`
+	ListenSequentialPacket string `json:"ListenSequentialPacket,omitempty"`
+	ListenFifo             string `json:"ListenFifo,omitempty"`
+	SocketUser             string `json:"SocketUser,omitempty"`
+	SocketGroup            string `json:"SocketGroup,omitempty"`
+	SocketMode             string `json:"SocketMode,omitempty"`
+	DirectoryMode          string `json:"DirectoryMode,omitempty"`
+	Accept                 string `json:"Accept,omitempty"`
+	RuntimeDirectory       string `json:"RuntimeDirectory,omitempty"`
+	RemoveOnStop           string `json:"RemoveOnStop,omitempty"`
+}
+
 type InstallSection struct {
 	RequiredBy []string `json:"RequiredBy,omitempty"`
 	WantedBy   []string `json:"WantedBy,omitempty"`
@@ -59,6 +74,7 @@ type SystemdServiceUnit struct {
 	Unit    *UnitSection    `json:"Unit"`
 	Service *ServiceSection `json:"Service"`
 	Mount   *MountSection   `json:"Mount,omitempty"`
+	Socket  *SocketSection  `json:"Socket,omitempty"`
 	Install *InstallSection `json:"Install"`
 }
 

--- a/pkg/osbuild/systemd_unit_create_stage.go
+++ b/pkg/osbuild/systemd_unit_create_stage.go
@@ -71,7 +71,7 @@ type InstallSection struct {
 	WantedBy   []string `json:"WantedBy,omitempty"`
 }
 
-type SystemdServiceUnit struct {
+type SystemdUnit struct {
 	Unit    *UnitSection    `json:"Unit"`
 	Service *ServiceSection `json:"Service"`
 	Mount   *MountSection   `json:"Mount,omitempty"`
@@ -80,10 +80,10 @@ type SystemdServiceUnit struct {
 }
 
 type SystemdUnitCreateStageOptions struct {
-	Filename string             `json:"filename"`
-	UnitType unitType           `json:"unit-type,omitempty"` // unitType defined in ./systemd_unit_stage.go
-	UnitPath SystemdUnitPath    `json:"unit-path,omitempty"`
-	Config   SystemdServiceUnit `json:"config"`
+	Filename string          `json:"filename"`
+	UnitType unitType        `json:"unit-type,omitempty"` // unitType defined in ./systemd_unit_stage.go
+	UnitPath SystemdUnitPath `json:"unit-path,omitempty"`
+	Config   SystemdUnit     `json:"config"`
 }
 
 func (SystemdUnitCreateStageOptions) isStageOptions() {}
@@ -94,6 +94,13 @@ func (o *SystemdUnitCreateStageOptions) validateService() error {
 	}
 	if o.Config.Install == nil {
 		return fmt.Errorf("systemd service unit %q requires an Install section", o.Filename)
+	}
+
+	if o.Config.Mount != nil {
+		return fmt.Errorf("systemd service unit %q contains invalid section Mount", o.Filename)
+	}
+	if o.Config.Socket != nil {
+		return fmt.Errorf("systemd service unit %q contains invalid section Socket", o.Filename)
 	}
 
 	vre := regexp.MustCompile(envVarRegex)
@@ -112,6 +119,12 @@ func (o *SystemdUnitCreateStageOptions) validateMount() error {
 	if o.Config.Mount == nil {
 		return fmt.Errorf("systemd mount unit %q requires a Mount section", o.Filename)
 	}
+	if o.Config.Service != nil {
+		return fmt.Errorf("systemd mount unit %q contains invalid section Service", o.Filename)
+	}
+	if o.Config.Socket != nil {
+		return fmt.Errorf("systemd mount unit %q contains invalid section Socket", o.Filename)
+	}
 
 	if o.Config.Mount.What == "" {
 		return fmt.Errorf("What option for Mount section of systemd unit %q is required", o.Filename)
@@ -126,6 +139,12 @@ func (o *SystemdUnitCreateStageOptions) validateMount() error {
 func (o *SystemdUnitCreateStageOptions) validateSocket() error {
 	if o.Config.Socket == nil {
 		return fmt.Errorf("systemd socket unit %q requires a Socket section", o.Filename)
+	}
+	if o.Config.Mount != nil {
+		return fmt.Errorf("systemd socket unit %q contains invalid section Mount", o.Filename)
+	}
+	if o.Config.Service != nil {
+		return fmt.Errorf("systemd socket unit %q contains invalid section Service", o.Filename)
 	}
 
 	return nil

--- a/pkg/osbuild/systemd_unit_create_stage.go
+++ b/pkg/osbuild/systemd_unit_create_stage.go
@@ -43,15 +43,23 @@ type Service struct {
 	EnvironmentFile []string              `json:"EnvironmentFile,omitempty"`
 }
 
+type MountSection struct {
+	What    string `json:"What"`
+	Where   string `json:"Where"`
+	Type    string `json:"Type,omitempty"`
+	Options string `json:"Options,omitempty"`
+}
+
 type Install struct {
 	RequiredBy []string `json:"RequiredBy,omitempty"`
 	WantedBy   []string `json:"WantedBy,omitempty"`
 }
 
 type SystemdServiceUnit struct {
-	Unit    *Unit    `json:"Unit"`
-	Service *Service `json:"Service"`
-	Install *Install `json:"Install"`
+	Unit    *Unit         `json:"Unit"`
+	Service *Service      `json:"Service"`
+	Mount   *MountSection `json:"Mount,omitempty"`
+	Install *Install      `json:"Install"`
 }
 
 type SystemdUnitCreateStageOptions struct {
@@ -81,6 +89,16 @@ func (o *SystemdUnitCreateStageOptions) validate() error {
 			}
 		}
 	}
+
+	if o.Config.Mount != nil {
+		if o.Config.Mount.What == "" {
+			return fmt.Errorf("What option for Mount section of systemd unit is required")
+		}
+		if o.Config.Mount.Where == "" {
+			return fmt.Errorf("Where option for Mount section of systemd unit is required")
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/osbuild/systemd_unit_create_stage.go
+++ b/pkg/osbuild/systemd_unit_create_stage.go
@@ -22,7 +22,7 @@ const (
 	UsrUnitPath SystemdUnitPath = "usr"
 )
 
-type Unit struct {
+type UnitSection struct {
 	Description              string   `json:"Description,omitempty"`
 	DefaultDependencies      *bool    `json:"DefaultDependencies,omitempty"`
 	ConditionPathExists      []string `json:"ConditionPathExists,omitempty"`
@@ -33,7 +33,7 @@ type Unit struct {
 	Before                   []string `json:"Before,omitempty"`
 }
 
-type Service struct {
+type ServiceSection struct {
 	Type            SystemdServiceType    `json:"Type,omitempty"`
 	RemainAfterExit bool                  `json:"RemainAfterExit,omitempty"`
 	ExecStartPre    []string              `json:"ExecStartPre,omitempty"`
@@ -50,16 +50,16 @@ type MountSection struct {
 	Options string `json:"Options,omitempty"`
 }
 
-type Install struct {
+type InstallSection struct {
 	RequiredBy []string `json:"RequiredBy,omitempty"`
 	WantedBy   []string `json:"WantedBy,omitempty"`
 }
 
 type SystemdServiceUnit struct {
-	Unit    *Unit         `json:"Unit"`
-	Service *Service      `json:"Service"`
-	Mount   *MountSection `json:"Mount,omitempty"`
-	Install *Install      `json:"Install"`
+	Unit    *UnitSection    `json:"Unit"`
+	Service *ServiceSection `json:"Service"`
+	Mount   *MountSection   `json:"Mount,omitempty"`
+	Install *InstallSection `json:"Install"`
 }
 
 type SystemdUnitCreateStageOptions struct {

--- a/pkg/osbuild/systemd_unit_create_stage_test.go
+++ b/pkg/osbuild/systemd_unit_create_stage_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func createSystemdUnit() SystemdServiceUnit {
+func createSystemdUnit() SystemdUnit {
 
 	var unit = UnitSection{
 		Description:              "Create directory and files",
@@ -30,7 +30,7 @@ func createSystemdUnit() SystemdServiceUnit {
 		WantedBy:   []string{"sshd.service"},
 	}
 
-	var systemdUnit = SystemdServiceUnit{
+	var systemdUnit = SystemdUnit{
 		Unit:    &unit,
 		Service: &service,
 		Install: &install,
@@ -42,7 +42,7 @@ func createSystemdUnit() SystemdServiceUnit {
 func TestNewSystemdUnitCreateStage(t *testing.T) {
 	systemdServiceConfig := createSystemdUnit()
 	var options = SystemdUnitCreateStageOptions{
-		Filename: "create-dir-files",
+		Filename: "create-dir-files.service",
 		Config:   systemdServiceConfig,
 	}
 	expectedStage := &Stage{
@@ -57,7 +57,7 @@ func TestNewSystemdUnitCreateStage(t *testing.T) {
 func TestNewSystemdUnitCreateStageInEtc(t *testing.T) {
 	systemdServiceConfig := createSystemdUnit()
 	var options = SystemdUnitCreateStageOptions{
-		Filename: "create-dir-files",
+		Filename: "create-dir-files.service",
 		Config:   systemdServiceConfig,
 		UnitPath: EtcUnitPath,
 		UnitType: Global,

--- a/pkg/osbuild/systemd_unit_create_stage_test.go
+++ b/pkg/osbuild/systemd_unit_create_stage_test.go
@@ -9,7 +9,7 @@ import (
 
 func createSystemdUnit() SystemdServiceUnit {
 
-	var unit = Unit{
+	var unit = UnitSection{
 		Description:              "Create directory and files",
 		DefaultDependencies:      common.ToPtr(true),
 		ConditionPathExists:      []string{"!/etc/myfile"},
@@ -17,7 +17,7 @@ func createSystemdUnit() SystemdServiceUnit {
 		Requires:                 []string{"dbus.service", "libvirtd.service"},
 		Wants:                    []string{"local-fs.target"},
 	}
-	var service = Service{
+	var service = ServiceSection{
 		Type:            OneshotServiceType,
 		RemainAfterExit: true,
 		ExecStartPre:    []string{"echo creating_files"},
@@ -25,7 +25,7 @@ func createSystemdUnit() SystemdServiceUnit {
 		ExecStart:       []string{"mkdir -p /etc/mydir", "touch /etc/myfiles"},
 	}
 
-	var install = Install{
+	var install = InstallSection{
 		RequiredBy: []string{"multi-user.target", "boot-complete.target"},
 		WantedBy:   []string{"sshd.service"},
 	}

--- a/pkg/osbuild/systemd_unit_create_stage_test.go
+++ b/pkg/osbuild/systemd_unit_create_stage_test.go
@@ -1,6 +1,7 @@
 package osbuild
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/osbuild/images/internal/common"
@@ -69,4 +70,308 @@ func TestNewSystemdUnitCreateStageInEtc(t *testing.T) {
 
 	actualStage := NewSystemdUnitCreateStage(&options)
 	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestSystemdUnitStageOptionsValidation(t *testing.T) {
+	unitSection := &UnitSection{
+		Description:         "test-mount",
+		DefaultDependencies: common.ToPtr(true),
+	}
+	mountSection := &MountSection{
+		What:    "/dev/test",
+		Where:   "/test",
+		Type:    "ext4",
+		Options: "defaults",
+	}
+	installSection := &InstallSection{
+		WantedBy: []string{"multi-user.target"},
+	}
+	serviceSection := &ServiceSection{
+		Type:            "oneshot",
+		RemainAfterExit: true,
+		ExecStart:       []string{"true"},
+	}
+	socketSection := &SocketSection{
+		ListenStream: "/run/test/api.socket",
+		SocketGroup:  "testgroup",
+		SocketMode:   "660",
+	}
+
+	type testCase struct {
+		options  SystemdUnitCreateStageOptions
+		expected error
+	}
+
+	testCases := map[string]testCase{
+		// OK
+		"service-ok": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.service",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit:    unitSection,
+					Service: serviceSection,
+					Install: installSection,
+				},
+			},
+			expected: nil,
+		},
+		"mount-ok": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.mount",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit:    unitSection,
+					Mount:   mountSection,
+					Install: installSection,
+				},
+			},
+			expected: nil,
+		},
+		"socket-ok": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.socket",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit:    unitSection,
+					Install: installSection,
+					Socket:  socketSection,
+				},
+			},
+			expected: nil,
+		},
+
+		// missing required section
+		"service-no-Service": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.service",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit:    unitSection,
+					Install: installSection,
+				},
+			},
+			expected: fmt.Errorf(`systemd service unit "test.service" requires a Service section`),
+		},
+		"service-no-Install": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.service",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit:    unitSection,
+					Service: serviceSection,
+				},
+			},
+			expected: fmt.Errorf(`systemd service unit "test.service" requires an Install section`),
+		},
+		"mount-no-Mount": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.mount",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit:    unitSection,
+					Install: installSection,
+				},
+			},
+			expected: fmt.Errorf(`systemd mount unit "test.mount" requires a Mount section`),
+		},
+		"socket-no-Socket": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.socket",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit:    unitSection,
+					Install: installSection,
+				},
+			},
+			expected: fmt.Errorf(`systemd socket unit "test.socket" requires a Socket section`),
+		},
+
+		// incorrect section for type
+		"service-with-mount": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.service",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit:    unitSection,
+					Service: serviceSection,
+					Mount:   mountSection,
+					Install: installSection,
+				},
+			},
+			expected: fmt.Errorf(`systemd service unit "test.service" contains invalid section Mount`),
+		},
+		"service-with-socket": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.service",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit:    unitSection,
+					Service: serviceSection,
+					Socket:  socketSection,
+					Install: installSection,
+				},
+			},
+			expected: fmt.Errorf(`systemd service unit "test.service" contains invalid section Socket`),
+		},
+		"mount-with-service": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.mount",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit:    unitSection,
+					Mount:   mountSection,
+					Service: serviceSection,
+					Install: installSection,
+				},
+			},
+			expected: fmt.Errorf(`systemd mount unit "test.mount" contains invalid section Service`),
+		},
+		"mount-with-socket": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.mount",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit:    unitSection,
+					Mount:   mountSection,
+					Socket:  socketSection,
+					Install: installSection,
+				},
+			},
+			expected: fmt.Errorf(`systemd mount unit "test.mount" contains invalid section Socket`),
+		},
+		"socket-with-Service": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.socket",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit:    unitSection,
+					Install: installSection,
+					Socket:  socketSection,
+					Service: serviceSection,
+				},
+			},
+			expected: fmt.Errorf(`systemd socket unit "test.socket" contains invalid section Service`),
+		},
+		"socket-with-Mount": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.socket",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit:    unitSection,
+					Install: installSection,
+					Socket:  socketSection,
+					Mount:   mountSection,
+				},
+			},
+			expected: fmt.Errorf(`systemd socket unit "test.socket" contains invalid section Mount`),
+		},
+
+		// bad filename
+		"bad-filename": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "//not-a-good-path//",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit:    unitSection,
+					Service: serviceSection,
+					Install: installSection,
+				},
+			},
+			expected: fmt.Errorf("invalid filename \"//not-a-good-path//\" for systemd unit: does not conform to schema (%s)", filenameRegex),
+		},
+
+		// bad extension
+		"bad-extension": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.whatever",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+			},
+			expected: fmt.Errorf(`invalid filename "test.whatever" for systemd unit: extension must be one of .service, .mount, or .socket`),
+		},
+
+		// missing required options
+		"mount-no-what": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.mount",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit: unitSection,
+					Mount: &MountSection{
+						Where:   "/test",
+						Type:    "ext4",
+						Options: "defaults",
+					},
+					Install: installSection,
+				},
+			},
+			expected: fmt.Errorf(`What option for Mount section of systemd unit "test.mount" is required`),
+		},
+		"mount-no-where": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.mount",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit: unitSection,
+					Mount: &MountSection{
+						What:    "/dev/test",
+						Type:    "ext4",
+						Options: "defaults",
+					},
+					Install: installSection,
+				},
+			},
+			expected: fmt.Errorf(`Where option for Mount section of systemd unit "test.mount" is required`),
+		},
+
+		// invalid values
+		"service-bad-env-vars": {
+			options: SystemdUnitCreateStageOptions{
+				Filename: "test.service",
+				UnitType: Global,
+				UnitPath: EtcUnitPath,
+				Config: SystemdUnit{
+					Unit: unitSection,
+					Service: &ServiceSection{
+
+						Type:            "oneshot",
+						RemainAfterExit: true,
+						ExecStart:       []string{"true"},
+						Environment: []EnvironmentVariable{
+							{
+								Key:   ":bad_var/",
+								Value: "can-be-whatever",
+							},
+						},
+					},
+					Install: installSection,
+				},
+			},
+			expected: fmt.Errorf("variable name \":bad_var/\" doesn't conform to schema (%s)", envVarRegex),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.options.validate()
+			assert.Equal(t, tc.expected, err)
+		})
+	}
 }


### PR DESCRIPTION
This PR updates the org.osbuild.systemd.unit.create stage to match the options in osbuild, especially the new sections for mount and socket unit types.
Tests added to cover all validation failures.