### PR TITLE
manifest: add devices/mounts to the files/dir stages in bootc

### DIFF
--- a/pkg/manifest/raw_bootc.go
+++ b/pkg/manifest/raw_bootc.go
@@ -210,11 +210,22 @@ func (p *RawBootcImage) serialize() osbuild.Pipeline {
 
 	// First create custom directories, because some of the custom files may depend on them
 	if len(p.Directories) > 0 {
-		pipeline.AddStages(osbuild.GenDirectoryNodesStages(p.Directories)...)
+
+		stages := osbuild.GenDirectoryNodesStages(p.Directories)
+		for _, stage := range stages {
+			stage.Mounts = mounts
+			stage.Devices = devices
+		}
+		pipeline.AddStages(stages...)
 	}
 
 	if len(p.Files) > 0 {
-		pipeline.AddStages(osbuild.GenFileNodesStages(p.Files)...)
+		stages := osbuild.GenFileNodesStages(p.Files)
+		for _, stage := range stages {
+			stage.Mounts = mounts
+			stage.Devices = devices
+		}
+		pipeline.AddStages(stages...)
 	}
 
 	// XXX: maybe go back to adding this conditionally when we stop

--- a/pkg/manifest/raw_bootc_test.go
+++ b/pkg/manifest/raw_bootc_test.go
@@ -315,6 +315,7 @@ func TestRawBootcImageSerializeCreateFilesDirs(t *testing.T) {
 				require.NotNil(t, mkdirStage)
 				mkdirOptions := mkdirStage.Options.(*osbuild.MkdirStageOptions)
 				assert.Equal(t, "/path/to/dir", mkdirOptions.Paths[0].Path)
+				assertBootcDeploymentAndBindMount(t, mkdirStage)
 			} else {
 				assert.Nil(t, mkdirStage)
 			}
@@ -326,6 +327,7 @@ func TestRawBootcImageSerializeCreateFilesDirs(t *testing.T) {
 				require.NotNil(t, copyStage)
 				copyOptions := copyStage.Options.(*osbuild.CopyStageOptions)
 				assert.Equal(t, "tree:///path/to/file", copyOptions.Paths[0].To)
+				assertBootcDeploymentAndBindMount(t, copyStage)
 			} else {
 				assert.Nil(t, copyStage)
 			}


### PR DESCRIPTION
Without this the files/dir stages will not have access to the generated container filesystem.

This was found by the integration test in
https://github.com/osbuild/bootc-image-builder/pull/841


P.S. this is now integration tested with https://github.com/osbuild/bootc-image-builder/pull/841 that pulls this in temporarily - the bib integration test now passes locally
[edit: the integration test in bib in https://github.com/osbuild/bootc-image-builder/pull/841 has now passed with this change in CI as well]