### PR TITLE
Add cloud init options to WSL images

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -420,6 +420,20 @@ func mkWslImgType(d distribution) imageType {
 			osPkgsKey: packageSetLoader,
 		},
 		defaultImageConfig: &distro.ImageConfig{
+			CloudInit: []*osbuild.CloudInitStageOptions{
+				{
+					Filename: "99_wsl.cfg",
+					Config: osbuild.CloudInitConfigFile{
+						DatasourceList: []string{
+							"WSL",
+							"None",
+						},
+						Network: &osbuild.CloudInitConfigNetwork{
+							Config: "disabled",
+						},
+					},
+				},
+			},
 			NoSElinux:   common.ToPtr(true),
 			ExcludeDocs: common.ToPtr(true),
 			Locale:      common.ToPtr("C.UTF-8"),

--- a/pkg/distro/packagesets/fedora/package_sets.yaml
+++ b/pkg/distro/packagesets/fedora/package_sets.yaml
@@ -772,7 +772,7 @@ image_installer:
         include:
           - "dmidecode"
 
-container: &container
+container:
   include:
     - "bash"
     - "coreutils"
@@ -818,8 +818,49 @@ container: &container
     - "whois-nls"
     - "xkeyboard-config"
 
+
 wsl:
-  <<: *container
+  include:
+    - "bash"
+    - "coreutils"
+    - "cloud-init"
+    - "yum"
+    - "dnf"
+    - "fedora-release-container"
+    - "glibc-minimal-langpack"
+    - "rootfiles"
+    - "rpm"
+    - "sudo"
+    - "tar"
+    - "util-linux-core"
+    - "vim-minimal"
+  exclude:
+    - "crypto-policies-scripts"
+    - "deltarpm"
+    - "dosfstools"
+    - "elfutils-debuginfod-client"
+    - "gawk-all-langpacks"
+    - "glibc-gconv-extra"
+    - "glibc-langpack-en"
+    - "gnupg2-smime"
+    - "grubby"
+    - "kernel-core"
+    - "kernel-debug-core"
+    - "kernel"
+    - "langpacks-en_GB"
+    - "langpacks-en"
+    - "libxcrypt-compat"
+    - "nano"
+    - "openssl-pkcs11"
+    - "pinentry"
+    - "python3-unbound"
+    - "shared-mime-info"
+    - "sssd-client"
+    - "sudo-python-plugin"
+    - "trousers"
+    - "whois-nls"
+    - "xkeyboard-config"
+
 
 minimal_raw: &minimal
   include:

--- a/pkg/distro/rhel/rhel10/ubi.go
+++ b/pkg/distro/rhel/rhel10/ubi.go
@@ -14,7 +14,7 @@ func mkWSLImgType() *rhel.ImageType {
 		"disk.tar.gz",
 		"application/x-tar",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: ubiCommonPackageSet,
+			rhel.OSPkgsKey: wslPackageSet,
 		},
 		rhel.TarImage,
 		[]string{"build"},
@@ -23,6 +23,20 @@ func mkWSLImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = &distro.ImageConfig{
+		CloudInit: []*osbuild.CloudInitStageOptions{
+			{
+				Filename: "99_wsl.cfg",
+				Config: osbuild.CloudInitConfigFile{
+					DatasourceList: []string{
+						"WSL",
+						"None",
+					},
+					Network: &osbuild.CloudInitConfigNetwork{
+						Config: "disabled",
+					},
+				},
+			},
+		},
 		NoSElinux: common.ToPtr(true),
 		WSLConfig: &osbuild.WSLConfStageOptions{
 			Boot: osbuild.WSLConfBootOptions{
@@ -92,4 +106,14 @@ func ubiCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	}
 
 	return ps
+}
+
+func wslPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
+	pkgset := ubiCommonPackageSet(t)
+	pkgset = pkgset.Append(rpmmd.PackageSet{
+		Include: []string{
+			"cloud-init",
+		},
+	})
+	return pkgset
 }

--- a/pkg/distro/rhel/rhel8/ubi.go
+++ b/pkg/distro/rhel/rhel8/ubi.go
@@ -14,7 +14,7 @@ func mkWslImgType() *rhel.ImageType {
 		"disk.tar.gz",
 		"application/x-tar",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: ubiCommonPackageSet,
+			rhel.OSPkgsKey: wslPackageSet,
 		},
 		rhel.TarImage,
 		[]string{"build"},
@@ -23,6 +23,20 @@ func mkWslImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = &distro.ImageConfig{
+		CloudInit: []*osbuild.CloudInitStageOptions{
+			{
+				Filename: "99_wsl.cfg",
+				Config: osbuild.CloudInitConfigFile{
+					DatasourceList: []string{
+						"WSL",
+						"None",
+					},
+					Network: &osbuild.CloudInitConfigNetwork{
+						Config: "disabled",
+					},
+				},
+			},
+		},
 		Locale:    common.ToPtr("en_US.UTF-8"),
 		NoSElinux: common.ToPtr(true),
 		WSLConfig: &osbuild.WSLConfStageOptions{
@@ -143,4 +157,14 @@ func ubiCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	}
 
 	return ps
+}
+
+func wslPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
+	pkgset := ubiCommonPackageSet(t)
+	pkgset = pkgset.Append(rpmmd.PackageSet{
+		Include: []string{
+			"cloud-init",
+		},
+	})
+	return pkgset
 }

--- a/pkg/distro/rhel/rhel9/ubi.go
+++ b/pkg/distro/rhel/rhel9/ubi.go
@@ -14,7 +14,7 @@ func mkWSLImgType() *rhel.ImageType {
 		"disk.tar.gz",
 		"application/x-tar",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: ubiCommonPackageSet,
+			rhel.OSPkgsKey: wslPackageSet,
 		},
 		rhel.TarImage,
 		[]string{"build"},
@@ -23,6 +23,20 @@ func mkWSLImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = &distro.ImageConfig{
+		CloudInit: []*osbuild.CloudInitStageOptions{
+			{
+				Filename: "99_wsl.cfg",
+				Config: osbuild.CloudInitConfigFile{
+					DatasourceList: []string{
+						"WSL",
+						"None",
+					},
+					Network: &osbuild.CloudInitConfigNetwork{
+						Config: "disabled",
+					},
+				},
+			},
+		},
 		Locale:    common.ToPtr("en_US.UTF-8"),
 		NoSElinux: common.ToPtr(true),
 		WSLConfig: &osbuild.WSLConfStageOptions{
@@ -93,4 +107,14 @@ func ubiCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	}
 
 	return ps
+}
+
+func wslPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
+	pkgset := ubiCommonPackageSet(t)
+	pkgset = pkgset.Append(rpmmd.PackageSet{
+		Include: []string{
+			"cloud-init",
+		},
+	})
+	return pkgset
 }

--- a/pkg/osbuild/cloud_init_stage_test.go
+++ b/pkg/osbuild/cloud_init_stage_test.go
@@ -73,6 +73,15 @@ func TestCloudInitStage_NewStage_Invalid(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "empty-network-section",
+			options: CloudInitStageOptions{
+				Filename: "00-default_user.cfg",
+				Config: CloudInitConfigFile{
+					Network: &CloudInitConfigNetwork{},
+				},
+			},
+		},
 	}
 	for idx := range tests {
 		tt := tests[idx]


### PR DESCRIPTION
This mirrors the Ubuntu images in the MS store. The WSL datasource looks for userdata on the Windows host.

---

also see https://cloudinit.readthedocs.io/en/latest/reference/datasources/wsl.html