### PR TITLE
fix(fedora-iot-raw): enable ignition-firstboot-complete.service

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -265,6 +265,7 @@ var (
 			OSTreeConfSysrootReadOnly: common.ToPtr(true),
 			LockRootUser:              common.ToPtr(true),
 			IgnitionPlatform:          common.ToPtr("metal"),
+			EnabledServices:           []string{"ignition-firstboot-complete.service"},
 		},
 		defaultSize:         4 * datasizes.GibiByte,
 		rpmOstree:           true,

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -307,6 +307,9 @@ func ostreeDeploymentCustomizations(
 		deploymentConf.CustomFileSystems = append(deploymentConf.CustomFileSystems, fs.Mountpoint)
 	}
 
+	deploymentConf.EnabledServices = imageConfig.EnabledServices
+	deploymentConf.DisabledServices = imageConfig.DisabledServices
+
 	return deploymentConf, nil
 }
 

--- a/pkg/image/ostree_disk.go
+++ b/pkg/image/ostree_disk.go
@@ -81,8 +81,8 @@ func baseRawOstreeImage(img *OSTreeDiskImage, buildPipeline manifest.Build, opts
 
 	// other image types (e.g. live) pass the workload to the pipeline.
 	if img.Workload != nil {
-		osPipeline.EnabledServices = img.Workload.GetServices()
-		osPipeline.DisabledServices = img.Workload.GetDisabledServices()
+		osPipeline.OSTreeDeploymentCustomizations.EnabledServices = append(osPipeline.OSTreeDeploymentCustomizations.EnabledServices, img.Workload.GetServices()...)
+		osPipeline.OSTreeDeploymentCustomizations.DisabledServices = append(osPipeline.OSTreeDeploymentCustomizations.DisabledServices, img.Workload.GetDisabledServices()...)
 	}
 	return manifest.NewRawOStreeImage(buildPipeline, osPipeline, img.Platform)
 }


### PR DESCRIPTION
fixes: https://github.com/fedora-iot/iot-distro/issues/14 

- enabling this service by default so that /boot/ignition.firstboot file is removed on first boot successfully, which is expected behavior. 
- Since this was missing earlier, /boot/ignition.firstboot was never removed and at each boot any changes to systemd services were reset.