### PR TITLE
 many: move machine id first boot to image config

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -134,8 +134,9 @@ func mkIotCommitImgType(d distribution) imageType {
 			osPkgsKey: packageSetLoader,
 		},
 		defaultImageConfig: &distro.ImageConfig{
-			EnabledServices: iotServicesForVersion(&d),
-			DracutConf:      []*osbuild.DracutConfStageOptions{osbuild.FIPSDracutConfStageOptions},
+			EnabledServices:        iotServicesForVersion(&d),
+			DracutConf:             []*osbuild.DracutConfStageOptions{osbuild.FIPSDracutConfStageOptions},
+			MachineIdUninitialized: common.ToPtr(false),
 		},
 		rpmOstree:              true,
 		image:                  iotCommitImage,
@@ -153,6 +154,9 @@ func mkIotBootableContainer(d distribution) imageType {
 		mimeType: "application/x-tar",
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: packageSetLoader,
+		},
+		defaultImageConfig: &distro.ImageConfig{
+			MachineIdUninitialized: common.ToPtr(false),
 		},
 		rpmOstree:              true,
 		image:                  bootableContainerImage,
@@ -176,8 +180,9 @@ func mkIotOCIImgType(d distribution) imageType {
 			},
 		},
 		defaultImageConfig: &distro.ImageConfig{
-			EnabledServices: iotServicesForVersion(&d),
-			DracutConf:      []*osbuild.DracutConfStageOptions{osbuild.FIPSDracutConfStageOptions},
+			EnabledServices:        iotServicesForVersion(&d),
+			DracutConf:             []*osbuild.DracutConfStageOptions{osbuild.FIPSDracutConfStageOptions},
+			MachineIdUninitialized: common.ToPtr(false),
 		},
 		rpmOstree:              true,
 		bootISO:                false,

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -488,6 +488,7 @@ var defaultDistroImageConfig = &distro.ImageConfig{
 	Locale:                 common.ToPtr("C.UTF-8"),
 	DefaultOSCAPDatastream: common.ToPtr(oscap.DefaultFedoraDatastream()),
 	InstallWeakDeps:        common.ToPtr(true),
+	MachineIdUninitialized: common.ToPtr(true),
 }
 
 func defaultDistroInstallerConfig(d *distribution) *distro.InstallerConfig {

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -238,6 +238,10 @@ func osCustomizations(
 		osc.CACerts = ca.PEMCerts
 	}
 
+	if imageConfig.MachineIdUninitialized != nil {
+		osc.MachineIdUninitialized = *imageConfig.MachineIdUninitialized
+	}
+
 	return osc, nil
 }
 
@@ -348,9 +352,6 @@ func diskImage(workload workload.Workload,
 	img.PartitionTable = pt
 
 	img.Filename = t.Filename()
-
-	d := t.arch.distro
-	img.FirstBoot = common.VersionGreaterThanOrEqual(d.osVersion, VERSION_FIRSTBOOT)
 
 	return img, nil
 }

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -98,6 +98,11 @@ type ImageConfig struct {
 	// InstallWeakDeps enables installation of weak dependencies for packages
 	// that are statically defined for the pipeline.
 	InstallWeakDeps *bool
+
+	// How to handle the /etc/machine-id file, when set to true it causes the
+	// machine id to be set to 'uninitialized' which causes ConditionFirstboot
+	// to be triggered in systemd
+	MachineIdUninitialized *bool
 }
 
 // InheritFrom inherits unset values from the provided parent configuration and

--- a/pkg/image/disk.go
+++ b/pkg/image/disk.go
@@ -36,7 +36,9 @@ type DiskImage struct {
 	OSVersion string
 	OSNick    string
 
-	FirstBoot bool
+	// InstallWeakDeps enables installation of weak dependencies for packages
+	// that are statically defined for the payload pipeline of the image.
+	InstallWeakDeps *bool
 }
 
 func NewDiskImage() *DiskImage {
@@ -61,7 +63,10 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.OSProduct = img.OSProduct
 	osPipeline.OSVersion = img.OSVersion
 	osPipeline.OSNick = img.OSNick
-	osPipeline.FirstBoot = img.FirstBoot
+
+	if img.InstallWeakDeps != nil {
+		osPipeline.InstallWeakDeps = *img.InstallWeakDeps
+	}
 
 	rawImagePipeline := manifest.NewRawImage(buildPipeline, osPipeline)
 	rawImagePipeline.PartTool = img.PartTool

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -149,15 +149,14 @@ type OSCustomizations struct {
 	// instead of BLS. Required for legacy systems like RHEL 7.
 	NoBLS bool
 
-	// FirstBoot sets if the machine-id should be written with the
-	// magic value that determines if the machine is being booted for the
-	// first time.
-	FirstBoot bool
-
 	// InstallWeakDeps enables installation of weak dependencies for packages
 	// that are statically defined for the pipeline.
 	// Defaults to True.
 	InstallWeakDeps bool
+
+	// Determines if the machine id should be set to "uninitialized" which allows
+	// "ConditionFirstBoot" to work in systemd
+	MachineIdUninitialized bool
 }
 
 // OS represents the filesystem tree of the target image. This roughly
@@ -812,7 +811,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 		pipeline.AddStage(osbuild.NewCAStageStage())
 	}
 
-	if p.FirstBoot {
+	if p.MachineIdUninitialized {
 		pipeline.AddStage(osbuild.NewMachineIdStage(&osbuild.MachineIdStageOptions{
 			FirstBoot: osbuild.MachineIdFirstBootYes,
 		}))

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -231,17 +231,17 @@ func testTomlPkgsFor(t *testing.T, os *OS) {
 	}
 }
 
-func TestFirstBootIncludesMachineIdStage(t *testing.T) {
+func TestMachineIdUninitializedIncludesMachineIdStage(t *testing.T) {
 	os := NewTestOS()
 
-	os.FirstBoot = true
+	os.MachineIdUninitialized = true
 
 	pipeline := os.serialize()
 	st := findStage("org.osbuild.machine-id", pipeline.Stages)
 	require.NotNil(t, st)
 }
 
-func TestFirstBootDoesNotIncludeMachineIdStage(t *testing.T) {
+func TestMachineIdUninitializedDoesNotIncludeMachineIdStage(t *testing.T) {
 	os := NewTestOS()
 
 	pipeline := os.serialize()

--- a/pkg/osbuild/machine_id_stage.go
+++ b/pkg/osbuild/machine_id_stage.go
@@ -3,9 +3,9 @@ package osbuild
 type MachineIdFirstBoot string
 
 const (
-	MachineIdFirstBootYes       MachineIdFirstBoot = "yes"
-	MachineIdFirstBootNo        MachineIdFirstBoot = "no"
-	MachineIdFirstBootPreserver MachineIdFirstBoot = "preserve"
+	MachineIdFirstBootYes      MachineIdFirstBoot = "yes"
+	MachineIdFirstBootNo       MachineIdFirstBoot = "no"
+	MachineIdFirstBootPreserve MachineIdFirstBoot = "preserve"
 )
 
 type MachineIdStageOptions struct {


### PR DESCRIPTION
This moves the machine id handling from specific to Fedora to the image config.

---

Had a chat with @achilleas-k and @thozza today who pointed out that they'd prefer this to live in the image config. Is this the right approach?