### PR TITLE
fedora: reset machine-id for disk images

### DIFF
--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -345,6 +345,9 @@ func diskImage(workload workload.Workload,
 
 	img.Filename = t.Filename()
 
+	d := t.arch.distro
+	img.FirstBoot = common.VersionGreaterThanOrEqual(d.osVersion, VERSION_FIRSTBOOT)
+
 	return img, nil
 }
 

--- a/pkg/distro/fedora/version.go
+++ b/pkg/distro/fedora/version.go
@@ -7,6 +7,10 @@ const VERSION_RAWHIDE = "42"
 // compressing an ext4 filesystem.
 const VERSION_ROOTFS_SQUASHFS = "41"
 
+// Fedora 43 and later we reset the machine-id file to align ourselves with the
+// other Fedora variants.
+const VERSION_FIRSTBOOT = "43"
+
 func VersionReplacements() map[string]string {
 	return map[string]string{
 		"VERSION_BRANCHED":        VERSION_BRANCHED,

--- a/pkg/image/disk.go
+++ b/pkg/image/disk.go
@@ -39,6 +39,8 @@ type DiskImage struct {
 	// InstallWeakDeps enables installation of weak dependencies for packages
 	// that are statically defined for the payload pipeline of the image.
 	InstallWeakDeps *bool
+
+	FirstBoot bool
 }
 
 func NewDiskImage() *DiskImage {
@@ -66,6 +68,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 	if img.InstallWeakDeps != nil {
 		osPipeline.InstallWeakDeps = *img.InstallWeakDeps
 	}
+	osPipeline.FirstBoot = img.FirstBoot
 
 	rawImagePipeline := manifest.NewRawImage(buildPipeline, osPipeline)
 	rawImagePipeline.PartTool = img.PartTool

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -148,6 +148,11 @@ type OSCustomizations struct {
 	// NoBLS configures the image bootloader with traditional menu entries
 	// instead of BLS. Required for legacy systems like RHEL 7.
 	NoBLS bool
+
+	// FirstBoot sets if the machine-id should be written with the
+	// magic value that determines if the machine is being booted for the
+	// first time.
+	FirstBoot bool
 }
 
 // OS represents the filesystem tree of the target image. This roughly
@@ -806,6 +811,12 @@ func (p *OS) serialize() osbuild.Pipeline {
 			}
 		}
 		pipeline.AddStage(osbuild.NewCAStageStage())
+	}
+
+	if p.FirstBoot {
+		pipeline.AddStage(osbuild.NewMachineIdStage(&osbuild.MachineIdStageOptions{
+			FirstBoot: "yes",
+		}))
 	}
 
 	if p.SElinux != "" {

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -230,3 +230,21 @@ func testTomlPkgsFor(t *testing.T, os *OS) {
 		assert.Contains(t, buildPkgs, tc.expectedTomlPkg)
 	}
 }
+
+func TestFirstBootIncludesMachineIdStage(t *testing.T) {
+	os := NewTestOS()
+
+	os.FirstBoot = true
+
+	pipeline := os.serialize()
+	st := findStage("org.osbuild.machine-id", pipeline.Stages)
+	require.NotNil(t, st)
+}
+
+func TestFirstBootDoesNotIncludeMachineIdStage(t *testing.T) {
+	os := NewTestOS()
+
+	pipeline := os.serialize()
+	st := findStage("org.osbuild.machine-id", pipeline.Stages)
+	require.Nil(t, st)
+}

--- a/pkg/osbuild/machine_id_stage.go
+++ b/pkg/osbuild/machine_id_stage.go
@@ -1,0 +1,22 @@
+package osbuild
+
+type MachineIdStageOptions struct {
+	// Determines the state of `/etc/machine-id`, valid values are
+	// `yes` (reset to `uninitialized`), `no` (empty), `preserve` (keep).
+	FirstBoot string `json:"first-boot"`
+}
+
+func (MachineIdStageOptions) isStageOptions() {}
+
+func NewMachineIdStageOptions(firstboot string) *MachineIdStageOptions {
+	return &MachineIdStageOptions{
+		FirstBoot: firstboot,
+	}
+}
+
+func NewMachineIdStage(options *MachineIdStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.machine-id",
+		Options: options,
+	}
+}

--- a/pkg/osbuild/machine_id_stage_test.go
+++ b/pkg/osbuild/machine_id_stage_test.go
@@ -1,0 +1,30 @@
+package osbuild
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMachineIdStageOptions(t *testing.T) {
+	firstboot := "yes"
+
+	expectedOptions := &MachineIdStageOptions{
+		FirstBoot: firstboot,
+	}
+
+	actualOptions := NewMachineIdStageOptions(firstboot)
+	assert.Equal(t, expectedOptions, actualOptions)
+}
+
+func TestNewMachineIdStage(t *testing.T) {
+	firstboot := "yes"
+
+	expectedStage := &Stage{
+		Type:    "org.osbuild.machine-id",
+		Options: NewMachineIdStageOptions(firstboot),
+	}
+
+	actualStage := NewMachineIdStage(NewMachineIdStageOptions(firstboot))
+	assert.Equal(t, expectedStage, actualStage)
+}


### PR DESCRIPTION
Fedora resets the `/etc/machine-id` file for [any disk image](https://pagure.io/fedora-kiwi-descriptions/blob/960270bb861a0e54bc837f7feeb9c3a9b9a18661/f/config.sh#_117); let's do the same here.

Enables `ConditionFirstBoot` which is/was also part of a [request](https://github.com/fedora-minimal/distribution-minimal/issues/3) for Fedora Minimal to support `systemd-firstboot`.