### PR TITLE
packagesets: introduce  `IMAGE_BUILDER_EXPERIMENTAL=yamldir=...`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,27 @@ Please refer to the [developer guide](https://www.osbuild.org/docs/developer-gui
 
 See also the [local developer documentation](./docs/developer) for useful information about working with this specific project.
 
+#### YAML based image definitions
+
+More and more parts of the library are converted to use yaml to define core
+parts of an image. See this [example](./pkg/distro/packagesets/fedora/)
+directory. For local development that just changes the YAML based
+definitions the library can be forced to use alternative yaml dirs.
+
+E.g. if there is a `./my-yaml/fedora/package-sets.yaml` then that can be
+used via:
+```console
+$ IMAGE_BUILDER_EXPERIMENTAL=yamldir=./my-yaml image-builder build minimal-raw --distro fedora-42
+```
+WARNING: this is an experimental feature and unsupported feature that should
+never be used in production and may change anytime.
+
+We do plan to eventually stabilize this so that it can be a switch for
+the `image-builder` tool but for now this environment option is
+required.
+
+#### Build requirements
+
 The build-requirements of the Go library for Fedora and rpm-based distributions are:
 
 - `go`

--- a/pkg/distro/packagesets/loader.go
+++ b/pkg/distro/packagesets/loader.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
 	"github.com/osbuild/images/internal/common"
@@ -60,6 +61,7 @@ func Load(it distro.ImageType, overrideTypeName string, replacements map[string]
 	// searchPaths down the stack instead
 	var dataFS fs.FS = DataFS
 	if overrideDir := experimentalflags.String("yamldir"); overrideDir != "" {
+		logrus.Warnf("using experimental override dir %q", overrideDir)
 		dataFS = os.DirFS(overrideDir)
 	}
 	f, err := dataFS.Open(filepath.Join(distroName, "package_sets.yaml"))


### PR DESCRIPTION
This commit adds a new `IMAGE_BUILDER_EXPERIMENTAL=yamldir=...`
experimental flag to force setting the datadir for the yaml
directory to override e.g. packagesets.

Ideally we would pass this all the way down the stack via a
search path but this will require a bunch of more refactoring.
So to give people the ability to tweak packagesets today, start
here.

Thanks to Ondrej for the suggestion, see also https://github.com/osbuild/images/pull/1283 where this will become immediately useful when the centos folks start hacking on our package lists.