### PR TITLE
monitor: increase buffer to deal with very big messages

### DIFF
--- a/pkg/osbuild/monitor.go
+++ b/pkg/osbuild/monitor.go
@@ -62,8 +62,15 @@ type Progress struct {
 // NewStatusScanner returns a StatusScanner that can parse osbuild
 // jsonseq monitor status messages
 func NewStatusScanner(r io.Reader) *StatusScanner {
+	scanner := bufio.NewScanner(r)
+	// osbuild can currently generate very long messages, the default
+	// 64kb is too small for e.g. the dracut stage (see also
+	// https://github.com/osbuild/osbuild/issues/1976). Increase for
+	// but to unblock us.
+	buf := make([]byte, 0, 512_000)
+	scanner.Buffer(buf, 512_000)
 	return &StatusScanner{
-		scanner:         bufio.NewScanner(r),
+		scanner:         scanner,
 		contextMap:      make(map[string]*contextJSON),
 		stageContextMap: make(map[string]*stageContextJSON),
 	}

--- a/pkg/osbuild/monitor_test.go
+++ b/pkg/osbuild/monitor_test.go
@@ -2,7 +2,9 @@ package osbuild_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -115,4 +117,17 @@ func TestScannerSmoke(t *testing.T) {
 		}
 		assert.NotEqual(t, time.Time{}, st.Timestamp)
 	}
+}
+
+func TestScannerVeryLongLines(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	fmt.Fprint(buf, `{"message": "`)
+	fmt.Fprint(buf, strings.Repeat("1", 128_000))
+	fmt.Fprint(buf, `"}`)
+
+	scanner := osbuild.NewStatusScanner(buf)
+	st, err := scanner.Status()
+	assert.NoError(t, err)
+	require.NotNil(t, st)
+	assert.Equal(t, 128_000, len(st.Trace))
 }


### PR DESCRIPTION
This commit incrases the buffer os the osbuild message scanner to deal with very big messages. The default size of 64kb is too small for the `dracut` stage which will generate 5447 messages that /dev/log is not available and they come so rapidly that osbuild will pick them up in one big chunk.

This is a short term fix, the deeper fix should be to tweak the osbuild monitor to have a smaller buffer size when sending stdout/stderr output from stages to the monitor. This will fix a crash in the bootc-image-builder anaconda builds that is currently breaking the integration test in konflux.

See also https://github.com/osbuild/osbuild/issues/1976