### PR TITLE
fedora: move hostname to image config

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -470,6 +470,7 @@ type distribution struct {
 
 // Fedora based OS image configuration defaults
 var defaultDistroImageConfig = &distro.ImageConfig{
+	Hostname:               common.ToPtr("localhost.localdomain"),
 	Timezone:               common.ToPtr("UTC"),
 	Locale:                 common.ToPtr("C.UTF-8"),
 	DefaultOSCAPDatastream: common.ToPtr(oscap.DefaultFedoraDatastream()),

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -106,8 +106,8 @@ func osCustomizations(
 
 	if hostname := c.GetHostname(); hostname != nil {
 		osc.Hostname = *hostname
-	} else {
-		osc.Hostname = "localhost.localdomain"
+	} else if imageConfig.Hostname != nil {
+		osc.Hostname = *imageConfig.Hostname
 	}
 
 	timezone, ntpServers := c.GetTimezoneSettings()

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -12,6 +12,7 @@ import (
 
 // ImageConfig represents a (default) configuration applied to the image payload.
 type ImageConfig struct {
+	Hostname            *string
 	Timezone            *string
 	TimeSynchronization *osbuild.ChronyStageOptions
 	Locale              *string


### PR DESCRIPTION
Moves the hostname to the image config.

---

This is part of the preparation work for Fedora Minimal to support `systemd-firstboot`.