### PR TITLE
osbuild: do not assume osbuild stage messages have a final \n

### DIFF
--- a/pkg/osbuild/monitor.go
+++ b/pkg/osbuild/monitor.go
@@ -18,11 +18,12 @@ import (
 // and based on what we learn here we may consider tweaking
 // the osbuild progress
 type Status struct {
-	// Trace contains a single log line, usually very low-level or
-	// stage output but useful for e.g. bug reporting. Should in
-	// general not be displayed to the user but the concatenation
-	// of all "trace" lines should give the same information as
-	// running osbuild on a terminal
+	// Trace contains log lines, usually very low-level or stage
+	// output but useful for e.g. bug reporting. Should in general
+	// not be displayed to the user but the concatenation of all
+	// "trace" lines should give the same information as running
+	// osbuild on a terminal. It may contain multiple lines and
+	// may not end with a \n
 	Trace string
 
 	// Message contains a high level user-visible message about
@@ -106,7 +107,9 @@ func (sr *StatusScanner) Status() (*Status, error) {
 	if context.Origin == "osbuild.monitor" {
 		msg = strings.TrimSpace(status.Message)
 	} else {
-		trace = strings.TrimSpace(status.Message)
+		// arbitrary osbuild messages can be very long and
+		// may not end with a \n so do not assume this
+		trace = status.Message
 	}
 
 	st := &Status{

--- a/pkg/osbuild/monitor_test.go
+++ b/pkg/osbuild/monitor_test.go
@@ -27,7 +27,7 @@ func TestScannerSimple(t *testing.T) {
 	st, err := scanner.Status()
 	assert.NoError(t, err)
 	assert.Equal(t, &osbuild.Status{
-		Trace: "source/org.osbuild.curl (org.osbuild.curl): Downloaded https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-fedora-20231109/Packages/k/kpartx-0.9.5-2.fc39.x86_64.rpm",
+		Trace: "source/org.osbuild.curl (org.osbuild.curl): Downloaded https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-fedora-20231109/Packages/k/kpartx-0.9.5-2.fc39.x86_64.rpm\n",
 		Progress: &osbuild.Progress{
 			Done:    0,
 			Total:   4,
@@ -39,7 +39,7 @@ func TestScannerSimple(t *testing.T) {
 	st, err = scanner.Status()
 	assert.NoError(t, err)
 	assert.Equal(t, &osbuild.Status{
-		Trace: "source/org.osbuild.curl (org.osbuild.curl): Downloaded https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-fedora-20231109/Packages/l/langpacks-fonts-en-4.0-9.fc39.noarch.rpm",
+		Trace: "source/org.osbuild.curl (org.osbuild.curl): Downloaded https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-fedora-20231109/Packages/l/langpacks-fonts-en-4.0-9.fc39.noarch.rpm\n",
 		Progress: &osbuild.Progress{
 			Done:    0,
 			Total:   4,


### PR DESCRIPTION
[draft as this needs coresponding image-builder-cli/bib changs]

This commit tweaks the osbuild monitor code to deal correctly with messages from osbuild stage that may not contain a final newline. So far the code assumed this and stripped the final newline when storing the message in the status. But sometimes there are messages without a final \n (e.g. when messages get very long). So just put the message in verbatim and let the caller do a "print" instead of a "println" when processing the messages (arguably the trim for traces was always strong).