### PR TITLE
golangci: remove exclude-dirs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,4 @@
 ---
-exclude-dirs:
-  - vendor
-
 linters-settings:
   govet:
     disable:


### PR DESCRIPTION
The action now runs config validation automatically [1], which fails on our config because 'exclude-dirs' is not a valid top-level key.  Also, we don't have a vendor directory any more so let's just drop it.

    golangci-lint --config ./.golangci.yml config verify
    jsonschema: "" does not validate with "/additionalProperties": additionalProperties 'exclude-dirs' not allowed
    Failed executing command with error: the configuration contains invalid elements

https://github.com/golangci/golangci-lint-action/releases/tag/v6.5.0