### PR TITLE
Use grub2 for BIOS iso booting

### DIFF
--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -737,6 +737,11 @@ func iotInstallerImage(workload workload.Workload,
 		img.RootfsType = manifest.SquashfsRootfs
 	}
 
+	// Enable grub2 BIOS iso on x86_64 only
+	if img.Platform.GetArch() == arch.ARCH_X86_64 {
+		img.ISOBoot = manifest.Grub2ISOBoot
+	}
+
 	if locale := t.getDefaultImageConfig().Locale; locale != nil {
 		img.Locale = *locale
 	}

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/workload"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/anaconda"
@@ -417,6 +418,11 @@ func liveInstallerImage(workload workload.Workload,
 
 	if common.VersionGreaterThanOrEqual(img.OSVersion, VERSION_ROOTFS_SQUASHFS) {
 		img.RootfsType = manifest.SquashfsRootfs
+	}
+
+	// Enable grub2 BIOS iso on x86_64 only
+	if img.Platform.GetArch() == arch.ARCH_X86_64 {
+		img.ISOBoot = manifest.Grub2ISOBoot
 	}
 
 	if locale := t.getDefaultImageConfig().Locale; locale != nil {

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -526,6 +526,11 @@ func imageInstallerImage(workload workload.Workload,
 		img.RootfsType = manifest.SquashfsRootfs
 	}
 
+	// Enable grub2 BIOS iso on x86_64 only
+	if img.Platform.GetArch() == arch.ARCH_X86_64 {
+		img.ISOBoot = manifest.Grub2ISOBoot
+	}
+
 	return img, nil
 }
 

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -750,6 +750,17 @@ func ImageInstallerImage(workload workload.Workload,
 		img.RootfsType = manifest.SquashfsRootfs
 	}
 
+	// Enable BIOS iso on x86_64 only
+	// Use grub2 on RHEL10, otherwise use syslinux
+	// NOTE: Will need to be updated for RHEL11 and later
+	if img.Platform.GetArch() == arch.ARCH_X86_64 {
+		if t.Arch().Distro().Releasever() == "10" {
+			img.ISOBoot = manifest.Grub2ISOBoot
+		} else {
+			img.ISOBoot = manifest.SyslinuxISOBoot
+		}
+	}
+
 	// put the kickstart file in the root of the iso
 	img.ISORootKickstart = true
 

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 
 	"github.com/osbuild/images/internal/workload"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/anaconda"
@@ -510,6 +511,17 @@ func EdgeInstallerImage(workload workload.Workload,
 	img.RootfsCompression = "xz"
 	if t.Arch().Distro().Releasever() == "10" {
 		img.RootfsType = manifest.SquashfsRootfs
+	}
+
+	// Enable BIOS iso on x86_64 only
+	// Use grub2 on RHEL10, otherwise use syslinux
+	// NOTE: Will need to be updated for RHEL11 and later
+	if img.Platform.GetArch() == arch.ARCH_X86_64 {
+		if t.Arch().Distro().Releasever() == "10" {
+			img.ISOBoot = manifest.Grub2ISOBoot
+		} else {
+			img.ISOBoot = manifest.SyslinuxISOBoot
+		}
 	}
 
 	installerConfig, err := t.getDefaultInstallerConfig()

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -24,6 +24,7 @@ type AnacondaContainerInstaller struct {
 
 	RootfsCompression string
 	RootfsType        manifest.RootfsType
+	ISOBoot           manifest.ISOBootType
 
 	ISOLabel  string
 	Product   string
@@ -131,9 +132,6 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 		bootTreePipeline.KernelOpts = append(bootTreePipeline.KernelOpts, "fips=1")
 	}
 
-	// enable ISOLinux on x86_64 only
-	isoLinuxEnabled := img.Platform.GetArch() == arch.ARCH_X86_64
-
 	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(buildPipeline, anacondaPipeline, rootfsImagePipeline, bootTreePipeline)
 	isoTreePipeline.PartitionTable = efiBootPartitionTable(rng)
 	isoTreePipeline.Release = img.Release
@@ -147,14 +145,14 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.PayloadRemoveSignatures = img.ContainerRemoveSignatures
 
 	isoTreePipeline.ContainerSource = &img.ContainerSource
-	isoTreePipeline.ISOLinux = isoLinuxEnabled
+	isoTreePipeline.ISOBoot = img.ISOBoot
 	if img.FIPS {
 		isoTreePipeline.KernelOpts = append(isoTreePipeline.KernelOpts, "fips=1")
 	}
 
 	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, img.ISOLabel)
 	isoPipeline.SetFilename(img.Filename)
-	isoPipeline.ISOLinux = isoLinuxEnabled
+	isoPipeline.ISOBoot = img.ISOBoot
 	artifact := isoPipeline.Export()
 
 	return artifact, nil

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -25,6 +25,7 @@ type AnacondaLiveInstaller struct {
 
 	RootfsCompression string
 	RootfsType        manifest.RootfsType
+	ISOBoot           manifest.ISOBootType
 
 	ISOLabel  string
 	Product   string
@@ -105,22 +106,19 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	bootTreePipeline.KernelOpts = kernelOpts
 
-	// enable ISOLinux on x86_64 only
-	isoLinuxEnabled := img.Platform.GetArch() == arch.ARCH_X86_64
-
 	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(buildPipeline, livePipeline, rootfsImagePipeline, bootTreePipeline)
 	isoTreePipeline.PartitionTable = efiBootPartitionTable(rng)
 	isoTreePipeline.Release = img.Release
 
 	isoTreePipeline.KernelOpts = kernelOpts
-	isoTreePipeline.ISOLinux = isoLinuxEnabled
+	isoTreePipeline.ISOBoot = img.ISOBoot
 
 	isoTreePipeline.RootfsCompression = img.RootfsCompression
 	isoTreePipeline.RootfsType = img.RootfsType
 
 	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, img.ISOLabel)
 	isoPipeline.SetFilename(img.Filename)
-	isoPipeline.ISOLinux = isoLinuxEnabled
+	isoPipeline.ISOBoot = img.ISOBoot
 
 	artifact := isoPipeline.Export()
 

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -30,6 +30,7 @@ type AnacondaOSTreeInstaller struct {
 
 	RootfsCompression string
 	RootfsType        manifest.RootfsType
+	ISOBoot           manifest.ISOBootType
 
 	ISOLabel  string
 	Product   string
@@ -133,9 +134,6 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 		bootTreePipeline.KernelOpts = append(bootTreePipeline.KernelOpts, "fips=1")
 	}
 
-	// enable ISOLinux on x86_64 only
-	isoLinuxEnabled := img.Platform.GetArch() == arch.ARCH_X86_64
-
 	var subscriptionPipeline *manifest.Subscription
 	if img.Subscription != nil {
 		// pipeline that will create subscription service and key file to be copied out
@@ -152,7 +150,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.PayloadPath = "/ostree/repo"
 
 	isoTreePipeline.OSTreeCommitSource = &img.Commit
-	isoTreePipeline.ISOLinux = isoLinuxEnabled
+	isoTreePipeline.ISOBoot = img.ISOBoot
 	if img.FIPS {
 		isoTreePipeline.KernelOpts = append(isoTreePipeline.KernelOpts, "fips=1")
 	}
@@ -160,7 +158,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, img.ISOLabel)
 	isoPipeline.SetFilename(img.Filename)
-	isoPipeline.ISOLinux = isoLinuxEnabled
+	isoPipeline.ISOBoot = img.ISOBoot
 	artifact := isoPipeline.Export()
 
 	return artifact, nil

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -58,6 +58,7 @@ type AnacondaTarInstaller struct {
 
 	RootfsCompression string
 	RootfsType        manifest.RootfsType
+	ISOBoot           manifest.ISOBootType
 
 	ISOLabel  string
 	Product   string
@@ -184,9 +185,6 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.Environment = img.Environment
 	osPipeline.Workload = img.Workload
 
-	// enable ISOLinux on x86_64 only
-	isoLinuxEnabled := img.Platform.GetArch() == arch.ARCH_X86_64
-
 	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(buildPipeline, anacondaPipeline, rootfsImagePipeline, bootTreePipeline)
 	// TODO: the partition table is required - make it a ctor arg or set a default one in the pipeline
 	isoTreePipeline.PartitionTable = efiBootPartitionTable(rng)
@@ -206,11 +204,11 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 		isoTreePipeline.KernelOpts = append(isoTreePipeline.KernelOpts, "fips=1")
 	}
 
-	isoTreePipeline.ISOLinux = isoLinuxEnabled
+	isoTreePipeline.ISOBoot = img.ISOBoot
 
 	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, img.ISOLabel)
 	isoPipeline.SetFilename(img.Filename)
-	isoPipeline.ISOLinux = isoLinuxEnabled
+	isoPipeline.ISOBoot = img.ISOBoot
 
 	artifact := isoPipeline.Export()
 

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -156,7 +156,9 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, isoLabel)
 	isoPipeline.SetFilename(img.Filename)
-	isoPipeline.ISOLinux = isoLinuxEnabled
+	if isoLinuxEnabled {
+		isoPipeline.ISOBoot = manifest.SyslinuxISOBoot
+	}
 
 	artifact := isoPipeline.Export()
 	return artifact, nil

--- a/pkg/manifest/iso_test.go
+++ b/pkg/manifest/iso_test.go
@@ -1,0 +1,27 @@
+package manifest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestISOBoot(t *testing.T) {
+	options := xorrisofsStageOptions("boot.iso", "test-iso-1", Grub2UEFIOnlyISOBoot)
+	assert.Nil(t, options.Boot)
+	assert.Equal(t, "", options.IsohybridMBR)
+	assert.Equal(t, "", options.Grub2MBR)
+
+	options = xorrisofsStageOptions("boot.iso", "test-iso-1", SyslinuxISOBoot)
+	require.NotNil(t, options.Boot)
+	assert.Equal(t, "isolinux/isolinux.bin", options.Boot.Image)
+	assert.Equal(t, "/usr/share/syslinux/isohdpfx.bin", options.IsohybridMBR)
+	assert.Equal(t, "", options.Grub2MBR)
+
+	options = xorrisofsStageOptions("boot.iso", "test-iso-1", Grub2ISOBoot)
+	require.NotNil(t, options.Boot)
+	assert.Equal(t, "images/eltorito.img", options.Boot.Image)
+	assert.Equal(t, "/usr/lib/grub/i386-pc/boot_hybrid.img", options.Grub2MBR)
+	assert.Equal(t, "", options.IsohybridMBR)
+}

--- a/pkg/osbuild/grub2_inst_stage_test.go
+++ b/pkg/osbuild/grub2_inst_stage_test.go
@@ -13,7 +13,7 @@ func TestNewGrub2InstStage(t *testing.T) {
 	options := Grub2InstStageOptions{
 		Filename: "img.raw",
 		Platform: "i386-pc",
-		Location: 2048,
+		Location: common.ToPtr(uint64(2048)),
 		Core: CoreMkImage{
 			Type:       "mkimage",
 			PartLabel:  "gpt",
@@ -22,7 +22,7 @@ func TestNewGrub2InstStage(t *testing.T) {
 		Prefix: PrefixPartition{
 			Type:      "partition",
 			PartLabel: "gpt",
-			Number:    1,
+			Number:    common.ToPtr(uint(1)),
 			Path:      "/boot/grub2",
 		},
 		SectorSize: common.ToPtr(uint64(512)),
@@ -42,7 +42,7 @@ func TestMarshalGrub2InstStage(t *testing.T) {
 		return Grub2InstStageOptions{
 			Filename: "img.raw",
 			Platform: "i386-pc",
-			Location: 2048,
+			Location: common.ToPtr(uint64(2048)),
 			Core: CoreMkImage{
 				Type:       "mkimage",
 				PartLabel:  "gpt",
@@ -51,7 +51,7 @@ func TestMarshalGrub2InstStage(t *testing.T) {
 			Prefix: PrefixPartition{
 				Type:      "partition",
 				PartLabel: "gpt",
-				Number:    1,
+				Number:    common.ToPtr(uint(1)),
 				Path:      "/boot/grub2",
 			},
 			SectorSize: common.ToPtr(uint64(512)),
@@ -110,4 +110,11 @@ func TestMarshalGrub2InstStage(t *testing.T) {
 		_, err := json.Marshal(stage)
 		assert.Error(t, err)
 	}
+}
+
+func TestMarshalGrub2InstStageISO9660(t *testing.T) {
+	options := NewGrub2InstISO9660StageOption("image/eltorito.img", "/boot/grub2")
+	stage := NewGrub2InstStage(options)
+	_, err := json.Marshal(stage)
+	assert.NoError(t, err)
 }

--- a/pkg/osbuild/grub2_iso_legacy_stage.go
+++ b/pkg/osbuild/grub2_iso_legacy_stage.go
@@ -1,0 +1,50 @@
+package osbuild
+
+import "fmt"
+
+const grub2isoLegacyStageType = "org.osbuild.grub2.iso.legacy"
+
+type Grub2ISOLegacyStageOptions struct {
+	Product Product `json:"product"`
+
+	Kernel ISOKernel `json:"kernel"`
+
+	ISOLabel string `json:"isolabel"`
+}
+
+func (Grub2ISOLegacyStageOptions) isStageOptions() {}
+
+func (o Grub2ISOLegacyStageOptions) validate() error {
+	// The stage schema marks product.name, product.version, kernel.dir, and
+	// isolabel as required.  Empty values are technically valid according to
+	// the schema, but here we will consider them invalid.
+
+	if o.Product.Name == "" {
+		return fmt.Errorf("%s: product.name option is required", grub2isoLegacyStageType)
+	}
+
+	if o.Product.Version == "" {
+		return fmt.Errorf("%s: product.version option is required", grub2isoLegacyStageType)
+	}
+
+	if o.Kernel.Dir == "" {
+		return fmt.Errorf("%s: kernel.dir option is required", grub2isoLegacyStageType)
+	}
+
+	if o.ISOLabel == "" {
+		return fmt.Errorf("%s: isolabel option is required", grub2isoLegacyStageType)
+	}
+
+	return nil
+}
+
+// Assemble a file system tree for a bootable ISO
+func NewGrub2ISOLegacyStage(options *Grub2ISOLegacyStageOptions) *Stage {
+	if err := options.validate(); err != nil {
+		panic(err)
+	}
+	return &Stage{
+		Type:    grub2isoLegacyStageType,
+		Options: options,
+	}
+}

--- a/pkg/osbuild/grub2_iso_legacy_stage_test.go
+++ b/pkg/osbuild/grub2_iso_legacy_stage_test.go
@@ -1,0 +1,92 @@
+package osbuild_test
+
+import (
+	"testing"
+
+	"github.com/osbuild/images/pkg/osbuild"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGrub2IsoLegacyStageValidation(t *testing.T) {
+	type testCase struct {
+		options       osbuild.Grub2ISOLegacyStageOptions
+		expectedError string
+	}
+
+	testCases := map[string]testCase{
+		"happy": {
+			options: osbuild.Grub2ISOLegacyStageOptions{
+				Product: osbuild.Product{
+					Name:    "whatever",
+					Version: "42",
+				},
+				Kernel: osbuild.ISOKernel{
+					Dir: "/path",
+				},
+				ISOLabel: "whatever-42-workstation",
+			},
+		},
+		"no product name": {
+			options: osbuild.Grub2ISOLegacyStageOptions{
+				Product: osbuild.Product{
+					Version: "42",
+				},
+				Kernel: osbuild.ISOKernel{
+					Dir: "/path",
+				},
+				ISOLabel: "whatever-42-workstation",
+			},
+			expectedError: "org.osbuild.grub2.iso.legacy: product.name option is required",
+		},
+		"no product version": {
+			options: osbuild.Grub2ISOLegacyStageOptions{
+				Product: osbuild.Product{
+					Name: "whatever",
+				},
+				Kernel: osbuild.ISOKernel{
+					Dir: "/path",
+				},
+				ISOLabel: "whatever-42-workstation",
+			},
+			expectedError: "org.osbuild.grub2.iso.legacy: product.version option is required",
+		},
+		"no kernel dir": {
+			options: osbuild.Grub2ISOLegacyStageOptions{
+				Product: osbuild.Product{
+					Name:    "whatever",
+					Version: "13",
+				},
+				Kernel:   osbuild.ISOKernel{},
+				ISOLabel: "whatever-42-workstation",
+			},
+			expectedError: "org.osbuild.grub2.iso.legacy: kernel.dir option is required",
+		},
+		"no isolabel": {
+			options: osbuild.Grub2ISOLegacyStageOptions{
+				Product: osbuild.Product{
+					Name:    "whatever",
+					Version: "13",
+				},
+				Kernel: osbuild.ISOKernel{
+					Dir: "/doesnt/matter",
+				},
+			},
+			expectedError: "org.osbuild.grub2.iso.legacy: isolabel option is required",
+		},
+	}
+
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
+			if tc.expectedError == "" {
+				assert.NotPanics(t, func() { osbuild.NewGrub2ISOLegacyStage(&tc.options) })
+			} else {
+				assert.PanicsWithError(
+					t,
+					tc.expectedError,
+					func() { osbuild.NewGrub2ISOLegacyStage(&tc.options) },
+				)
+			}
+		})
+	}
+}

--- a/pkg/osbuild/xorrisofs_stage.go
+++ b/pkg/osbuild/xorrisofs_stage.go
@@ -19,6 +19,11 @@ type XorrisofsStageOptions struct {
 
 	// The ISO 9660 version (limits data size and filenames; min: 1, max: 4)
 	ISOLevel int `json:"isolevel,omitempty"`
+
+	// Path to grub2 hybrid mbr boot image
+	// This will cause the created iso to use grub2 instead of syslinux/isolinux
+	// when booting on BIOS systems.
+	Grub2MBR string `json:"grub2mbr,omitempty"`
 }
 
 type XorrisofsBoot struct {


### PR DESCRIPTION
This adds support for using grub2 instead of syslinux (which is no longer updated) when booting an iso on BIOS systems. This matches how Lorax creates the boot.iso and live media images. This applies to BIOS bootin on the x86 architecture for all of the anaconda live install images created by osbuild-composer. It does not change how the ostree simplified image boots (it still uses syslinux) and it does not change how the coreos iso boots since it uses it's own self-contained stage.