### PR TITLE
packagesets: add yaml based merge support

### DIFF
--- a/pkg/distro/packagesets/fedora/package_sets.yaml
+++ b/pkg/distro/packagesets/fedora/package_sets.yaml
@@ -1,922 +1,605 @@
 ---
-cloud_base:  # not used directly; added for reference
-  include:
-    - "@Fedora Cloud Server"
-    - "chrony"  # not mentioned in the kickstart anaconda pulls it when setting the timezone
-    - "langpacks-en"
-  exclude:
-    - "dracut-config-rescue"
-    - "firewalld"
-    - "geolite2-city"
-    - "geolite2-country"
-    - "plymouth"
+cloud_base: &cloud_base
+  clouse_base:
+    include:
+      - "@Fedora Cloud Server"
+      - "chrony"  # not mentioned in the kickstart anaconda pulls it when setting the timezone
+      - "langpacks-en"
+    exclude:
+      - "dracut-config-rescue"
+      - "firewalld"
+      - "geolite2-city"
+      - "geolite2-country"
+      - "plymouth"
 
 qcow2: &qcow2
-  include:
-    # cloud_base
-    - "@Fedora Cloud Server"
-    - "chrony"  # not mentioned in the kickstart anaconda pulls it when setting the timezone
-    - "langpacks-en"
+  <<: *cloud_base
+  qcow2:
+    include:
+      - "qemu-guest-agent"
 
-    # qcow2
-    - "qemu-guest-agent"
-  exclude:
-    # cloud_base
-    - "dracut-config-rescue"
-    - "firewalld"
-    - "geolite2-city"
-    - "geolite2-country"
-    - "plymouth"
+ami: *qcow2
 
-ami:
-  <<: *qcow2
+oci: *qcow2
 
-oci:
-  <<: *qcow2
-
-openstack:
-  <<: *qcow2
+openstack: *qcow2
 
 vhd:
-  include:
-    # cloud_base
-    - "@Fedora Cloud Server"
-    - "chrony"  # not mentioned in the kickstart anaconda pulls it when setting the timezone
-    - "langpacks-en"
-
-    # vhd
-    - "WALinuxAgent"
-  exclude:
-    # cloud_base
-    - "dracut-config-rescue"
-    - "firewalld"
-    - "geolite2-city"
-    - "geolite2-country"
-    - "plymouth"
+  <<: *cloud_base
+  vhd:
+    include:
+      - "WALinuxAgent"
 
 vmdk: &vmdk
-  include:
-    - "@Fedora Cloud Server"
-    - "chrony"
-    - "systemd-udev"
-    - "langpacks-en"
-    - "open-vm-tools"
-  exclude:
-    - "dracut-config-rescue"
-    - "etables"
-    - "firewalld"
-    - "geolite2-city"
-    - "geolite2-country"
-    - "gobject-introspection"
-    - "plymouth"
-    - "zram-generator-defaults"
-    - "grubby-deprecated"
-    - "extlinux-bootloader"
+  vmdk:
+    include:
+      - "@Fedora Cloud Server"
+      - "chrony"
+      - "systemd-udev"
+      - "langpacks-en"
+      - "open-vm-tools"
+    exclude:
+      - "dracut-config-rescue"
+      - "etables"
+      - "firewalld"
+      - "geolite2-city"
+      - "geolite2-country"
+      - "gobject-introspection"
+      - "plymouth"
+      - "zram-generator-defaults"
+      - "grubby-deprecated"
+      - "extlinux-bootloader"
 
-ova:
-  <<: *vmdk
+ova: *vmdk
 
 # NOTE: keep in sync with official fedora-iot definitions:
 # https://pagure.io/fedora-iot/ostree/blob/main/f/fedora-iot-base.yaml
 iot_commit: &iot_commit
-  include:
-    - "NetworkManager"
-    - "NetworkManager-wifi"
-    - "NetworkManager-wwan"
-    - "aardvark-dns"
-    - "atheros-firmware"
-    - "attr"
-    - "authselect"
-    - "bash"
-    - "bash-completion"
-    - "brcmfmac-firmware"
-    - "chrony"
-    - "clevis"
-    - "clevis-dracut"
-    - "clevis-luks"
-    - "clevis-pin-tpm2"
-    - "container-selinux"
-    - "containernetworking-plugins"
-    - "coreutils"
-    - "cracklib-dicts"
-    - "criu"
-    - "cryptsetup"
-    - "curl"
-    - "dosfstools"
-    - "dracut-config-generic"
-    - "dracut-network"
-    - "e2fsprogs"
-    - "efibootmgr"
-    - "fdo-client"
-    - "fdo-owner-cli"
-    - "fedora-iot-config"
-    - "fedora-release-iot"
-    - "firewalld"
-    - "fwupd"
-    - "fwupd-efi"
-    - "fwupd-plugin-modem-manager"
-    - "fwupd-plugin-uefi-capsule-data"
-    - "glibc"
-    - "glibc-minimal-langpack"
-    - "gnupg2"
-    - "greenboot"
-    - "greenboot-default-health-checks"
-    - "gzip"
-    - "hostname"
-    - "ignition"
-    - "ignition-edge"
-    - "ima-evm-utils"
-    - "iproute"
-    - "iputils"
-    - "iwd"
-    - "iwlwifi-mvm-firmware"
-    - "keyutils"
-    - "less"
-    - "libsss_sudo"
-    - "linux-firmware"
-    - "lvm2"
-    - "netavark"
-    - "nss-altfiles"
-    - "openssh-clients"
-    - "openssh-server"
-    - "openssl"
-    - "pinentry"
-    - "podman"
-    - "policycoreutils"
-    - "polkit"
-    - "procps-ng"
-    - "realtek-firmware"
-    - "rootfiles"
-    - "rpm"
-    - "screen"
-    - "selinux-policy-targeted"
-    - "setools-console"
-    - "setup"
-    - "shadow-utils"
-    - "skopeo"
-    - "slirp4netns"
-    - "ssh-key-dir"
-    - "sssd-client"
-    - "sudo"
-    - "systemd"
-    - "systemd-resolved"
-    - "tar"
-    - "tmux"
-    - "tpm2-pkcs11"
-    - "traceroute"
-    - "usbguard"
-    - "util-linux"
-    - "vim-minimal"
-    - "wireless-regdb"
-    - "wpa_supplicant"
-    - "xfsprogs"
-    - "xz"
-    - "zram-generator"
-  condition:
-    version_less_than:
-      "41":
-        include:
-          - "dnsmasq"
-      "42":
-        include:
-          - "dbus-parsec"
-          - "kernel-tools"
-          - "parsec"
-          - "policycoreutils-python-utils"
-          - "zezere-ignition"
-      "43":
-        include:
-          - "basesystem"
-    version_greater_or_equal:
-      "41":
-        include:
-          - "bootupd"
-      "43":
-        include:
-          - "filesystem"
+  iot_commit:
+    include:
+      - "NetworkManager"
+      - "NetworkManager-wifi"
+      - "NetworkManager-wwan"
+      - "aardvark-dns"
+      - "atheros-firmware"
+      - "attr"
+      - "authselect"
+      - "bash"
+      - "bash-completion"
+      - "brcmfmac-firmware"
+      - "chrony"
+      - "clevis"
+      - "clevis-dracut"
+      - "clevis-luks"
+      - "clevis-pin-tpm2"
+      - "container-selinux"
+      - "containernetworking-plugins"
+      - "coreutils"
+      - "cracklib-dicts"
+      - "criu"
+      - "cryptsetup"
+      - "curl"
+      - "dosfstools"
+      - "dracut-config-generic"
+      - "dracut-network"
+      - "e2fsprogs"
+      - "efibootmgr"
+      - "fdo-client"
+      - "fdo-owner-cli"
+      - "fedora-iot-config"
+      - "fedora-release-iot"
+      - "firewalld"
+      - "fwupd"
+      - "fwupd-efi"
+      - "fwupd-plugin-modem-manager"
+      - "fwupd-plugin-uefi-capsule-data"
+      - "glibc"
+      - "glibc-minimal-langpack"
+      - "gnupg2"
+      - "greenboot"
+      - "greenboot-default-health-checks"
+      - "gzip"
+      - "hostname"
+      - "ignition"
+      - "ignition-edge"
+      - "ima-evm-utils"
+      - "iproute"
+      - "iputils"
+      - "iwd"
+      - "iwlwifi-mvm-firmware"
+      - "keyutils"
+      - "less"
+      - "libsss_sudo"
+      - "linux-firmware"
+      - "lvm2"
+      - "netavark"
+      - "nss-altfiles"
+      - "openssh-clients"
+      - "openssh-server"
+      - "openssl"
+      - "pinentry"
+      - "podman"
+      - "policycoreutils"
+      - "polkit"
+      - "procps-ng"
+      - "realtek-firmware"
+      - "rootfiles"
+      - "rpm"
+      - "screen"
+      - "selinux-policy-targeted"
+      - "setools-console"
+      - "setup"
+      - "shadow-utils"
+      - "skopeo"
+      - "slirp4netns"
+      - "ssh-key-dir"
+      - "sssd-client"
+      - "sudo"
+      - "systemd"
+      - "systemd-resolved"
+      - "tar"
+      - "tmux"
+      - "tpm2-pkcs11"
+      - "traceroute"
+      - "usbguard"
+      - "util-linux"
+      - "vim-minimal"
+      - "wireless-regdb"
+      - "wpa_supplicant"
+      - "xfsprogs"
+      - "xz"
+      - "zram-generator"
+    condition:
+      version_less_than:
+        "41":
+          include:
+            - "dnsmasq"
+        "42":
+          include:
+            - "dbus-parsec"
+            - "kernel-tools"
+            - "parsec"
+            - "policycoreutils-python-utils"
+            - "zezere-ignition"
+        "43":
+          include:
+            - "basesystem"
+      version_greater_or_equal:
+        "41":
+          include:
+            - "bootupd"
+        "43":
+          include:
+            - "filesystem"
 
-iot_container:
-  <<: *iot_commit
+iot_container: *iot_commit
 
 iot_bootable_container:
-  include:
-    - "acl"
-    - "attr"  # used by admins interactively
-    - "bootc"
-    - "bootupd"
-    - "chrony"  # NTP support
-    - "container-selinux"
-    - "container-selinux"
-    - "crun"
-    - "cryptsetup"
-    - "dnf"
-    - "dosfstools"
-    - "e2fsprogs"
-    - "fwupd"  # if you're using linux-firmware you probably also want fwupd
-    - "gdisk"
-    - "iproute"  # route manipulation and QoS
-    - "iproute-tc"
-    - "iptables"  # firewall manipulation
-    - "nftables"
-    - "iptables-services"  # additional firewall support
-    - "kbd"               # i18n
-    - "keyutils"          # Manipulating the kernel keyring; used by bootc
-    - "libsss_sudo"       # allow communication between sudo and SSSD for caching sudo rules by SSSD
-    - "linux-firmware"    # linux-firmware now a recommends so let's explicitly include it
-    - "logrotate"         # There are things that write outside of the journal still (such as the classic wtmp etc.). auditd also writes outside the journal but it has its own log rotation.  Anything package layered will also tend to expect files dropped in /etc/logrotate.d to work. Really this is a legacy thing but if we don't have it then people's disks will slowly fill up with logs.
-    - "lsof"
-    - "lvm2"                       # Storage configuration/management
-    - "nano"                       # default editor
-    - "ncurses"                    # provides terminal tools like clear reset tput and tset
-    - "NetworkManager-cloud-setup"  # support for cloud quirks and dynamic config in real rootfs: https:#github.com/coreos/fedora-coreos-tracker/issues/320
-    - "NetworkManager"  # standard tools for configuring network/hostname
-    - "hostname"
-    - "NetworkManager-team"  # teaming https:#github.com/coreos/fedora-coreos-config/pull/289 and http:#bugzilla.redhat.com/1758162
-    - "teamd"
-    - "NetworkManager-tui"               # interactive Networking configuration during coreos-install
-    - "nfs-utils-coreos"  # minimal NFS client
-    - "iptables-nft"
-    - "nss-altfiles"
-    - "openssh-clients"
-    - "openssh-server"
-    - "openssl"
-    - "ostree"
-    - "shadow-utils"  # User configuration
-    - "podman"
-    - "rpm-ostree"
-    - "selinux-policy-targeted"
-    - "sg3_utils"
-    - "skopeo"
-    - "socat"  # interactive network tools for admins
-    - "net-tools"
-    - "bind-utils"
-    - "sssd-client"  # SSSD backends
-    - "sssd-ad"
-    - "sssd-ipa"
-    - "sssd-krb5"
-    - "sssd-ldap"
-    - "stalld"               # Boost starving threads https:#github.com/coreos/fedora-coreos-tracker/issues/753
-    - "subscription-manager"  # To ensure we can enable client certs to access RHEL content
-    - "sudo"
-    - "systemd"
-    - "systemd-resolved"  # resolved was broken out to its own package in rawhide/f35
-    - "tpm2-tools"        # needed for tpm2 bound luks
-    - "WALinuxAgent-udev"  # udev rules for Azure (rhbz#1748432)
-    - "xfsprogs"
-    - "zram-generator"  # zram-generator (but not zram-generator-defaults) for F33 change
-  exclude:
-    - "cowsay"  # just in case
-    - "grubby"
-    - "initscripts"                         # make sure initscripts doesn't get pulled back in https:#github.com/coreos/fedora-coreos-tracker/issues/220#issuecomment-611566254
-    - "NetworkManager-initscripts-ifcfg-rh"  # do not use legacy ifcfg config format in NetworkManager See https:#github.com/coreos/fedora-coreos-config/pull/1991
-    - "nodejs"
-    - "plymouth"         # for (datacenter/cloud oriented) servers we want to see the details by default.  https:#lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/HSMISZ3ETWQ4ETVLWZQJ55ARZT27AAV3/
-    - "systemd-networkd"  # we use NetworkManager
-  condition:
-    architecture:
-      aarch64:
-        include:
-          - "irqbalance"
-          - "ostree-grub2"
-        exclude:
-          - "perl"
-          - "perl-interpreter"
-      ppc64le:
-        include:
-          - "irqbalance"
-          - "librtas"
-          - "powerpc-utils-core"
-          - "ppc64-diag-rtas"
-      x86_64:
-        include:
-          - "irqbalance"
-        exclude:
-          - "perl"
-          - "perl-interpreter"
+  iot_bootable_container:
+    include:
+      - "acl"
+      - "attr"  # used by admins interactively
+      - "bootc"
+      - "bootupd"
+      - "chrony"  # NTP support
+      - "container-selinux"
+      - "container-selinux"
+      - "crun"
+      - "cryptsetup"
+      - "dnf"
+      - "dosfstools"
+      - "e2fsprogs"
+      - "fwupd"  # if you're using linux-firmware you probably also want fwupd
+      - "gdisk"
+      - "iproute"  # route manipulation and QoS
+      - "iproute-tc"
+      - "iptables"  # firewall manipulation
+      - "nftables"
+      - "iptables-services"  # additional firewall support
+      - "kbd"               # i18n
+      - "keyutils"          # Manipulating the kernel keyring; used by bootc
+      - "libsss_sudo"       # allow communication between sudo and SSSD for caching sudo rules by SSSD
+      - "linux-firmware"    # linux-firmware now a recommends so let's explicitly include it
+      - "logrotate"         # There are things that write outside of the journal still (such as the classic wtmp etc.). auditd also writes outside the journal but it has its own log rotation.  Anything package layered will also tend to expect files dropped in /etc/logrotate.d to work. Really this is a legacy thing but if we don't have it then people's disks will slowly fill up with logs.
+      - "lsof"
+      - "lvm2"                       # Storage configuration/management
+      - "nano"                       # default editor
+      - "ncurses"                    # provides terminal tools like clear reset tput and tset
+      - "NetworkManager-cloud-setup"  # support for cloud quirks and dynamic config in real rootfs: https:#github.com/coreos/fedora-coreos-tracker/issues/320
+      - "NetworkManager"  # standard tools for configuring network/hostname
+      - "hostname"
+      - "NetworkManager-team"  # teaming https:#github.com/coreos/fedora-coreos-config/pull/289 and http:#bugzilla.redhat.com/1758162
+      - "teamd"
+      - "NetworkManager-tui"               # interactive Networking configuration during coreos-install
+      - "nfs-utils-coreos"  # minimal NFS client
+      - "iptables-nft"
+      - "nss-altfiles"
+      - "openssh-clients"
+      - "openssh-server"
+      - "openssl"
+      - "ostree"
+      - "shadow-utils"  # User configuration
+      - "podman"
+      - "rpm-ostree"
+      - "selinux-policy-targeted"
+      - "sg3_utils"
+      - "skopeo"
+      - "socat"  # interactive network tools for admins
+      - "net-tools"
+      - "bind-utils"
+      - "sssd-client"  # SSSD backends
+      - "sssd-ad"
+      - "sssd-ipa"
+      - "sssd-krb5"
+      - "sssd-ldap"
+      - "stalld"               # Boost starving threads https:#github.com/coreos/fedora-coreos-tracker/issues/753
+      - "subscription-manager"  # To ensure we can enable client certs to access RHEL content
+      - "sudo"
+      - "systemd"
+      - "systemd-resolved"  # resolved was broken out to its own package in rawhide/f35
+      - "tpm2-tools"        # needed for tpm2 bound luks
+      - "WALinuxAgent-udev"  # udev rules for Azure (rhbz#1748432)
+      - "xfsprogs"
+      - "zram-generator"  # zram-generator (but not zram-generator-defaults) for F33 change
+    exclude:
+      - "cowsay"  # just in case
+      - "grubby"
+      - "initscripts"                         # make sure initscripts doesn't get pulled back in https:#github.com/coreos/fedora-coreos-tracker/issues/220#issuecomment-611566254
+      - "NetworkManager-initscripts-ifcfg-rh"  # do not use legacy ifcfg config format in NetworkManager See https:#github.com/coreos/fedora-coreos-config/pull/1991
+      - "nodejs"
+      - "plymouth"         # for (datacenter/cloud oriented) servers we want to see the details by default.  https:#lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/HSMISZ3ETWQ4ETVLWZQJ55ARZT27AAV3/
+      - "systemd-networkd"  # we use NetworkManager
+    condition:
+      architecture:
+        aarch64:
+          include:
+            - "irqbalance"
+            - "ostree-grub2"
+          exclude:
+            - "perl"
+            - "perl-interpreter"
+        ppc64le:
+          include:
+            - "irqbalance"
+            - "librtas"
+            - "powerpc-utils-core"
+            - "ppc64-diag-rtas"
+        x86_64:
+          include:
+            - "irqbalance"
+          exclude:
+            - "perl"
+            - "perl-interpreter"
 
-installer:
-  include:
-    - "anaconda-dracut"
-    - "atheros-firmware"
-    - "brcmfmac-firmware"
-    - "curl"
-    - "dracut-config-generic"
-    - "dracut-network"
-    - "hostname"
-    - "iwlwifi-dvm-firmware"
-    - "iwlwifi-mvm-firmware"
-    - "kernel"
-    - "linux-firmware"
-    - "less"
-    - "nfs-utils"
-    - "openssh-clients"
-    - "ostree"
-    - "plymouth"
-    - "realtek-firmware"
-    - "rng-tools"
-    - "rpcbind"
-    - "selinux-policy-targeted"
-    - "systemd"
-    - "tar"
-    - "xfsprogs"
-    - "xz"
+installer: &installer
+  installer:
+    include:
+      - "anaconda-dracut"
+      - "atheros-firmware"
+      - "brcmfmac-firmware"
+      - "curl"
+      - "dracut-config-generic"
+      - "dracut-network"
+      - "hostname"
+      - "iwlwifi-dvm-firmware"
+      - "iwlwifi-mvm-firmware"
+      - "kernel"
+      - "linux-firmware"
+      - "less"
+      - "nfs-utils"
+      - "openssh-clients"
+      - "ostree"
+      - "plymouth"
+      - "realtek-firmware"
+      - "rng-tools"
+      - "rpcbind"
+      - "selinux-policy-targeted"
+      - "systemd"
+      - "tar"
+      - "xfsprogs"
+      - "xz"
 
 
-anaconda:
-  include:
-    - "aajohan-comfortaa-fonts"
-    - "abattis-cantarell-fonts"
-    - "alsa-firmware"
-    - "alsa-tools-firmware"
-    - "anaconda"
-    - "anaconda-dracut"
-    - "anaconda-install-img-deps"
-    - "anaconda-widgets"
-    - "atheros-firmware"
-    - "audit"
-    - "bind-utils"
-    - "bitmap-fangsongti-fonts"
-    - "brcmfmac-firmware"
-    - "bzip2"
-    - "cryptsetup"
-    - "curl"
-    - "dbus-x11"
-    - "dejavu-sans-fonts"
-    - "dejavu-sans-mono-fonts"
-    - "device-mapper-persistent-data"
-    - "dmidecode"
-    - "dnf"
-    - "dracut-config-generic"
-    - "dracut-network"
-    - "efibootmgr"
-    - "ethtool"
-    - "fcoe-utils"
-    - "ftp"
-    - "gdb-gdbserver"
-    - "gdisk"
-    - "glibc-all-langpacks"
-    - "gnome-kiosk"
-    - "google-noto-sans-cjk-ttc-fonts"
-    - "grub2-tools"
-    - "grub2-tools-extra"
-    - "grub2-tools-minimal"
-    - "grubby"
-    - "gsettings-desktop-schemas"
-    - "hdparm"
-    - "hexedit"
-    - "hostname"
-    - "initscripts"
-    - "ipmitool"
-    - "iwlwifi-dvm-firmware"
-    - "iwlwifi-mvm-firmware"
-    - "jomolhari-fonts"
-    - "kacst-farsi-fonts"
-    - "kacst-qurn-fonts"
-    - "kbd"
-    - "kbd-misc"
-    - "kdump-anaconda-addon"
-    - "kernel"
-    - "khmeros-base-fonts"
-    - "less"
-    - "libblockdev-lvm-dbus"
-    - "libibverbs"
-    - "libreport-plugin-bugzilla"
-    - "libreport-plugin-reportuploader"
-    - "librsvg2"
-    - "linux-firmware"
-    - "lldpad"
-    - "lohit-assamese-fonts"
-    - "lohit-bengali-fonts"
-    - "lohit-devanagari-fonts"
-    - "lohit-gujarati-fonts"
-    - "lohit-gurmukhi-fonts"
-    - "lohit-kannada-fonts"
-    - "lohit-odia-fonts"
-    - "lohit-tamil-fonts"
-    - "lohit-telugu-fonts"
-    - "lsof"
-    - "madan-fonts"
-    - "mtr"
-    - "mt-st"
-    - "net-tools"
-    - "nfs-utils"
-    - "nmap-ncat"
-    - "nm-connection-editor"
-    - "nss-tools"
-    - "openssh-clients"
-    - "openssh-server"
-    - "ostree"
-    - "pciutils"
-    - "perl-interpreter"
-    - "pigz"
-    - "plymouth"
-    - "python3-pyatspi"
-    - "rdma-core"
-    - "realtek-firmware"
-    - "rit-meera-new-fonts"
-    - "rng-tools"
-    - "rpcbind"
-    - "rpm-ostree"
-    - "rsync"
-    - "rsyslog"
-    - "selinux-policy-targeted"
-    - "sg3_utils"
-    - "sil-abyssinica-fonts"
-    - "sil-padauk-fonts"
-    - "sil-scheherazade-new-fonts"
-    - "smartmontools"
-    - "spice-vdagent"
-    - "strace"
-    - "systemd"
-    - "tar"
-    - "thai-scalable-waree-fonts"
-    - "tigervnc-server-minimal"
-    - "tigervnc-server-module"
-    - "udisks2"
-    - "udisks2-iscsi"
-    - "usbutils"
-    - "vim-minimal"
-    - "volume_key"
-    - "wget"
-    - "xfsdump"
-    - "xfsprogs"
-    - "xorg-x11-drivers"
-    - "xorg-x11-fonts-misc"
-    - "xorg-x11-server-Xorg"
-    - "xorg-x11-xauth"
-    - "metacity"
-    - "xrdb"
-    - "xz"
-  condition:
-    architecture:
-      x86_64:
-        include:
-          - "biosdevname"
-          - "dmidecode"
-          - "grub2-tools-efi"
-          - "memtest86+"
-      aarch64:
-        include:
-          - "dmidecode"
+anaconda: &anaconda
+  anaconda:
+    include:
+      - "aajohan-comfortaa-fonts"
+      - "abattis-cantarell-fonts"
+      - "alsa-firmware"
+      - "alsa-tools-firmware"
+      - "anaconda"
+      - "anaconda-dracut"
+      - "anaconda-install-img-deps"
+      - "anaconda-widgets"
+      - "atheros-firmware"
+      - "audit"
+      - "bind-utils"
+      - "bitmap-fangsongti-fonts"
+      - "brcmfmac-firmware"
+      - "bzip2"
+      - "cryptsetup"
+      - "curl"
+      - "dbus-x11"
+      - "dejavu-sans-fonts"
+      - "dejavu-sans-mono-fonts"
+      - "device-mapper-persistent-data"
+      - "dmidecode"
+      - "dnf"
+      - "dracut-config-generic"
+      - "dracut-network"
+      - "efibootmgr"
+      - "ethtool"
+      - "fcoe-utils"
+      - "ftp"
+      - "gdb-gdbserver"
+      - "gdisk"
+      - "glibc-all-langpacks"
+      - "gnome-kiosk"
+      - "google-noto-sans-cjk-ttc-fonts"
+      - "grub2-tools"
+      - "grub2-tools-extra"
+      - "grub2-tools-minimal"
+      - "grubby"
+      - "gsettings-desktop-schemas"
+      - "hdparm"
+      - "hexedit"
+      - "hostname"
+      - "initscripts"
+      - "ipmitool"
+      - "iwlwifi-dvm-firmware"
+      - "iwlwifi-mvm-firmware"
+      - "jomolhari-fonts"
+      - "kacst-farsi-fonts"
+      - "kacst-qurn-fonts"
+      - "kbd"
+      - "kbd-misc"
+      - "kdump-anaconda-addon"
+      - "kernel"
+      - "khmeros-base-fonts"
+      - "less"
+      - "libblockdev-lvm-dbus"
+      - "libibverbs"
+      - "libreport-plugin-bugzilla"
+      - "libreport-plugin-reportuploader"
+      - "librsvg2"
+      - "linux-firmware"
+      - "lldpad"
+      - "lohit-assamese-fonts"
+      - "lohit-bengali-fonts"
+      - "lohit-devanagari-fonts"
+      - "lohit-gujarati-fonts"
+      - "lohit-gurmukhi-fonts"
+      - "lohit-kannada-fonts"
+      - "lohit-odia-fonts"
+      - "lohit-tamil-fonts"
+      - "lohit-telugu-fonts"
+      - "lsof"
+      - "madan-fonts"
+      - "mtr"
+      - "mt-st"
+      - "net-tools"
+      - "nfs-utils"
+      - "nmap-ncat"
+      - "nm-connection-editor"
+      - "nss-tools"
+      - "openssh-clients"
+      - "openssh-server"
+      - "ostree"
+      - "pciutils"
+      - "perl-interpreter"
+      - "pigz"
+      - "plymouth"
+      - "python3-pyatspi"
+      - "rdma-core"
+      - "realtek-firmware"
+      - "rit-meera-new-fonts"
+      - "rng-tools"
+      - "rpcbind"
+      - "rpm-ostree"
+      - "rsync"
+      - "rsyslog"
+      - "selinux-policy-targeted"
+      - "sg3_utils"
+      - "sil-abyssinica-fonts"
+      - "sil-padauk-fonts"
+      - "sil-scheherazade-new-fonts"
+      - "smartmontools"
+      - "spice-vdagent"
+      - "strace"
+      - "systemd"
+      - "tar"
+      - "thai-scalable-waree-fonts"
+      - "tigervnc-server-minimal"
+      - "tigervnc-server-module"
+      - "udisks2"
+      - "udisks2-iscsi"
+      - "usbutils"
+      - "vim-minimal"
+      - "volume_key"
+      - "wget"
+      - "xfsdump"
+      - "xfsprogs"
+      - "xorg-x11-drivers"
+      - "xorg-x11-fonts-misc"
+      - "xorg-x11-server-Xorg"
+      - "xorg-x11-xauth"
+      - "metacity"
+      - "xrdb"
+      - "xz"
+    condition:
+      architecture:
+        x86_64:
+          include:
+            - "biosdevname"
+            - "dmidecode"
+            - "grub2-tools-efi"
+            - "memtest86+"
+        aarch64:
+          include:
+            - "dmidecode"
 
 iot_installer:
-  # anaconda
-  include:
-    - "aajohan-comfortaa-fonts"
-    - "abattis-cantarell-fonts"
-    - "alsa-firmware"
-    - "alsa-tools-firmware"
-    - "anaconda"
-    - "anaconda-dracut"
-    - "anaconda-install-img-deps"
-    - "anaconda-widgets"
-    - "atheros-firmware"
-    - "audit"
-    - "bind-utils"
-    - "bitmap-fangsongti-fonts"
-    - "brcmfmac-firmware"
-    - "bzip2"
-    - "cryptsetup"
-    - "curl"
-    - "dbus-x11"
-    - "dejavu-sans-fonts"
-    - "dejavu-sans-mono-fonts"
-    - "device-mapper-persistent-data"
-    - "dmidecode"
-    - "dnf"
-    - "dracut-config-generic"
-    - "dracut-network"
-    - "efibootmgr"
-    - "ethtool"
-    - "fcoe-utils"
-    - "ftp"
-    - "gdb-gdbserver"
-    - "gdisk"
-    - "glibc-all-langpacks"
-    - "gnome-kiosk"
-    - "google-noto-sans-cjk-ttc-fonts"
-    - "grub2-tools"
-    - "grub2-tools-extra"
-    - "grub2-tools-minimal"
-    - "grubby"
-    - "gsettings-desktop-schemas"
-    - "hdparm"
-    - "hexedit"
-    - "hostname"
-    - "initscripts"
-    - "ipmitool"
-    - "iwlwifi-dvm-firmware"
-    - "iwlwifi-mvm-firmware"
-    - "jomolhari-fonts"
-    - "kacst-farsi-fonts"
-    - "kacst-qurn-fonts"
-    - "kbd"
-    - "kbd-misc"
-    - "kdump-anaconda-addon"
-    - "kernel"
-    - "khmeros-base-fonts"
-    - "less"
-    - "libblockdev-lvm-dbus"
-    - "libibverbs"
-    - "libreport-plugin-bugzilla"
-    - "libreport-plugin-reportuploader"
-    - "librsvg2"
-    - "linux-firmware"
-    - "lldpad"
-    - "lohit-assamese-fonts"
-    - "lohit-bengali-fonts"
-    - "lohit-devanagari-fonts"
-    - "lohit-gujarati-fonts"
-    - "lohit-gurmukhi-fonts"
-    - "lohit-kannada-fonts"
-    - "lohit-odia-fonts"
-    - "lohit-tamil-fonts"
-    - "lohit-telugu-fonts"
-    - "lsof"
-    - "madan-fonts"
-    - "mtr"
-    - "mt-st"
-    - "net-tools"
-    - "nfs-utils"
-    - "nmap-ncat"
-    - "nm-connection-editor"
-    - "nss-tools"
-    - "openssh-clients"
-    - "openssh-server"
-    - "ostree"
-    - "pciutils"
-    - "perl-interpreter"
-    - "pigz"
-    - "plymouth"
-    - "python3-pyatspi"
-    - "rdma-core"
-    - "realtek-firmware"
-    - "rit-meera-new-fonts"
-    - "rng-tools"
-    - "rpcbind"
-    - "rpm-ostree"
-    - "rsync"
-    - "rsyslog"
-    - "selinux-policy-targeted"
-    - "sg3_utils"
-    - "sil-abyssinica-fonts"
-    - "sil-padauk-fonts"
-    - "sil-scheherazade-new-fonts"
-    - "smartmontools"
-    - "spice-vdagent"
-    - "strace"
-    - "systemd"
-    - "tar"
-    - "thai-scalable-waree-fonts"
-    - "tigervnc-server-minimal"
-    - "tigervnc-server-module"
-    - "udisks2"
-    - "udisks2-iscsi"
-    - "usbutils"
-    - "vim-minimal"
-    - "volume_key"
-    - "wget"
-    - "xfsdump"
-    - "xfsprogs"
-    - "xorg-x11-drivers"
-    - "xorg-x11-fonts-misc"
-    - "xorg-x11-server-Xorg"
-    - "xorg-x11-xauth"
-    - "metacity"
-    - "xrdb"
-    - "xz"
-
-    # iot_installer
-    - "fedora-release-iot"
-  condition:
-    # anaconda
-    architecture:
-      x86_64:
-        include:
-          - "biosdevname"
-          - "dmidecode"
-          - "grub2-tools-efi"
-          - "memtest86+"
-      aarch64:
-        include:
-          - "dmidecode"
+  <<: *anaconda
+  iot_installer:
+    include:
+      - "fedora-release-iot"
 
 
 live_installer:
-  include:
-    - "@workstation-product-environment"
-    - "@anaconda-tools"
-    - "anaconda-install-env-deps"
-    - "anaconda-live"
-    - "anaconda-dracut"
-    - "dracut-live"
-    - "glibc-all-langpacks"
-    - "kernel"
-    - "kernel-modules"
-    - "kernel-modules-extra"
-    - "livesys-scripts"
-    - "rng-tools"
-    - "rdma-core"
-    - "gnome-kiosk"
-  exclude:
-    - "@dial-up"
-    - "@input-methods"
-    - "@standard"
-    - "device-mapper-multipath"
-    - "fcoe-utils"
-    - "gfs2-utils"
-    - "reiserfs-utils"
-    - "sdubby"
-  condition:
-    version_greater_or_equal:
-      VERSION_RAWHIDE:
-        include:
-          - "anaconda-webui"
+  live_installer:
+    include:
+      - "@workstation-product-environment"
+      - "@anaconda-tools"
+      - "anaconda-install-env-deps"
+      - "anaconda-live"
+      - "anaconda-dracut"
+      - "dracut-live"
+      - "glibc-all-langpacks"
+      - "kernel"
+      - "kernel-modules"
+      - "kernel-modules-extra"
+      - "livesys-scripts"
+      - "rng-tools"
+      - "rdma-core"
+      - "gnome-kiosk"
+    exclude:
+      - "@dial-up"
+      - "@input-methods"
+      - "@standard"
+      - "device-mapper-multipath"
+      - "fcoe-utils"
+      - "gfs2-utils"
+      - "reiserfs-utils"
+      - "sdubby"
+    condition:
+      version_greater_or_equal:
+        VERSION_RAWHIDE:
+          include:
+            - "anaconda-webui"
 
 
-image_installer:
-  # anaconda
-  include:
-    - "aajohan-comfortaa-fonts"
-    - "abattis-cantarell-fonts"
-    - "alsa-firmware"
-    - "alsa-tools-firmware"
-    - "anaconda"
-    - "anaconda-dracut"
-    - "anaconda-install-img-deps"
-    - "anaconda-widgets"
-    - "atheros-firmware"
-    - "audit"
-    - "bind-utils"
-    - "bitmap-fangsongti-fonts"
-    - "brcmfmac-firmware"
-    - "bzip2"
-    - "cryptsetup"
-    - "curl"
-    - "dbus-x11"
-    - "dejavu-sans-fonts"
-    - "dejavu-sans-mono-fonts"
-    - "device-mapper-persistent-data"
-    - "dmidecode"
-    - "dnf"
-    - "dracut-config-generic"
-    - "dracut-network"
-    - "efibootmgr"
-    - "ethtool"
-    - "fcoe-utils"
-    - "ftp"
-    - "gdb-gdbserver"
-    - "gdisk"
-    - "glibc-all-langpacks"
-    - "gnome-kiosk"
-    - "google-noto-sans-cjk-ttc-fonts"
-    - "grub2-tools"
-    - "grub2-tools-extra"
-    - "grub2-tools-minimal"
-    - "grubby"
-    - "gsettings-desktop-schemas"
-    - "hdparm"
-    - "hexedit"
-    - "hostname"
-    - "initscripts"
-    - "ipmitool"
-    - "iwlwifi-dvm-firmware"
-    - "iwlwifi-mvm-firmware"
-    - "jomolhari-fonts"
-    - "kacst-farsi-fonts"
-    - "kacst-qurn-fonts"
-    - "kbd"
-    - "kbd-misc"
-    - "kdump-anaconda-addon"
-    - "kernel"
-    - "khmeros-base-fonts"
-    - "less"
-    - "libblockdev-lvm-dbus"
-    - "libibverbs"
-    - "libreport-plugin-bugzilla"
-    - "libreport-plugin-reportuploader"
-    - "librsvg2"
-    - "linux-firmware"
-    - "lldpad"
-    - "lohit-assamese-fonts"
-    - "lohit-bengali-fonts"
-    - "lohit-devanagari-fonts"
-    - "lohit-gujarati-fonts"
-    - "lohit-gurmukhi-fonts"
-    - "lohit-kannada-fonts"
-    - "lohit-odia-fonts"
-    - "lohit-tamil-fonts"
-    - "lohit-telugu-fonts"
-    - "lsof"
-    - "madan-fonts"
-    - "mtr"
-    - "mt-st"
-    - "net-tools"
-    - "nfs-utils"
-    - "nmap-ncat"
-    - "nm-connection-editor"
-    - "nss-tools"
-    - "openssh-clients"
-    - "openssh-server"
-    - "ostree"
-    - "pciutils"
-    - "perl-interpreter"
-    - "pigz"
-    - "plymouth"
-    - "python3-pyatspi"
-    - "rdma-core"
-    - "realtek-firmware"
-    - "rit-meera-new-fonts"
-    - "rng-tools"
-    - "rpcbind"
-    - "rpm-ostree"
-    - "rsync"
-    - "rsyslog"
-    - "selinux-policy-targeted"
-    - "sg3_utils"
-    - "sil-abyssinica-fonts"
-    - "sil-padauk-fonts"
-    - "sil-scheherazade-new-fonts"
-    - "smartmontools"
-    - "spice-vdagent"
-    - "strace"
-    - "systemd"
-    - "tar"
-    - "thai-scalable-waree-fonts"
-    - "tigervnc-server-minimal"
-    - "tigervnc-server-module"
-    - "udisks2"
-    - "udisks2-iscsi"
-    - "usbutils"
-    - "vim-minimal"
-    - "volume_key"
-    - "wget"
-    - "xfsdump"
-    - "xfsprogs"
-    - "xorg-x11-drivers"
-    - "xorg-x11-fonts-misc"
-    - "xorg-x11-server-Xorg"
-    - "xorg-x11-xauth"
-    - "metacity"
-    - "xrdb"
-    - "xz"
-  condition:
-    architecture:
-      x86_64:
-        include:
-          - "biosdevname"
-          - "dmidecode"
-          - "grub2-tools-efi"
-          - "memtest86+"
-      aarch64:
-        include:
-          - "dmidecode"
+image_installer: *anaconda
 
 container: &container
-  include:
-    - "bash"
-    - "coreutils"
-    - "yum"
-    - "dnf"
-    - "fedora-release-container"
-    - "glibc-minimal-langpack"
-    - "rootfiles"
-    - "rpm"
-    - "sudo"
-    - "tar"
-    - "util-linux-core"
-    - "vim-minimal"
-  exclude:
-    - "crypto-policies-scripts"
-    - "dbus-broker"
-    - "deltarpm"
-    - "dosfstools"
-    - "e2fsprogs"
-    - "elfutils-debuginfod-client"
-    - "fuse-libs"
-    - "gawk-all-langpacks"
-    - "glibc-gconv-extra"
-    - "glibc-langpack-en"
-    - "gnupg2-smime"
-    - "grubby"
-    - "kernel-core"
-    - "kernel-debug-core"
-    - "kernel"
-    - "langpacks-en_GB"
-    - "langpacks-en"
-    - "libss"
-    - "libxcrypt-compat"
-    - "nano"
-    - "openssl-pkcs11"
-    - "pinentry"
-    - "python3-unbound"
-    - "shared-mime-info"
-    - "sssd-client"
-    - "sudo-python-plugin"
-    - "systemd"
-    - "trousers"
-    - "whois-nls"
-    - "xkeyboard-config"
+  container:
+    include:
+      - "bash"
+      - "coreutils"
+      - "yum"
+      - "dnf"
+      - "fedora-release-container"
+      - "glibc-minimal-langpack"
+      - "rootfiles"
+      - "rpm"
+      - "sudo"
+      - "tar"
+      - "util-linux-core"
+      - "vim-minimal"
+    exclude:
+      - "crypto-policies-scripts"
+      - "dbus-broker"
+      - "deltarpm"
+      - "dosfstools"
+      - "e2fsprogs"
+      - "elfutils-debuginfod-client"
+      - "fuse-libs"
+      - "gawk-all-langpacks"
+      - "glibc-gconv-extra"
+      - "glibc-langpack-en"
+      - "gnupg2-smime"
+      - "grubby"
+      - "kernel-core"
+      - "kernel-debug-core"
+      - "kernel"
+      - "langpacks-en_GB"
+      - "langpacks-en"
+      - "libss"
+      - "libxcrypt-compat"
+      - "nano"
+      - "openssl-pkcs11"
+      - "pinentry"
+      - "python3-unbound"
+      - "shared-mime-info"
+      - "sssd-client"
+      - "sudo-python-plugin"
+      - "systemd"
+      - "trousers"
+      - "whois-nls"
+      - "xkeyboard-config"
 
-wsl:
-  <<: *container
+wsl: *container
 
 minimal_raw: &minimal
-  include:
-    - "@core"
-    - "initial-setup"
-    - "libxkbcommon"
-    - "NetworkManager-wifi"
-    - "brcmfmac-firmware"
-    - "realtek-firmware"
-    - "iwlwifi-mvm-firmware"
-  exclude:
-    - "dracut-config-rescue"
-  condition:
-    architecture:
-      riscv64:
-        include:
-          # missing from @core in riscv64
-          - "dnf5"
-          - "policycoreutils"
-          - "selinux-policy-targeted"
-    version_greater_or_equal:
-      "43":
-        exclude:
-          - "firewalld"
+  minimal_raw:
+    include:
+      - "@core"
+      - "initial-setup"
+      - "libxkbcommon"
+      - "NetworkManager-wifi"
+      - "brcmfmac-firmware"
+      - "realtek-firmware"
+      - "iwlwifi-mvm-firmware"
+    exclude:
+      - "dracut-config-rescue"
+    condition:
+      architecture:
+        riscv64:
+          include:
+            # missing from @core in riscv64
+            - "dnf5"
+            - "policycoreutils"
+            - "selinux-policy-targeted"
+      version_greater_or_equal:
+        "43":
+          exclude:
+            - "firewalld"
 
-minimal_raw_zst:
-  <<: *minimal
+minimal_raw_zst: *minimal
 
 iot_simplified_installer:
-  include:
-    # installer.include
-    - "anaconda-dracut"
-    - "atheros-firmware"
-    - "brcmfmac-firmware"
-    - "curl"
-    - "dracut-config-generic"
-    - "dracut-network"
-    - "hostname"
-    - "iwlwifi-dvm-firmware"
-    - "iwlwifi-mvm-firmware"
-    - "kernel"
-    - "linux-firmware"
-    - "less"
-    - "nfs-utils"
-    - "openssh-clients"
-    - "ostree"
-    - "plymouth"
-    - "realtek-firmware"
-    - "rng-tools"
-    - "rpcbind"
-    - "selinux-policy-targeted"
-    - "systemd"
-    - "tar"
-    - "xfsprogs"
-    - "xz"
-
-    # iot_simplified_installer.include
-    - "attr"
-    - "basesystem"
-    - "binutils"
-    - "bsdtar"
-    - "clevis-dracut"
-    - "clevis-luks"
-    - "cloud-utils-growpart"
-    - "coreos-installer"
-    - "coreos-installer-dracut"
-    - "coreutils"
-    - "device-mapper-multipath"
-    - "dosfstools"
-    - "dracut-live"
-    - "e2fsprogs"
-    - "fcoe-utils"
-    - "fdo-init"
-    - "fedora-logos"
-    - "gdisk"
-    - "gzip"
-    - "ima-evm-utils"
-    - "iproute"
-    - "iptables"
-    - "iputils"
-    - "iscsi-initiator-utils"
-    - "keyutils"
-    - "lldpad"
-    - "lvm2"
-    - "mdadm"
-    - "nss-softokn"
-    - "policycoreutils"
-    - "policycoreutils-python-utils"
-    - "procps-ng"
-    - "rootfiles"
-    - "setools-console"
-    - "sudo"
-    - "traceroute"
-    - "util-linux"
-    - "shadow-utils"  # includes passwd
-  condition:
-    version_less_than:
-      "41":
-        include:
-          - "dnsmasq"  # deprecated for F41+
+  <<: *installer
+  iot_simplified_installer:
+    include:
+      - "attr"
+      - "basesystem"
+      - "binutils"
+      - "bsdtar"
+      - "clevis-dracut"
+      - "clevis-luks"
+      - "cloud-utils-growpart"
+      - "coreos-installer"
+      - "coreos-installer-dracut"
+      - "coreutils"
+      - "device-mapper-multipath"
+      - "dosfstools"
+      - "dracut-live"
+      - "e2fsprogs"
+      - "fcoe-utils"
+      - "fdo-init"
+      - "fedora-logos"
+      - "gdisk"
+      - "gzip"
+      - "ima-evm-utils"
+      - "iproute"
+      - "iptables"
+      - "iputils"
+      - "iscsi-initiator-utils"
+      - "keyutils"
+      - "lldpad"
+      - "lvm2"
+      - "mdadm"
+      - "nss-softokn"
+      - "policycoreutils"
+      - "policycoreutils-python-utils"
+      - "procps-ng"
+      - "rootfiles"
+      - "setools-console"
+      - "sudo"
+      - "traceroute"
+      - "util-linux"
+      - "shadow-utils"  # includes passwd
+    condition:
+      version_less_than:
+        "41":
+          include:
+            - "dnsmasq"  # deprecated for F41+


### PR DESCRIPTION
This commit adds yaml based merge support for package sets by adding another level of indirection. This is already a useful feature so that we can e.g. avoid duplicating the `cloud_base` or `anaconda` package sets.

It works by adding another layer of map under the top-level image type key. This is typically just the image type name again. But it allows us to write:
```yaml
qcow2: &qcow2
  <<: *cloud_base
  qcow2:
    include:
      - "qemu-guest-agent"
```
and benefit from the yaml mapping merge support. It would be more natural to have a sequence here but merging of sequences is not support so we need this workaround.

Another alternative would be we introduce a new custom key next to `condition` like `merge` and to this ourselfs but that is more custom code.

Another splitout/cleanup of https://github.com/osbuild/images/pull/1283 where we will need this for e.g. the SAP packages.