### PR TITLE
many: make bootstrap container usage a manifest option

### DIFF
--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -134,6 +134,8 @@ type ImageOptions struct {
 	Subscription     *subscription.ImageOptions `json:"subscription,omitempty"`
 	Facts            *facts.ImageOptions        `json:"facts,omitempty"`
 	PartitioningMode disk.PartitioningMode      `json:"partitioning-mode,omitempty"`
+
+	UseBootstrapContainer bool `json:"use_bootstrap_container,omitempty"`
 }
 
 type BasePartitionTableMap map[string]disk.PartitionTable

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -310,6 +310,9 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 	}
 	mf := manifest.New()
 	mf.Distro = manifest.DISTRO_FEDORA
+	if options.UseBootstrapContainer {
+		mf.DistroBootstrapRef = bootstrapContainerFor(t)
+	}
 	_, err = img.InstantiateManifest(&mf, repos, t.arch.distro.runner, rng)
 	if err != nil {
 		return nil, nil, err
@@ -509,4 +512,20 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 	}
 
 	return warnings, nil
+}
+
+// XXX: this will become part of the yaml distro definitions, i.e.
+// the yaml will have a "bootstrap_ref" key for each distro/arch
+func bootstrapContainerFor(t *imageType) string {
+	arch := t.arch.Name()
+	distro := t.arch.distro
+
+	// XXX: remove once fedora containers are part of the upstream
+	// fedora registry (and can be validated via tls)
+	if arch == "riscv64" {
+		return "ghcr.io/mvo5/fedora-buildroot:" + distro.OsVersion()
+	}
+
+	// we need fedora-toolbox to get python3
+	return "registry.fedoraproject.org/fedora-toolbox:" + distro.OsVersion()
 }

--- a/pkg/manifest/build_test.go
+++ b/pkg/manifest/build_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -165,9 +164,8 @@ func TestNewBuildWithExperimentalOverride(t *testing.T) {
 			assert.True(t, ok)
 			assert.Equal(t, []container.SourceSpec{
 				{
-					Source:    "ghcr.io/ondrejbudai/cool:stuff",
-					Name:      "ghcr.io/ondrejbudai/cool:stuff",
-					TLSVerify: common.ToPtr(false),
+					Source: "ghcr.io/ondrejbudai/cool:stuff",
+					Name:   "ghcr.io/ondrejbudai/cool:stuff",
 				},
 			}, br.containers)
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -66,6 +66,13 @@ type Manifest struct {
 	// generate. It is used for determining package names that differ between
 	// different distributions and version.
 	Distro Distro
+
+	// DistroBootstrapRef defines if a bootstrap container should be used
+	// to generate the buildroot
+	// XXX: ideally we would have "Distro distro.Distro" here and a
+	// "BoostrapContainerRef()" method on this but we cannot because of
+	// circular imports so we use the same workaround as Distro above.
+	DistroBootstrapRef string
 }
 
 func New() Manifest {

--- a/pkg/manifestgen/manifestgen.go
+++ b/pkg/manifestgen/manifestgen.go
@@ -62,6 +62,10 @@ type Options struct {
 	Depsolver         DepsolveFunc
 	ContainerResolver ContainerResolverFunc
 	CommitResolver    CommitResolverFunc
+
+	// Use the a bootstrap container to buildroot (useful for e.g.
+	// cross-arch or cross-distro builds)
+	UseBootstrapContainer bool
 }
 
 // Generator can generate an osbuild manifest from a given repository
@@ -82,6 +86,8 @@ type Generator struct {
 
 	customSeed    *int64
 	overrideRepos []rpmmd.RepoConfig
+
+	useBootstrapContainer bool
 }
 
 // New will create a new manifest generator
@@ -92,16 +98,17 @@ func New(reporegistry *reporegistry.RepoRegistry, opts *Options) (*Generator, er
 	mg := &Generator{
 		reporegistry: reporegistry,
 
-		cacheDir:          opts.Cachedir,
-		out:               opts.Output,
-		depsolver:         opts.Depsolver,
-		containerResolver: opts.ContainerResolver,
-		commitResolver:    opts.CommitResolver,
-		rpmDownloader:     opts.RpmDownloader,
-		sbomWriter:        opts.SBOMWriter,
-		warningsOutput:    opts.WarningsOutput,
-		customSeed:        opts.CustomSeed,
-		overrideRepos:     opts.OverrideRepos,
+		cacheDir:              opts.Cachedir,
+		out:                   opts.Output,
+		depsolver:             opts.Depsolver,
+		containerResolver:     opts.ContainerResolver,
+		commitResolver:        opts.CommitResolver,
+		rpmDownloader:         opts.RpmDownloader,
+		sbomWriter:            opts.SBOMWriter,
+		warningsOutput:        opts.WarningsOutput,
+		customSeed:            opts.CustomSeed,
+		overrideRepos:         opts.OverrideRepos,
+		useBootstrapContainer: opts.UseBootstrapContainer,
 	}
 	if mg.out == nil {
 		mg.out = os.Stdout
@@ -125,6 +132,7 @@ func (mg *Generator) Generate(bp *blueprint.Blueprint, dist distro.Distro, imgTy
 	if imgOpts == nil {
 		imgOpts = &distro.ImageOptions{}
 	}
+	imgOpts.UseBootstrapContainer = mg.useBootstrapContainer
 
 	var repos []rpmmd.RepoConfig
 	if mg.overrideRepos != nil {


### PR DESCRIPTION
[draft as a) it lacks tests b) there are multiple ways of doing this and this outlines the one I like best but that may not match with the others of course]

This commit adds the option to use a bootstrap container when
generating the manifest. This allows a seamless experience when
using e.g. image-builder:
```console
$ image-builder build --arch=riscv64 minimal-raw --distro fedora-42
```

The approach is to make the distro bootstrap container ref part of
the manifest struct just like we set "Distro" there. This is not
ideal, it would be much nicer if manifest would hold the full
`distro.Distro` and this way we could simply run something like
`distro.BootstrapContainerRef()` when needed. However because
of circular inputs that is not possible.

The other option is to make it part of every `imageFunc()` call,
this was suggested by Achilleas (thanks!) this requires some
refactor. Or we could make it part of `InstantiateManifest()`
and pass a new generalized `RepoAndContainersConfig` there that
would contain both the []rpmmd.RepoConfig and the BootstrapRef.

Note that I think eventually the bootstrap container ref will be
part of the "distro.yaml" and the currently (slightly ugly) helper
`bootstrapContainerFor()` will go away.


The matching and small image-builder-cli changes are in https://github.com/osbuild/image-builder-cli/compare/main...mvo5:cross-arch-for-all-2?expand=1 (and the cross-build test in there passes locally but takes ~30min for all 4 tested arches and it lacks a check that inside the generate container image we actually have binaries of the expected architecture)

Note that cross-arch building will not support selinux in the buildroot yet - see the second commit about how we can still archive this in the future.