### PR TITLE
packagesets: add distro_name condition

### DIFF
--- a/pkg/distro/packagesets/export_test.go
+++ b/pkg/distro/packagesets/export_test.go
@@ -1,0 +1,13 @@
+package packagesets
+
+import (
+	"os"
+)
+
+func MockDataFS(path string) (restore func()) {
+	saved := DataFS
+	DataFS = os.DirFS(path)
+	return func() {
+		DataFS = saved
+	}
+}

--- a/pkg/distro/packagesets/loader_test.go
+++ b/pkg/distro/packagesets/loader_test.go
@@ -1,0 +1,63 @@
+package packagesets_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distro/packagesets"
+	"github.com/osbuild/images/pkg/distro/test_distro"
+	"github.com/osbuild/images/pkg/rpmmd"
+)
+
+func makeTestImageType(t *testing.T) distro.ImageType {
+	// XXX: it would be nice if testdistro had a ready-made image-type,
+	// i.e. testdistro.TestImageType1
+	distro := test_distro.DistroFactory(test_distro.TestDistro1Name)
+	arch, err := distro.GetArch(test_distro.TestArchName)
+	assert.NoError(t, err)
+	it, err := arch.GetImageType(test_distro.TestImageTypeName)
+	assert.NoError(t, err)
+	return it
+}
+
+func makeFakePkgsSet(t *testing.T, distroName, content string) string {
+	tmpdir := t.TempDir()
+	fakePkgsSetPath := filepath.Join(tmpdir, distroName, "package_sets.yaml")
+	err := os.MkdirAll(filepath.Dir(fakePkgsSetPath), 0755)
+	assert.NoError(t, err)
+	err = os.WriteFile(fakePkgsSetPath, []byte(content), 0644)
+	assert.NoError(t, err)
+	return tmpdir
+}
+
+func TestLoadConditionDistro(t *testing.T) {
+	it := makeTestImageType(t)
+	fakePkgsSetYaml := `
+test_type:
+  include: [inc1]
+  exclude: [exc1]
+  condition:
+    distro_name:
+      test-distro:
+        include: [from-condition-inc2]
+        exclude: [from-condition-exc2]
+      other-distro:
+        include: [inc3]
+        exclude: [exc3]
+`
+	// XXX: we cannot use distro.Name() as it will give us a name+ver
+	baseDir := makeFakePkgsSet(t, test_distro.TestDistroNameBase, fakePkgsSetYaml)
+	restore := packagesets.MockDataFS(baseDir)
+	defer restore()
+
+	pkgSet := packagesets.Load(it, nil)
+	assert.NotNil(t, pkgSet)
+	assert.Equal(t, rpmmd.PackageSet{
+		Include: []string{"inc1", "from-condition-inc2"},
+		Exclude: []string{"exc1", "from-condition-exc2"},
+	}, pkgSet)
+}


### PR DESCRIPTION
This commit allows packagesets to be conditional on the distribution name. This is useful when we define packagesets for RHEL/Centos where we only want to pull in certain packages like "subscription-manager" when building images for RHEL.

Cleaned up split out of https://github.com/osbuild/images/pull/1283/commits