### PR TITLE
osbuild: constants for machine-id

### DIFF
--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -815,7 +815,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 
 	if p.FirstBoot {
 		pipeline.AddStage(osbuild.NewMachineIdStage(&osbuild.MachineIdStageOptions{
-			FirstBoot: "yes",
+			FirstBoot: osbuild.MachineIdFirstBootYes,
 		}))
 	}
 

--- a/pkg/osbuild/machine_id_stage.go
+++ b/pkg/osbuild/machine_id_stage.go
@@ -1,14 +1,22 @@
 package osbuild
 
+type MachineIdFirstBoot string
+
+const (
+	MachineIdFirstBootYes       MachineIdFirstBoot = "yes"
+	MachineIdFirstBootNo        MachineIdFirstBoot = "no"
+	MachineIdFirstBootPreserver MachineIdFirstBoot = "preserve"
+)
+
 type MachineIdStageOptions struct {
 	// Determines the state of `/etc/machine-id`, valid values are
 	// `yes` (reset to `uninitialized`), `no` (empty), `preserve` (keep).
-	FirstBoot string `json:"first-boot"`
+	FirstBoot MachineIdFirstBoot `json:"first-boot"`
 }
 
 func (MachineIdStageOptions) isStageOptions() {}
 
-func NewMachineIdStageOptions(firstboot string) *MachineIdStageOptions {
+func NewMachineIdStageOptions(firstboot MachineIdFirstBoot) *MachineIdStageOptions {
 	return &MachineIdStageOptions{
 		FirstBoot: firstboot,
 	}

--- a/pkg/osbuild/machine_id_stage_test.go
+++ b/pkg/osbuild/machine_id_stage_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestNewMachineIdStageOptions(t *testing.T) {
-	firstboot := "yes"
+	firstboot := MachineIdFirstBootYes
 
 	expectedOptions := &MachineIdStageOptions{
 		FirstBoot: firstboot,
@@ -18,7 +18,7 @@ func TestNewMachineIdStageOptions(t *testing.T) {
 }
 
 func TestNewMachineIdStage(t *testing.T) {
-	firstboot := "yes"
+	firstboot := MachineIdFirstBootYes
 
 	expectedStage := &Stage{
 		Type:    "org.osbuild.machine-id",


### PR DESCRIPTION
Changes the strings used in the `machine-id` stage to be constants with their own type instead. This was requested as a followup.

---

Followup for #1251.