### PR TITLE
[RFC] packagesets: add basic imagetype yaml to merge pkgSets

### DIFF
--- a/pkg/distro/packagesets/loader.go
+++ b/pkg/distro/packagesets/loader.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/osbuild/images/internal/common"
@@ -17,6 +18,15 @@ import (
 var data embed.FS
 
 var DataFS fs.FS = data
+
+type toplevelYAML struct {
+	ImageTypes         map[string]imageType  `yaml:"image_types"`
+	VirtualPackageSets map[string]packageSet `yaml:"virtual_package_sets"`
+}
+
+type imageType struct {
+	PackageSets []packageSet `yaml:"package_sets"`
+}
 
 type packageSet struct {
 	Include   []string    `yaml:"include"`
@@ -51,59 +61,68 @@ func Load(it distro.ImageType, replacements map[string]string) rpmmd.PackageSet 
 	decoder := yaml.NewDecoder(distroSets)
 	decoder.KnownFields(true)
 
-	var pkgSets map[string]packageSet
-	if err := decoder.Decode(&pkgSets); err != nil {
+	// each imagetype can have multiple package sets, so that we can
+	// use yaml aliases/anchors to de-duplicate them
+	var toplevel toplevelYAML
+	if err := decoder.Decode(&toplevel); err != nil {
 		panic(err)
 	}
 
-	pkgSet, ok := pkgSets[typeName]
+	imgType, ok := toplevel.ImageTypes[typeName]
 	if !ok {
-		panic(fmt.Sprintf("unknown package set name %q", typeName))
-	}
-	rpmmdPkgSet := rpmmd.PackageSet{
-		Include: pkgSet.Include,
-		Exclude: pkgSet.Exclude,
+		panic(fmt.Errorf("unknown image type name %q", typeName))
 	}
 
-	if pkgSet.Condition != nil {
-		// process conditions
-		if archSet, ok := pkgSet.Condition.Architecture[archName]; ok {
-			rpmmdPkgSet = rpmmdPkgSet.Append(rpmmd.PackageSet{
-				Include: archSet.Include,
-				Exclude: archSet.Exclude,
-			})
-		}
-		if distroNameSet, ok := pkgSet.Condition.DistroName[distroName]; ok {
-			rpmmdPkgSet = rpmmdPkgSet.Append(rpmmd.PackageSet{
-				Include: distroNameSet.Include,
-				Exclude: distroNameSet.Exclude,
-			})
-		}
+	var rpmmdPkgSet rpmmd.PackageSet
+	for _, pkgSet := range imgType.PackageSets {
+		rpmmdPkgSet = rpmmdPkgSet.Append(rpmmd.PackageSet{
+			Include: pkgSet.Include,
+			Exclude: pkgSet.Exclude,
+		})
 
-		for ltVer, ltSet := range pkgSet.Condition.VersionLessThan {
-			if r, ok := replacements[ltVer]; ok {
-				ltVer = r
-			}
-			if common.VersionLessThan(distroVersion, ltVer) {
+		if pkgSet.Condition != nil {
+			// process conditions
+			if archSet, ok := pkgSet.Condition.Architecture[archName]; ok {
 				rpmmdPkgSet = rpmmdPkgSet.Append(rpmmd.PackageSet{
-					Include: ltSet.Include,
-					Exclude: ltSet.Exclude,
+					Include: archSet.Include,
+					Exclude: archSet.Exclude,
 				})
 			}
-		}
-
-		for gteqVer, gteqSet := range pkgSet.Condition.VersionGreaterOrEqual {
-			if r, ok := replacements[gteqVer]; ok {
-				gteqVer = r
-			}
-			if common.VersionGreaterThanOrEqual(distroVersion, gteqVer) {
+			if distroNameSet, ok := pkgSet.Condition.DistroName[distroName]; ok {
 				rpmmdPkgSet = rpmmdPkgSet.Append(rpmmd.PackageSet{
-					Include: gteqSet.Include,
-					Exclude: gteqSet.Exclude,
+					Include: distroNameSet.Include,
+					Exclude: distroNameSet.Exclude,
 				})
+			}
+
+			for ltVer, ltSet := range pkgSet.Condition.VersionLessThan {
+				if r, ok := replacements[ltVer]; ok {
+					ltVer = r
+				}
+				if common.VersionLessThan(distroVersion, ltVer) {
+					rpmmdPkgSet = rpmmdPkgSet.Append(rpmmd.PackageSet{
+						Include: ltSet.Include,
+						Exclude: ltSet.Exclude,
+					})
+				}
+			}
+
+			for gteqVer, gteqSet := range pkgSet.Condition.VersionGreaterOrEqual {
+				if r, ok := replacements[gteqVer]; ok {
+					gteqVer = r
+				}
+				if common.VersionGreaterThanOrEqual(distroVersion, gteqVer) {
+					rpmmdPkgSet = rpmmdPkgSet.Append(rpmmd.PackageSet{
+						Include: gteqSet.Include,
+						Exclude: gteqSet.Exclude,
+					})
+				}
 			}
 		}
 	}
+	// mostly for tests
+	sort.Strings(rpmmdPkgSet.Include)
+	sort.Strings(rpmmdPkgSet.Exclude)
 
 	return rpmmdPkgSet
 }

--- a/pkg/distro/packagesets/loader_test.go
+++ b/pkg/distro/packagesets/loader_test.go
@@ -37,17 +37,19 @@ func makeFakePkgsSet(t *testing.T, distroName, content string) string {
 func TestLoadConditionDistro(t *testing.T) {
 	it := makeTestImageType(t)
 	fakePkgsSetYaml := `
-test_type:
-  include: [inc1]
-  exclude: [exc1]
-  condition:
-    distro_name:
-      test-distro:
-        include: [from-condition-inc2]
-        exclude: [from-condition-exc2]
-      other-distro:
-        include: [inc3]
-        exclude: [exc3]
+image_types:
+  test_type:
+    package_sets:
+      - include: [inc1]
+        exclude: [exc1]
+        condition:
+          distro_name:
+            test-distro:
+              include: [from-condition-inc2]
+              exclude: [from-condition-exc2]
+            other-distro:
+              include: [inc3]
+              exclude: [exc3]
 `
 	// XXX: we cannot use distro.Name() as it will give us a name+ver
 	baseDir := makeFakePkgsSet(t, test_distro.TestDistroNameBase, fakePkgsSetYaml)
@@ -57,7 +59,52 @@ test_type:
 	pkgSet := packagesets.Load(it, nil)
 	assert.NotNil(t, pkgSet)
 	assert.Equal(t, rpmmd.PackageSet{
-		Include: []string{"inc1", "from-condition-inc2"},
+		Include: []string{"from-condition-inc2", "inc1"},
 		Exclude: []string{"exc1", "from-condition-exc2"},
+	}, pkgSet)
+}
+
+func TestLoadYamlMergingWorks(t *testing.T) {
+	it := makeTestImageType(t)
+	fakePkgsSetYaml := `
+# package_sets not associated with an imagetype can be defined here
+virtual_package_sets:
+  base: &base_pkgset
+    include: [from-base-inc]
+    exclude: [from-base-exc]
+    condition:
+      distro_name:
+        test-distro:
+          include: [from-base-condition-inc]
+          exclude: [from-base-condition-exc]
+
+image_types:
+  other_type:
+    package_sets:
+      - &other_type_pkgset
+        include: [from-other-type-inc]
+        exclude: [from-other-type-exc]
+  test_type:
+    package_sets:
+      - *base_pkgset
+      - *other_type_pkgset
+      - include: [from-type-inc]
+        exclude: [from-type-exc]
+        condition:
+          distro_name:
+            test-distro:
+              include: [from-condition-inc]
+              exclude: [from-condition-exc]
+`
+	// XXX: we cannot use distro.Name() as it will give us a name+ver
+	baseDir := makeFakePkgsSet(t, test_distro.TestDistroNameBase, fakePkgsSetYaml)
+	restore := packagesets.MockDataFS(baseDir)
+	defer restore()
+
+	pkgSet := packagesets.Load(it, nil)
+	assert.NotNil(t, pkgSet)
+	assert.Equal(t, rpmmd.PackageSet{
+		Include: []string{"from-base-condition-inc", "from-base-inc", "from-condition-inc", "from-other-type-inc", "from-type-inc"},
+		Exclude: []string{"from-base-condition-exc", "from-base-exc", "from-condition-exc", "from-other-type-exc", "from-type-exc"},
 	}, pkgSet)
 }


### PR DESCRIPTION
[draft as this is one possible way of doing it, all fedora package_sets.yaml needs converting, I like this because its very symetric but it is not perfect, alternative version of https://github.com/osbuild/images/pull/1294]

This commit adds a basic imagetype yaml to support merging of package sets  This is a useful feature so that we can e.g. avoid duplicating the `cloud_base` or `anaconda` package sets.

It works by adding new toplevels "image_types" and "virtual_package_sets" in the package_sets.yaml and then using anchors/refs to refer to them in the image_type yaml.

It allows us to write:
```yaml
# this key is optional but would come in handy for cloud_base in fedora
virtual_package_sets:
  base: &base_pkgset
    include: [from-base-inc]
    exclude: [from-base-exc]
    condition:
      distro_name:
        test-distro:
          include: [from-base-condition-inc]
          exclude: [from-base-condition-exc]

image_types:
  other_type:
    package_sets:
      - &other_type_pkgset
        include: [from-other-type-inc]
        exclude: [from-other-type-exc]
  test_type:
    package_sets:
      - *base_pkgset
      - *other_type_pkgset
      - include: [from-type-inc]
        exclude: [from-type-exc]
        condition:
          distro_name:
            test-distro:
              include: [from-condition-inc]
              exclude: [from-condition-exc]
```
The downside of this approach is that:
1. it requires the anchor to be there before the ref, which can be confusing (we could solve this later via includes)
2. if the anchor is forgotten the error becomes very obscure
3. its a bit "hardcore" yaml

The upside is that it is very symetrical and actually feels quite nice.