### PR TITLE
Replace ifcfg with net-lib for EL10 and F42 installers

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -475,6 +475,18 @@ var defaultDistroImageConfig = &distro.ImageConfig{
 	DefaultOSCAPDatastream: common.ToPtr(oscap.DefaultFedoraDatastream()),
 }
 
+func defaultDistroInstallerConfig(d *distribution) *distro.InstallerConfig {
+	config := distro.InstallerConfig{}
+	// In Fedora 42 the ifcfg module was replaced by net-lib.
+	if common.VersionLessThan(d.osVersion, "42") {
+		config.AdditionalDracutModules = append(config.AdditionalDracutModules, "ifcfg")
+	} else {
+		config.AdditionalDracutModules = append(config.AdditionalDracutModules, "net-lib")
+	}
+
+	return &config
+}
+
 func getISOLabelFunc(variant string) isoLabelFunc {
 	const ISO_LABEL = "%s-%s-%s-%s"
 
@@ -746,6 +758,12 @@ func newDistro(version int) distro.Distro {
 		containerImgType,
 		wslImgType,
 	)
+
+	// add distro installer configuration to all installer types
+	distroInstallerConfig := defaultDistroInstallerConfig(&rd)
+	liveInstallerImgType.defaultInstallerConfig = distroInstallerConfig
+	imageInstallerImgType.defaultInstallerConfig = distroInstallerConfig
+	iotInstallerImgType.defaultInstallerConfig = distroInstallerConfig
 	x86_64.addImageTypes(
 		&platform.X86{
 			BasePlatform: platform.BasePlatform{
@@ -907,6 +925,7 @@ func newDistro(version int) distro.Distro {
 		minimalrawImgType,
 	)
 
+	iotSimplifiedInstallerImgType.defaultInstallerConfig = distroInstallerConfig
 	x86_64.addImageTypes(
 		&platform.X86{
 			BasePlatform: platform.BasePlatform{

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -411,6 +411,16 @@ func liveInstallerImage(workload workload.Workload,
 		img.Locale = *locale
 	}
 
+	installerConfig, err := t.getDefaultInstallerConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if installerConfig != nil {
+		img.AdditionalDracutModules = append(img.AdditionalDracutModules, installerConfig.AdditionalDracutModules...)
+		img.AdditionalDrivers = append(img.AdditionalDrivers, installerConfig.AdditionalDrivers...)
+	}
+
 	return img, nil
 }
 
@@ -463,6 +473,16 @@ func imageInstallerImage(workload workload.Workload,
 	img.Workload = workload
 
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
+
+	installerConfig, err := t.getDefaultInstallerConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if installerConfig != nil {
+		img.AdditionalDracutModules = append(img.AdditionalDracutModules, installerConfig.AdditionalDracutModules...)
+		img.AdditionalDrivers = append(img.AdditionalDrivers, installerConfig.AdditionalDrivers...)
+	}
 
 	d := t.arch.distro
 
@@ -671,6 +691,16 @@ func iotInstallerImage(workload workload.Workload,
 		anaconda.ModuleUsers,
 	}...)
 
+	installerConfig, err := t.getDefaultInstallerConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if installerConfig != nil {
+		img.AdditionalDracutModules = append(img.AdditionalDracutModules, installerConfig.AdditionalDracutModules...)
+		img.AdditionalDrivers = append(img.AdditionalDrivers, installerConfig.AdditionalDrivers...)
+	}
+
 	img.Product = d.product
 	img.Variant = "IoT"
 	img.OSVersion = d.osVersion
@@ -792,6 +822,16 @@ func iotSimplifiedInstallerImage(workload workload.Workload,
 				return nil, err
 			}
 		}
+	}
+
+	installerConfig, err := t.getDefaultInstallerConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if installerConfig != nil {
+		img.AdditionalDracutModules = append(img.AdditionalDracutModules, installerConfig.AdditionalDracutModules...)
+		img.AdditionalDrivers = append(img.AdditionalDrivers, installerConfig.AdditionalDrivers...)
 	}
 
 	img.AdditionalDracutModules = append(img.AdditionalDracutModules, "dbus-broker")

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -30,24 +30,25 @@ type packageSetFunc func(t *imageType) rpmmd.PackageSet
 type isoLabelFunc func(t *imageType) string
 
 type imageType struct {
-	arch               *architecture
-	platform           platform.Platform
-	environment        environment.Environment
-	workload           workload.Workload
-	name               string
-	nameAliases        []string
-	filename           string
-	compression        string
-	mimeType           string
-	packageSets        map[string]packageSetFunc
-	defaultImageConfig *distro.ImageConfig
-	kernelOptions      string
-	defaultSize        uint64
-	buildPipelines     []string
-	payloadPipelines   []string
-	exports            []string
-	image              imageFunc
-	isoLabel           isoLabelFunc
+	arch                   *architecture
+	platform               platform.Platform
+	environment            environment.Environment
+	workload               workload.Workload
+	name                   string
+	nameAliases            []string
+	filename               string
+	compression            string
+	mimeType               string
+	packageSets            map[string]packageSetFunc
+	defaultImageConfig     *distro.ImageConfig
+	defaultInstallerConfig *distro.InstallerConfig
+	kernelOptions          string
+	defaultSize            uint64
+	buildPipelines         []string
+	payloadPipelines       []string
+	exports                []string
+	image                  imageFunc
+	isoLabel               isoLabelFunc
 
 	// bootISO: installable ISO
 	bootISO bool
@@ -194,6 +195,14 @@ func (t *imageType) getDefaultImageConfig() *distro.ImageConfig {
 	}
 	return imageConfig.InheritFrom(t.arch.distro.getDefaultImageConfig())
 
+}
+
+func (t *imageType) getDefaultInstallerConfig() (*distro.InstallerConfig, error) {
+	if !t.bootISO {
+		return nil, fmt.Errorf("image type %q is not an ISO", t.name)
+	}
+
+	return t.defaultInstallerConfig, nil
 }
 
 func (t *imageType) PartitionType() disk.PartitionTableType {

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -506,8 +506,8 @@ func EdgeInstallerImage(workload workload.Workload,
 	}
 
 	if installerConfig != nil {
-		img.AdditionalDracutModules = installerConfig.AdditionalDracutModules
-		img.AdditionalDrivers = installerConfig.AdditionalDrivers
+		img.AdditionalDracutModules = append(img.AdditionalDracutModules, installerConfig.AdditionalDracutModules...)
+		img.AdditionalDrivers = append(img.AdditionalDrivers, installerConfig.AdditionalDrivers...)
 	}
 
 	instCust, err := customizations.GetInstaller()
@@ -660,7 +660,8 @@ func EdgeSimplifiedInstallerImage(workload workload.Workload,
 	}
 
 	if installerConfig != nil {
-		img.AdditionalDracutModules = installerConfig.AdditionalDracutModules
+		img.AdditionalDracutModules = append(img.AdditionalDracutModules, installerConfig.AdditionalDracutModules...)
+		img.AdditionalDrivers = append(img.AdditionalDrivers, installerConfig.AdditionalDrivers...)
 	}
 
 	return img, nil
@@ -706,8 +707,8 @@ func ImageInstallerImage(workload workload.Workload,
 	}
 
 	if installerConfig != nil {
-		img.AdditionalDracutModules = installerConfig.AdditionalDracutModules
-		img.AdditionalDrivers = installerConfig.AdditionalDrivers
+		img.AdditionalDracutModules = append(img.AdditionalDracutModules, installerConfig.AdditionalDracutModules...)
+		img.AdditionalDrivers = append(img.AdditionalDrivers, installerConfig.AdditionalDrivers...)
 	}
 
 	instCust, err := customizations.GetInstaller()

--- a/pkg/distro/rhel/rhel10/bare_metal.go
+++ b/pkg/distro/rhel/rhel10/bare_metal.go
@@ -53,6 +53,7 @@ func mkImageInstallerImgType() *rhel.ImageType {
 			"nvdimm", // non-volatile DIMM firmware (provides nfit, cuse, and nd_e820)
 			"prefixdevname",
 			"prefixdevname-tools",
+			"net-lib",
 		},
 		AdditionalDrivers: []string{
 			"ipmi_devintf",

--- a/pkg/distro/rhel/rhel8/bare_metal.go
+++ b/pkg/distro/rhel/rhel8/bare_metal.go
@@ -32,6 +32,7 @@ func mkImageInstaller() *rhel.ImageType {
 		AdditionalDracutModules: []string{
 			"prefixdevname",
 			"prefixdevname-tools",
+			"ifcfg",
 		},
 	}
 

--- a/pkg/distro/rhel/rhel8/edge.go
+++ b/pkg/distro/rhel/rhel8/edge.go
@@ -130,6 +130,7 @@ func mkEdgeInstallerImgType(rd *rhel.Distribution) *rhel.ImageType {
 		AdditionalDracutModules: []string{
 			"prefixdevname",
 			"prefixdevname-tools",
+			"ifcfg",
 		},
 	}
 	it.RPMOSTree = true

--- a/pkg/distro/rhel/rhel9/bare_metal.go
+++ b/pkg/distro/rhel/rhel9/bare_metal.go
@@ -54,6 +54,7 @@ func mkImageInstallerImgType() *rhel.ImageType {
 			"nvdimm", // non-volatile DIMM firmware (provides nfit, cuse, and nd_e820)
 			"prefixdevname",
 			"prefixdevname-tools",
+			"ifcfg",
 		},
 		AdditionalDrivers: []string{
 			"cuse",

--- a/pkg/distro/rhel/rhel9/edge.go
+++ b/pkg/distro/rhel/rhel9/edge.go
@@ -148,6 +148,7 @@ func mkEdgeInstallerImgType() *rhel.ImageType {
 			"nvdimm", // non-volatile DIMM firmware (provides nfit, cuse, and nd_e820)
 			"prefixdevname",
 			"prefixdevname-tools",
+			"ifcfg",
 		},
 		AdditionalDrivers: []string{
 			"cuse",

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -38,11 +38,13 @@ type AnacondaContainerInstaller struct {
 
 	Filename string
 
-	AdditionalDracutModules   []string
 	AdditionalAnacondaModules []string
 	DisabledAnacondaModules   []string
-	AdditionalDrivers         []string
-	FIPS                      bool
+
+	AdditionalDracutModules []string
+	AdditionalDrivers       []string
+
+	FIPS bool
 
 	Kickstart *kickstart.Options
 
@@ -92,7 +94,6 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline.Variant = img.Variant
 	anacondaPipeline.Biosdevname = (img.Platform.GetArch() == arch.ARCH_X86_64)
 	anacondaPipeline.Checkpoint()
-	anacondaPipeline.AdditionalDracutModules = img.AdditionalDracutModules
 	anacondaPipeline.AdditionalAnacondaModules = img.AdditionalAnacondaModules
 	anacondaPipeline.DisabledAnacondaModules = img.DisabledAnacondaModules
 	if img.FIPS {
@@ -101,6 +102,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 			anaconda.ModuleSecurity,
 		)
 	}
+	anacondaPipeline.AdditionalDracutModules = img.AdditionalDracutModules
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers
 	anacondaPipeline.Locale = img.Locale
 

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -40,6 +40,9 @@ type AnacondaLiveInstaller struct {
 	// Locale for the installer. This should be set to the same locale as the
 	// ISO OS payload, if known.
 	Locale string
+
+	AdditionalDracutModules []string
+	AdditionalDrivers       []string
 }
 
 func NewAnacondaLiveInstaller() *AnacondaLiveInstaller {

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -42,11 +42,13 @@ type AnacondaOSTreeInstaller struct {
 
 	Filename string
 
-	AdditionalDracutModules   []string
 	AdditionalAnacondaModules []string
 	DisabledAnacondaModules   []string
-	AdditionalDrivers         []string
-	FIPS                      bool
+
+	AdditionalDracutModules []string
+	AdditionalDrivers       []string
+
+	FIPS bool
 
 	// Uses the old, deprecated, Anaconda config option "kickstart-modules".
 	// Only for RHEL 8.

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -71,8 +71,9 @@ type AnacondaTarInstaller struct {
 	AdditionalKernelOpts      []string
 	AdditionalAnacondaModules []string
 	DisabledAnacondaModules   []string
-	AdditionalDracutModules   []string
-	AdditionalDrivers         []string
+
+	AdditionalDracutModules []string
+	AdditionalDrivers       []string
 
 	// Uses the old, deprecated, Anaconda config option "kickstart-modules".
 	// Only for RHEL 8.

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -59,6 +59,7 @@ type OSTreeSimplifiedInstaller struct {
 	IgnitionEmbedded *ignition.EmbeddedOptions
 
 	AdditionalDracutModules []string
+	AdditionalDrivers       []string
 }
 
 func NewOSTreeSimplifiedInstaller(rawImage *OSTreeDiskImage, installDevice string) *OSTreeSimplifiedInstaller {
@@ -98,6 +99,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	coiPipeline.Biosdevname = (img.Platform.GetArch() == arch.ARCH_X86_64)
 	coiPipeline.Variant = img.Variant
 	coiPipeline.AdditionalDracutModules = img.AdditionalDracutModules
+	coiPipeline.AdditionalDrivers = img.AdditionalDrivers
 
 	var isoLabel string
 

--- a/pkg/image/ostree_simplified_installer_test.go
+++ b/pkg/image/ostree_simplified_installer_test.go
@@ -1,0 +1,51 @@
+package image_test
+
+import (
+	"testing"
+
+	"github.com/osbuild/images/internal/testdisk"
+	"github.com/osbuild/images/pkg/image"
+	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/ostree"
+	"github.com/osbuild/images/pkg/platform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimplifiedInstallerDracut(t *testing.T) {
+	commit := ostree.SourceSpec{}
+	ostreeDiskImage := image.NewOSTreeDiskImageFromCommit(commit)
+	ostreeDiskImage.PartitionTable = testdisk.MakeFakePartitionTable("/")
+	ostreeDiskImage.Platform = &platform.X86{}
+	img := image.NewOSTreeSimplifiedInstaller(ostreeDiskImage, "")
+	img.Product = product
+	img.OSVersion = osversion
+	img.ISOLabel = isolabel
+
+	testModules := []string{"test-module"}
+	testDrivers := []string{"test-driver"}
+
+	img.AdditionalDracutModules = testModules
+	img.AdditionalDrivers = testDrivers
+
+	commitSpec := map[string][]ostree.CommitSpec{
+		"ostree-deployment": {
+			{
+				Ref: "test/ostree/3",
+				URL: "http://localhost:8080/repo",
+			},
+		},
+	}
+
+	packageSets := mockPackageSets()
+	packageSets["coi-tree"] = packageSets["os"]
+
+	assert.NotNil(t, img)
+	img.Platform = testPlatform
+	mfs := instantiateAndSerialize(t, img, packageSets, nil, commitSpec)
+	modules, drivers := findDracutStageOptions(t, manifest.OSBuildManifest(mfs), "coi-tree")
+	assert.NotNil(t, modules)
+	assert.NotNil(t, drivers)
+
+	assert.Subset(t, modules, testModules)
+	assert.Subset(t, drivers, testDrivers)
+}

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -422,7 +422,6 @@ func dracutStageOptions(kernelVer string, biosdevname bool, additionalModules []
 		"convertfs",
 		"network-manager",
 		"network",
-		"ifcfg",
 		"url-lib",
 		"drm",
 		"plymouth",

--- a/pkg/manifest/coreos_installer.go
+++ b/pkg/manifest/coreos_installer.go
@@ -42,6 +42,7 @@ type CoreOSInstaller struct {
 	Ignition *ignition.EmbeddedOptions
 
 	AdditionalDracutModules []string
+	AdditionalDrivers       []string
 }
 
 // NewCoreOSInstaller creates an CoreOS installer pipeline object.
@@ -206,10 +207,12 @@ func (p *CoreOSInstaller) serialize() osbuild.Pipeline {
 	if p.Biosdevname {
 		dracutModules = append(dracutModules, "biosdevname")
 	}
+	drivers := p.AdditionalDrivers
 	dracutStageOptions := &osbuild.DracutStageOptions{
-		Kernel:  []string{p.kernelVer},
-		Modules: dracutModules,
-		Install: []string{"/.buildstamp"},
+		Kernel:     []string{p.kernelVer},
+		Modules:    dracutModules,
+		Install:    []string{"/.buildstamp"},
+		AddDrivers: drivers,
 	}
 	if p.FDO != nil && p.FDO.DiunPubKeyRootCerts != "" {
 		pipeline.AddStage(osbuild.NewFDOStageForRootCerts(p.FDO.DiunPubKeyRootCerts))

--- a/pkg/manifest/coreos_installer_test.go
+++ b/pkg/manifest/coreos_installer_test.go
@@ -1,0 +1,56 @@
+package manifest
+
+import (
+	"testing"
+
+	"github.com/osbuild/images/pkg/dnfjson"
+	"github.com/osbuild/images/pkg/osbuild"
+	"github.com/osbuild/images/pkg/platform"
+	"github.com/osbuild/images/pkg/rpmmd"
+	"github.com/osbuild/images/pkg/runner"
+	"github.com/stretchr/testify/require"
+)
+
+func newCoreOSInstaller() *CoreOSInstaller {
+	m := &Manifest{}
+	runner := &runner.Linux{}
+	build := NewBuild(m, runner, nil, nil)
+
+	x86plat := &platform.X86{}
+
+	product := ""
+	osversion := ""
+
+	installer := NewCoreOSInstaller(build, x86plat, nil, "kernel", product, osversion)
+	return installer
+}
+
+func TestCoreOSInstallerDracutModulesAndDrivers(t *testing.T) {
+	pkgs := []rpmmd.PackageSpec{
+		{
+			Name:     "kernel",
+			Checksum: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+		},
+	}
+
+	coiPipeline := newCoreOSInstaller()
+	coiPipeline.AdditionalDracutModules = []string{"test-module"}
+	coiPipeline.AdditionalDrivers = []string{"test-driver"}
+	coiPipeline.serializeStart(Inputs{Depsolved: dnfjson.DepsolveResult{Packages: pkgs}})
+	pipeline := coiPipeline.serialize()
+
+	require := require.New(t)
+	require.NotNil(pipeline)
+	require.NotNil(pipeline.Stages)
+
+	var stageOptions *osbuild.DracutStageOptions
+	for _, stage := range pipeline.Stages {
+		if stage.Type == "org.osbuild.dracut" {
+			stageOptions = stage.Options.(*osbuild.DracutStageOptions)
+		}
+	}
+
+	require.NotNil(stageOptions, "serialized anaconda pipeline does not contain an org.osbuild.anaconda stage")
+	require.Contains(stageOptions.Modules, "test-module")
+	require.Contains(stageOptions.AddDrivers, "test-driver")
+}

--- a/test/scripts/generate-ostree-build-config
+++ b/test/scripts/generate-ostree-build-config
@@ -24,7 +24,7 @@ build/{distro}/{arch}/{image_type}/{config_name}:
     INTERNAL_NETWORK: "{internal}"
   needs:
     - pipeline: "$PARENT_PIPELINE_ID"
-      job: generate-ostree-build-config-{distro}-{arch}
+      job: "generate-ostree-build-config: [{distro}, {arch}]"
 """
 
 


### PR DESCRIPTION
In RHEL 10 and Fedora 42, the ifcfg module was replaced by net-lib.

This PR removes ifcfg from common anaconda dracut stage modules and adds either ifcfg or net-lib to each installer based on distro version.