### PR TITLE
testdisk: move TestPartitionTables to a function

### DIFF
--- a/internal/testdisk/partition.go
+++ b/internal/testdisk/partition.go
@@ -19,201 +19,48 @@ const FakePartitionSize = uint64(789) * MiB
 // generators below (MakeFake*). Maybe use NewCustomPartitionTable() to
 // generate test partition tables instead.
 
-var TestPartitionTables = map[string]disk.PartitionTable{
-	"plain": {
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: disk.PT_GPT,
-		Partitions: []disk.Partition{
-			{
-				Size:     1 * MiB,
-				Bootable: true,
-				Type:     disk.BIOSBootPartitionGUID,
-				UUID:     disk.BIOSBootPartitionUUID,
-			},
-			{
-				Size: 200 * MiB,
-				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
-					Mountpoint:   "/boot/efi",
-					Label:        "EFI-SYSTEM",
-					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-					FSTabFreq:    0,
-					FSTabPassNo:  2,
+func TestPartitionTables() map[string]disk.PartitionTable {
+	return map[string]disk.PartitionTable{
+		"plain": {
+			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+			Type: disk.PT_GPT,
+			Partitions: []disk.Partition{
+				{
+					Size:     1 * MiB,
+					Bootable: true,
+					Type:     disk.BIOSBootPartitionGUID,
+					UUID:     disk.BIOSBootPartitionUUID,
 				},
-			},
-			{
-				Size: 500 * MiB,
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.DataPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "xfs",
-					Mountpoint:   "/boot",
-					Label:        "boot",
-					FSTabOptions: "defaults",
-					FSTabFreq:    0,
-					FSTabPassNo:  0,
+				{
+					Size: 200 * MiB,
+					Type: disk.EFISystemPartitionGUID,
+					UUID: disk.EFISystemPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "vfat",
+						UUID:         disk.EFIFilesystemUUID,
+						Mountpoint:   "/boot/efi",
+						Label:        "EFI-SYSTEM",
+						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+						FSTabFreq:    0,
+						FSTabPassNo:  2,
+					},
 				},
-			},
-			{
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "xfs",
-					Label:        "root",
-					Mountpoint:   "/",
-					FSTabOptions: "defaults",
-					FSTabFreq:    0,
-					FSTabPassNo:  0,
+				{
+					Size: 500 * MiB,
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.DataPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Mountpoint:   "/boot",
+						Label:        "boot",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
 				},
-			},
-		},
-	},
-
-	"plain-swap": {
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: disk.PT_GPT,
-		Partitions: []disk.Partition{
-			{
-				Size:     1 * MiB,
-				Bootable: true,
-				Type:     disk.BIOSBootPartitionGUID,
-				UUID:     disk.BIOSBootPartitionUUID,
-			},
-			{
-				Size: 200 * MiB,
-				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
-					Mountpoint:   "/boot/efi",
-					Label:        "EFI-SYSTEM",
-					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-					FSTabFreq:    0,
-					FSTabPassNo:  2,
-				},
-			},
-			{
-				Size: 500 * MiB,
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.DataPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "xfs",
-					Mountpoint:   "/boot",
-					Label:        "boot",
-					FSTabOptions: "defaults",
-					FSTabFreq:    0,
-					FSTabPassNo:  0,
-				},
-			},
-			{
-				Size: 512 * MiB,
-				Type: disk.SwapPartitionGUID,
-				Payload: &disk.Swap{
-					Label:        "swap",
-					FSTabOptions: "defaults",
-				},
-			},
-			{
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "xfs",
-					Label:        "root",
-					Mountpoint:   "/",
-					FSTabOptions: "defaults",
-					FSTabFreq:    0,
-					FSTabPassNo:  0,
-				},
-			},
-		},
-	},
-
-	"plain-noboot": {
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: disk.PT_GPT,
-		Partitions: []disk.Partition{
-			{
-				Size:     1 * MiB,
-				Bootable: true,
-				Type:     disk.BIOSBootPartitionGUID,
-				UUID:     disk.BIOSBootPartitionUUID,
-			},
-			{
-				Size: 200 * MiB,
-				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
-					Mountpoint:   "/boot/efi",
-					Label:        "EFI-SYSTEM",
-					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-					FSTabFreq:    0,
-					FSTabPassNo:  2,
-				},
-			},
-			{
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "xfs",
-					Label:        "root",
-					Mountpoint:   "/",
-					FSTabOptions: "defaults",
-					FSTabFreq:    0,
-					FSTabPassNo:  0,
-				},
-			},
-		},
-	},
-
-	"luks": {
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: disk.PT_GPT,
-		Partitions: []disk.Partition{
-			{
-				Size:     1 * MiB,
-				Bootable: true,
-				Type:     disk.BIOSBootPartitionGUID,
-				UUID:     disk.BIOSBootPartitionUUID,
-			},
-			{
-				Size: 200 * MiB,
-				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
-					Mountpoint:   "/boot/efi",
-					Label:        "EFI-SYSTEM",
-					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-					FSTabFreq:    0,
-					FSTabPassNo:  2,
-				},
-			},
-			{
-				Size: 500 * MiB,
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.DataPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "xfs",
-					Mountpoint:   "/boot",
-					Label:        "boot",
-					FSTabOptions: "defaults",
-					FSTabFreq:    0,
-					FSTabPassNo:  0,
-				},
-			},
-			{
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
-				Payload: &disk.LUKSContainer{
-					UUID:  "",
-					Label: "crypt_root",
+				{
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.RootPartitionUUID,
 					Payload: &disk.Filesystem{
 						Type:         "xfs",
 						Label:        "root",
@@ -225,74 +72,229 @@ var TestPartitionTables = map[string]disk.PartitionTable{
 				},
 			},
 		},
-	},
-	"luks+lvm": {
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: disk.PT_GPT,
-		Partitions: []disk.Partition{
-			{
-				Size:     1 * MiB,
-				Bootable: true,
-				Type:     disk.BIOSBootPartitionGUID,
-				UUID:     disk.BIOSBootPartitionUUID,
-			},
-			{
-				Size: 200 * MiB,
-				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
-					Mountpoint:   "/boot/efi",
-					Label:        "EFI-SYSTEM",
-					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-					FSTabFreq:    0,
-					FSTabPassNo:  2,
+
+		"plain-swap": {
+			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+			Type: disk.PT_GPT,
+			Partitions: []disk.Partition{
+				{
+					Size:     1 * MiB,
+					Bootable: true,
+					Type:     disk.BIOSBootPartitionGUID,
+					UUID:     disk.BIOSBootPartitionUUID,
+				},
+				{
+					Size: 200 * MiB,
+					Type: disk.EFISystemPartitionGUID,
+					UUID: disk.EFISystemPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "vfat",
+						UUID:         disk.EFIFilesystemUUID,
+						Mountpoint:   "/boot/efi",
+						Label:        "EFI-SYSTEM",
+						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+						FSTabFreq:    0,
+						FSTabPassNo:  2,
+					},
+				},
+				{
+					Size: 500 * MiB,
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.DataPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Mountpoint:   "/boot",
+						Label:        "boot",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
+				},
+				{
+					Size: 512 * MiB,
+					Type: disk.SwapPartitionGUID,
+					Payload: &disk.Swap{
+						Label:        "swap",
+						FSTabOptions: "defaults",
+					},
+				},
+				{
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.RootPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Label:        "root",
+						Mountpoint:   "/",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
 				},
 			},
-			{
-				Size: 500 * MiB,
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.DataPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "xfs",
-					Mountpoint:   "/boot",
-					Label:        "boot",
-					FSTabOptions: "defaults",
-					FSTabFreq:    0,
-					FSTabPassNo:  0,
+		},
+
+		"plain-noboot": {
+			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+			Type: disk.PT_GPT,
+			Partitions: []disk.Partition{
+				{
+					Size:     1 * MiB,
+					Bootable: true,
+					Type:     disk.BIOSBootPartitionGUID,
+					UUID:     disk.BIOSBootPartitionUUID,
+				},
+				{
+					Size: 200 * MiB,
+					Type: disk.EFISystemPartitionGUID,
+					UUID: disk.EFISystemPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "vfat",
+						UUID:         disk.EFIFilesystemUUID,
+						Mountpoint:   "/boot/efi",
+						Label:        "EFI-SYSTEM",
+						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+						FSTabFreq:    0,
+						FSTabPassNo:  2,
+					},
+				},
+				{
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.RootPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Label:        "root",
+						Mountpoint:   "/",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
 				},
 			},
-			{
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
-				Size: 5 * GiB,
-				Payload: &disk.LUKSContainer{
-					UUID: "",
-					Payload: &disk.LVMVolumeGroup{
-						Name:        "",
-						Description: "",
-						LogicalVolumes: []disk.LVMLogicalVolume{
-							{
-								Size: 2 * GiB,
-								Payload: &disk.Filesystem{
-									Type:         "xfs",
-									Label:        "root",
-									Mountpoint:   "/",
-									FSTabOptions: "defaults",
-									FSTabFreq:    0,
-									FSTabPassNo:  0,
+		},
+
+		"luks": {
+			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+			Type: disk.PT_GPT,
+			Partitions: []disk.Partition{
+				{
+					Size:     1 * MiB,
+					Bootable: true,
+					Type:     disk.BIOSBootPartitionGUID,
+					UUID:     disk.BIOSBootPartitionUUID,
+				},
+				{
+					Size: 200 * MiB,
+					Type: disk.EFISystemPartitionGUID,
+					UUID: disk.EFISystemPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "vfat",
+						UUID:         disk.EFIFilesystemUUID,
+						Mountpoint:   "/boot/efi",
+						Label:        "EFI-SYSTEM",
+						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+						FSTabFreq:    0,
+						FSTabPassNo:  2,
+					},
+				},
+				{
+					Size: 500 * MiB,
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.DataPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Mountpoint:   "/boot",
+						Label:        "boot",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
+				},
+				{
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.RootPartitionUUID,
+					Payload: &disk.LUKSContainer{
+						UUID:  "",
+						Label: "crypt_root",
+						Payload: &disk.Filesystem{
+							Type:         "xfs",
+							Label:        "root",
+							Mountpoint:   "/",
+							FSTabOptions: "defaults",
+							FSTabFreq:    0,
+							FSTabPassNo:  0,
+						},
+					},
+				},
+			},
+		},
+		"luks+lvm": {
+			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+			Type: disk.PT_GPT,
+			Partitions: []disk.Partition{
+				{
+					Size:     1 * MiB,
+					Bootable: true,
+					Type:     disk.BIOSBootPartitionGUID,
+					UUID:     disk.BIOSBootPartitionUUID,
+				},
+				{
+					Size: 200 * MiB,
+					Type: disk.EFISystemPartitionGUID,
+					UUID: disk.EFISystemPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "vfat",
+						UUID:         disk.EFIFilesystemUUID,
+						Mountpoint:   "/boot/efi",
+						Label:        "EFI-SYSTEM",
+						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+						FSTabFreq:    0,
+						FSTabPassNo:  2,
+					},
+				},
+				{
+					Size: 500 * MiB,
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.DataPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Mountpoint:   "/boot",
+						Label:        "boot",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
+				},
+				{
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.RootPartitionUUID,
+					Size: 5 * GiB,
+					Payload: &disk.LUKSContainer{
+						UUID: "",
+						Payload: &disk.LVMVolumeGroup{
+							Name:        "",
+							Description: "",
+							LogicalVolumes: []disk.LVMLogicalVolume{
+								{
+									Size: 2 * GiB,
+									Payload: &disk.Filesystem{
+										Type:         "xfs",
+										Label:        "root",
+										Mountpoint:   "/",
+										FSTabOptions: "defaults",
+										FSTabFreq:    0,
+										FSTabPassNo:  0,
+									},
 								},
-							},
-							{
-								Size: 2 * GiB,
-								Payload: &disk.Filesystem{
-									Type:         "xfs",
-									Label:        "root",
-									Mountpoint:   "/home",
-									FSTabOptions: "defaults",
-									FSTabFreq:    0,
-									FSTabPassNo:  0,
+								{
+									Size: 2 * GiB,
+									Payload: &disk.Filesystem{
+										Type:         "xfs",
+										Label:        "root",
+										Mountpoint:   "/home",
+										FSTabOptions: "defaults",
+										FSTabFreq:    0,
+										FSTabPassNo:  0,
+									},
 								},
 							},
 						},
@@ -300,70 +302,70 @@ var TestPartitionTables = map[string]disk.PartitionTable{
 				},
 			},
 		},
-	},
-	"btrfs": {
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: disk.PT_GPT,
-		Partitions: []disk.Partition{
-			{
-				Size:     1 * MiB,
-				Bootable: true,
-				Type:     disk.BIOSBootPartitionGUID,
-				UUID:     disk.BIOSBootPartitionUUID,
-			},
-			{
-				Size: 200 * MiB,
-				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
-					Mountpoint:   "/boot/efi",
-					Label:        "EFI-SYSTEM",
-					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-					FSTabFreq:    0,
-					FSTabPassNo:  2,
+		"btrfs": {
+			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+			Type: disk.PT_GPT,
+			Partitions: []disk.Partition{
+				{
+					Size:     1 * MiB,
+					Bootable: true,
+					Type:     disk.BIOSBootPartitionGUID,
+					UUID:     disk.BIOSBootPartitionUUID,
 				},
-			},
-			{
-				Size: 500 * MiB,
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.DataPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "xfs",
-					Mountpoint:   "/boot",
-					Label:        "boot",
-					FSTabOptions: "defaults",
-					FSTabFreq:    0,
-					FSTabPassNo:  0,
+				{
+					Size: 200 * MiB,
+					Type: disk.EFISystemPartitionGUID,
+					UUID: disk.EFISystemPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "vfat",
+						UUID:         disk.EFIFilesystemUUID,
+						Mountpoint:   "/boot/efi",
+						Label:        "EFI-SYSTEM",
+						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+						FSTabFreq:    0,
+						FSTabPassNo:  2,
+					},
 				},
-			},
-			{
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
-				Size: 10 * GiB,
-				Payload: &disk.Btrfs{
-					UUID:       "",
-					Label:      "",
-					Mountpoint: "",
-					Subvolumes: []disk.BtrfsSubvolume{
-						{
-							Name:       "root",
-							Size:       0,
-							Mountpoint: "/",
-							GroupID:    0,
-						},
-						{
-							Name:       "var",
-							Size:       5 * GiB,
-							Mountpoint: "/var",
-							GroupID:    0,
+				{
+					Size: 500 * MiB,
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.DataPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Mountpoint:   "/boot",
+						Label:        "boot",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
+				},
+				{
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.RootPartitionUUID,
+					Size: 10 * GiB,
+					Payload: &disk.Btrfs{
+						UUID:       "",
+						Label:      "",
+						Mountpoint: "",
+						Subvolumes: []disk.BtrfsSubvolume{
+							{
+								Name:       "root",
+								Size:       0,
+								Mountpoint: "/",
+								GroupID:    0,
+							},
+							{
+								Name:       "var",
+								Size:       5 * GiB,
+								Mountpoint: "/var",
+								GroupID:    0,
+							},
 						},
 					},
 				},
 			},
 		},
-	},
+	}
 }
 
 // MakeFakePartitionTable is a helper to create partition table structs

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -2680,13 +2680,12 @@ func TestPartitionTableFeatures(t *testing.T) {
 		"btrfs":        {XFS: true, FAT: true, Btrfs: true},
 	}
 
-	for name := range testdisk.TestPartitionTables {
+	for name, pt := range testdisk.TestPartitionTables() {
 		// print an informative failure message if a new test partition
 		// table is added and this test is not updated (instead of failing
 		// at the final Equal() check)
 		exp, ok := testCases[name]
 		require.True(ok, "expected test result not defined for test partition table %q: please update the %s test", name, t.Name())
-		pt := testdisk.TestPartitionTables[name]
 		require.Equal(exp, disk.GetPartitionTableFeatures(pt))
 	}
 }

--- a/pkg/osbuild/fstab_stage_test.go
+++ b/pkg/osbuild/fstab_stage_test.go
@@ -103,12 +103,11 @@ func TestNewFSTabStageOptions(t *testing.T) {
 		},
 	}
 	// Use the test partition tables from the disk package.
-	for name := range testdisk.TestPartitionTables {
+	for name, pt := range testdisk.TestPartitionTables() {
 		// use a different name for the internal testing argument so we can
 		// refer to the global test by t.Name() in the error message
 		t.Run(name, func(ts *testing.T) {
 			require := require.New(ts)
-			pt := testdisk.TestPartitionTables[name]
 
 			// math/rand is good enough in this case
 			/* #nosec G404 */


### PR DESCRIPTION
Move the static TestPartitionTables into a function.  Having them in a mutable, package-global, public map makes any modification in one test affect subsequent ones.