### PR TITLE
osbuild: set the cache-max-size to 20 G when checkpoints are defined

### DIFF
--- a/pkg/osbuild/osbuild-exec.go
+++ b/pkg/osbuild/osbuild-exec.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/osbuild/images/pkg/datasizes"
 )
 
 // Run an instance of osbuild, returning a parsed osbuild.Result.
@@ -32,6 +34,11 @@ func RunOSBuild(manifest []byte, store, outputDirectory string, exports, checkpo
 
 	for _, checkpoint := range checkpoints {
 		cmd.Args = append(cmd.Args, "--checkpoint", checkpoint)
+	}
+
+	if len(checkpoints) > 0 {
+		// set the cache-max-size to a reasonable size that the checkpoints actually get stored
+		cmd.Args = append(cmd.Args, "--cache-max-size", fmt.Sprint(20*datasizes.GiB))
 	}
 
 	if result {


### PR DESCRIPTION
Adding --checkpoints to the osbuild call has no effect right now unless a previous run of osbuild set the max size already. Since we support passing checkpoint args to the osbuild call, let's also set the cache size to a baseline default value to have those checkpoints actually checkpoint.