### PR TITLE
manifest: use experimentalflags.String("bootstrap")

### DIFF
--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -3,7 +3,9 @@ package manifest
 import (
 	"fmt"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/experimentalflags"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/runner"
@@ -57,6 +59,11 @@ func NewBuild(m *Manifest, runner runner.Runner, repos []rpmmd.RepoConfig, opts 
 		repos:              filterRepos(repos, name),
 		containerBuildable: opts.ContainerBuildable,
 	}
+
+	// This allows to bootstrap the buildroot with a custom container
+	// for e.g. cross-arch-build experiments,
+	maybeAddExperimentalContainerBootstrap(m, runner, opts, pipeline)
+
 	m.addPipeline(pipeline)
 	return pipeline
 }
@@ -147,6 +154,39 @@ func (p *BuildrootFromPackages) getSELinuxLabels() map[string]string {
 		}
 	}
 	return labels
+}
+
+// maybeAddExperimentalContainerBootstrap will return a container buildroot
+// if the "IMAGE_BUILDER_EXPERIMENTAL=bootstrap=<container-ref>" is
+// defined. This allows us to do cross-arch build experimentation.
+//
+// A "bootstrap" container has only these requirements:
+// - python3 for the runners
+// - rpm so that the real buildroot rpms can get installed
+// - setfiles so that the selinux stage for the real buildroot can run
+// (and does not even need a working dnf or repo setup).
+func maybeAddExperimentalContainerBootstrap(m *Manifest, runner runner.Runner, opts *BuildOptions, build *BuildrootFromPackages) {
+	bootstrapBuildrootRef := experimentalflags.String("bootstrap")
+	if bootstrapBuildrootRef == "" {
+		return
+	}
+
+	cntSrcs := []container.SourceSpec{
+		{
+			Source:    bootstrapBuildrootRef,
+			Name:      bootstrapBuildrootRef,
+			TLSVerify: common.ToPtr(false),
+		},
+	}
+	name := "bootstrap-buildroot"
+	bootstrapPipeline := &BuildrootFromContainer{
+		Base:       NewBase(name, nil),
+		runner:     runner,
+		dependents: make([]Pipeline, 0),
+		containers: cntSrcs,
+	}
+	m.addPipeline(bootstrapPipeline)
+	build.build = bootstrapPipeline
 }
 
 type BuildrootFromContainer struct {

--- a/pkg/manifest/build_test.go
+++ b/pkg/manifest/build_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -145,4 +146,39 @@ func TestBuildFromContainerSpecsGetSelinuxLabelsWithContainerBuildable(t *testin
 		"/usr/bin/mount":  "system_u:object_r:install_exec_t:s0",
 		"/usr/bin/umount": "system_u:object_r:install_exec_t:s0",
 	})
+}
+
+func TestNewBuildWithExperimentalOverride(t *testing.T) {
+	for _, withForcedBuildroot := range []bool{false, true} {
+		if withForcedBuildroot {
+			t.Setenv("IMAGE_BUILDER_EXPERIMENTAL", "bootstrap=ghcr.io/ondrejbudai/cool:stuff")
+		} else {
+			t.Setenv("IMAGE_BUILDER_EXPERIMENTAL", "")
+		}
+		mf := New()
+		runner := &runner.Fedora{Version: 42}
+		buildIf := NewBuild(&mf, runner, nil, nil)
+		require.NotNil(t, buildIf)
+		if withForcedBuildroot {
+			bootstrapPipeline := mf.pipelines[0]
+			br, ok := bootstrapPipeline.(*BuildrootFromContainer)
+			assert.True(t, ok)
+			assert.Equal(t, []container.SourceSpec{
+				{
+					Source:    "ghcr.io/ondrejbudai/cool:stuff",
+					Name:      "ghcr.io/ondrejbudai/cool:stuff",
+					TLSVerify: common.ToPtr(false),
+				},
+			}, br.containers)
+
+			buildPipeline := mf.pipelines[1]
+			br2, ok := buildPipeline.(*BuildrootFromPackages)
+			assert.True(t, ok)
+			assert.Equal(t, bootstrapPipeline, br2.build)
+		} else {
+			br, ok := buildIf.(*BuildrootFromPackages)
+			assert.True(t, ok)
+			assert.Nil(t, br.build)
+		}
+	}
 }


### PR DESCRIPTION
This commit allows to use a container to bootstrap the buildroot via the experimtnal "bootstrap" flag:
```console
$ IMAGE_BUILDER_EXPERIMENTAL=bootstrap=ghcr.io/mvo5/fedora-buildroot:41 \
   image-builder manifest --arch=riscv64 minimal-raw --distro=fedora-41
```
and it will use the given container to bootstap the buildroot.

This will allow to do cross-arch building for riscv. The generated manifest can be build with osbuild (as long as qemu-user is installed) and will generate a minimal-raw for riscv64.

Cross-building is useful because qemu-user is a lot faster (and easier to setup) than full riscv system emulation. A minimal raw build on a really fast AWS machine takes about 100 minutes. A full minimal-raw build on my (moderate) PC takes about 20min - which is fast enough so that we can run this in GH workflows as part of the CI.

The approach with the bootstrap buildroot [0] allows us to generalize this later so that each distro would (in addition to the repos) an upstream container ref. With that we could auto-detect cross builds and we would just add this upstream container to bootstrap the buildroot.

[0] Thanks to Ondrej, Achilleas, Thozza, Simon and Florian.

P.S. With that we can also do:
```
$ IMAGE_BUILDER_EXPERIMENTAL=bootstrap=registry.fedoraproject.org/fedora-toolbox:41 image-builder manifest --arch=aarch64 --distro fedora-41 minimal-raw
# or
IMAGE_BUILDER_EXPERIMENTAL=bootstrap=registry.access.redhat.com/ubi9/ubi:latest image-builder manifest --arch=ppc64le --distro centos-9 qcow2
```
so we will not have to maintain our own containers (there are still some assumption like that the container contains python3 for the runners).
