### PR TITLE
distro: rhel9: edge: exclude bootupd

### DIFF
--- a/pkg/distro/rhel/rhel9/edge.go
+++ b/pkg/distro/rhel/rhel9/edge.go
@@ -710,6 +710,7 @@ func edgeCommitPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 		},
 		Exclude: []string{
 			"rng-tools",
+			"bootupd",
 		},
 	}
 


### PR DESCRIPTION
From Colin:

If the Edge-9.6 setup isn't ready for bootupd then at the current time the package needs to be excluded.

we do this already in fedora indeed...