### PR TITLE
os: conditional stages

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -492,6 +492,7 @@ type distribution struct {
 
 // Fedora based OS image configuration defaults
 var defaultDistroImageConfig = &distro.ImageConfig{
+	Hostname:               common.ToPtr("localhost.localdomain"),
 	Timezone:               common.ToPtr("UTC"),
 	Locale:                 common.ToPtr("C.UTF-8"),
 	DefaultOSCAPDatastream: common.ToPtr(oscap.DefaultFedoraDatastream()),

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -106,8 +106,8 @@ func osCustomizations(
 
 	if hostname := c.GetHostname(); hostname != nil {
 		osc.Hostname = *hostname
-	} else {
-		osc.Hostname = "localhost.localdomain"
+	} else if imageConfig.Hostname != nil {
+		osc.Hostname = *imageConfig.Hostname
 	}
 
 	if imageConfig.InstallWeakDeps != nil {

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -12,6 +12,7 @@ import (
 
 // ImageConfig represents a (default) configuration applied to the image payload.
 type ImageConfig struct {
+	Hostname            *string
 	Timezone            *string
 	TimeSynchronization *osbuild.ChronyStageOptions
 	Locale              *string

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -495,7 +495,10 @@ func (p *OS) serialize() osbuild.Pipeline {
 	if p.Hostname != "" {
 		pipeline.AddStage(osbuild.NewHostnameStage(&osbuild.HostnameStageOptions{Hostname: p.Hostname}))
 	}
-	pipeline.AddStage(osbuild.NewTimezoneStage(&osbuild.TimezoneStageOptions{Zone: p.Timezone}))
+
+	if p.Timezone != "" {
+		pipeline.AddStage(osbuild.NewTimezoneStage(&osbuild.TimezoneStageOptions{Zone: p.Timezone}))
+	}
 
 	if len(p.NTPServers) > 0 {
 		chronyOptions := &osbuild.ChronyStageOptions{Servers: p.NTPServers}

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -480,7 +480,9 @@ func (p *OS) serialize() osbuild.Pipeline {
 		}
 	}
 
-	pipeline.AddStage(osbuild.NewLocaleStage(&osbuild.LocaleStageOptions{Language: p.Language}))
+	if p.Language != "" {
+		pipeline.AddStage(osbuild.NewLocaleStage(&osbuild.LocaleStageOptions{Language: p.Language}))
+	}
 
 	if p.Keyboard != nil {
 		keymapOptions := &osbuild.KeymapStageOptions{Keymap: *p.Keyboard}

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -258,6 +258,7 @@ func TestModularityDoesNotIncludeConfigStage(t *testing.T) {
 	st := manifest.FindStage("org.osbuild.dnf.module-config", pipeline.Stages)
 	require.Nil(t, st)
 }
+
 func checkStagesForFSTab(t *testing.T, stages []*osbuild.Stage) {
 	fstab := manifest.FindStage("org.osbuild.fstab", stages)
 	require.NotNil(t, fstab)
@@ -313,4 +314,22 @@ func TestOSPipelineMountUnitStages(t *testing.T) {
 	os.MountUnits = true
 
 	checkStagesForMountUnits(t, os.Serialize().Stages, expectedUnits)
+}
+
+func TestLanguageIncludesLocaleStage(t *testing.T) {
+	os := manifest.NewTestOS()
+
+	os.Language = "en_US.UTF-8"
+
+	pipeline := os.Serialize()
+	st := manifest.FindStage("org.osbuild.locale", pipeline.Stages)
+	require.NotNil(t, st)
+}
+
+func TestLanguageDoesNotIncludeLocaleStage(t *testing.T) {
+	os := manifest.NewTestOS()
+
+	pipeline := os.Serialize()
+	st := manifest.FindStage("org.osbuild.locale", pipeline.Stages)
+	require.Nil(t, st)
 }

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -333,3 +333,21 @@ func TestLanguageDoesNotIncludeLocaleStage(t *testing.T) {
 	st := manifest.FindStage("org.osbuild.locale", pipeline.Stages)
 	require.Nil(t, st)
 }
+
+func TestTimezoneIncludesTimezoneStage(t *testing.T) {
+	os := manifest.NewTestOS()
+
+	os.Timezone = "Etc/UTC"
+
+	pipeline := os.Serialize()
+	st := manifest.FindStage("org.osbuild.timezone", pipeline.Stages)
+	require.NotNil(t, st)
+}
+
+func TestTimezoneDoesNotIncludeTimezoneStage(t *testing.T) {
+	os := manifest.NewTestOS()
+
+	pipeline := os.Serialize()
+	st := manifest.FindStage("org.osbuild.timezone", pipeline.Stages)
+	require.Nil(t, st)
+}

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -351,3 +351,21 @@ func TestTimezoneDoesNotIncludeTimezoneStage(t *testing.T) {
 	st := manifest.FindStage("org.osbuild.timezone", pipeline.Stages)
 	require.Nil(t, st)
 }
+
+func TestHostnameIncludesHostnameStage(t *testing.T) {
+	os := manifest.NewTestOS()
+
+	os.Hostname = "funky.name"
+
+	pipeline := os.Serialize()
+	st := manifest.FindStage("org.osbuild.hostname", pipeline.Stages)
+	require.NotNil(t, st)
+}
+
+func TestHostnameDoesNotIncludeHostnameStage(t *testing.T) {
+	os := manifest.NewTestOS()
+
+	pipeline := os.Serialize()
+	st := manifest.FindStage("org.osbuild.hostname", pipeline.Stages)
+	require.Nil(t, st)
+}


### PR DESCRIPTION
In preparation for first-boot support [1] there are some changes that can already be PR'ed to reduce the size of that PR.

This PR makes the injection of stages conditional so no files are created when the image configs are explicitly set to none.

[1]: https://github.com/osbuild/images/pull/1264