### PR TITLE
fedora: enable minimal-raw-zst for riscv64

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -1087,6 +1087,7 @@ func newDistro(version int) distro.Distro {
 			},
 		},
 		minimalrawImgType,
+		minimalrawZstdImgType,
 	)
 
 	rd.addArches(x86_64, aarch64, ppc64le, s390x, riscv64)

--- a/pkg/distro/fedora/distro_test.go
+++ b/pkg/distro/fedora/distro_test.go
@@ -620,6 +620,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 			imgNames: []string{
 				"container",
 				"minimal-raw",
+				"minimal-raw-zst",
 			},
 		},
 	}


### PR DESCRIPTION
xz is super-slow on riscv64, so let's enable the zstd variant on riscv64.