### PR TITLE
customization: sshkeys

### DIFF
--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -34,6 +34,7 @@ type Customizations struct {
 	RPM                *RPMCustomization              `json:"rpm,omitempty" toml:"rpm,omitempty"`
 	RHSM               *RHSMCustomization             `json:"rhsm,omitempty" toml:"rhsm,omitempty"`
 	CACerts            *CACustomization               `json:"cacerts,omitempty" toml:"cacerts,omitempty"`
+	SSHKey             []SSHKeyCustomization          `json:"sshkey,omitempty" toml:"sshkey,omitempty"`
 }
 
 type IgnitionCustomization struct {
@@ -231,6 +232,16 @@ func (c *Customizations) GetTimezoneSettings() (*string, []string) {
 		return nil, nil
 	}
 	return c.Timezone.Timezone, c.Timezone.NTPServers
+}
+
+func (c *Customizations) GetSSHKeys() []SSHKeyCustomization {
+	if c == nil || c.SSHKey == nil {
+		return nil
+	}
+
+	sshkeys := c.SSHKey
+
+	return sshkeys
 }
 
 func (c *Customizations) GetUsers() []UserCustomization {

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -573,3 +573,23 @@ func TestGetRepositoriesInstallFrom(t *testing.T) {
 	filtered := RepoCustomizationsInstallFromOnly(repos)
 	assert.Equal(t, expected, filtered)
 }
+
+func TestGetSSHKeys(t *testing.T) {
+	User := "testuser"
+	Key := "testkey"
+
+	expectedSSHKeys := []SSHKeyCustomization{
+		{
+			User: User,
+			Key:  Key,
+		},
+	}
+
+	TestCustomizations := Customizations{
+		SSHKey: expectedSSHKeys,
+	}
+
+	retSSHKeys := TestCustomizations.GetSSHKeys()
+
+	assert.ElementsMatch(t, expectedSSHKeys, retSSHKeys)
+}

--- a/pkg/customizations/sshkeys/sshkeys.go
+++ b/pkg/customizations/sshkeys/sshkeys.go
@@ -1,0 +1,6 @@
+package sshkeys
+
+type SSHKey struct {
+	User string
+	Key  string
+}

--- a/pkg/customizations/sshkeys/sshkeys.go
+++ b/pkg/customizations/sshkeys/sshkeys.go
@@ -1,6 +1,20 @@
 package sshkeys
 
+import "github.com/osbuild/images/pkg/blueprint"
+
 type SSHKey struct {
 	User string
 	Key  string
+}
+
+func SSHKeysFromBP(sshKeyCustomizations []blueprint.SSHKeyCustomization) []SSHKey {
+	sshkeys := make([]SSHKey, len(sshKeyCustomizations))
+
+	for idx := range sshKeyCustomizations {
+		// currently, they have the same structure, so we convert directly
+		// this will fail to compile as soon as one of the two changes
+		sshkeys[idx] = SSHKey(sshKeyCustomizations[idx])
+	}
+
+	return sshkeys
 }

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -15,6 +15,7 @@ import (
 	"github.com/osbuild/images/pkg/customizations/ignition"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
 	"github.com/osbuild/images/pkg/customizations/oscap"
+	"github.com/osbuild/images/pkg/customizations/sshkeys"
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/image"
@@ -67,10 +68,12 @@ func osCustomizations(
 	}
 
 	if !t.bootISO {
-		// don't put users and groups in the payload of an installer
+		// don't put users, groups or sshkeys, in the payload of an installer
 		// add them via kickstart instead
 		osc.Groups = users.GroupsFromBP(c.GetGroups())
 		osc.Users = users.UsersFromBP(c.GetUsers())
+
+		osc.SSHKeys = sshkeys.SSHKeysFromBP(c.GetSSHKeys())
 	}
 
 	osc.EnabledServices = imageConfig.EnabledServices

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -13,6 +13,7 @@ import (
 	"github.com/osbuild/images/pkg/customizations/ignition"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
 	"github.com/osbuild/images/pkg/customizations/oscap"
+	"github.com/osbuild/images/pkg/customizations/sshkeys"
 	"github.com/osbuild/images/pkg/customizations/subscription"
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/distro"
@@ -69,10 +70,12 @@ func osCustomizations(
 	}
 
 	if !t.BootISO {
-		// don't put users and groups in the payload of an installer
+		// don't put users, groups, or sshkeys, in the payload of an installer
 		// add them via kickstart instead
 		osc.Groups = users.GroupsFromBP(c.GetGroups())
 		osc.Users = users.UsersFromBP(c.GetUsers())
+
+		osc.SSHKeys = sshkeys.SSHKeysFromBP(c.GetSSHKeys())
 	}
 
 	osc.EnabledServices = imageConfig.EnabledServices

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -16,6 +16,7 @@ import (
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/oscap"
 	"github.com/osbuild/images/pkg/customizations/shell"
+	"github.com/osbuild/images/pkg/customizations/sshkeys"
 	"github.com/osbuild/images/pkg/customizations/subscription"
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/disk"
@@ -95,6 +96,8 @@ type OSCustomizations struct {
 
 	Groups []users.Group
 	Users  []users.User
+
+	SSHKeys []sshkeys.SSHKey
 
 	ShellInit []shell.InitFile
 


### PR DESCRIPTION
On Matrix it was figured out that our documented `SSHKey` customization doesn't work. After taking a look it seems like it wasn't actually ever plumbed through...

Since we've documented it I assume we want to support it so here's an initial PR that does just that. This PR would close https://github.com/osbuild/image-builder-cli/issues/142

After this PR the stages get injected to create files and directories:

```console
$ cat sshkey.toml 
[[customizations.sshkey]]
user = "testuser"
key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKNh/u8oWHfYwr01X8G8ijSC3hPfKfLpK8MISxg2mq1O user@muja.home.arpa"
$ ./image-builder manifest --distro fedora-43 --blueprint sshkey.toml minimal-raw-zst | jq . | rg testuser
                "path": "/home/testuser/.ssh",
                "to": "tree:///home/testuser/.ssh/authorized_keys",
                "to": "tree:///home/testuser/.ssh/authorized_keys",
```

Note that setting the SSH key for a nonexistent user will lead to a build failure.

---

As draft now as it needs tests, defensiveness in the customization parsing so we can fail earlier, and to move the filesystem generation to a helper function.

@achilleas-k how do we (or should we) handle the ostree case here? I see authorized keys is normally punted to a firstboot script.