### PR TITLE
distro: conditionally include basesystem/filesystem

### DIFF
--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -80,7 +80,6 @@ func iotCommitPackageSet(t *imageType) rpmmd.PackageSet {
 			"atheros-firmware",
 			"attr",
 			"authselect",
-			"basesystem",
 			"bash",
 			"bash-completion",
 			"brcmfmac-firmware",
@@ -193,6 +192,22 @@ func iotCommitPackageSet(t *imageType) rpmmd.PackageSet {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"bootupd", // Added in F41+
+			},
+		})
+	}
+	// See https://pagure.io/fedora-iot/ostree/pull-request/72
+	// See https://src.fedoraproject.org/rpms/filesystem/c/3f741bf2a89c9e1bb685943c41fd298e6683dd50?branch=rawhide
+	if common.VersionLessThan(t.arch.distro.osVersion, "43") {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"basesystem",
+			},
+		})
+	}
+	if common.VersionGreaterThanOrEqual(t.arch.distro.osVersion, "43") {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"filesystem",
 			},
 		})
 	}


### PR DESCRIPTION
The `basesystem` package is being obsoleted by `filesystem` in Rawhide (F43). Change the definition of the `iot-commit` to conditionally include the correct package based on the Fedora version.