### PR TITLE
reporegistry: re-export `LoadAllRepositories`

### DIFF
--- a/pkg/reporegistry/reporegistry.go
+++ b/pkg/reporegistry/reporegistry.go
@@ -22,7 +22,7 @@ type RepoRegistry struct {
 // Note that the confPaths must point directly to the directory with
 // the json repo files.
 func New(repoConfigPaths []string, repoConfigFS []fs.FS) (*RepoRegistry, error) {
-	repositories, err := loadAllRepositories(repoConfigPaths, repoConfigFS)
+	repositories, err := LoadAllRepositories(repoConfigPaths, repoConfigFS)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reporegistry/repository.go
+++ b/pkg/reporegistry/repository.go
@@ -12,9 +12,9 @@ import (
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-// loadAllRepositories loads all repositories for given distros from the given list of paths.
+// LoadAllRepositories loads all repositories for given distros from the given list of paths.
 // Behavior is the same as with the LoadRepositories() method.
-func loadAllRepositories(confPaths []string, confFSes []fs.FS) (rpmmd.DistrosRepoConfigs, error) {
+func LoadAllRepositories(confPaths []string, confFSes []fs.FS) (rpmmd.DistrosRepoConfigs, error) {
 	var mergedFSes []fs.FS
 
 	for _, confPath := range confPaths {

--- a/pkg/reporegistry/repository_test.go
+++ b/pkg/reporegistry/repository_test.go
@@ -280,7 +280,7 @@ func Test_LoadAllRepositories(t *testing.T) {
 
 	confPaths := getConfPaths(t)
 
-	distroReposMap, err := loadAllRepositories(confPaths, nil)
+	distroReposMap, err := LoadAllRepositories(confPaths, nil)
 	assert.NotNil(t, distroReposMap)
 	assert.Nil(t, err)
 	assert.Equal(t, len(distroReposMap), len(expectedReposMap))
@@ -307,7 +307,7 @@ func TestLoadRepositoriesLogging(t *testing.T) {
 	logrus.AddHook(logHook)
 
 	confPaths := getConfPaths(t)
-	_, err := loadAllRepositories(confPaths, nil)
+	_, err := LoadAllRepositories(confPaths, nil)
 	require.NoError(t, err)
 	needle := "Loaded repository configuration file: rhel-8.10.json"
 	assert.True(t, slices.ContainsFunc(logHook.AllEntries(), func(entry *logrus.Entry) bool {


### PR DESCRIPTION
This commit re-export the `LoadAllRepositories` helper. It was unexported (by me) in https://github.com/osbuild/images/pull/1179 but that was a bit premature as it is still required for advanced use-cases like https://github.com/osbuild/image-builder-cli/pull/113

Sorry for this back-and-forth here.