### PR TITLE
imagefilter: adjust `short` output format

### DIFF
--- a/pkg/imagefilter/formatter.go
+++ b/pkg/imagefilter/formatter.go
@@ -99,12 +99,6 @@ type textShortResultsFormatter struct{}
 func (*textShortResultsFormatter) Output(w io.Writer, all []Result) error {
 	var errs []error
 
-	// deliberately break the yaml until the feature is stable, there
-	// are open questions, e.g. how this relates to:
-	// https://github.com/osbuild/osbuild-composer/pull/4336
-	// which adds a similar but slightly different API
-	fmt.Fprint(w, "@WARNING - the output format is not stable yet and may change\n")
-
 	outputMap := make(map[string]map[string][]string)
 	for _, res := range all {
 		if _, ok := outputMap[res.Distro.Name()]; !ok {
@@ -133,10 +127,10 @@ func (*textShortResultsFormatter) Output(w io.Writer, all []Result) error {
 		for _, t := range types {
 			arches := outputMap[distro][t]
 			sort.Strings(arches)
-			typeArchPairs = append(typeArchPairs, fmt.Sprintf("%s: [ %s ]", t, strings.Join(arches, ", ")))
+			typeArchPairs = append(typeArchPairs, fmt.Sprintf("%s: %s", t, strings.Join(arches, ", ")))
 		}
 
-		if _, err := fmt.Fprintf(w, "%s:\n  %s\n", distro, strings.Join(typeArchPairs, "\n  ")); err != nil {
+		if _, err := fmt.Fprintf(w, "%s\n  %s\n", distro, strings.Join(typeArchPairs, "\n  ")); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/imagefilter/formatter_test.go
+++ b/pkg/imagefilter/formatter_test.go
@@ -74,7 +74,7 @@ func TestResultsFormatter(t *testing.T) {
 		{
 			"short",
 			[]string{"test-distro-1:qcow2:test_arch3"},
-			"@WARNING - the output format is not stable yet and may change\ntest-distro-1:\n  qcow2: [ test_arch3 ]\n",
+			"test-distro-1\n  qcow2: test_arch3\n",
 		},
 		{
 			"short",
@@ -82,7 +82,7 @@ func TestResultsFormatter(t *testing.T) {
 				"test-distro-9:qcow2:test_arch3",
 				"test-distro-10:qcow2:test_arch3",
 			},
-			"@WARNING - the output format is not stable yet and may change\ntest-distro-9:\n  qcow2: [ test_arch3 ]\ntest-distro-10:\n  qcow2: [ test_arch3 ]\n",
+			"test-distro-9\n  qcow2: test_arch3\ntest-distro-10\n  qcow2: test_arch3\n",
 		},
 		{
 			"short",
@@ -90,7 +90,7 @@ func TestResultsFormatter(t *testing.T) {
 				"test-distro-1:test_type:test_arch",
 				"test-distro-1:test_type:test_arch2",
 			},
-			"@WARNING - the output format is not stable yet and may change\ntest-distro-1:\n  test_type: [ test_arch, test_arch2 ]\n",
+			"test-distro-1\n  test_type: test_arch, test_arch2\n",
 		},
 	} {
 		res := make([]imagefilter.Result, len(tc.fakeResults))


### PR DESCRIPTION
This is now a short text-only output focused only on a condensed and readable output.

```
centos-10
  ami: aarch64, x86_64
  gce: x86_64
  image-installer: aarch64, x86_64
  oci: x86_64
  ova: x86_64
  qcow2: aarch64, ppc64le, s390x, x86_64
  tar: aarch64, ppc64le, s390x, x86_64
  vhd: aarch64, x86_64
  vmdk: x86_64
  wsl: aarch64, x86_64
fedora-40
  ami: aarch64, x86_64
  container: aarch64, ppc64le, riscv64, s390x, x86_64
  image-installer: aarch64, x86_64
  iot-bootable-container: aarch64, ppc64le, s390x, x86_64
  iot-commit: aarch64, x86_64
  iot-container: aarch64, x86_64
…
```

There is an additional suggestion to implement a proper `yaml` output: #1268 