### PR TITLE
github: install jq for the osbuild-composer integration tests

### DIFF
--- a/.github/workflows/test-osbuild-composer-integration.yml
+++ b/.github/workflows/test-osbuild-composer-integration.yml
@@ -69,7 +69,7 @@ jobs:
       # gcc is needed to build the mock depsolver binary for the unit tests
       # gpgme-devel is needed for container upload dependencies
       - name: Install build and test dependencies
-        run: dnf -y install krb5-devel gcc git-core go gpgme-devel osbuild-depsolve-dnf btrfs-progs-devel device-mapper-devel
+        run: dnf -y install krb5-devel gcc git-core go gpgme-devel osbuild-depsolve-dnf btrfs-progs-devel device-mapper-devel jq
 
       - name: Check out osbuild-composer main branch
         uses: actions/checkout@v4


### PR DESCRIPTION
Running ./tools/prepare-source.sh in osbuild-composer now requires jq for the version check.

https://github.com/osbuild/osbuild-composer/pull/4600