### PR TITLE
distro: tweak the packagesets.Loader() interface

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -69,11 +69,7 @@ func mkImageInstallerImgType(d distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: func(t *imageType) rpmmd.PackageSet {
 				// use the minimal raw image type for the OS package set
-				ft := &imageType{
-					name: "minimal-raw",
-					arch: t.arch,
-				}
-				return packagesets.Load(ft, VersionReplacements())
+				return packagesets.Load(t, "minimal-raw", VersionReplacements())
 			},
 			installerPkgsKey: packageSetLoader,
 		},

--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -6,5 +6,5 @@ import (
 )
 
 func packageSetLoader(t *imageType) rpmmd.PackageSet {
-	return packagesets.Load(t, VersionReplacements())
+	return packagesets.Load(t, "", VersionReplacements())
 }

--- a/pkg/distro/packagesets/loader_test.go
+++ b/pkg/distro/packagesets/loader_test.go
@@ -54,10 +54,33 @@ test_type:
 	restore := packagesets.MockDataFS(baseDir)
 	defer restore()
 
-	pkgSet := packagesets.Load(it, nil)
+	pkgSet := packagesets.Load(it, "", nil)
 	assert.NotNil(t, pkgSet)
 	assert.Equal(t, rpmmd.PackageSet{
 		Include: []string{"inc1", "from-condition-inc2"},
 		Exclude: []string{"exc1", "from-condition-exc2"},
+	}, pkgSet)
+}
+
+func TestLoadOverrideTypeName(t *testing.T) {
+	it := makeTestImageType(t)
+	fakePkgsSetYaml := `
+override_name:
+  include: [from-override-inc1]
+  exclude: [from-override-exc1]
+test_type:
+  include: [default-inc2]
+  exclude: [default-exc2]
+`
+	// XXX: we cannot use distro.Name() as it will give us a name+ver
+	baseDir := makeFakePkgsSet(t, test_distro.TestDistroNameBase, fakePkgsSetYaml)
+	restore := packagesets.MockDataFS(baseDir)
+	defer restore()
+
+	pkgSet := packagesets.Load(it, "override-name", nil)
+	assert.NotNil(t, pkgSet)
+	assert.Equal(t, rpmmd.PackageSet{
+		Include: []string{"from-override-inc1"},
+		Exclude: []string{"from-override-exc1"},
 	}, pkgSet)
 }


### PR DESCRIPTION
The current `packagesets.Loader()` takes a single imagetype argument to determine what packagesets to load from YAML.

This generally works great but its a challenge for image types like the anaconda installer where we need a different package set for the iso and the os. In fedora we workaround this by re-using the minimal-raw package set for the anaconda installers "os" package set. However in Centos/RHEL this is less straightforward so having the ability to "override" the pkgset name is required.

Another trivial split out from https://github.com/osbuild/images/pull/1283