### PR TITLE
osbuild: add insights-client config stage (HMS-5670)

### DIFF
--- a/pkg/customizations/subscription/subscription.go
+++ b/pkg/customizations/subscription/subscription.go
@@ -15,6 +15,7 @@ type ImageOptions struct {
 	BaseUrl       string `json:"base_url"`
 	Insights      bool   `json:"insights"`
 	Rhc           bool   `json:"rhc"`
+	Proxy         string `json:"proxy"`
 }
 
 type RHSMStatus string

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -228,6 +228,9 @@ func osCustomizations(
 	var subscriptionStatus subscription.RHSMStatus
 	if options.Subscription != nil {
 		subscriptionStatus = subscription.RHSMConfigWithSubscription
+		if options.Subscription.Proxy != "" {
+			osc.InsightsClientConfig = &osbuild.InsightsClientConfigStageOptions{Proxy: options.Subscription.Proxy}
+		}
 	} else {
 		subscriptionStatus = subscription.RHSMConfigNoSubscription
 	}

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -99,35 +99,36 @@ type OSCustomizations struct {
 	ShellInit []shell.InitFile
 
 	// TODO: drop osbuild types from the API
-	Firewall            *osbuild.FirewallStageOptions
-	Grub2Config         *osbuild.GRUB2Config
-	Sysconfig           []*osbuild.SysconfigStageOptions
-	SystemdLogind       []*osbuild.SystemdLogindStageOptions
-	CloudInit           []*osbuild.CloudInitStageOptions
-	Modprobe            []*osbuild.ModprobeStageOptions
-	DracutConf          []*osbuild.DracutConfStageOptions
-	SystemdUnit         []*osbuild.SystemdUnitStageOptions
-	Authselect          *osbuild.AuthselectStageOptions
-	SELinuxConfig       *osbuild.SELinuxConfigStageOptions
-	Tuned               *osbuild.TunedStageOptions
-	Tmpfilesd           []*osbuild.TmpfilesdStageOptions
-	PamLimitsConf       []*osbuild.PamLimitsConfStageOptions
-	Sysctld             []*osbuild.SysctldStageOptions
-	DNFConfig           []*osbuild.DNFConfigStageOptions
-	DNFAutomaticConfig  *osbuild.DNFAutomaticConfigStageOptions
-	YUMConfig           *osbuild.YumConfigStageOptions
-	YUMRepos            []*osbuild.YumReposStageOptions
-	SshdConfig          *osbuild.SshdConfigStageOptions
-	GCPGuestAgentConfig *osbuild.GcpGuestAgentConfigOptions
-	AuthConfig          *osbuild.AuthconfigStageOptions
-	PwQuality           *osbuild.PwqualityConfStageOptions
-	NTPServers          []osbuild.ChronyConfigServer
-	WAAgentConfig       *osbuild.WAAgentConfStageOptions
-	UdevRules           *osbuild.UdevRulesStageOptions
-	WSLConfig           *osbuild.WSLConfStageOptions
-	LeapSecTZ           *string
-	Presets             []osbuild.Preset
-	ContainersStorage   *string
+	Firewall             *osbuild.FirewallStageOptions
+	Grub2Config          *osbuild.GRUB2Config
+	Sysconfig            []*osbuild.SysconfigStageOptions
+	SystemdLogind        []*osbuild.SystemdLogindStageOptions
+	CloudInit            []*osbuild.CloudInitStageOptions
+	Modprobe             []*osbuild.ModprobeStageOptions
+	DracutConf           []*osbuild.DracutConfStageOptions
+	SystemdUnit          []*osbuild.SystemdUnitStageOptions
+	Authselect           *osbuild.AuthselectStageOptions
+	SELinuxConfig        *osbuild.SELinuxConfigStageOptions
+	Tuned                *osbuild.TunedStageOptions
+	Tmpfilesd            []*osbuild.TmpfilesdStageOptions
+	PamLimitsConf        []*osbuild.PamLimitsConfStageOptions
+	Sysctld              []*osbuild.SysctldStageOptions
+	DNFConfig            []*osbuild.DNFConfigStageOptions
+	DNFAutomaticConfig   *osbuild.DNFAutomaticConfigStageOptions
+	YUMConfig            *osbuild.YumConfigStageOptions
+	YUMRepos             []*osbuild.YumReposStageOptions
+	SshdConfig           *osbuild.SshdConfigStageOptions
+	GCPGuestAgentConfig  *osbuild.GcpGuestAgentConfigOptions
+	AuthConfig           *osbuild.AuthconfigStageOptions
+	PwQuality            *osbuild.PwqualityConfStageOptions
+	NTPServers           []osbuild.ChronyConfigServer
+	WAAgentConfig        *osbuild.WAAgentConfStageOptions
+	UdevRules            *osbuild.UdevRulesStageOptions
+	WSLConfig            *osbuild.WSLConfStageOptions
+	InsightsClientConfig *osbuild.InsightsClientConfigStageOptions
+	LeapSecTZ            *string
+	Presets              []osbuild.Preset
+	ContainersStorage    *string
 
 	// OpenSCAP config
 	OpenSCAPRemediationConfig *oscap.RemediationConfig
@@ -634,7 +635,11 @@ func (p *OS) serialize() osbuild.Pipeline {
 	}
 
 	if p.SshdConfig != nil {
-		pipeline.AddStage((osbuild.NewSshdConfigStage(p.SshdConfig)))
+		pipeline.AddStage(osbuild.NewSshdConfigStage(p.SshdConfig))
+	}
+
+	if p.InsightsClientConfig != nil {
+		pipeline.AddStage(osbuild.NewInsightsClientConfigStage(p.InsightsClientConfig))
 	}
 
 	if p.AuthConfig != nil {

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -166,6 +166,17 @@ func TestBootupdStage(t *testing.T) {
 	require.NotNil(t, st)
 }
 
+func TestInsightsClientConfigStage(t *testing.T) {
+	os := manifest.NewTestOS()
+	os.OSCustomizations.InsightsClientConfig = &osbuild.InsightsClientConfigStageOptions{
+		Proxy: "some-proxy",
+		Path:  "some/path",
+	}
+	pipeline := os.Serialize()
+	st := manifest.FindStage("org.osbuild.insights-client.config", pipeline.Stages)
+	require.NotNil(t, st)
+}
+
 func TestTomlLibUsedNoneByDefault(t *testing.T) {
 	os := manifest.NewTestOS()
 	buildPkgs := os.GetBuildPackages(manifest.DISTRO_FEDORA)

--- a/pkg/osbuild/insights_client_config_stage.go
+++ b/pkg/osbuild/insights_client_config_stage.go
@@ -1,0 +1,15 @@
+package osbuild
+
+type InsightsClientConfigStageOptions struct {
+	Proxy string `json:"proxy,omitempty"`
+	Path  string `json:"path,omitempty"`
+}
+
+func (InsightsClientConfigStageOptions) isStageOptions() {}
+
+func NewInsightsClientConfigStage(options *InsightsClientConfigStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.insights-client.config",
+		Options: options,
+	}
+}

--- a/pkg/osbuild/insights_client_config_stage_test.go
+++ b/pkg/osbuild/insights_client_config_stage_test.go
@@ -1,0 +1,15 @@
+package osbuild
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewInsightsClientConfigStage(t *testing.T) {
+	expectedStage := &Stage{
+		Type:    "org.osbuild.insights-client.config",
+		Options: &InsightsClientConfigStageOptions{},
+	}
+	actualStage := NewInsightsClientConfigStage(&InsightsClientConfigStageOptions{})
+	assert.Equal(t, expectedStage, actualStage)
+}


### PR DESCRIPTION
Supports adding the insights-client config stage. Feedback and help much appreciated :)

stage added to osbuild here: https://github.com/osbuild/osbuild/pull/2030

JIRA: [HMS-5670](https://issues.redhat.com/browse/HMS-5670)