### PR TITLE
many: `systemd-firstboot` support

### DIFF
--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -584,6 +584,7 @@ image_types:
           - "iwlwifi-mvm-firmware"
         exclude:
           - "dracut-config-rescue"
+          - "plymouth"
         condition:
           architecture:
             riscv64:

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -9,7 +9,6 @@ import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/environment"
 	"github.com/osbuild/images/pkg/arch"
-	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/oscap"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
@@ -464,9 +463,6 @@ func mkMinimalRawImgType(d distribution) imageType {
 		},
 		defaultImageConfig: &distro.ImageConfig{
 			EnabledServices: minimalServicesForVersion(&d),
-			// NOTE: temporary workaround for a bug in initial-setup that
-			// requires a kickstart file in the root directory.
-			Files: []*fsnode.File{initialSetupKickstart()},
 			Grub2Config: &osbuild.GRUB2Config{
 				// Overwrite the default Grub2 timeout value.
 				Timeout: 5,

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -474,6 +474,8 @@ func mkMinimalRawImgType(d distribution) imageType {
 			InstallWeakDeps: common.ToPtr(common.VersionLessThan(d.osVersion, VERSION_MINIMAL_WEAKDEPS)),
 			// Unset hostname so it isn't written (necessary for systemd-firstboot).
 			Hostname: common.ToPtr(""),
+			// Unset locale so it isn't written (necessary for systemd-firstboot).
+			Locale: common.ToPtr(""),
 		},
 		rpmOstree:              false,
 		kernelOptions:          defaultKernelOptions(),

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -472,6 +472,8 @@ func mkMinimalRawImgType(d distribution) imageType {
 				Timeout: 5,
 			},
 			InstallWeakDeps: common.ToPtr(common.VersionLessThan(d.osVersion, VERSION_MINIMAL_WEAKDEPS)),
+			// Unset hostname so it isn't written (necessary for systemd-firstboot).
+			Hostname: common.ToPtr(""),
 		},
 		rpmOstree:              false,
 		kernelOptions:          defaultKernelOptions(),

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -476,6 +476,8 @@ func mkMinimalRawImgType(d distribution) imageType {
 			Hostname: common.ToPtr(""),
 			// Unset locale so it isn't written (necessary for systemd-firstboot).
 			Locale: common.ToPtr(""),
+			// Unset timezone so it isn't written (necessary for systemd-firstboot).
+			Timezone: common.ToPtr(""),
 		},
 		rpmOstree:              false,
 		kernelOptions:          defaultKernelOptions(),

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -933,13 +933,3 @@ func makeOSTreePayloadCommit(options *ostree.ImageOptions, defaultRef string) (o
 		RHSM: options.RHSM,
 	}, nil
 }
-
-// initialSetupKickstart returns the File configuration for a kickstart file
-// that's required to enable initial-setup to run on first boot.
-func initialSetupKickstart() *fsnode.File {
-	file, err := fsnode.NewFile("/root/anaconda-ks.cfg", nil, "root", "root", []byte("# Run initial-setup on first boot\n# Created by osbuild\nfirstboot --reconfig\n"))
-	if err != nil {
-		panic(err)
-	}
-	return file
-}


### PR DESCRIPTION
This PR introduces a bunch of preliminary work to get `systemd-firstboot` to work with the Fedora Minimal spin though it is set up that it could be configured with other image types as well.

For the eventual interface I *think* we don't want each image type to define all the parts separately but to instead have a single flag in the image config to 'SystemdFirstBootable' or such.

The work is not yet done but this PR serves for documentation of encountered problems and such.

---

## Problems, challenges, fun, quirks

1. `systemd-firstboot --image=...` works great, everything is configurable.

However when booting an image more software runs and things start to get funky.

1. `systemd-tmpfiles` is configured on Fedora to create (amongst others) the `/etc/locale.conf`, `/etc/vconsole.conf` files (see: `/usr/lib/tmpfiles.d/etc.conf`). `systemd-tmpfiles` is explicitly requested to run *before* `systemd-firstboot`. This needs to be changed either in the Fedora-shipped RPMs or it needs to be worked around at build time (patch the `tmpfiles.d` configurations? change the order?) otherwise those options cannot be configured.
2. The `systemd-firstboot` prompt is 'broken'. To start with we get a bunch of output that goes straight through the prompt, perhaps some ordering issue; for now a `PreExecStart=/bin/sleep 1` fixes this but is not the right thing to do. 
3. The `systemd-firstboot` prompt is 'broken'. Initial keypresses do not work on the console. Potentially we'd want to wait for `udev-settle` or not at all.
4. The `root` user needs to be handled, currently it is created by either `systemd-tmpfiles` or `systemd-sysusers` (haven't looked yet) *before* `systemd-firstboot` runs since. 