### PR TITLE
fedora: allow disabling weak dependencies

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -455,6 +455,7 @@ func mkMinimalRawImgType(d distribution) imageType {
 				// Overwrite the default Grub2 timeout value.
 				Timeout: 5,
 			},
+			InstallWeakDeps: common.ToPtr(common.VersionLessThan(d.osVersion, VERSION_MINIMAL_WEAKDEPS)),
 		},
 		rpmOstree:              false,
 		kernelOptions:          defaultKernelOptions,
@@ -486,6 +487,7 @@ var defaultDistroImageConfig = &distro.ImageConfig{
 	Timezone:               common.ToPtr("UTC"),
 	Locale:                 common.ToPtr("C.UTF-8"),
 	DefaultOSCAPDatastream: common.ToPtr(oscap.DefaultFedoraDatastream()),
+	InstallWeakDeps:        common.ToPtr(true),
 }
 
 func defaultDistroInstallerConfig(d *distribution) *distro.InstallerConfig {

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -110,6 +110,10 @@ func osCustomizations(
 		osc.Hostname = "localhost.localdomain"
 	}
 
+	if imageConfig.InstallWeakDeps != nil {
+		osc.InstallWeakDeps = *imageConfig.InstallWeakDeps
+	}
+
 	timezone, ntpServers := c.GetTimezoneSettings()
 	if timezone != nil {
 		osc.Timezone = *timezone
@@ -334,7 +338,7 @@ func diskImage(workload workload.Workload,
 	img.Compression = t.compression
 	if bp.Minimal {
 		// Disable weak dependencies if the 'minimal' option is enabled
-		img.InstallWeakDeps = common.ToPtr(false)
+		img.OSCustomizations.InstallWeakDeps = false
 	}
 	// TODO: move generation into LiveImage
 	pt, err := t.getPartitionTable(bp.Customizations, options, rng)

--- a/pkg/distro/fedora/version.go
+++ b/pkg/distro/fedora/version.go
@@ -11,6 +11,9 @@ const VERSION_ROOTFS_SQUASHFS = "41"
 // other Fedora variants.
 const VERSION_FIRSTBOOT = "43"
 
+// Version at which we stop installing weak dependencies for Fedora Minimal
+const VERSION_MINIMAL_WEAKDEPS = "43"
+
 func VersionReplacements() map[string]string {
 	return map[string]string{
 		"VERSION_BRANCHED":        VERSION_BRANCHED,

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -94,6 +94,10 @@ type ImageConfig struct {
 	LockRootUser *bool
 
 	IgnitionPlatform *string
+
+	// InstallWeakDeps enables installation of weak dependencies for packages
+	// that are statically defined for the pipeline.
+	InstallWeakDeps *bool
 }
 
 // InheritFrom inherits unset values from the provided parent configuration and

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -279,6 +279,10 @@ func osCustomizations(
 		osc.CACerts = ca.PEMCerts
 	}
 
+	if imageConfig.InstallWeakDeps != nil {
+		osc.InstallWeakDeps = *imageConfig.InstallWeakDeps
+	}
+
 	return osc, nil
 }
 

--- a/pkg/distro/rhel/rhel10/distro.go
+++ b/pkg/distro/rhel/rhel10/distro.go
@@ -66,6 +66,7 @@ func defaultDistroImageConfig(d *rhel.Distribution) *distro.ImageConfig {
 			},
 		},
 		DefaultOSCAPDatastream: common.ToPtr(oscap.DefaultRHEL10Datastream(d.IsRHEL())),
+		InstallWeakDeps:        common.ToPtr(true),
 	}
 }
 

--- a/pkg/distro/rhel/rhel7/distro.go
+++ b/pkg/distro/rhel/rhel7/distro.go
@@ -33,6 +33,7 @@ func defaultDistroImageConfig(d *rhel.Distribution) *distro.ImageConfig {
 		},
 		KernelOptionsBootloader: common.ToPtr(true),
 		NoBLS:                   common.ToPtr(true), // RHEL 7 grub does not support BLS
+		InstallWeakDeps:         common.ToPtr(true),
 	}
 }
 

--- a/pkg/distro/rhel/rhel8/distro.go
+++ b/pkg/distro/rhel/rhel8/distro.go
@@ -54,6 +54,7 @@ func defaultDistroImageConfig(d *rhel.Distribution) *distro.ImageConfig {
 		},
 		KernelOptionsBootloader: common.ToPtr(true),
 		DefaultOSCAPDatastream:  common.ToPtr(oscap.DefaultRHEL8Datastream(d.IsRHEL())),
+		InstallWeakDeps:         common.ToPtr(true),
 	}
 }
 

--- a/pkg/distro/rhel/rhel9/distro.go
+++ b/pkg/distro/rhel/rhel9/distro.go
@@ -69,6 +69,7 @@ func defaultDistroImageConfig(d *rhel.Distribution) *distro.ImageConfig {
 			},
 		},
 		DefaultOSCAPDatastream: common.ToPtr(oscap.DefaultRHEL9Datastream(d.IsRHEL())),
+		InstallWeakDeps:        common.ToPtr(true),
 	}
 }
 

--- a/pkg/image/disk.go
+++ b/pkg/image/disk.go
@@ -36,10 +36,6 @@ type DiskImage struct {
 	OSVersion string
 	OSNick    string
 
-	// InstallWeakDeps enables installation of weak dependencies for packages
-	// that are statically defined for the payload pipeline of the image.
-	InstallWeakDeps *bool
-
 	FirstBoot bool
 }
 
@@ -65,9 +61,6 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.OSProduct = img.OSProduct
 	osPipeline.OSVersion = img.OSVersion
 	osPipeline.OSNick = img.OSNick
-	if img.InstallWeakDeps != nil {
-		osPipeline.InstallWeakDeps = *img.InstallWeakDeps
-	}
 	osPipeline.FirstBoot = img.FirstBoot
 
 	rawImagePipeline := manifest.NewRawImage(buildPipeline, osPipeline)

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -153,6 +153,11 @@ type OSCustomizations struct {
 	// magic value that determines if the machine is being booted for the
 	// first time.
 	FirstBoot bool
+
+	// InstallWeakDeps enables installation of weak dependencies for packages
+	// that are statically defined for the pipeline.
+	// Defaults to True.
+	InstallWeakDeps bool
 }
 
 // OS represents the filesystem tree of the target image. This roughly
@@ -193,11 +198,6 @@ type OS struct {
 	OSProduct string
 	OSVersion string
 	OSNick    string
-
-	// InstallWeakDeps enables installation of weak dependencies for packages
-	// that are statically defined for the pipeline.
-	// Defaults to True.
-	InstallWeakDeps bool
 }
 
 // NewOS creates a new OS pipeline. build is the build pipeline to use for
@@ -206,10 +206,9 @@ type OS struct {
 func NewOS(buildPipeline Build, platform platform.Platform, repos []rpmmd.RepoConfig) *OS {
 	name := "os"
 	p := &OS{
-		Base:            NewBase(name, buildPipeline),
-		repos:           filterRepos(repos, name),
-		platform:        platform,
-		InstallWeakDeps: true,
+		Base:     NewBase(name, buildPipeline),
+		repos:    filterRepos(repos, name),
+		platform: platform,
 	}
 	buildPipeline.addDependent(p)
 	return p


### PR DESCRIPTION
Weak dependency resolution is hardcoded per imagetype. This commit changes it so weak dependency resolution can be turned off per image.

We guard on the Fedora version to ensure we don't accidentally change older images.

This commit also disables weak dependency resolution for Fedora Minimal which I have mentioned [here](https://github.com/fedora-minimal/distribution-minimal/issues/13).