### PR TITLE
imagefilter: improve supported filters discoverability

### DIFF
--- a/pkg/imagefilter/filter.go
+++ b/pkg/imagefilter/filter.go
@@ -10,6 +10,11 @@ import (
 	"github.com/osbuild/images/pkg/distro"
 )
 
+// SupportedFilters returns what filter prefixes are supported
+func SupportedFilters() []string {
+	return supportedFilters
+}
+
 func splitPrefixSearchTerm(s string) (string, string) {
 	l := strings.SplitN(s, ":", 2)
 	if len(l) == 1 {
@@ -36,8 +41,8 @@ func newFilter(sl ...string) (*filter, error) {
 	}
 	for i, s := range sl {
 		prefix, searchTerm := splitPrefixSearchTerm(s)
-		if !slices.Contains(supportedFilters, prefix) {
-			return nil, fmt.Errorf("unsupported filter prefix: %q (supported: %v)", prefix, strings.Join(supportedFilters[1:], ","))
+		if prefix != "" && !slices.Contains(supportedFilters, prefix) {
+			return nil, fmt.Errorf("unsupported filter prefix: %q (supported: %v)", prefix, strings.Join(supportedFilters, ","))
 		}
 		gl, err := glob.Compile(searchTerm)
 		if err != nil {
@@ -50,7 +55,7 @@ func newFilter(sl ...string) (*filter, error) {
 }
 
 var supportedFilters = []string{
-	"", "distro", "arch", "type", "bootmode",
+	"distro", "arch", "type", "bootmode",
 }
 
 type term struct {

--- a/pkg/imagefilter/filter.go
+++ b/pkg/imagefilter/filter.go
@@ -37,7 +37,7 @@ func newFilter(sl ...string) (*filter, error) {
 	for i, s := range sl {
 		prefix, searchTerm := splitPrefixSearchTerm(s)
 		if !slices.Contains(supportedFilters, prefix) {
-			return nil, fmt.Errorf("unsupported filter prefix: %q", prefix)
+			return nil, fmt.Errorf("unsupported filter prefix: %q (supported: %v)", prefix, strings.Join(supportedFilters[1:], ","))
 		}
 		gl, err := glob.Compile(searchTerm)
 		if err != nil {

--- a/pkg/imagefilter/filter_test.go
+++ b/pkg/imagefilter/filter_test.go
@@ -61,3 +61,8 @@ func TestImageFilterFilter(t *testing.T) {
 		assert.Equal(t, tc.expectsMatch, match, tc)
 	}
 }
+
+func TestImageFilterError(t *testing.T) {
+	_, err := newFilter("random:filter")
+	require.EqualError(t, err, `unsupported filter prefix: "random" (supported: distro,arch,type,bootmode)`)
+}

--- a/pkg/imagefilter/filter_test.go
+++ b/pkg/imagefilter/filter_test.go
@@ -66,3 +66,7 @@ func TestImageFilterError(t *testing.T) {
 	_, err := newFilter("random:filter")
 	require.EqualError(t, err, `unsupported filter prefix: "random" (supported: distro,arch,type,bootmode)`)
 }
+
+func TestSupportedFilters(t *testing.T) {
+	assert.Contains(t, SupportedFilters(), "distro")
+}


### PR DESCRIPTION
imagefilter: add `SupportedFilter()` that returns known
 prefixes

This commit adds a new `SupportedFilter()` function that returns
the available filter prefixes.

See https://github.com/osbuild/image-builder-cli/issues/104

---

imagefilter: show supported filters when giving one

This commit tweaks the error message for unsupported filter prefixes
to include what is actually supported.

See https://github.com/osbuild/image-builder-cli/issues/104
