### PR TITLE
fedora: drop `firewalld` for minimal

### DIFF
--- a/pkg/distro/packagesets/fedora/package_sets.yaml
+++ b/pkg/distro/packagesets/fedora/package_sets.yaml
@@ -838,6 +838,10 @@ minimal_raw: &minimal
           - "dnf5"
           - "policycoreutils"
           - "selinux-policy-targeted"
+    version_greater_or_equal:
+      "43":
+        exclude:
+          - "firewalld"
 
 minimal_raw_zst:
   <<: *minimal


### PR DESCRIPTION
Drops `firewalld` for Fedora Minimal in rawhide for now, see issue [1].

[1]: https://github.com/fedora-minimal/distribution-minimal/issues/1