### PR TITLE
fedora: remove rescue kernels from minimal

### DIFF
--- a/pkg/distro/packagesets/fedora/package_sets.yaml
+++ b/pkg/distro/packagesets/fedora/package_sets.yaml
@@ -828,7 +828,11 @@ minimal_raw:
     - "brcmfmac-firmware"
     - "realtek-firmware"
     - "iwlwifi-mvm-firmware"
-
+  condition:
+    version_greater_or_equal:
+      "43":
+        exclude:
+          - "dracut-config-rescue"
 
 iot_simplified_installer:
   include:


### PR DESCRIPTION
After some discussion [1] Fedora Minimal would like to disable the generation of rescue kernels. This is because historically they weren't included in images (before switching to `image-builder`) and also because the current `/etc/machine-id` implementation of `image-builder` leads to duplicate rescue kernels being generated [2].

---

This also slightly improves build time (by about 10-20 seconds on my system).

[1]: https://github.com/fedora-minimal/distribution-minimal/issues/10
[2]: https://github.com/osbuild/images/issues/1244