### PR TITLE
cmd/gen-manifests: sort package sets in mock depsolver

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -314,7 +315,9 @@ func mockDepsolve(packageSets map[string][]rpmmd.PackageSet, repos []rpmmd.RepoC
 	for name, pkgSetChain := range packageSets {
 		specSet := make([]rpmmd.PackageSpec, 0)
 		for _, pkgSet := range pkgSetChain {
-			for _, pkgName := range pkgSet.Include {
+			include := pkgSet.Include
+			slices.Sort(include)
+			for _, pkgName := range include {
 				checksum := fmt.Sprintf("%x", sha256.Sum256([]byte(pkgName)))
 				// generate predictable but non-empty
 				// release/version numbers
@@ -331,7 +334,10 @@ func mockDepsolve(packageSets map[string][]rpmmd.PackageSet, repos []rpmmd.RepoC
 				}
 				specSet = append(specSet, spec)
 			}
-			for _, excludeName := range pkgSet.Exclude {
+
+			exclude := pkgSet.Exclude
+			slices.Sort(exclude)
+			for _, excludeName := range exclude {
 				pkgName := fmt.Sprintf("exclude:%s", excludeName)
 				checksum := fmt.Sprintf("%x", sha256.Sum256([]byte(pkgName)))
 				spec := rpmmd.PackageSpec{


### PR DESCRIPTION
Since the packages were extracted into yaml files in #1205, the package list order has become unstable, in particular when packages are added conditionally.  I'm not entirely sure where the instability comes from, but generating manifests with the mock depsolver creates lists with different order for the OS pipeline for the image types that conditionally add "dnsmasq".

Sorting the package lists ensures that manifests don't change from this instability.  It also makes the manifests reproducible when the package lists are reordered internally, which we would prefer to have, since the package order pre-depsolve shouldn't affect the final manifest.