### PR TITLE
fedora: default locale `C.UTF-8`

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -471,7 +471,7 @@ type distribution struct {
 // Fedora based OS image configuration defaults
 var defaultDistroImageConfig = &distro.ImageConfig{
 	Timezone:               common.ToPtr("UTC"),
-	Locale:                 common.ToPtr("en_US"),
+	Locale:                 common.ToPtr("C.UTF-8"),
 	DefaultOSCAPDatastream: common.ToPtr(oscap.DefaultFedoraDatastream()),
 }
 


### PR DESCRIPTION
We had the default locale set to `en_US`. This causes problems on some systems as its an invalid value in some cases. Set it to the more widely accepted `C.UTF-8`, same as RHEL.

---

The value is invalid when `initial-setup` does not run during first boot, hence nothing replaces the value with something acceptable.
