### PR TITLE
fedora: remove rescue kernels from minimal

### DIFF
--- a/pkg/distro/packagesets/fedora/package_sets.yaml
+++ b/pkg/distro/packagesets/fedora/package_sets.yaml
@@ -828,11 +828,9 @@ minimal_raw: &minimal
     - "brcmfmac-firmware"
     - "realtek-firmware"
     - "iwlwifi-mvm-firmware"
+  exclude:
+    - "dracut-config-rescue"
   condition:
-    version_greater_or_equal:
-      "43":
-        exclude:
-          - "dracut-config-rescue"
     architecture:
       riscv64:
         include:


### PR DESCRIPTION
Let's remove the rescue kernels from all versions. This could be considered a bug or regression so turn it off.

Helps speed up the work on RISC-V due to saving time in cross-compilation as well.

---

Initially turned off for Fedora >= 43 in: #1245.