### PR TITLE
Pin CI workflows to ubuntu 24.04

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -8,7 +8,7 @@ permissions: write-all
 
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Approve a PR

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -9,7 +9,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   tag-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Upstream tag

--- a/.github/workflows/gitlab-helper.yml
+++ b/.github/workflows/gitlab-helper.yml
@@ -15,7 +15,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   prepare:
     name: "🔍 Check source preparation and test configs"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       # workaround for expired cert at source of indirect dependency
       # (go.opencensus.io/trace)
@@ -57,7 +57,7 @@ jobs:
 
   gitlab-ci-helper:
     name: "Gitlab CI trigger helper"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Trigger
         run: echo "GitLab trigger complete"

--- a/.github/workflows/pr_best_practices.yml
+++ b/.github/workflows/pr_best_practices.yml
@@ -10,7 +10,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   pr-best-practices:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: PR best practice check
         uses: osbuild/pr-best-practices@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Upstream release
         uses: osbuild/release-action@main

--- a/.github/workflows/stale-cleanup.yml
+++ b/.github/workflows/stale-cleanup.yml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/test-osbuild-composer-integration.yml
+++ b/.github/workflows/test-osbuild-composer-integration.yml
@@ -50,7 +50,7 @@ jobs:
 
   unit-tests:
     name: "🛃 Unit tests"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: registry.fedoraproject.org/fedora:latest
     env:
@@ -137,7 +137,7 @@ jobs:
     name: "Post notice"
     permissions:
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: unit-tests
     steps:
       - name: Add comment (breakage)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
           - 41
       fail-fast: false  # if one fails, keep the other(s) running
     name: "🛃 Unit tests (Fedora ${{ matrix.fedora_version }})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: registry.fedoraproject.org/fedora:${{ matrix.fedora_version }}
     env:
       # workaround for expired cert at source of indirect dependency
@@ -58,7 +58,7 @@ jobs:
 
   container-resolver-tests:
     name: "🛃 Container resolver tests"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       # workaround for expired cert at source of indirect dependency
       # (go.opencensus.io/trace)
@@ -98,7 +98,7 @@ jobs:
             image_tag: stream10-development
       fail-fast: false  # if one fails, keep the other(s) running
     name: "🛃 Unit tests (CentOS Stream ${{ matrix.centos_stream.version }})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: quay.io/centos/centos:${{ matrix.centos_stream.image_tag }}
     env:
@@ -143,7 +143,7 @@ jobs:
 
   lint:
     name: "⌨ Lint"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       # workaround for expired cert at source of indirect dependency
       # (go.opencensus.io/trace)
@@ -179,7 +179,7 @@ jobs:
 
   shellcheck:
     name: "🐚 Shellcheck"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       # workaround for expired cert at source of indirect dependency
       # (go.opencensus.io/trace)
@@ -199,7 +199,7 @@ jobs:
 
   python-test:
     name: "🐍 pytest (imgtestlib and test scripts)"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       # workaround for expired cert at source of indirect dependency
       # (go.opencensus.io/trace)
@@ -222,7 +222,7 @@ jobs:
 
   python-lint:
     name: "🐍 Lint (test scripts)"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       # workaround for expired cert at source of indirect dependency
       # (go.opencensus.io/trace)

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -12,7 +12,7 @@ jobs:
   trigger-gitlab:
     # this should never fail, but check it anyway in case we ever change it
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       IMAGEBUILDER_BOT_GITLAB_SSH_KEY: ${{ secrets.IMAGEBUILDER_BOT_GITLAB_SSH_KEY }}
     steps:

--- a/.github/workflows/update-bootc-image-builder.yml
+++ b/.github/workflows/update-bootc-image-builder.yml
@@ -11,7 +11,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   update-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Apt update
         run: sudo apt update

--- a/.github/workflows/update-osbuild.yml
+++ b/.github/workflows/update-osbuild.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   update-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Apt update
         run: sudo apt update


### PR DESCRIPTION
This replaces ubuntu-latest with ubuntu-24.04 to avoid unexpected changes.