### PR TITLE
Fix static json strings with mixed-indent

### DIFF
--- a/cmd/otk/osbuild-gen-partition-table/main_test.go
+++ b/cmd/otk/osbuild-gen-partition-table/main_test.go
@@ -180,38 +180,38 @@ func TestUnmarshalOutput(t *testing.T) {
 	assert.Equal(t, expectedOutput, string(output))
 }
 
-var partInputsSimple = `
-{
+var partInputsSimple = `{
   "tree": {
     "properties": {
       "create": {
-	"bios_boot_partition": true,
-	"esp_partition": true,
-	"esp_partition_size": "2 GiB"
+        "bios_boot_partition": true,
+        "esp_partition": true,
+        "esp_partition_size": "2 GiB"
       },
       "type": "gpt",
       "default_size": "10 GiB",
       "start_offset": "8 MB",
-	  "architecture": "x86_64"
+      "architecture": "x86_64"
     },
     "partitions": [
       {
-	"name": "root",
-	"mountpoint": "/",
-	"label": "root",
-	"size": "7 GiB",
-	"type": "ext4"
+        "name": "root",
+        "mountpoint": "/",
+        "label": "root",
+        "size": "7 GiB",
+        "type": "ext4"
       },
       {
-	"name": "home",
-	"mountpoint": "/home",
-	"label": "home",
-	"size": "2 GiB",
-	"type": "ext4"
+        "name": "home",
+        "mountpoint": "/home",
+        "label": "home",
+        "size": "2 GiB",
+        "type": "ext4"
       }
     ]
   }
-}`
+}
+`
 
 // XXX: anything under "internal" we don't actually need to test
 // as we do not make any gurantees to the outside

--- a/cmd/otk/osbuild-make-ostree-source/main_test.go
+++ b/cmd/otk/osbuild-make-ostree-source/main_test.go
@@ -11,14 +11,13 @@ import (
 func TestSourceMakerBasic(t *testing.T) {
 	require := require.New(t)
 
-	input := `
-{
+	input := `{
   "tree": {
-	"const": {
-	  "ref": "does/not/matter",
-	  "checksum": "d04105393ca0617856b34f897842833d785522e41617e17dca2063bf97e294ef",
-	  "url": "https://ostree.example.org/repo"
-	}
+    "const": {
+      "ref": "does/not/matter",
+      "checksum": "d04105393ca0617856b34f897842833d785522e41617e17dca2063bf97e294ef",
+      "url": "https://ostree.example.org/repo"
+    }
   }
 }`
 

--- a/pkg/blueprint/blueprint_test.go
+++ b/pkg/blueprint/blueprint_test.go
@@ -29,29 +29,31 @@ minsize = 2147483648
 mountpoint = "/opt"
 minsize = "20 GiB"
 `
-	blueprintJSON := `{
-		"name": "test",
-                "description": "Test description",
-                "version": "0.0.0",
-                "packages": [
-                  {
-                    "name": "httpd",
-                    "version": "2.4.*"
-                  }
-                ],
-		"customizations": {
-		  "filesystem": [
-                    {
-			"mountpoint": "/var",
-			"minsize": 2147483648
-		    },
-                    {
-			"mountpoint": "/opt",
-			"minsize": "20 GiB"
-                    }
-                  ]
-		}
-	  }`
+	blueprintJSON := `
+{
+  "name": "test",
+  "description": "Test description",
+  "version": "0.0.0",
+  "packages": [
+    {
+      "name": "httpd",
+      "version": "2.4.*"
+    }
+  ],
+  "customizations": {
+    "filesystem": [
+      {
+        "mountpoint": "/var",
+        "minsize": 2147483648
+      },
+      {
+        "mountpoint": "/opt",
+        "minsize": "20 GiB"
+      }
+    ]
+  }
+}
+`
 
 	var bp, bp2 Blueprint
 	err := toml.Unmarshal([]byte(blueprintToml), &bp)


### PR DESCRIPTION
Some of our static json strings used in testing had mixed indentation (tabs and spaces).  This commit unifies them all to be indented with 2 spaces.

This does not unify *all* cases of static json strings to be indented with 2 spaces, only the ones found to have mixed indentation.
