### PR TITLE
packagesets: add basic imagetype yaml to merge pkgSets

### DIFF
--- a/pkg/distro/packagesets/fedora/package_sets.yaml
+++ b/pkg/distro/packagesets/fedora/package_sets.yaml
@@ -1,922 +1,600 @@
 ---
-cloud_base:  # not used directly; added for reference
-  include:
-    - "@Fedora Cloud Server"
-    - "chrony"  # not mentioned in the kickstart anaconda pulls it when setting the timezone
-    - "langpacks-en"
-  exclude:
-    - "dracut-config-rescue"
-    - "firewalld"
-    - "geolite2-city"
-    - "geolite2-country"
-    - "plymouth"
+.common:
+  cloud_base_pkgset: &cloud_base_pkgset
+    include:
+      - "@Fedora Cloud Server"
+      - "chrony"  # not mentioned in the kickstart anaconda pulls it when setting the timezone
+      - "langpacks-en"
+    exclude:
+      - "dracut-config-rescue"
+      - "firewalld"
+      - "geolite2-city"
+      - "geolite2-country"
+      - "plymouth"
 
-qcow2: &qcow2
-  include:
-    # cloud_base
-    - "@Fedora Cloud Server"
-    - "chrony"  # not mentioned in the kickstart anaconda pulls it when setting the timezone
-    - "langpacks-en"
+image_types:
+  qcow2: &qcow2
+    package_sets:
+     - *cloud_base_pkgset
+     - include:
+         - "qemu-guest-agent"
+  ami: *qcow2
+  oci: *qcow2
+  openstack: *qcow2
 
-    # qcow2
-    - "qemu-guest-agent"
-  exclude:
-    # cloud_base
-    - "dracut-config-rescue"
-    - "firewalld"
-    - "geolite2-city"
-    - "geolite2-country"
-    - "plymouth"
+  vhd:
+    package_sets:
+      - *cloud_base_pkgset
+      - include:
+          - "WALinuxAgent"
 
-ami:
-  <<: *qcow2
-
-oci:
-  <<: *qcow2
-
-openstack:
-  <<: *qcow2
-
-vhd:
-  include:
-    # cloud_base
-    - "@Fedora Cloud Server"
-    - "chrony"  # not mentioned in the kickstart anaconda pulls it when setting the timezone
-    - "langpacks-en"
-
-    # vhd
-    - "WALinuxAgent"
-  exclude:
-    # cloud_base
-    - "dracut-config-rescue"
-    - "firewalld"
-    - "geolite2-city"
-    - "geolite2-country"
-    - "plymouth"
-
-vmdk: &vmdk
-  include:
-    - "@Fedora Cloud Server"
-    - "chrony"
-    - "systemd-udev"
-    - "langpacks-en"
-    - "open-vm-tools"
-  exclude:
-    - "dracut-config-rescue"
-    - "etables"
-    - "firewalld"
-    - "geolite2-city"
-    - "geolite2-country"
-    - "gobject-introspection"
-    - "plymouth"
-    - "zram-generator-defaults"
-    - "grubby-deprecated"
-    - "extlinux-bootloader"
-
-ova:
-  <<: *vmdk
-
-# NOTE: keep in sync with official fedora-iot definitions:
-# https://pagure.io/fedora-iot/ostree/blob/main/f/fedora-iot-base.yaml
-iot_commit: &iot_commit
-  include:
-    - "NetworkManager"
-    - "NetworkManager-wifi"
-    - "NetworkManager-wwan"
-    - "aardvark-dns"
-    - "atheros-firmware"
-    - "attr"
-    - "authselect"
-    - "bash"
-    - "bash-completion"
-    - "brcmfmac-firmware"
-    - "chrony"
-    - "clevis"
-    - "clevis-dracut"
-    - "clevis-luks"
-    - "clevis-pin-tpm2"
-    - "container-selinux"
-    - "containernetworking-plugins"
-    - "coreutils"
-    - "cracklib-dicts"
-    - "criu"
-    - "cryptsetup"
-    - "curl"
-    - "dosfstools"
-    - "dracut-config-generic"
-    - "dracut-network"
-    - "e2fsprogs"
-    - "efibootmgr"
-    - "fdo-client"
-    - "fdo-owner-cli"
-    - "fedora-iot-config"
-    - "fedora-release-iot"
-    - "firewalld"
-    - "fwupd"
-    - "fwupd-efi"
-    - "fwupd-plugin-modem-manager"
-    - "fwupd-plugin-uefi-capsule-data"
-    - "glibc"
-    - "glibc-minimal-langpack"
-    - "gnupg2"
-    - "greenboot"
-    - "greenboot-default-health-checks"
-    - "gzip"
-    - "hostname"
-    - "ignition"
-    - "ignition-edge"
-    - "ima-evm-utils"
-    - "iproute"
-    - "iputils"
-    - "iwd"
-    - "iwlwifi-mvm-firmware"
-    - "keyutils"
-    - "less"
-    - "libsss_sudo"
-    - "linux-firmware"
-    - "lvm2"
-    - "netavark"
-    - "nss-altfiles"
-    - "openssh-clients"
-    - "openssh-server"
-    - "openssl"
-    - "pinentry"
-    - "podman"
-    - "policycoreutils"
-    - "polkit"
-    - "procps-ng"
-    - "realtek-firmware"
-    - "rootfiles"
-    - "rpm"
-    - "screen"
-    - "selinux-policy-targeted"
-    - "setools-console"
-    - "setup"
-    - "shadow-utils"
-    - "skopeo"
-    - "slirp4netns"
-    - "ssh-key-dir"
-    - "sssd-client"
-    - "sudo"
-    - "systemd"
-    - "systemd-resolved"
-    - "tar"
-    - "tmux"
-    - "tpm2-pkcs11"
-    - "traceroute"
-    - "usbguard"
-    - "util-linux"
-    - "vim-minimal"
-    - "wireless-regdb"
-    - "wpa_supplicant"
-    - "xfsprogs"
-    - "xz"
-    - "zram-generator"
-  condition:
-    version_less_than:
-      "41":
-        include:
-          - "dnsmasq"
-      "42":
-        include:
-          - "dbus-parsec"
-          - "kernel-tools"
-          - "parsec"
-          - "policycoreutils-python-utils"
-          - "zezere-ignition"
-      "43":
-        include:
-          - "basesystem"
-    version_greater_or_equal:
-      "41":
-        include:
-          - "bootupd"
-      "43":
-        include:
-          - "filesystem"
-
-iot_container:
-  <<: *iot_commit
-
-iot_bootable_container:
-  include:
-    - "acl"
-    - "attr"  # used by admins interactively
-    - "bootc"
-    - "bootupd"
-    - "chrony"  # NTP support
-    - "container-selinux"
-    - "container-selinux"
-    - "crun"
-    - "cryptsetup"
-    - "dnf"
-    - "dosfstools"
-    - "e2fsprogs"
-    - "fwupd"  # if you're using linux-firmware you probably also want fwupd
-    - "gdisk"
-    - "iproute"  # route manipulation and QoS
-    - "iproute-tc"
-    - "iptables"  # firewall manipulation
-    - "nftables"
-    - "iptables-services"  # additional firewall support
-    - "kbd"               # i18n
-    - "keyutils"          # Manipulating the kernel keyring; used by bootc
-    - "libsss_sudo"       # allow communication between sudo and SSSD for caching sudo rules by SSSD
-    - "linux-firmware"    # linux-firmware now a recommends so let's explicitly include it
-    - "logrotate"         # There are things that write outside of the journal still (such as the classic wtmp etc.). auditd also writes outside the journal but it has its own log rotation.  Anything package layered will also tend to expect files dropped in /etc/logrotate.d to work. Really this is a legacy thing but if we don't have it then people's disks will slowly fill up with logs.
-    - "lsof"
-    - "lvm2"                       # Storage configuration/management
-    - "nano"                       # default editor
-    - "ncurses"                    # provides terminal tools like clear reset tput and tset
-    - "NetworkManager-cloud-setup"  # support for cloud quirks and dynamic config in real rootfs: https:#github.com/coreos/fedora-coreos-tracker/issues/320
-    - "NetworkManager"  # standard tools for configuring network/hostname
-    - "hostname"
-    - "NetworkManager-team"  # teaming https:#github.com/coreos/fedora-coreos-config/pull/289 and http:#bugzilla.redhat.com/1758162
-    - "teamd"
-    - "NetworkManager-tui"               # interactive Networking configuration during coreos-install
-    - "nfs-utils-coreos"  # minimal NFS client
-    - "iptables-nft"
-    - "nss-altfiles"
-    - "openssh-clients"
-    - "openssh-server"
-    - "openssl"
-    - "ostree"
-    - "shadow-utils"  # User configuration
-    - "podman"
-    - "rpm-ostree"
-    - "selinux-policy-targeted"
-    - "sg3_utils"
-    - "skopeo"
-    - "socat"  # interactive network tools for admins
-    - "net-tools"
-    - "bind-utils"
-    - "sssd-client"  # SSSD backends
-    - "sssd-ad"
-    - "sssd-ipa"
-    - "sssd-krb5"
-    - "sssd-ldap"
-    - "stalld"               # Boost starving threads https:#github.com/coreos/fedora-coreos-tracker/issues/753
-    - "subscription-manager"  # To ensure we can enable client certs to access RHEL content
-    - "sudo"
-    - "systemd"
-    - "systemd-resolved"  # resolved was broken out to its own package in rawhide/f35
-    - "tpm2-tools"        # needed for tpm2 bound luks
-    - "WALinuxAgent-udev"  # udev rules for Azure (rhbz#1748432)
-    - "xfsprogs"
-    - "zram-generator"  # zram-generator (but not zram-generator-defaults) for F33 change
-  exclude:
-    - "cowsay"  # just in case
-    - "grubby"
-    - "initscripts"                         # make sure initscripts doesn't get pulled back in https:#github.com/coreos/fedora-coreos-tracker/issues/220#issuecomment-611566254
-    - "NetworkManager-initscripts-ifcfg-rh"  # do not use legacy ifcfg config format in NetworkManager See https:#github.com/coreos/fedora-coreos-config/pull/1991
-    - "nodejs"
-    - "plymouth"         # for (datacenter/cloud oriented) servers we want to see the details by default.  https:#lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/HSMISZ3ETWQ4ETVLWZQJ55ARZT27AAV3/
-    - "systemd-networkd"  # we use NetworkManager
-  condition:
-    architecture:
-      aarch64:
-        include:
-          - "irqbalance"
-          - "ostree-grub2"
+  vmdk: &vmdk
+    package_sets:
+      - include:
+          - "@Fedora Cloud Server"
+          - "chrony"
+          - "systemd-udev"
+          - "langpacks-en"
+          - "open-vm-tools"
         exclude:
-          - "perl"
-          - "perl-interpreter"
-      ppc64le:
-        include:
-          - "irqbalance"
-          - "librtas"
-          - "powerpc-utils-core"
-          - "ppc64-diag-rtas"
-      x86_64:
-        include:
-          - "irqbalance"
-        exclude:
-          - "perl"
-          - "perl-interpreter"
-
-installer:
-  include:
-    - "anaconda-dracut"
-    - "atheros-firmware"
-    - "brcmfmac-firmware"
-    - "curl"
-    - "dracut-config-generic"
-    - "dracut-network"
-    - "hostname"
-    - "iwlwifi-dvm-firmware"
-    - "iwlwifi-mvm-firmware"
-    - "kernel"
-    - "linux-firmware"
-    - "less"
-    - "nfs-utils"
-    - "openssh-clients"
-    - "ostree"
-    - "plymouth"
-    - "realtek-firmware"
-    - "rng-tools"
-    - "rpcbind"
-    - "selinux-policy-targeted"
-    - "systemd"
-    - "tar"
-    - "xfsprogs"
-    - "xz"
-
-
-anaconda:
-  include:
-    - "aajohan-comfortaa-fonts"
-    - "abattis-cantarell-fonts"
-    - "alsa-firmware"
-    - "alsa-tools-firmware"
-    - "anaconda"
-    - "anaconda-dracut"
-    - "anaconda-install-img-deps"
-    - "anaconda-widgets"
-    - "atheros-firmware"
-    - "audit"
-    - "bind-utils"
-    - "bitmap-fangsongti-fonts"
-    - "brcmfmac-firmware"
-    - "bzip2"
-    - "cryptsetup"
-    - "curl"
-    - "dbus-x11"
-    - "dejavu-sans-fonts"
-    - "dejavu-sans-mono-fonts"
-    - "device-mapper-persistent-data"
-    - "dmidecode"
-    - "dnf"
-    - "dracut-config-generic"
-    - "dracut-network"
-    - "efibootmgr"
-    - "ethtool"
-    - "fcoe-utils"
-    - "ftp"
-    - "gdb-gdbserver"
-    - "gdisk"
-    - "glibc-all-langpacks"
-    - "gnome-kiosk"
-    - "google-noto-sans-cjk-ttc-fonts"
-    - "grub2-tools"
-    - "grub2-tools-extra"
-    - "grub2-tools-minimal"
-    - "grubby"
-    - "gsettings-desktop-schemas"
-    - "hdparm"
-    - "hexedit"
-    - "hostname"
-    - "initscripts"
-    - "ipmitool"
-    - "iwlwifi-dvm-firmware"
-    - "iwlwifi-mvm-firmware"
-    - "jomolhari-fonts"
-    - "kacst-farsi-fonts"
-    - "kacst-qurn-fonts"
-    - "kbd"
-    - "kbd-misc"
-    - "kdump-anaconda-addon"
-    - "kernel"
-    - "khmeros-base-fonts"
-    - "less"
-    - "libblockdev-lvm-dbus"
-    - "libibverbs"
-    - "libreport-plugin-bugzilla"
-    - "libreport-plugin-reportuploader"
-    - "librsvg2"
-    - "linux-firmware"
-    - "lldpad"
-    - "lohit-assamese-fonts"
-    - "lohit-bengali-fonts"
-    - "lohit-devanagari-fonts"
-    - "lohit-gujarati-fonts"
-    - "lohit-gurmukhi-fonts"
-    - "lohit-kannada-fonts"
-    - "lohit-odia-fonts"
-    - "lohit-tamil-fonts"
-    - "lohit-telugu-fonts"
-    - "lsof"
-    - "madan-fonts"
-    - "mtr"
-    - "mt-st"
-    - "net-tools"
-    - "nfs-utils"
-    - "nmap-ncat"
-    - "nm-connection-editor"
-    - "nss-tools"
-    - "openssh-clients"
-    - "openssh-server"
-    - "ostree"
-    - "pciutils"
-    - "perl-interpreter"
-    - "pigz"
-    - "plymouth"
-    - "python3-pyatspi"
-    - "rdma-core"
-    - "realtek-firmware"
-    - "rit-meera-new-fonts"
-    - "rng-tools"
-    - "rpcbind"
-    - "rpm-ostree"
-    - "rsync"
-    - "rsyslog"
-    - "selinux-policy-targeted"
-    - "sg3_utils"
-    - "sil-abyssinica-fonts"
-    - "sil-padauk-fonts"
-    - "sil-scheherazade-new-fonts"
-    - "smartmontools"
-    - "spice-vdagent"
-    - "strace"
-    - "systemd"
-    - "tar"
-    - "thai-scalable-waree-fonts"
-    - "tigervnc-server-minimal"
-    - "tigervnc-server-module"
-    - "udisks2"
-    - "udisks2-iscsi"
-    - "usbutils"
-    - "vim-minimal"
-    - "volume_key"
-    - "wget"
-    - "xfsdump"
-    - "xfsprogs"
-    - "xorg-x11-drivers"
-    - "xorg-x11-fonts-misc"
-    - "xorg-x11-server-Xorg"
-    - "xorg-x11-xauth"
-    - "metacity"
-    - "xrdb"
-    - "xz"
-  condition:
-    architecture:
-      x86_64:
-        include:
-          - "biosdevname"
-          - "dmidecode"
-          - "grub2-tools-efi"
-          - "memtest86+"
-      aarch64:
-        include:
-          - "dmidecode"
-
-iot_installer:
-  # anaconda
-  include:
-    - "aajohan-comfortaa-fonts"
-    - "abattis-cantarell-fonts"
-    - "alsa-firmware"
-    - "alsa-tools-firmware"
-    - "anaconda"
-    - "anaconda-dracut"
-    - "anaconda-install-img-deps"
-    - "anaconda-widgets"
-    - "atheros-firmware"
-    - "audit"
-    - "bind-utils"
-    - "bitmap-fangsongti-fonts"
-    - "brcmfmac-firmware"
-    - "bzip2"
-    - "cryptsetup"
-    - "curl"
-    - "dbus-x11"
-    - "dejavu-sans-fonts"
-    - "dejavu-sans-mono-fonts"
-    - "device-mapper-persistent-data"
-    - "dmidecode"
-    - "dnf"
-    - "dracut-config-generic"
-    - "dracut-network"
-    - "efibootmgr"
-    - "ethtool"
-    - "fcoe-utils"
-    - "ftp"
-    - "gdb-gdbserver"
-    - "gdisk"
-    - "glibc-all-langpacks"
-    - "gnome-kiosk"
-    - "google-noto-sans-cjk-ttc-fonts"
-    - "grub2-tools"
-    - "grub2-tools-extra"
-    - "grub2-tools-minimal"
-    - "grubby"
-    - "gsettings-desktop-schemas"
-    - "hdparm"
-    - "hexedit"
-    - "hostname"
-    - "initscripts"
-    - "ipmitool"
-    - "iwlwifi-dvm-firmware"
-    - "iwlwifi-mvm-firmware"
-    - "jomolhari-fonts"
-    - "kacst-farsi-fonts"
-    - "kacst-qurn-fonts"
-    - "kbd"
-    - "kbd-misc"
-    - "kdump-anaconda-addon"
-    - "kernel"
-    - "khmeros-base-fonts"
-    - "less"
-    - "libblockdev-lvm-dbus"
-    - "libibverbs"
-    - "libreport-plugin-bugzilla"
-    - "libreport-plugin-reportuploader"
-    - "librsvg2"
-    - "linux-firmware"
-    - "lldpad"
-    - "lohit-assamese-fonts"
-    - "lohit-bengali-fonts"
-    - "lohit-devanagari-fonts"
-    - "lohit-gujarati-fonts"
-    - "lohit-gurmukhi-fonts"
-    - "lohit-kannada-fonts"
-    - "lohit-odia-fonts"
-    - "lohit-tamil-fonts"
-    - "lohit-telugu-fonts"
-    - "lsof"
-    - "madan-fonts"
-    - "mtr"
-    - "mt-st"
-    - "net-tools"
-    - "nfs-utils"
-    - "nmap-ncat"
-    - "nm-connection-editor"
-    - "nss-tools"
-    - "openssh-clients"
-    - "openssh-server"
-    - "ostree"
-    - "pciutils"
-    - "perl-interpreter"
-    - "pigz"
-    - "plymouth"
-    - "python3-pyatspi"
-    - "rdma-core"
-    - "realtek-firmware"
-    - "rit-meera-new-fonts"
-    - "rng-tools"
-    - "rpcbind"
-    - "rpm-ostree"
-    - "rsync"
-    - "rsyslog"
-    - "selinux-policy-targeted"
-    - "sg3_utils"
-    - "sil-abyssinica-fonts"
-    - "sil-padauk-fonts"
-    - "sil-scheherazade-new-fonts"
-    - "smartmontools"
-    - "spice-vdagent"
-    - "strace"
-    - "systemd"
-    - "tar"
-    - "thai-scalable-waree-fonts"
-    - "tigervnc-server-minimal"
-    - "tigervnc-server-module"
-    - "udisks2"
-    - "udisks2-iscsi"
-    - "usbutils"
-    - "vim-minimal"
-    - "volume_key"
-    - "wget"
-    - "xfsdump"
-    - "xfsprogs"
-    - "xorg-x11-drivers"
-    - "xorg-x11-fonts-misc"
-    - "xorg-x11-server-Xorg"
-    - "xorg-x11-xauth"
-    - "metacity"
-    - "xrdb"
-    - "xz"
-
-    # iot_installer
-    - "fedora-release-iot"
-  condition:
-    # anaconda
-    architecture:
-      x86_64:
-        include:
-          - "biosdevname"
-          - "dmidecode"
-          - "grub2-tools-efi"
-          - "memtest86+"
-      aarch64:
-        include:
-          - "dmidecode"
-
-
-live_installer:
-  include:
-    - "@workstation-product-environment"
-    - "@anaconda-tools"
-    - "anaconda-install-env-deps"
-    - "anaconda-live"
-    - "anaconda-dracut"
-    - "dracut-live"
-    - "glibc-all-langpacks"
-    - "kernel"
-    - "kernel-modules"
-    - "kernel-modules-extra"
-    - "livesys-scripts"
-    - "rng-tools"
-    - "rdma-core"
-    - "gnome-kiosk"
-  exclude:
-    - "@dial-up"
-    - "@input-methods"
-    - "@standard"
-    - "device-mapper-multipath"
-    - "fcoe-utils"
-    - "gfs2-utils"
-    - "reiserfs-utils"
-    - "sdubby"
-  condition:
-    version_greater_or_equal:
-      VERSION_RAWHIDE:
-        include:
-          - "anaconda-webui"
-
-
-image_installer:
-  # anaconda
-  include:
-    - "aajohan-comfortaa-fonts"
-    - "abattis-cantarell-fonts"
-    - "alsa-firmware"
-    - "alsa-tools-firmware"
-    - "anaconda"
-    - "anaconda-dracut"
-    - "anaconda-install-img-deps"
-    - "anaconda-widgets"
-    - "atheros-firmware"
-    - "audit"
-    - "bind-utils"
-    - "bitmap-fangsongti-fonts"
-    - "brcmfmac-firmware"
-    - "bzip2"
-    - "cryptsetup"
-    - "curl"
-    - "dbus-x11"
-    - "dejavu-sans-fonts"
-    - "dejavu-sans-mono-fonts"
-    - "device-mapper-persistent-data"
-    - "dmidecode"
-    - "dnf"
-    - "dracut-config-generic"
-    - "dracut-network"
-    - "efibootmgr"
-    - "ethtool"
-    - "fcoe-utils"
-    - "ftp"
-    - "gdb-gdbserver"
-    - "gdisk"
-    - "glibc-all-langpacks"
-    - "gnome-kiosk"
-    - "google-noto-sans-cjk-ttc-fonts"
-    - "grub2-tools"
-    - "grub2-tools-extra"
-    - "grub2-tools-minimal"
-    - "grubby"
-    - "gsettings-desktop-schemas"
-    - "hdparm"
-    - "hexedit"
-    - "hostname"
-    - "initscripts"
-    - "ipmitool"
-    - "iwlwifi-dvm-firmware"
-    - "iwlwifi-mvm-firmware"
-    - "jomolhari-fonts"
-    - "kacst-farsi-fonts"
-    - "kacst-qurn-fonts"
-    - "kbd"
-    - "kbd-misc"
-    - "kdump-anaconda-addon"
-    - "kernel"
-    - "khmeros-base-fonts"
-    - "less"
-    - "libblockdev-lvm-dbus"
-    - "libibverbs"
-    - "libreport-plugin-bugzilla"
-    - "libreport-plugin-reportuploader"
-    - "librsvg2"
-    - "linux-firmware"
-    - "lldpad"
-    - "lohit-assamese-fonts"
-    - "lohit-bengali-fonts"
-    - "lohit-devanagari-fonts"
-    - "lohit-gujarati-fonts"
-    - "lohit-gurmukhi-fonts"
-    - "lohit-kannada-fonts"
-    - "lohit-odia-fonts"
-    - "lohit-tamil-fonts"
-    - "lohit-telugu-fonts"
-    - "lsof"
-    - "madan-fonts"
-    - "mtr"
-    - "mt-st"
-    - "net-tools"
-    - "nfs-utils"
-    - "nmap-ncat"
-    - "nm-connection-editor"
-    - "nss-tools"
-    - "openssh-clients"
-    - "openssh-server"
-    - "ostree"
-    - "pciutils"
-    - "perl-interpreter"
-    - "pigz"
-    - "plymouth"
-    - "python3-pyatspi"
-    - "rdma-core"
-    - "realtek-firmware"
-    - "rit-meera-new-fonts"
-    - "rng-tools"
-    - "rpcbind"
-    - "rpm-ostree"
-    - "rsync"
-    - "rsyslog"
-    - "selinux-policy-targeted"
-    - "sg3_utils"
-    - "sil-abyssinica-fonts"
-    - "sil-padauk-fonts"
-    - "sil-scheherazade-new-fonts"
-    - "smartmontools"
-    - "spice-vdagent"
-    - "strace"
-    - "systemd"
-    - "tar"
-    - "thai-scalable-waree-fonts"
-    - "tigervnc-server-minimal"
-    - "tigervnc-server-module"
-    - "udisks2"
-    - "udisks2-iscsi"
-    - "usbutils"
-    - "vim-minimal"
-    - "volume_key"
-    - "wget"
-    - "xfsdump"
-    - "xfsprogs"
-    - "xorg-x11-drivers"
-    - "xorg-x11-fonts-misc"
-    - "xorg-x11-server-Xorg"
-    - "xorg-x11-xauth"
-    - "metacity"
-    - "xrdb"
-    - "xz"
-  condition:
-    architecture:
-      x86_64:
-        include:
-          - "biosdevname"
-          - "dmidecode"
-          - "grub2-tools-efi"
-          - "memtest86+"
-      aarch64:
-        include:
-          - "dmidecode"
-
-container: &container
-  include:
-    - "bash"
-    - "coreutils"
-    - "yum"
-    - "dnf"
-    - "fedora-release-container"
-    - "glibc-minimal-langpack"
-    - "rootfiles"
-    - "rpm"
-    - "sudo"
-    - "tar"
-    - "util-linux-core"
-    - "vim-minimal"
-  exclude:
-    - "crypto-policies-scripts"
-    - "dbus-broker"
-    - "deltarpm"
-    - "dosfstools"
-    - "e2fsprogs"
-    - "elfutils-debuginfod-client"
-    - "fuse-libs"
-    - "gawk-all-langpacks"
-    - "glibc-gconv-extra"
-    - "glibc-langpack-en"
-    - "gnupg2-smime"
-    - "grubby"
-    - "kernel-core"
-    - "kernel-debug-core"
-    - "kernel"
-    - "langpacks-en_GB"
-    - "langpacks-en"
-    - "libss"
-    - "libxcrypt-compat"
-    - "nano"
-    - "openssl-pkcs11"
-    - "pinentry"
-    - "python3-unbound"
-    - "shared-mime-info"
-    - "sssd-client"
-    - "sudo-python-plugin"
-    - "systemd"
-    - "trousers"
-    - "whois-nls"
-    - "xkeyboard-config"
-
-wsl:
-  <<: *container
-
-minimal_raw: &minimal
-  include:
-    - "@core"
-    - "initial-setup"
-    - "libxkbcommon"
-    - "NetworkManager-wifi"
-    - "brcmfmac-firmware"
-    - "realtek-firmware"
-    - "iwlwifi-mvm-firmware"
-  exclude:
-    - "dracut-config-rescue"
-  condition:
-    architecture:
-      riscv64:
-        include:
-          # missing from @core in riscv64
-          - "dnf5"
-          - "policycoreutils"
-          - "selinux-policy-targeted"
-    version_greater_or_equal:
-      "43":
-        exclude:
+          - "dracut-config-rescue"
+          - "etables"
           - "firewalld"
+          - "geolite2-city"
+          - "geolite2-country"
+          - "gobject-introspection"
+          - "plymouth"
+          - "zram-generator-defaults"
+          - "grubby-deprecated"
+          - "extlinux-bootloader"
 
-minimal_raw_zst:
-  <<: *minimal
+  ova: *vmdk
 
-iot_simplified_installer:
-  include:
-    # installer.include
-    - "anaconda-dracut"
-    - "atheros-firmware"
-    - "brcmfmac-firmware"
-    - "curl"
-    - "dracut-config-generic"
-    - "dracut-network"
-    - "hostname"
-    - "iwlwifi-dvm-firmware"
-    - "iwlwifi-mvm-firmware"
-    - "kernel"
-    - "linux-firmware"
-    - "less"
-    - "nfs-utils"
-    - "openssh-clients"
-    - "ostree"
-    - "plymouth"
-    - "realtek-firmware"
-    - "rng-tools"
-    - "rpcbind"
-    - "selinux-policy-targeted"
-    - "systemd"
-    - "tar"
-    - "xfsprogs"
-    - "xz"
+  # NOTE: keep in sync with official fedora-iot definitions:
+  # https://pagure.io/fedora-iot/ostree/blob/main/f/fedora-iot-base.yaml
+  iot_commit: &iot_commit
+    package_sets:
+      - include:
+          - "NetworkManager"
+          - "NetworkManager-wifi"
+          - "NetworkManager-wwan"
+          - "aardvark-dns"
+          - "atheros-firmware"
+          - "attr"
+          - "authselect"
+          - "bash"
+          - "bash-completion"
+          - "brcmfmac-firmware"
+          - "chrony"
+          - "clevis"
+          - "clevis-dracut"
+          - "clevis-luks"
+          - "clevis-pin-tpm2"
+          - "container-selinux"
+          - "containernetworking-plugins"
+          - "coreutils"
+          - "cracklib-dicts"
+          - "criu"
+          - "cryptsetup"
+          - "curl"
+          - "dosfstools"
+          - "dracut-config-generic"
+          - "dracut-network"
+          - "e2fsprogs"
+          - "efibootmgr"
+          - "fdo-client"
+          - "fdo-owner-cli"
+          - "fedora-iot-config"
+          - "fedora-release-iot"
+          - "firewalld"
+          - "fwupd"
+          - "fwupd-efi"
+          - "fwupd-plugin-modem-manager"
+          - "fwupd-plugin-uefi-capsule-data"
+          - "glibc"
+          - "glibc-minimal-langpack"
+          - "gnupg2"
+          - "greenboot"
+          - "greenboot-default-health-checks"
+          - "gzip"
+          - "hostname"
+          - "ignition"
+          - "ignition-edge"
+          - "ima-evm-utils"
+          - "iproute"
+          - "iputils"
+          - "iwd"
+          - "iwlwifi-mvm-firmware"
+          - "keyutils"
+          - "less"
+          - "libsss_sudo"
+          - "linux-firmware"
+          - "lvm2"
+          - "netavark"
+          - "nss-altfiles"
+          - "openssh-clients"
+          - "openssh-server"
+          - "openssl"
+          - "pinentry"
+          - "podman"
+          - "policycoreutils"
+          - "polkit"
+          - "procps-ng"
+          - "realtek-firmware"
+          - "rootfiles"
+          - "rpm"
+          - "screen"
+          - "selinux-policy-targeted"
+          - "setools-console"
+          - "setup"
+          - "shadow-utils"
+          - "skopeo"
+          - "slirp4netns"
+          - "ssh-key-dir"
+          - "sssd-client"
+          - "sudo"
+          - "systemd"
+          - "systemd-resolved"
+          - "tar"
+          - "tmux"
+          - "tpm2-pkcs11"
+          - "traceroute"
+          - "usbguard"
+          - "util-linux"
+          - "vim-minimal"
+          - "wireless-regdb"
+          - "wpa_supplicant"
+          - "xfsprogs"
+          - "xz"
+          - "zram-generator"
+        condition:
+          version_less_than:
+            "41":
+              include:
+                - "dnsmasq"
+            "42":
+              include:
+                - "dbus-parsec"
+                - "kernel-tools"
+                - "parsec"
+                - "policycoreutils-python-utils"
+                - "zezere-ignition"
+            "43":
+              include:
+                - "basesystem"
+          version_greater_or_equal:
+            "41":
+              include:
+                - "bootupd"
+            "43":
+              include:
+                - "filesystem"
 
-    # iot_simplified_installer.include
-    - "attr"
-    - "basesystem"
-    - "binutils"
-    - "bsdtar"
-    - "clevis-dracut"
-    - "clevis-luks"
-    - "cloud-utils-growpart"
-    - "coreos-installer"
-    - "coreos-installer-dracut"
-    - "coreutils"
-    - "device-mapper-multipath"
-    - "dosfstools"
-    - "dracut-live"
-    - "e2fsprogs"
-    - "fcoe-utils"
-    - "fdo-init"
-    - "fedora-logos"
-    - "gdisk"
-    - "gzip"
-    - "ima-evm-utils"
-    - "iproute"
-    - "iptables"
-    - "iputils"
-    - "iscsi-initiator-utils"
-    - "keyutils"
-    - "lldpad"
-    - "lvm2"
-    - "mdadm"
-    - "nss-softokn"
-    - "policycoreutils"
-    - "policycoreutils-python-utils"
-    - "procps-ng"
-    - "rootfiles"
-    - "setools-console"
-    - "sudo"
-    - "traceroute"
-    - "util-linux"
-    - "shadow-utils"  # includes passwd
-  condition:
-    version_less_than:
-      "41":
+  iot_container: *iot_commit
+
+  iot_bootable_container:
+    package_sets:
+      - include:
+          - "acl"
+          - "attr"  # used by admins interactively
+          - "bootc"
+          - "bootupd"
+          - "chrony"  # NTP support
+          - "container-selinux"
+          - "container-selinux"
+          - "crun"
+          - "cryptsetup"
+          - "dnf"
+          - "dosfstools"
+          - "e2fsprogs"
+          - "fwupd"  # if you're using linux-firmware you probably also want fwupd
+          - "gdisk"
+          - "iproute"  # route manipulation and QoS
+          - "iproute-tc"
+          - "iptables"  # firewall manipulation
+          - "nftables"
+          - "iptables-services"  # additional firewall support
+          - "kbd"               # i18n
+          - "keyutils"          # Manipulating the kernel keyring; used by bootc
+          - "libsss_sudo"       # allow communication between sudo and SSSD for caching sudo rules by SSSD
+          - "linux-firmware"    # linux-firmware now a recommends so let's explicitly include it
+          - "logrotate"         # There are things that write outside of the journal still (such as the classic wtmp etc.). auditd also writes outside the journal but it has its own log rotation.  Anything package layered will also tend to expect files dropped in /etc/logrotate.d to work. Really this is a legacy thing but if we don't have it then people's disks will slowly fill up with logs.
+          - "lsof"
+          - "lvm2"                       # Storage configuration/management
+          - "nano"                       # default editor
+          - "ncurses"                    # provides terminal tools like clear reset tput and tset
+          - "NetworkManager-cloud-setup"  # support for cloud quirks and dynamic config in real rootfs: https:#github.com/coreos/fedora-coreos-tracker/issues/320
+          - "NetworkManager"  # standard tools for configuring network/hostname
+          - "hostname"
+          - "NetworkManager-team"  # teaming https:#github.com/coreos/fedora-coreos-config/pull/289 and http:#bugzilla.redhat.com/1758162
+          - "teamd"
+          - "NetworkManager-tui"               # interactive Networking configuration during coreos-install
+          - "nfs-utils-coreos"  # minimal NFS client
+          - "iptables-nft"
+          - "nss-altfiles"
+          - "openssh-clients"
+          - "openssh-server"
+          - "openssl"
+          - "ostree"
+          - "shadow-utils"  # User configuration
+          - "podman"
+          - "rpm-ostree"
+          - "selinux-policy-targeted"
+          - "sg3_utils"
+          - "skopeo"
+          - "socat"  # interactive network tools for admins
+          - "net-tools"
+          - "bind-utils"
+          - "sssd-client"  # SSSD backends
+          - "sssd-ad"
+          - "sssd-ipa"
+          - "sssd-krb5"
+          - "sssd-ldap"
+          - "stalld"               # Boost starving threads https:#github.com/coreos/fedora-coreos-tracker/issues/753
+          - "subscription-manager"  # To ensure we can enable client certs to access RHEL content
+          - "sudo"
+          - "systemd"
+          - "systemd-resolved"  # resolved was broken out to its own package in rawhide/f35
+          - "tpm2-tools"        # needed for tpm2 bound luks
+          - "WALinuxAgent-udev"  # udev rules for Azure (rhbz#1748432)
+          - "xfsprogs"
+          - "zram-generator"  # zram-generator (but not zram-generator-defaults) for F33 change
+        exclude:
+          - "cowsay"  # just in case
+          - "grubby"
+          - "initscripts"                         # make sure initscripts doesn't get pulled back in https:#github.com/coreos/fedora-coreos-tracker/issues/220#issuecomment-611566254
+          - "NetworkManager-initscripts-ifcfg-rh"  # do not use legacy ifcfg config format in NetworkManager See https:#github.com/coreos/fedora-coreos-config/pull/1991
+          - "nodejs"
+          - "plymouth"         # for (datacenter/cloud oriented) servers we want to see the details by default.  https:#lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/HSMISZ3ETWQ4ETVLWZQJ55ARZT27AAV3/
+          - "systemd-networkd"  # we use NetworkManager
+        condition:
+          architecture:
+            aarch64:
+              include:
+                - "irqbalance"
+                - "ostree-grub2"
+              exclude:
+                - "perl"
+                - "perl-interpreter"
+            ppc64le:
+              include:
+                - "irqbalance"
+                - "librtas"
+                - "powerpc-utils-core"
+                - "ppc64-diag-rtas"
+            x86_64:
+              include:
+                - "irqbalance"
+              exclude:
+                - "perl"
+                - "perl-interpreter"
+
+  installer:
+    package_sets:
+      - &installer_pkgset
         include:
-          - "dnsmasq"  # deprecated for F41+
+          - "anaconda-dracut"
+          - "atheros-firmware"
+          - "brcmfmac-firmware"
+          - "curl"
+          - "dracut-config-generic"
+          - "dracut-network"
+          - "hostname"
+          - "iwlwifi-dvm-firmware"
+          - "iwlwifi-mvm-firmware"
+          - "kernel"
+          - "linux-firmware"
+          - "less"
+          - "nfs-utils"
+          - "openssh-clients"
+          - "ostree"
+          - "plymouth"
+          - "realtek-firmware"
+          - "rng-tools"
+          - "rpcbind"
+          - "selinux-policy-targeted"
+          - "systemd"
+          - "tar"
+          - "xfsprogs"
+          - "xz"
+
+  anaconda: &anaconda
+    package_sets:
+      - &anaconda_pkgset
+        include:
+          - "aajohan-comfortaa-fonts"
+          - "abattis-cantarell-fonts"
+          - "alsa-firmware"
+          - "alsa-tools-firmware"
+          - "anaconda"
+          - "anaconda-dracut"
+          - "anaconda-install-img-deps"
+          - "anaconda-widgets"
+          - "atheros-firmware"
+          - "audit"
+          - "bind-utils"
+          - "bitmap-fangsongti-fonts"
+          - "brcmfmac-firmware"
+          - "bzip2"
+          - "cryptsetup"
+          - "curl"
+          - "dbus-x11"
+          - "dejavu-sans-fonts"
+          - "dejavu-sans-mono-fonts"
+          - "device-mapper-persistent-data"
+          - "dmidecode"
+          - "dnf"
+          - "dracut-config-generic"
+          - "dracut-network"
+          - "efibootmgr"
+          - "ethtool"
+          - "fcoe-utils"
+          - "ftp"
+          - "gdb-gdbserver"
+          - "gdisk"
+          - "glibc-all-langpacks"
+          - "gnome-kiosk"
+          - "google-noto-sans-cjk-ttc-fonts"
+          - "grub2-tools"
+          - "grub2-tools-extra"
+          - "grub2-tools-minimal"
+          - "grubby"
+          - "gsettings-desktop-schemas"
+          - "hdparm"
+          - "hexedit"
+          - "hostname"
+          - "initscripts"
+          - "ipmitool"
+          - "iwlwifi-dvm-firmware"
+          - "iwlwifi-mvm-firmware"
+          - "jomolhari-fonts"
+          - "kacst-farsi-fonts"
+          - "kacst-qurn-fonts"
+          - "kbd"
+          - "kbd-misc"
+          - "kdump-anaconda-addon"
+          - "kernel"
+          - "khmeros-base-fonts"
+          - "less"
+          - "libblockdev-lvm-dbus"
+          - "libibverbs"
+          - "libreport-plugin-bugzilla"
+          - "libreport-plugin-reportuploader"
+          - "librsvg2"
+          - "linux-firmware"
+          - "lldpad"
+          - "lohit-assamese-fonts"
+          - "lohit-bengali-fonts"
+          - "lohit-devanagari-fonts"
+          - "lohit-gujarati-fonts"
+          - "lohit-gurmukhi-fonts"
+          - "lohit-kannada-fonts"
+          - "lohit-odia-fonts"
+          - "lohit-tamil-fonts"
+          - "lohit-telugu-fonts"
+          - "lsof"
+          - "madan-fonts"
+          - "mtr"
+          - "mt-st"
+          - "net-tools"
+          - "nfs-utils"
+          - "nmap-ncat"
+          - "nm-connection-editor"
+          - "nss-tools"
+          - "openssh-clients"
+          - "openssh-server"
+          - "ostree"
+          - "pciutils"
+          - "perl-interpreter"
+          - "pigz"
+          - "plymouth"
+          - "python3-pyatspi"
+          - "rdma-core"
+          - "realtek-firmware"
+          - "rit-meera-new-fonts"
+          - "rng-tools"
+          - "rpcbind"
+          - "rpm-ostree"
+          - "rsync"
+          - "rsyslog"
+          - "selinux-policy-targeted"
+          - "sg3_utils"
+          - "sil-abyssinica-fonts"
+          - "sil-padauk-fonts"
+          - "sil-scheherazade-new-fonts"
+          - "smartmontools"
+          - "spice-vdagent"
+          - "strace"
+          - "systemd"
+          - "tar"
+          - "thai-scalable-waree-fonts"
+          - "tigervnc-server-minimal"
+          - "tigervnc-server-module"
+          - "udisks2"
+          - "udisks2-iscsi"
+          - "usbutils"
+          - "vim-minimal"
+          - "volume_key"
+          - "wget"
+          - "xfsdump"
+          - "xfsprogs"
+          - "xorg-x11-drivers"
+          - "xorg-x11-fonts-misc"
+          - "xorg-x11-server-Xorg"
+          - "xorg-x11-xauth"
+          - "metacity"
+          - "xrdb"
+          - "xz"
+        condition:
+          architecture:
+            x86_64:
+              include:
+                - "biosdevname"
+                - "dmidecode"
+                - "grub2-tools-efi"
+                - "memtest86+"
+            aarch64:
+              include:
+                - "dmidecode"
+
+  iot_installer:
+    package_sets:
+      - *anaconda_pkgset
+      - include:
+          - "fedora-release-iot"
+
+  live_installer:
+    package_sets:
+      - include:
+          - "@workstation-product-environment"
+          - "@anaconda-tools"
+          - "anaconda-install-env-deps"
+          - "anaconda-live"
+          - "anaconda-dracut"
+          - "dracut-live"
+          - "glibc-all-langpacks"
+          - "kernel"
+          - "kernel-modules"
+          - "kernel-modules-extra"
+          - "livesys-scripts"
+          - "rng-tools"
+          - "rdma-core"
+          - "gnome-kiosk"
+        exclude:
+          - "@dial-up"
+          - "@input-methods"
+          - "@standard"
+          - "device-mapper-multipath"
+          - "fcoe-utils"
+          - "gfs2-utils"
+          - "reiserfs-utils"
+          - "sdubby"
+        condition:
+          version_greater_or_equal:
+            VERSION_RAWHIDE:
+              include:
+                - "anaconda-webui"
+
+  image_installer: *anaconda
+
+  container: &container
+    package_sets:
+      - include:
+          - "bash"
+          - "coreutils"
+          - "yum"
+          - "dnf"
+          - "fedora-release-container"
+          - "glibc-minimal-langpack"
+          - "rootfiles"
+          - "rpm"
+          - "sudo"
+          - "tar"
+          - "util-linux-core"
+          - "vim-minimal"
+        exclude:
+          - "crypto-policies-scripts"
+          - "dbus-broker"
+          - "deltarpm"
+          - "dosfstools"
+          - "e2fsprogs"
+          - "elfutils-debuginfod-client"
+          - "fuse-libs"
+          - "gawk-all-langpacks"
+          - "glibc-gconv-extra"
+          - "glibc-langpack-en"
+          - "gnupg2-smime"
+          - "grubby"
+          - "kernel-core"
+          - "kernel-debug-core"
+          - "kernel"
+          - "langpacks-en_GB"
+          - "langpacks-en"
+          - "libss"
+          - "libxcrypt-compat"
+          - "nano"
+          - "openssl-pkcs11"
+          - "pinentry"
+          - "python3-unbound"
+          - "shared-mime-info"
+          - "sssd-client"
+          - "sudo-python-plugin"
+          - "systemd"
+          - "trousers"
+          - "whois-nls"
+          - "xkeyboard-config"
+  wsl: *container
+
+  minimal_raw: &minimal_raw
+    package_sets:
+      - include:
+          - "@core"
+          - "initial-setup"
+          - "libxkbcommon"
+          - "NetworkManager-wifi"
+          - "brcmfmac-firmware"
+          - "realtek-firmware"
+          - "iwlwifi-mvm-firmware"
+        exclude:
+          - "dracut-config-rescue"
+        condition:
+          architecture:
+            riscv64:
+              include:
+                # missing from @core in riscv64
+                - "dnf5"
+                - "policycoreutils"
+                - "selinux-policy-targeted"
+          version_greater_or_equal:
+            "43":
+              exclude:
+                - "firewalld"
+  minimal_raw_zst: *minimal_raw
+
+  iot_simplified_installer:
+    package_sets:
+      - *installer_pkgset
+      - include:
+          - "attr"
+          - "basesystem"
+          - "binutils"
+          - "bsdtar"
+          - "clevis-dracut"
+          - "clevis-luks"
+          - "cloud-utils-growpart"
+          - "coreos-installer"
+          - "coreos-installer-dracut"
+          - "coreutils"
+          - "device-mapper-multipath"
+          - "dosfstools"
+          - "dracut-live"
+          - "e2fsprogs"
+          - "fcoe-utils"
+          - "fdo-init"
+          - "fedora-logos"
+          - "gdisk"
+          - "gzip"
+          - "ima-evm-utils"
+          - "iproute"
+          - "iptables"
+          - "iputils"
+          - "iscsi-initiator-utils"
+          - "keyutils"
+          - "lldpad"
+          - "lvm2"
+          - "mdadm"
+          - "nss-softokn"
+          - "policycoreutils"
+          - "policycoreutils-python-utils"
+          - "procps-ng"
+          - "rootfiles"
+          - "setools-console"
+          - "sudo"
+          - "traceroute"
+          - "util-linux"
+          - "shadow-utils"  # includes passwd
+        condition:
+          version_less_than:
+            "41":
+              include:
+                - "dnsmasq"  # deprecated for F41+


### PR DESCRIPTION
[this is my personal winner in the race for best-yaml-for-shareing-pkgsets, based on a new idea of @ondrejbudai (thanks!), see also https://github.com/osbuild/images/pull/1294 and https://github.com/osbuild/images/pull/1296 and https://github.com/osbuild/images/pull/1295]

This commit adds a basic imagetype yaml to support merging of package sets  This is a useful feature so that we can e.g. avoid duplicating the `cloud_base` or `anaconda` package sets.

It works by adding new toplevels "image_types" in the package_sets.yaml and then using anchors/refs to refer to them in the image_type yaml. To allow sharing yaml that is not part of an image_type it also introduces a top-level `.common` that can have `any` yaml in it.

It allows us to write:
```yaml
.common:
  base: &base_pkgset
    include: [from-base-inc]
    exclude: [from-base-exc]
    condition:
      distro_name:
        test-distro:
          include: [from-base-condition-inc]
          exclude: [from-base-condition-exc]

image_types:
  other_type:
    package_sets:
      - &other_type_pkgset
        include: [from-other-type-inc]
        exclude: [from-other-type-exc]
  test_type:
    package_sets:
      - *base_pkgset
      - *other_type_pkgset
      - include: [from-type-inc]
        exclude: [from-type-exc]
        condition:
          distro_name:
            test-distro:
              include: [from-condition-inc]
              exclude: [from-condition-exc]
```
The downside of this approach is that:
1. it requires the anchor to be there before the ref, which can be confusing (we could solve this later via includes)
2. if the anchor is forgotten the error becomes very obscure
3. its a bit "hardcore" yaml

The upside is that it is very symetrical and actually feels quite nice.