### PR TITLE
manifest: remove unused `manifest.Arch`

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -22,15 +22,6 @@ import (
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-type Arch uint64
-
-const (
-	ARCH_X86_64 Arch = iota
-	ARCH_AARCH64
-	ARCH_S390X
-	ARCH_PPC64LE
-)
-
 type Distro uint64
 
 const (


### PR DESCRIPTION
AFAICT this is no longer used and even if it is used we have a `arch` package that should be used instead. This one also lacks `riscv64`.