### PR TITLE
[RFC] test: add new manifest reference tests

### DIFF
--- a/pkg/osbuild/rpm_stage.go
+++ b/pkg/osbuild/rpm_stage.go
@@ -126,15 +126,23 @@ func NewRpmStageSourceFilesInputs(specs []rpmmd.PackageSpec) *RPMStageInputs {
 }
 
 func pkgRefs(specs []rpmmd.PackageSpec) FilesInputRef {
-	refs := make([]FilesInputSourceArrayRefEntry, len(specs))
-	for idx, pkg := range specs {
+	refs := make([]FilesInputSourceArrayRefEntry, 0, len(specs))
+
+	// skip duplicated pkgs
+	seenChksums := make(map[string]bool, len(specs))
+	for _, pkg := range specs {
+		if seenChksums[pkg.Checksum] {
+			continue
+		}
+		seenChksums[pkg.Checksum] = true
+
 		var pkgMetadata FilesInputRefMetadata
 		if pkg.CheckGPG {
 			pkgMetadata = &RPMStageReferenceMetadata{
 				CheckGPG: pkg.CheckGPG,
 			}
 		}
-		refs[idx] = NewFilesInputSourceArrayRefEntry(pkg.Checksum, pkgMetadata)
+		refs = append(refs, NewFilesInputSourceArrayRefEntry(pkg.Checksum, pkgMetadata))
 	}
 	return NewFilesInputSourceArrayRef(refs)
 }

--- a/test/data/manifestdb-light/centos_10-aarch64-ami-all_customizations.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-ami-all_customizations.json
@@ -1,0 +1,1642 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "ab40c53a-9837-4547-a960-9b8f65990a6f",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0 debug"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3"
+                },
+                {
+                  "id": "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"
+                },
+                {
+                  "id": "sha256:52856879d4bfa1d564480850a56b0885e1c52a805af96fffe84122afc9b1c52b"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "el_CY.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "dvorak"
+          }
+        },
+        {
+          "type": "org.osbuild.hostname",
+          "options": {
+            "hostname": "my-host"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "Europe/London"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "time.example.com"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.groups",
+          "options": {
+            "groups": {
+              "group1": {
+                "gid": 1030
+              },
+              "group2": {
+                "gid": 1050
+              },
+              "user3": {
+                "gid": 1060
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+              "user1": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              },
+              "user2": {
+                "uid": 1020,
+                "gid": 1050,
+                "groups": [
+                  "group1"
+                ],
+                "description": "description 2",
+                "home": "/home/home2",
+                "shell": "/bin/sh",
+                "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              },
+              "user3": {
+                "uid": 1060,
+                "gid": 1060
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.yum.repos",
+          "options": {
+            "filename": "example.repo",
+            "repos": [
+              {
+                "id": "example",
+                "baseurl": [
+                  "https://example.com/download/yum"
+                ],
+                "enabled": true,
+                "gpgkey": [
+                  "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                ],
+                "name": "Example repo",
+                "gpgcheck": true,
+                "repo_gpgcheck": false
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "ab40c53a-9837-4547-a960-9b8f65990a6f",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "cc255ad5-9ddb-476c-acf6-3b9003a0c999",
+                "vfs_type": "xfs",
+                "path": "/boot",
+                "options": "defaults"
+              },
+              {
+                "uuid": "da09b60d-6bc9-4aad-80d2-be96ee8c3913",
+                "vfs_type": "xfs",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "8298d604-c07b-479b-9c71-1e3d80ede264",
+                "vfs_type": "xfs",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "779f5016-37e3-4169-835d-0d91b6d06b3f",
+                "vfs_type": "xfs",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "d56f3b42-021b-4475-b1ec-a9bff389e776",
+                "vfs_type": "xfs",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "423a166c-b82b-4b20-a979-7ef6d55ee736",
+                "vfs_type": "xfs",
+                "path": "/mnt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "24175efc-ac0f-40d0-bbbe-4661dbf2231a",
+                "vfs_type": "xfs",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "72001a23-3655-49c8-8c58-287c0cc68a8a",
+                "vfs_type": "xfs",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "1d2d8ff4-5f15-4748-977b-5d3420d724b0",
+                "vfs_type": "xfs",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "947415fd-4477-448f-a8d9-af01db9a16c5",
+                "vfs_type": "xfs",
+                "path": "/usr",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "ab40c53a-9837-4547-a960-9b8f65990a6f",
+            "boot_fs_uuid": "cc255ad5-9ddb-476c-acf6-3b9003a0c999",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0 debug",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/etc/systemd/system/custom.service.d",
+                "exist_ok": true
+              },
+              {
+                "path": "/etc/custom_dir"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/custom_dir": {
+                "mode": "0770"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/custom_dir": {
+                "user": 1020,
+                "group": 1050
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e"
+                }
+              ]
+            },
+            "file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2"
+                }
+              ]
+            },
+            "file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258"
+                }
+              ]
+            },
+            "file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                }
+              ]
+            },
+            "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e/sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e",
+                "to": "tree:///etc/systemd/system/custom.service",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2/sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2",
+                "to": "tree:///etc/systemd/system/custom.service.d/override.conf",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258/sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258",
+                "to": "tree:///etc/custom_file.txt",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "to": "tree:///etc/empty_file.txt",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/custom_file.txt": {
+                "mode": "0644"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/custom_file.txt": {
+                "user": "root",
+                "group": "root"
+              },
+              "/etc/empty_file.txt": {
+                "user": 0,
+                "group": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned",
+              "sshd.service",
+              "custom.service"
+            ],
+            "disabled_services": [
+              "bluetooth.service"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c/sha256:4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c",
+                "to": "tree:///etc/pki/ca-trust/source/anchors/27894af897dd2423607045716438a725f28a6d0b.pem",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/pki/ca-trust/source/anchors/27894af897dd2423607045716438a725f28a6d0b.pem": {
+                "user": "root",
+                "group": "root"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.pki.update-ca-trust"
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "16859004928"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 31467487,
+                "start": 1460224,
+                "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              },
+              {
+                "size": 1048576,
+                "start": 411648,
+                "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                "uuid": "36b7fad2-8fec-4995-b68e-4118aa57b59b"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.lvm2.create",
+          "options": {
+            "volumes": [
+              {
+                "name": "rootlv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "homelv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "home_shadowmanlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "foolv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "usrlv",
+                "size": "4294967296B"
+              },
+              {
+                "name": "optlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "medialv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "rootlv00",
+                "size": "1073741824B"
+              },
+              {
+                "name": "srvlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "mntlv",
+                "size": "1073741824B"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "ab40c53a-9837-4547-a960-9b8f65990a6f",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "8298d604-c07b-479b-9c71-1e3d80ede264"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "779f5016-37e3-4169-835d-0d91b6d06b3f"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "home_shadowmanlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "da09b60d-6bc9-4aad-80d2-be96ee8c3913"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "947415fd-4477-448f-a8d9-af01db9a16c5"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "24175efc-ac0f-40d0-bbbe-4661dbf2231a"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "d56f3b42-021b-4475-b1ec-a9bff389e776"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "72001a23-3655-49c8-8c58-287c0cc68a8a"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv00"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "1d2d8ff4-5f15-4748-977b-5d3420d724b0"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "423a166c-b82b-4b20-a979-7ef6d55ee736"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "mntlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "cc255ad5-9ddb-476c-acf6-3b9003a0c999"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 1048576,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 1048576
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "home_shadowmanlv"
+              }
+            },
+            "media": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "mnt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "mntlv"
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "root": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv00"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.xfs",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.xfs",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.xfs",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.xfs",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "mnt",
+              "type": "org.osbuild.xfs",
+              "source": "mnt",
+              "target": "/mnt"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.xfs",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.xfs",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.xfs",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.xfs",
+              "source": "usr",
+              "target": "/usr"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.lvm2.metadata",
+          "options": {
+            "vg_name": "rootvg"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb": {
+          "url": "https://example.com/repo/packages/passwd"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2": {
+          "url": "https://example.com/repo/packages/bash"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:52856879d4bfa1d564480850a56b0885e1c52a805af96fffe84122afc9b1c52b": {
+          "url": "https://example.com/repo/packages/bluez"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1": {
+          "url": "https://example.com/repo/packages/shadow-utils"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-baseos"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-appstream"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3": {
+          "url": "https://example.com/repo/packages/pam"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    },
+    "org.osbuild.inline": {
+      "items": {
+        "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+          "encoding": "base64",
+          "data": "W1VuaXRdCkRlc2NyaXB0aW9uPUN1c3RvbSBzZXJ2aWNlCgpbU2VydmljZV0KRXhlY1N0YXJ0PS91c3IvYmluL2ZhbHNlCgpbSW5zdGFsbF0KV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXQK"
+        },
+        "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+          "encoding": "base64",
+          "data": "W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NhdCAvZXRjL2N1c3RvbV9maWxlLnR4dAo="
+        },
+        "sha256:4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c": {
+          "encoding": "base64",
+          "data": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzekNDQXB1Z0F3SUJBZ0lVSjRsSytKZmRKQ05nY0VWeFpEaW5KZktLYlFzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2FERUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZRApWUVFIREFkU1lXeGxhV2RvTVJBd0RnWURWUVFLREFkU1pXUWdTR0YwTVJ3d0dnWURWUVFEREJOVVpYTjBJRU5CCklHWnZjaUJ2YzJKMWFXeGtNQ0FYRFRJME1Ea3dNekV6TWpreU1Gb1lEekl5T1Rnd05qRTRNVE15T1RJd1dqQm8KTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjTQpCMUpoYkdWcFoyZ3hFREFPQmdOVkJBb01CMUpsWkNCSVlYUXhIREFhQmdOVkJBTU1FMVJsYzNRZ1EwRWdabTl5CklHOXpZblZwYkdRd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURlQTdPY1dUclYKZ3N0b0JzVWFlSkttOG5lbGc3TGMwV05YSDZ5T1RMc3I0dGQ0eUhzMFlPdkZHd2dTZitmZlYzUkFHMW1ncW5NRwpNZ2tEMit6KzdRaEhiSEhzM3kwZDB6ZmhBMmJnMEtWdmZDV2s3Zk5SUEhZMFVPZVBwWGsyNDVCZnczRDBWVHBsCkY3bmVQazFJN1pZMDlzblBXVWViMnJqS1h6WWpLanpNMGgyNyt5a1Y4STgrRmJkeVBrL3BSOHdoeURxdEhMVWEKWGZGeTJURmxvRFNZTWtIS1ZkMzhCbkwwYmo5MXg1RitLc1prTjRIemZiWXd4TGJDUWZPU2d5N3E2VFdjZTlrcQpMbzZ0eWE5dnV2cFdGbTFkeWU3TCtCb2RBUUFxL2RJL0pNZUNmeVRiMGVGYit0eXpmcjVhVklvcXFETitwOWZ0CmN3NE9lZnBIYmh0TkFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUlYyQTlZbXVzZWtQenU1WWYwOGNWMG9QTDEKd2pBZkJnTlZIU01FR0RBV2dCUlYyQTlZbXVzZWtQenU1WWYwOGNWMG9QTDF3akFQQmdOVkhSTUJBZjhFQlRBRApBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFDZ1FaMlhmaitOeGFLQlpnbjJLTnhTME1UYmh6SFJ6NlJuCnFKcytoOE9VejJDcm1hZjZOK1JIbG1EUlpYVXJEalNIcHhWVDJMeEZ5N29mUnJMWUllekZEVVlmYjkyMFZra1YKU1ZjeGgxWURGUk9KYWxmTW9FNndkeVIvTG5LNE1KWlM5ZlVwZUNKSmMvQTBKKzlGSzlDd2N5VXJIZ0o4WGJKaApNS1l5UStjZjZPN3d6dXR1QnBNeVJxU0tTK2hWTTdCUVRtU0Z2djFlQUpsbzZrbEdBbW1LaVltQUV2Y1FhZEgxCmRqcnVqc0EzQ241dlgyTCsweXVpTEI1L3pveHF4NWNFeTk3VHVLVVlCOE9xTU11akFYTnpGNEwzSEpEVU5iYTIKQWhFa0Zvek1Yd1lYNzNUR2JHWjBtYXdQUzVEM3YzdFlURW1KRmY2U25WQ21VVzFmczU3ZwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        },
+        "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+          "encoding": "base64",
+          "data": "aW1hZ2UgYnVpbGRlciBpcyB0aGUgYmVzdA=="
+        },
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+          "encoding": "base64",
+          "data": ""
+        },
+        "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+          "encoding": "base64",
+          "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-aarch64-ami-all_customizations.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-ami-all_customizations.json
@@ -19,13 +19,7 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
@@ -37,37 +31,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -125,9 +101,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -138,9 +111,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
@@ -288,9 +258,6 @@
                 },
                 {
                   "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
-                },
-                {
-                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
                 },
                 {
                   "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"

--- a/test/data/manifestdb-light/centos_10-aarch64-ami-empty.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-ami-empty.json
@@ -1,0 +1,807 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "b1937d60-363d-44d2-9fc8-680f6d85b474",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "b1937d60-363d-44d2-9fc8-680f6d85b474",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "b1937d60-363d-44d2-9fc8-680f6d85b474",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20559839,
+                "start": 411648,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "b1937d60-363d-44d2-9fc8-680f6d85b474",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 20559839,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 20559839
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-baseos"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-appstream"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-aarch64-ami-empty.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-ami-empty.json
@@ -19,16 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -40,28 +34,13 @@
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -119,9 +98,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -132,9 +108,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/centos_10-aarch64-ami-partitioning_dos_lvm.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-ami-partitioning_dos_lvm.json
@@ -19,19 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
-                },
-                {
                   "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
                 },
                 {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
@@ -43,37 +34,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -131,9 +104,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -144,9 +114,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/centos_10-aarch64-ami-partitioning_dos_lvm.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-ami-partitioning_dos_lvm.json
@@ -1,0 +1,1340 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "cead2c6a-b42a-43b4-9edf-23d716570af9",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "cead2c6a-b42a-43b4-9edf-23d716570af9",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "b6615b05-7d46-4ece-9dd3-ee12ec8a1a94",
+                "vfs_type": "xfs",
+                "path": "/boot",
+                "options": "defaults"
+              },
+              {
+                "uuid": "fb3d5428-e997-4560-95b1-8fb6ec5246d0",
+                "vfs_type": "ext4",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "941d0ff3-b76d-4e85-8480-e4d3c86bdae0",
+                "vfs_type": "ext4",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "549a546b-de09-4f2d-bb28-a1e2675ea8f2",
+                "vfs_type": "ext4",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "fd16ffc1-ee2c-4838-bea0-1c2db1ff8a7c",
+                "vfs_type": "ext4",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7f890dc5-042b-4853-9395-3e3f15cc3207",
+                "vfs_type": "ext4",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7b71f575-22e5-4fb0-a312-41c23c69dc58",
+                "vfs_type": "ext4",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "4fb4cab1-31f5-4402-85f5-8ccafff4ee2c",
+                "vfs_type": "ext4",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "6afd0204-0a02-4dff-b969-b264319015d9",
+                "vfs_type": "ext4",
+                "path": "/usr",
+                "options": "defaults"
+              },
+              {
+                "uuid": "14415db5-bc92-4f4f-834d-2a3a05bcbe46",
+                "vfs_type": "swap",
+                "path": "none",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "cead2c6a-b42a-43b4-9edf-23d716570af9",
+            "boot_fs_uuid": "b6615b05-7d46-4ece-9dd3-ee12ec8a1a94",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "20079181824"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "dos",
+            "uuid": "87883ce1-e8b2-4413-81ee-e4f55bb1e4ac",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "ef",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 1048576,
+                "start": 411648,
+                "type": "83"
+              },
+              {
+                "size": 37756928,
+                "start": 1460224,
+                "type": "8e"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.lvm2.create",
+          "options": {
+            "volumes": [
+              {
+                "name": "homelv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "shadowmanlv",
+                "size": "5368709120B"
+              },
+              {
+                "name": "foolv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "usrlv",
+                "size": "4294967296B"
+              },
+              {
+                "name": "optlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "medialv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "roothomelv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "srvlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "swap-lv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "rootlv",
+                "size": "1073741824B"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "b6615b05-7d46-4ece-9dd3-ee12ec8a1a94",
+            "label": "boot"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 1048576,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "941d0ff3-b76d-4e85-8480-e4d3c86bdae0",
+            "label": "home"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "549a546b-de09-4f2d-bb28-a1e2675ea8f2"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "shadowmanlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "fb3d5428-e997-4560-95b1-8fb6ec5246d0"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "6afd0204-0a02-4dff-b969-b264319015d9"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "7f890dc5-042b-4853-9395-3e3f15cc3207"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "fd16ffc1-ee2c-4838-bea0-1c2db1ff8a7c"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "7b71f575-22e5-4fb0-a312-41c23c69dc58"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "roothomelv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "4fb4cab1-31f5-4402-85f5-8ccafff4ee2c"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkswap",
+          "options": {
+            "uuid": "14415db5-bc92-4f4f-834d-2a3a05bcbe46"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "swap-lv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "cead2c6a-b42a-43b4-9edf-23d716570af9",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 1048576
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "shadowmanlv"
+              }
+            },
+            "media": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "root": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "roothomelv"
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 37756928
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.ext4",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.ext4",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.ext4",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.ext4",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.ext4",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.ext4",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.ext4",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.ext4",
+              "source": "usr",
+              "target": "/usr"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.lvm2.metadata",
+          "options": {
+            "vg_name": "testvg"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-baseos"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-appstream"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-aarch64-ami-partitioning_lvm.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-ami-partitioning_lvm.json
@@ -19,19 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
-                },
-                {
                   "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
                 },
                 {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
@@ -43,37 +34,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -131,9 +104,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -144,9 +114,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/centos_10-aarch64-ami-partitioning_lvm.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-ami-partitioning_lvm.json
@@ -1,0 +1,1386 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "75d7d0a1-6770-479d-8e36-e0ad83936438",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "75d7d0a1-6770-479d-8e36-e0ad83936438",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "b845c5f0-e588-4c3b-b614-5f8aaf572536",
+                "vfs_type": "xfs",
+                "path": "/boot",
+                "options": "defaults"
+              },
+              {
+                "uuid": "5baf43a2-effe-4e6a-a817-dbe8cc8cfb7e",
+                "vfs_type": "ext4",
+                "path": "/data",
+                "options": "defaults"
+              },
+              {
+                "uuid": "014fb050-818f-4de2-88ad-f89c210bfb5a",
+                "vfs_type": "ext4",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "e64b4df0-23f2-46a3-943c-ed8a6574e3e9",
+                "vfs_type": "ext4",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "82ee790d-21d9-4416-8552-b4dc4889544d",
+                "vfs_type": "ext4",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "14db6c29-e73b-4cc3-a1e0-65782ab12dc5",
+                "vfs_type": "ext4",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "c40cac63-4be9-4d3a-b480-a4347cd48785",
+                "vfs_type": "ext4",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "bcc72e12-29f5-4899-ac69-d90ef5fba96f",
+                "vfs_type": "ext4",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "d44a259a-3905-423f-b23e-38835001be7e",
+                "vfs_type": "ext4",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "01a9b88a-5b23-4491-8e8b-311e33667883",
+                "vfs_type": "ext4",
+                "path": "/usr",
+                "options": "defaults"
+              },
+              {
+                "uuid": "b0d3ba47-3696-46e5-94f6-959019b06d62",
+                "vfs_type": "swap",
+                "path": "none",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "75d7d0a1-6770-479d-8e36-e0ad83936438",
+            "boot_fs_uuid": "b845c5f0-e588-4c3b-b614-5f8aaf572536",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "21153972224"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "63671409-aa1e-4cfd-a606-97842d9386c7",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 1048576,
+                "start": 411648,
+                "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                "uuid": "90eab1e3-a108-48e0-9d31-71089adfa2b6"
+              },
+              {
+                "size": 2097152,
+                "start": 1460224,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "a9510f74-eaeb-4b14-aac5-6502a7010aff"
+              },
+              {
+                "size": 37758943,
+                "start": 3557376,
+                "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+                "uuid": "c02afbfe-5655-4609-9f0c-0d6c6dc02aa8"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.lvm2.create",
+          "options": {
+            "volumes": [
+              {
+                "name": "homelv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "shadowmanlv",
+                "size": "5368709120B"
+              },
+              {
+                "name": "foolv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "usrlv",
+                "size": "4294967296B"
+              },
+              {
+                "name": "optlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "medialv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "roothomelv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "srvlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "swap-lv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "rootlv",
+                "size": "1073741824B"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "b845c5f0-e588-4c3b-b614-5f8aaf572536",
+            "label": "boot"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 1048576,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "5baf43a2-effe-4e6a-a817-dbe8cc8cfb7e",
+            "label": "data"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "e64b4df0-23f2-46a3-943c-ed8a6574e3e9",
+            "label": "home"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "82ee790d-21d9-4416-8552-b4dc4889544d"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "shadowmanlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "014fb050-818f-4de2-88ad-f89c210bfb5a"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "01a9b88a-5b23-4491-8e8b-311e33667883"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "c40cac63-4be9-4d3a-b480-a4347cd48785"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "14db6c29-e73b-4cc3-a1e0-65782ab12dc5"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "bcc72e12-29f5-4899-ac69-d90ef5fba96f"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "roothomelv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "d44a259a-3905-423f-b23e-38835001be7e"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkswap",
+          "options": {
+            "uuid": "b0d3ba47-3696-46e5-94f6-959019b06d62"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "swap-lv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "75d7d0a1-6770-479d-8e36-e0ad83936438",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 1048576
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600
+              }
+            },
+            "data": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 2097152
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "shadowmanlv"
+              }
+            },
+            "media": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "root": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "roothomelv"
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "data",
+              "type": "org.osbuild.ext4",
+              "source": "data",
+              "target": "/data"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.ext4",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.ext4",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.ext4",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.ext4",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.ext4",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.ext4",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.ext4",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.ext4",
+              "source": "usr",
+              "target": "/usr"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.lvm2.metadata",
+          "options": {
+            "vg_name": "testvg"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-baseos"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-appstream"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-aarch64-ami-partitioning_plain.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-ami-partitioning_plain.json
@@ -1,0 +1,1236 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "b531d3c1-43c4-4c9c-8e3d-474a499696fe",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "b531d3c1-43c4-4c9c-8e3d-474a499696fe",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "ecfdf4b0-45a3-4e84-a87e-903b02d9e971",
+                "vfs_type": "ext4",
+                "path": "/data",
+                "options": "defaults"
+              },
+              {
+                "uuid": "069aeae1-8fc9-45e8-8dbb-60363f8b0eb3",
+                "vfs_type": "ext4",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "fd0b85b6-20c7-4c47-8014-678a1a58bb4c",
+                "vfs_type": "ext4",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "651b335d-9b0f-4f9d-9339-63a83e23ba28",
+                "vfs_type": "ext4",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "a06cbd2e-339f-4795-b15f-49684d4d4975",
+                "vfs_type": "ext4",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "5e71e6db-895d-4eb4-9133-a125549076e3",
+                "vfs_type": "ext4",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "8b269bda-d473-4af1-832a-1d537f4cd052",
+                "vfs_type": "ext4",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "1bda848d-7ef7-4def-aa2c-4790df38e991",
+                "vfs_type": "xfs",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "a2d49f24-d276-441a-aee6-a69e7bdc293f",
+                "vfs_type": "xfs",
+                "path": "/var",
+                "options": "defaults"
+              },
+              {
+                "uuid": "3569b416-85dd-49c1-a7cf-a8a572301442",
+                "vfs_type": "swap",
+                "path": "none",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "b531d3c1-43c4-4c9c-8e3d-474a499696fe",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "17915969536"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "3c9947f6-c50d-41aa-8679-cac6885c08cc",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 2097152,
+                "start": 411648,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "932ac322-6698-4020-aba5-72219e313c0c"
+              },
+              {
+                "size": 4194304,
+                "start": 2508800,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "4463fc15-7292-4818-b30b-a9828a0a687d"
+              },
+              {
+                "size": 1024000,
+                "start": 6703104,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "20786407-4f24-4c8e-9efd-09e2fc1100db"
+              },
+              {
+                "size": 2097152,
+                "start": 7727104,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "ee7d52b1-54e3-4dc1-aa18-648efb7c7daf"
+              },
+              {
+                "size": 8388608,
+                "start": 9824256,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "4e49ed0a-f591-4aac-819b-33bf68324b8f"
+              },
+              {
+                "size": 2097152,
+                "start": 18212864,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "fe2cb94f-e464-4a64-9459-3d84d0cc1759"
+              },
+              {
+                "size": 2097152,
+                "start": 20310016,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "7cc87b07-f6e7-4f39-bf46-50ef85ea1ac0"
+              },
+              {
+                "size": 2097152,
+                "start": 22407168,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "9e2e360d-22b1-437f-b968-3a8dcfe28228"
+              },
+              {
+                "size": 2097152,
+                "start": 24504320,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "7f913d14-837a-4b54-bb80-9e83bb7733b0"
+              },
+              {
+                "size": 2097152,
+                "start": 26601472,
+                "type": "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F",
+                "uuid": "8b4ac29b-e5cc-4606-b77f-08e9c741bf56"
+              },
+              {
+                "size": 6293471,
+                "start": 28698624,
+                "type": "B921B045-1DF0-41C3-AF44-4C6F280D3FAE",
+                "uuid": "5b11ff3a-b4ac-4162-9e78-c2c61b73c478"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "ecfdf4b0-45a3-4e84-a87e-903b02d9e971"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "fd0b85b6-20c7-4c47-8014-678a1a58bb4c",
+            "label": "home"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2508800,
+                "size": 4194304,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "651b335d-9b0f-4f9d-9339-63a83e23ba28"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 6703104,
+                "size": 1024000,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "069aeae1-8fc9-45e8-8dbb-60363f8b0eb3"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 7727104,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "a2d49f24-d276-441a-aee6-a69e7bdc293f"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 9824256,
+                "size": 8388608,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "5e71e6db-895d-4eb4-9133-a125549076e3"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 18212864,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "a06cbd2e-339f-4795-b15f-49684d4d4975"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 20310016,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "8b269bda-d473-4af1-832a-1d537f4cd052"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 22407168,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "1bda848d-7ef7-4def-aa2c-4790df38e991"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 24504320,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkswap",
+          "options": {
+            "uuid": "3569b416-85dd-49c1-a7cf-a8a572301442"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 26601472,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "b531d3c1-43c4-4c9c-8e3d-474a499696fe",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 28698624,
+                "size": 6293471,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 28698624,
+                "size": 6293471
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600
+              }
+            },
+            "data": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 2097152
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 7727104,
+                "size": 2097152
+              }
+            },
+            "home": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2508800,
+                "size": 4194304
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 6703104,
+                "size": 1024000
+              }
+            },
+            "media": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 20310016,
+                "size": 2097152
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 18212864,
+                "size": 2097152
+              }
+            },
+            "root": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 22407168,
+                "size": 2097152
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 24504320,
+                "size": 2097152
+              }
+            },
+            "var": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 9824256,
+                "size": 8388608
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "data",
+              "type": "org.osbuild.ext4",
+              "source": "data",
+              "target": "/data"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.ext4",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.ext4",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.ext4",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.ext4",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.ext4",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.ext4",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.xfs",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "var",
+              "type": "org.osbuild.xfs",
+              "source": "var",
+              "target": "/var"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-baseos"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-appstream"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-aarch64-ami-partitioning_plain.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-ami-partitioning_plain.json
@@ -19,12 +19,6 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
-                },
-                {
                   "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
                 },
                 {
@@ -37,37 +31,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -125,9 +101,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -138,9 +111,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/centos_10-aarch64-image_installer-empty.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-image_installer-empty.json
@@ -1,0 +1,1623 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c"
+                },
+                {
+                  "id": "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:a788847c8c115aa9ae27ca92230418e77b3b36a6424f1d4f3436633864c93db9"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "anaconda-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:629e355a0345015e53cacd90ce641c7e2ef38405cd55e135f331a6303c51f509"
+                },
+                {
+                  "id": "sha256:1f2ce4e8c1aea4a2440b7e794e0440385f8e9c3f48b0fd65118f3dcdbca783bf"
+                },
+                {
+                  "id": "sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f"
+                },
+                {
+                  "id": "sha256:cd2c0f63ad37d585e77b3f1c584539e26bf7928710ac8fb19fd377f61b7326e6"
+                },
+                {
+                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
+                },
+                {
+                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
+                },
+                {
+                  "id": "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2"
+                },
+                {
+                  "id": "sha256:903be5b3913df555a8586e571d9016e1ac24eef2631a5d75b8c3f94c66f10955"
+                },
+                {
+                  "id": "sha256:b81f37a043a6f767e7c94d105f4bd31282f3ecc20680bb9d09bd93461cf4c863"
+                },
+                {
+                  "id": "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9"
+                },
+                {
+                  "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
+                },
+                {
+                  "id": "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c"
+                },
+                {
+                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
+                },
+                {
+                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
+                },
+                {
+                  "id": "sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112"
+                },
+                {
+                  "id": "sha256:5b8b6480d96480b779d6937e2d8694e03cdae14eb0664033ef24af50e1557726"
+                },
+                {
+                  "id": "sha256:75c008414c1be65c0e6954f74e1afdf3f706369f26899ea792b4ac0f31f287bc"
+                },
+                {
+                  "id": "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa"
+                },
+                {
+                  "id": "sha256:5e5d7e05a668f4ec5939a246b38d17cbb6ee83c0408ecbf584f6561a9d64a383"
+                },
+                {
+                  "id": "sha256:826c7f30d36dcc8cb4628bee44fc0e257a360eb06cfc31c49148a44b153e78ce"
+                },
+                {
+                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
+                },
+                {
+                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
+                },
+                {
+                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c"
+                },
+                {
+                  "id": "sha256:581265de790cf918fc770318449fe4cd07a18771c975d42867760b2e2f1bd18d"
+                },
+                {
+                  "id": "sha256:1f35e175b07fc080eb57fc9db22a3ce477d87bc5447466815f55864d3b6e6586"
+                },
+                {
+                  "id": "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31"
+                },
+                {
+                  "id": "sha256:9ac51bbcd5be0f507237b2d43367ad073eaf99398a65d26fa2a8fee5275f889b"
+                },
+                {
+                  "id": "sha256:f5f43514d2de810e4ea6d047203505e2e3c0c25f43941ec226968d17bb3aa1b5"
+                },
+                {
+                  "id": "sha256:24173b7985c9c52efc25b39e51f0fd41ac7b35e7031ed17da97788f293a3ce4e"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
+                },
+                {
+                  "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:9531c8584bbf61635c5c9b15733d9494cb6dd232a6eec85a946076c6c633e99f"
+                },
+                {
+                  "id": "sha256:5e4e6002bd0ef9491967c1f5f573b0c184ef5a41d165cff38c8c6c73606702cb"
+                },
+                {
+                  "id": "sha256:263acae321870b428781a1f4cb5e88740a897a4f9b614233a1798d295f805c54"
+                },
+                {
+                  "id": "sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1"
+                },
+                {
+                  "id": "sha256:8e901f9b6ca3996fe198c84d5f0a305b635bbaae54757fa84932ac52479c1efa"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111"
+                },
+                {
+                  "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:4ad76aeffa1e790eaf720b659f9860c50b6e0ba4787fa0a2d0e43dfa46193035"
+                },
+                {
+                  "id": "sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe"
+                },
+                {
+                  "id": "sha256:eeb3d09845f5cde069eeade2c4339532be58b6607120be00656123cc73ea727c"
+                },
+                {
+                  "id": "sha256:ce5b1962783aa6a9374a0a1b34941a112a799baac827c733bd28c78dbb4bcf36"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
+                },
+                {
+                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
+                },
+                {
+                  "id": "sha256:b498cfb546ddbfbd5953e28137e5b39a65ba6c7220bf4fe4c3cc9bcafc73c41b"
+                },
+                {
+                  "id": "sha256:f6453ebfd8ab070567bfcd4cda99cc41c2c849237745f24228c5f040cac5d562"
+                },
+                {
+                  "id": "sha256:f7f7a2e0133dfc81f9505bac28dfb7ee3398f3dc3b32c7682c86a9be5403bfee"
+                },
+                {
+                  "id": "sha256:cf732696c9aebd80fad833157535754f246445ad0fec66e918963443bd3cfb71"
+                },
+                {
+                  "id": "sha256:fe36b1d498f9c6057ed774ba5fb0a84c8592886c3a4c7c077ce7f41326373099"
+                },
+                {
+                  "id": "sha256:cb298bd94fae6f2f713a1108a16e0632f3a1e21820a288d7ea86c8b00a4d4fef"
+                },
+                {
+                  "id": "sha256:52999df2efd2afc3fcda19e416efb2d0f9b09562aa53331eaac2cde3c88ea207"
+                },
+                {
+                  "id": "sha256:b7110cc6e76089686855ae923d8e0212a0f067b8a48f3c96e8510d50c56061a7"
+                },
+                {
+                  "id": "sha256:2442f8197039e6fb34538a4651f00be2bcbaa8d2be3a15b734fa6ddf1bd8abba"
+                },
+                {
+                  "id": "sha256:a39d3ae3da34f2b4c01193e62202d5de0db79f800a039624b0f950734782b863"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686"
+                },
+                {
+                  "id": "sha256:316d18e697dfa41e92a9fe91d8d175629db5e330348a8adc1a5b43744d01d217"
+                },
+                {
+                  "id": "sha256:68d6e3ed85174ed856b83d5d1e16c23d5279cb5dc77915ae8570a768a5a65505"
+                },
+                {
+                  "id": "sha256:4381157a0ab3568cb31f727709b2edfca21522a8645e95c411f5798b8018393d"
+                },
+                {
+                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
+                },
+                {
+                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
+                },
+                {
+                  "id": "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a"
+                },
+                {
+                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
+                },
+                {
+                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
+                },
+                {
+                  "id": "sha256:500d641b95d95deab52480573126901d76d81dfe9fe0a5caf43445df38caad7b"
+                },
+                {
+                  "id": "sha256:5bc35fd09bee19e0dc22c7f7a731d1d8f4f68b81a3fd866e32273523eda30f9e"
+                },
+                {
+                  "id": "sha256:883642e660d2ef545d3d9f0cbd12790a99aea6358fb67c46664ff22fefa8b7df"
+                },
+                {
+                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
+                },
+                {
+                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
+                },
+                {
+                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
+                },
+                {
+                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
+                },
+                {
+                  "id": "sha256:990fde98d70a0a1a75bf55978f90138e8878a7f5cc1de475e03ee25b6744ee8a"
+                },
+                {
+                  "id": "sha256:95671115820a1fb4e74d1abed36bf069ce64a8233a3a37a8909cc62dffc57293"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
+                },
+                {
+                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
+                },
+                {
+                  "id": "sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:afed7d2fb0ea7b7e9d8dbcf1c1bb62ff53840c72d380cf165294a1eccb7fdeb1"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:cb6b44243b93acef33a5ee905d92203a2a55abdc6a3b7c446c8435a41a6ad137"
+                },
+                {
+                  "id": "sha256:61bfeb2957d080cbab70b332f16b482e1991b08e77ea7a8546b68b3cde90990c"
+                },
+                {
+                  "id": "sha256:28bdff3b22fe1fe1b18313472b2060d2706b9052cbabd91aaa7bed0c88c065de"
+                },
+                {
+                  "id": "sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a"
+                },
+                {
+                  "id": "sha256:85830c0611a0acd7053f7b3a29f52a0511acc3695f9c5ef39a29fcfb8b80e25b"
+                },
+                {
+                  "id": "sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d"
+                },
+                {
+                  "id": "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf"
+                },
+                {
+                  "id": "sha256:0a26024d87ac934c3aeca0ec8b27e579dfb6b268ac43f3a6f945579a54c46e6e"
+                },
+                {
+                  "id": "sha256:570e342d0e4708dab94b2025f6b928845b659b405872d824b45473c4635d7b1d"
+                },
+                {
+                  "id": "sha256:ce2b8ecf9afac9f546bdbbb0902afb6088fdcb8524269ad5b4adb9b9d4959b07"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.buildstamp",
+          "options": {
+            "arch": "aarch64",
+            "product": "CentOS Stream",
+            "version": "10-stream",
+            "final": true,
+            "variant": "",
+            "bugurl": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+              "install": {
+                "uid": 0,
+                "gid": 0,
+                "home": "/root",
+                "shell": "/usr/libexec/anaconda/run-anaconda",
+                "password": ""
+              },
+              "root": {
+                "password": ""
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.anaconda",
+          "options": {
+            "activatable-modules": [
+              "org.fedoraproject.Anaconda.Modules.Network",
+              "org.fedoraproject.Anaconda.Modules.Payloads",
+              "org.fedoraproject.Anaconda.Modules.Storage",
+              "org.fedoraproject.Anaconda.Modules.Users"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.lorax-script",
+          "options": {
+            "path": "99-generic/runtime-postinstall.tmpl",
+            "basearch": "aarch64",
+            "product": {
+              "name": "",
+              "version": ""
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.dracut",
+          "options": {
+            "kernel": [
+              "8-2.fk1.aarch64"
+            ],
+            "modules": [
+              "bash",
+              "systemd",
+              "fips",
+              "systemd-initrd",
+              "modsign",
+              "nss-softokn",
+              "i18n",
+              "convertfs",
+              "network-manager",
+              "network",
+              "url-lib",
+              "drm",
+              "plymouth",
+              "crypt",
+              "dm",
+              "dmsquash-live",
+              "kernel-modules",
+              "kernel-modules-extra",
+              "kernel-network-modules",
+              "livenet",
+              "lvm",
+              "mdraid",
+              "qemu",
+              "qemu-net",
+              "resume",
+              "rootfs-block",
+              "terminfo",
+              "udev-rules",
+              "dracut-systemd",
+              "pollcdrom",
+              "usrmount",
+              "base",
+              "fs-lib",
+              "img-lib",
+              "shutdown",
+              "uefi-lib",
+              "nvdimm",
+              "prefixdevname",
+              "prefixdevname-tools",
+              "net-lib",
+              "anaconda",
+              "rdma",
+              "rngd",
+              "multipath",
+              "fcoe",
+              "fcoe-uefi",
+              "iscsi",
+              "lunmask",
+              "nfs"
+            ],
+            "add_drivers": [
+              "ipmi_devintf",
+              "ipmi_msghandler"
+            ],
+            "install": [
+              "/.buildstamp"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux.config",
+          "options": {
+            "state": "permissive"
+          }
+        }
+      ]
+    },
+    {
+      "name": "efiboot-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.grub2.iso",
+          "options": {
+            "product": {
+              "name": "CentOS Stream",
+              "version": "10-stream"
+            },
+            "kernel": {
+              "dir": "/images/pxeboot",
+              "opts": [
+                "inst.stage2=hd:LABEL=CentOS-Stream-10-BaseOS-aarch64",
+                "inst.ks=hd:LABEL=CentOS-Stream-10-BaseOS-aarch64:/osbuild.ks"
+              ]
+            },
+            "isolabel": "CentOS-Stream-10-BaseOS-aarch64",
+            "architectures": [
+              "AA64"
+            ],
+            "vendor": "centos"
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111"
+                },
+                {
+                  "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd"
+                },
+                {
+                  "id": "sha256:d87d9e526f265be973fce2ba320c5ed3ae24f6c5560d816d0b9307d0ba4d357f"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bootiso-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/images"
+              },
+              {
+                "path": "/images/pxeboot"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://tree/boot/vmlinuz-8-2.fk1.aarch64",
+                "to": "tree:///images/pxeboot/vmlinuz"
+              },
+              {
+                "from": "input://tree/boot/initramfs-8-2.fk1.aarch64.img",
+                "to": "tree:///images/pxeboot/initrd.img"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.squashfs",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "filename": "images/install.img",
+            "compression": {
+              "method": "xz",
+              "options": {
+                "bcj": "arm"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "images/efiboot.img",
+            "size": "20971520"
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "3dce9b06"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "images/efiboot.img",
+                "size": 40960,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:efiboot-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "images/efiboot.img",
+                "size": 40960
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.fat",
+              "source": "-",
+              "target": "/"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:efiboot-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/EFI",
+                "to": "tree:///"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "/liveimg.tar.gz"
+          }
+        },
+        {
+          "type": "org.osbuild.kickstart",
+          "options": {
+            "path": "/osbuild.ks",
+            "liveimg": {
+              "url": "file:///run/install/repo/liveimg.tar.gz"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.discinfo",
+          "options": {
+            "basearch": "aarch64",
+            "release": "CentOS Stream 10-stream"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bootiso",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.xorrisofs",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:bootiso-tree"
+              ]
+            }
+          },
+          "options": {
+            "filename": "installer.iso",
+            "volid": "CentOS-Stream-10-BaseOS-aarch64",
+            "sysid": "LINUX",
+            "efi": "images/efiboot.img",
+            "isolevel": 3
+          }
+        },
+        {
+          "type": "org.osbuild.implantisomd5",
+          "options": {
+            "filename": "installer.iso"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a": {
+          "url": "https://example.com/repo/packages/net-tools"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112": {
+          "url": "https://example.com/repo/packages/dbus-x11"
+        },
+        "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3": {
+          "url": "https://example.com/repo/packages/bzip2"
+        },
+        "sha256:0a26024d87ac934c3aeca0ec8b27e579dfb6b268ac43f3a6f945579a54c46e6e": {
+          "url": "https://example.com/repo/packages/volume_key"
+        },
+        "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1": {
+          "url": "https://example.com/repo/packages/initscripts"
+        },
+        "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa": {
+          "url": "https://example.com/repo/packages/iwl105-firmware"
+        },
+        "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9": {
+          "url": "https://example.com/repo/packages/bind-utils"
+        },
+        "sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe": {
+          "url": "https://example.com/repo/packages/kbd"
+        },
+        "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa": {
+          "url": "https://example.com/repo/packages/anaconda-dracut"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:1f2ce4e8c1aea4a2440b7e794e0440385f8e9c3f48b0fd65118f3dcdbca783bf": {
+          "url": "https://example.com/repo/packages/alsa-firmware"
+        },
+        "sha256:1f35e175b07fc080eb57fc9db22a3ce477d87bc5447466815f55864d3b6e6586": {
+          "url": "https://example.com/repo/packages/ftp"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:24173b7985c9c52efc25b39e51f0fd41ac7b35e7031ed17da97788f293a3ce4e": {
+          "url": "https://example.com/repo/packages/google-noto-sans-cjk-ttc-fonts"
+        },
+        "sha256:2442f8197039e6fb34538a4651f00be2bcbaa8d2be3a15b734fa6ddf1bd8abba": {
+          "url": "https://example.com/repo/packages/mt-st"
+        },
+        "sha256:263acae321870b428781a1f4cb5e88740a897a4f9b614233a1798d295f805c54": {
+          "url": "https://example.com/repo/packages/hdparm"
+        },
+        "sha256:28bdff3b22fe1fe1b18313472b2060d2706b9052cbabd91aaa7bed0c88c065de": {
+          "url": "https://example.com/repo/packages/spice-vdagent"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686": {
+          "url": "https://example.com/repo/packages/nm-connection-editor"
+        },
+        "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa": {
+          "url": "https://example.com/repo/packages/dejavu-sans-fonts"
+        },
+        "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc": {
+          "url": "https://example.com/repo/packages/dmidecode"
+        },
+        "sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f": {
+          "url": "https://example.com/repo/packages/alsa-tools-firmware"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:316d18e697dfa41e92a9fe91d8d175629db5e330348a8adc1a5b43744d01d217": {
+          "url": "https://example.com/repo/packages/nmap-ncat"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1": {
+          "url": "https://example.com/repo/packages/dnf"
+        },
+        "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0": {
+          "url": "https://example.com/repo/packages/curl"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:4381157a0ab3568cb31f727709b2edfca21522a8645e95c411f5798b8018393d": {
+          "url": "https://example.com/repo/packages/nss-tools"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64-cdboot"
+        },
+        "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce": {
+          "url": "https://example.com/repo/packages/iwl100-firmware"
+        },
+        "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674": {
+          "url": "https://example.com/repo/packages/iwl2030-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4ad76aeffa1e790eaf720b659f9860c50b6e0ba4787fa0a2d0e43dfa46193035": {
+          "url": "https://example.com/repo/packages/jomolhari-fonts"
+        },
+        "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d": {
+          "url": "https://example.com/repo/packages/less"
+        },
+        "sha256:500d641b95d95deab52480573126901d76d81dfe9fe0a5caf43445df38caad7b": {
+          "url": "https://example.com/repo/packages/pciutils"
+        },
+        "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2": {
+          "url": "https://example.com/repo/packages/anaconda-install-img-deps"
+        },
+        "sha256:52999df2efd2afc3fcda19e416efb2d0f9b09562aa53331eaac2cde3c88ea207": {
+          "url": "https://example.com/repo/packages/madan-fonts"
+        },
+        "sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781": {
+          "url": "https://example.com/repo/packages/xorriso"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:570e342d0e4708dab94b2025f6b928845b659b405872d824b45473c4635d7b1d": {
+          "url": "https://example.com/repo/packages/wget"
+        },
+        "sha256:581265de790cf918fc770318449fe4cd07a18771c975d42867760b2e2f1bd18d": {
+          "url": "https://example.com/repo/packages/fcoe-utils"
+        },
+        "sha256:5b8b6480d96480b779d6937e2d8694e03cdae14eb0664033ef24af50e1557726": {
+          "url": "https://example.com/repo/packages/default-fonts-core-sans"
+        },
+        "sha256:5bc35fd09bee19e0dc22c7f7a731d1d8f4f68b81a3fd866e32273523eda30f9e": {
+          "url": "https://example.com/repo/packages/perl-interpreter"
+        },
+        "sha256:5e4e6002bd0ef9491967c1f5f573b0c184ef5a41d165cff38c8c6c73606702cb": {
+          "url": "https://example.com/repo/packages/gsettings-desktop-schemas"
+        },
+        "sha256:5e5d7e05a668f4ec5939a246b38d17cbb6ee83c0408ecbf584f6561a9d64a383": {
+          "url": "https://example.com/repo/packages/dejavu-sans-mono-fonts"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:61bfeb2957d080cbab70b332f16b482e1991b08e77ea7a8546b68b3cde90990c": {
+          "url": "https://example.com/repo/packages/smartmontools"
+        },
+        "sha256:629e355a0345015e53cacd90ce641c7e2ef38405cd55e135f331a6303c51f509": {
+          "url": "https://example.com/repo/packages/@hardware-support"
+        },
+        "sha256:68d6e3ed85174ed856b83d5d1e16c23d5279cb5dc77915ae8570a768a5a65505": {
+          "url": "https://example.com/repo/packages/nss-softokn"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682": {
+          "url": "https://example.com/repo/packages/hostname"
+        },
+        "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393": {
+          "url": "https://example.com/repo/packages/grub2-tools-minimal"
+        },
+        "sha256:75c008414c1be65c0e6954f74e1afdf3f706369f26899ea792b4ac0f31f287bc": {
+          "url": "https://example.com/repo/packages/default-fonts-other-sans"
+        },
+        "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-baseos"
+        },
+        "sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18": {
+          "url": "https://example.com/repo/packages/strace"
+        },
+        "sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980": {
+          "url": "https://example.com/repo/packages/hexedit"
+        },
+        "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764": {
+          "url": "https://example.com/repo/packages/grub2-tools-extra"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5": {
+          "url": "https://example.com/repo/packages/firewalld"
+        },
+        "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a": {
+          "url": "https://example.com/repo/packages/openssh-server"
+        },
+        "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467": {
+          "url": "https://example.com/repo/packages/iwl6050-firmware"
+        },
+        "sha256:826c7f30d36dcc8cb4628bee44fc0e257a360eb06cfc31c49148a44b153e78ce": {
+          "url": "https://example.com/repo/packages/device-mapper-persistent-data"
+        },
+        "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0": {
+          "url": "https://example.com/repo/packages/ostree"
+        },
+        "sha256:85830c0611a0acd7053f7b3a29f52a0511acc3695f9c5ef39a29fcfb8b80e25b": {
+          "url": "https://example.com/repo/packages/udisks2-iscsi"
+        },
+        "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071": {
+          "url": "https://example.com/repo/packages/iwl5150-firmware"
+        },
+        "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714": {
+          "url": "https://example.com/repo/packages/iwl135-firmware"
+        },
+        "sha256:883642e660d2ef545d3d9f0cbd12790a99aea6358fb67c46664ff22fefa8b7df": {
+          "url": "https://example.com/repo/packages/pigz"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111": {
+          "url": "https://example.com/repo/packages/iwl6000g2a-firmware"
+        },
+        "sha256:8e901f9b6ca3996fe198c84d5f0a305b635bbaae54757fa84932ac52479c1efa": {
+          "url": "https://example.com/repo/packages/ipmitool"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:903be5b3913df555a8586e571d9016e1ac24eef2631a5d75b8c3f94c66f10955": {
+          "url": "https://example.com/repo/packages/anaconda-widgets"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9531c8584bbf61635c5c9b15733d9494cb6dd232a6eec85a946076c6c633e99f": {
+          "url": "https://example.com/repo/packages/grubby"
+        },
+        "sha256:95671115820a1fb4e74d1abed36bf069ce64a8233a3a37a8909cc62dffc57293": {
+          "url": "https://example.com/repo/packages/rdma-core"
+        },
+        "sha256:990fde98d70a0a1a75bf55978f90138e8878a7f5cc1de475e03ee25b6744ee8a": {
+          "url": "https://example.com/repo/packages/python3-pyatspi"
+        },
+        "sha256:9ac51bbcd5be0f507237b2d43367ad073eaf99398a65d26fa2a8fee5275f889b": {
+          "url": "https://example.com/repo/packages/glibc-all-langpacks"
+        },
+        "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd": {
+          "url": "https://example.com/repo/packages/prefixdevname"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a39d3ae3da34f2b4c01193e62202d5de0db79f800a039624b0f950734782b863": {
+          "url": "https://example.com/repo/packages/mtr"
+        },
+        "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53": {
+          "url": "https://example.com/repo/packages/plymouth"
+        },
+        "sha256:a788847c8c115aa9ae27ca92230418e77b3b36a6424f1d4f3436633864c93db9": {
+          "url": "https://example.com/repo/packages/squashfs-tools"
+        },
+        "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018": {
+          "url": "https://example.com/repo/packages/iwl3160-firmware"
+        },
+        "sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d": {
+          "url": "https://example.com/repo/packages/usbutils"
+        },
+        "sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a": {
+          "url": "https://example.com/repo/packages/udisks2"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14": {
+          "url": "https://example.com/repo/packages/sg3_utils"
+        },
+        "sha256:afed7d2fb0ea7b7e9d8dbcf1c1bb62ff53840c72d380cf165294a1eccb7fdeb1": {
+          "url": "https://example.com/repo/packages/rsyslog"
+        },
+        "sha256:b498cfb546ddbfbd5953e28137e5b39a65ba6c7220bf4fe4c3cc9bcafc73c41b": {
+          "url": "https://example.com/repo/packages/libblockdev-lvm-dbus"
+        },
+        "sha256:b7110cc6e76089686855ae923d8e0212a0f067b8a48f3c96e8510d50c56061a7": {
+          "url": "https://example.com/repo/packages/mdadm"
+        },
+        "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be": {
+          "url": "https://example.com/repo/packages/rpcbind"
+        },
+        "sha256:b81f37a043a6f767e7c94d105f4bd31282f3ecc20680bb9d09bd93461cf4c863": {
+          "url": "https://example.com/repo/packages/audit"
+        },
+        "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf": {
+          "url": "https://example.com/repo/packages/vim-minimal"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8": {
+          "url": "https://example.com/repo/packages/iwl2000-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0": {
+          "url": "https://example.com/repo/packages/iwl5000-firmware"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c": {
+          "url": "https://example.com/repo/packages/ethtool"
+        },
+        "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0": {
+          "url": "https://example.com/repo/packages/iwl1000-firmware"
+        },
+        "sha256:cb298bd94fae6f2f713a1108a16e0632f3a1e21820a288d7ea86c8b00a4d4fef": {
+          "url": "https://example.com/repo/packages/lsof"
+        },
+        "sha256:cb6b44243b93acef33a5ee905d92203a2a55abdc6a3b7c446c8435a41a6ad137": {
+          "url": "https://example.com/repo/packages/sil-padauk-fonts"
+        },
+        "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31": {
+          "url": "https://example.com/repo/packages/gdb-gdbserver"
+        },
+        "sha256:cd2c0f63ad37d585e77b3f1c584539e26bf7928710ac8fb19fd377f61b7326e6": {
+          "url": "https://example.com/repo/packages/anaconda"
+        },
+        "sha256:ce2b8ecf9afac9f546bdbbb0902afb6088fdcb8524269ad5b4adb9b9d4959b07": {
+          "url": "https://example.com/repo/packages/xfsdump"
+        },
+        "sha256:ce5b1962783aa6a9374a0a1b34941a112a799baac827c733bd28c78dbb4bcf36": {
+          "url": "https://example.com/repo/packages/kdump-anaconda-addon"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c": {
+          "url": "https://example.com/repo/packages/cryptsetup"
+        },
+        "sha256:cf732696c9aebd80fad833157535754f246445ad0fec66e918963443bd3cfb71": {
+          "url": "https://example.com/repo/packages/linux-firmware"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9": {
+          "url": "https://example.com/repo/packages/iwl6000g2b-firmware"
+        },
+        "sha256:d87d9e526f265be973fce2ba320c5ed3ae24f6c5560d816d0b9307d0ba4d357f": {
+          "url": "https://example.com/repo/packages/lorax-templates-rhel"
+        },
+        "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd": {
+          "url": "https://example.com/repo/packages/lorax-templates-generic"
+        },
+        "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9": {
+          "url": "https://example.com/repo/packages/openssh-clients"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-appstream"
+        },
+        "sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d": {
+          "url": "https://example.com/repo/packages/rpm-ostree"
+        },
+        "sha256:eeb3d09845f5cde069eeade2c4339532be58b6607120be00656123cc73ea727c": {
+          "url": "https://example.com/repo/packages/kbd-misc"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f5f43514d2de810e4ea6d047203505e2e3c0c25f43941ec226968d17bb3aa1b5": {
+          "url": "https://example.com/repo/packages/gnome-kiosk"
+        },
+        "sha256:f6453ebfd8ab070567bfcd4cda99cc41c2c849237745f24228c5f040cac5d562": {
+          "url": "https://example.com/repo/packages/libibverbs"
+        },
+        "sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c": {
+          "url": "https://example.com/repo/packages/isomd5sum"
+        },
+        "sha256:f7f7a2e0133dfc81f9505bac28dfb7ee3398f3dc3b32c7682c86a9be5403bfee": {
+          "url": "https://example.com/repo/packages/librsvg2"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23": {
+          "url": "https://example.com/repo/packages/dracut-network"
+        },
+        "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7": {
+          "url": "https://example.com/repo/packages/iwl7260-firmware"
+        },
+        "sha256:fe36b1d498f9c6057ed774ba5fb0a84c8592886c3a4c7c077ce7f41326373099": {
+          "url": "https://example.com/repo/packages/lldpad"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-aarch64-image_installer-empty.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-image_installer-empty.json
@@ -55,12 +55,6 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
@@ -131,9 +125,6 @@
                   "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
                 },
                 {
-                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
-                },
-                {
                   "id": "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2"
                 },
                 {
@@ -150,9 +141,6 @@
                 },
                 {
                   "id": "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c"
-                },
-                {
-                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
                 },
                 {
                   "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
@@ -179,28 +167,13 @@
                   "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
                 },
                 {
-                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
-                },
-                {
                   "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
                   "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
-                },
-                {
-                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
                 },
                 {
                   "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
@@ -230,37 +203,13 @@
                   "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
                 },
                 {
-                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
-                },
-                {
-                  "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
-                },
-                {
                   "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
                 },
                 {
                   "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
                 },
                 {
-                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
-                },
-                {
-                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
-                },
-                {
                   "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
-                },
-                {
-                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
                 },
                 {
                   "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
@@ -281,9 +230,6 @@
                   "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
                 },
                 {
-                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
-                },
-                {
                   "id": "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1"
                 },
                 {
@@ -293,16 +239,7 @@
                   "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
                 },
                 {
-                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
-                },
-                {
                   "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
-                },
-                {
-                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
-                },
-                {
-                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
                 },
                 {
                   "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
@@ -311,16 +248,7 @@
                   "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
                 },
                 {
-                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
-                },
-                {
                   "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
-                },
-                {
-                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
-                },
-                {
-                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
                 },
                 {
                   "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
@@ -329,16 +257,7 @@
                   "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
                 },
                 {
-                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
-                },
-                {
                   "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
                 },
                 {
                   "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
@@ -351,12 +270,6 @@
                 },
                 {
                   "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
-                },
-                {
-                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
-                },
-                {
-                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
                 },
                 {
                   "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
@@ -375,12 +288,6 @@
                 },
                 {
                   "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
-                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
-                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
                 },
                 {
                   "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
@@ -422,9 +329,6 @@
                   "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
                 },
                 {
-                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
-                },
-                {
                   "id": "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686"
                 },
                 {
@@ -440,13 +344,7 @@
                   "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
                 },
                 {
-                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
-                },
-                {
                   "id": "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a"
-                },
-                {
-                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
                 },
                 {
                   "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
@@ -464,12 +362,6 @@
                   "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
                 },
                 {
-                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
-                },
-                {
-                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
-                },
-                {
                   "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
                 },
                 {
@@ -483,12 +375,6 @@
                 },
                 {
                   "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
                 },
                 {
                   "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
@@ -506,13 +392,7 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14"
-                },
-                {
-                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
                 },
                 {
                   "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
@@ -531,12 +411,6 @@
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
@@ -564,12 +438,6 @@
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
                 },
                 {
                   "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
@@ -775,9 +643,6 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
@@ -850,9 +715,6 @@
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
-                },
-                {
                   "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
                 },
                 {
@@ -863,9 +725,6 @@
                 },
                 {
                   "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -898,16 +757,10 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"

--- a/test/data/manifestdb-light/centos_10-aarch64-image_installer-unattended_iso.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-image_installer-unattended_iso.json
@@ -55,12 +55,6 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
@@ -131,9 +125,6 @@
                   "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
                 },
                 {
-                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
-                },
-                {
                   "id": "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2"
                 },
                 {
@@ -150,9 +141,6 @@
                 },
                 {
                   "id": "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c"
-                },
-                {
-                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
                 },
                 {
                   "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
@@ -179,28 +167,13 @@
                   "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
                 },
                 {
-                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
-                },
-                {
                   "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
                   "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
-                },
-                {
-                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
                 },
                 {
                   "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
@@ -230,37 +203,13 @@
                   "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
                 },
                 {
-                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
-                },
-                {
-                  "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
-                },
-                {
                   "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
                 },
                 {
                   "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
                 },
                 {
-                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
-                },
-                {
-                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
-                },
-                {
                   "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
-                },
-                {
-                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
                 },
                 {
                   "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
@@ -281,9 +230,6 @@
                   "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
                 },
                 {
-                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
-                },
-                {
                   "id": "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1"
                 },
                 {
@@ -293,16 +239,7 @@
                   "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
                 },
                 {
-                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
-                },
-                {
                   "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
-                },
-                {
-                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
-                },
-                {
-                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
                 },
                 {
                   "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
@@ -311,16 +248,7 @@
                   "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
                 },
                 {
-                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
-                },
-                {
                   "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
-                },
-                {
-                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
-                },
-                {
-                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
                 },
                 {
                   "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
@@ -329,16 +257,7 @@
                   "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
                 },
                 {
-                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
-                },
-                {
                   "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
                 },
                 {
                   "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
@@ -351,12 +270,6 @@
                 },
                 {
                   "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
-                },
-                {
-                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
-                },
-                {
-                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
                 },
                 {
                   "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
@@ -375,12 +288,6 @@
                 },
                 {
                   "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
-                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
-                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
                 },
                 {
                   "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
@@ -422,9 +329,6 @@
                   "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
                 },
                 {
-                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
-                },
-                {
                   "id": "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686"
                 },
                 {
@@ -440,13 +344,7 @@
                   "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
                 },
                 {
-                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
-                },
-                {
                   "id": "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a"
-                },
-                {
-                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
                 },
                 {
                   "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
@@ -464,12 +362,6 @@
                   "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
                 },
                 {
-                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
-                },
-                {
-                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
-                },
-                {
                   "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
                 },
                 {
@@ -483,12 +375,6 @@
                 },
                 {
                   "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
                 },
                 {
                   "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
@@ -506,13 +392,7 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14"
-                },
-                {
-                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
                 },
                 {
                   "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
@@ -531,12 +411,6 @@
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
@@ -564,12 +438,6 @@
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
                 },
                 {
                   "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
@@ -777,9 +645,6 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
@@ -852,9 +717,6 @@
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
-                },
-                {
                   "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
                 },
                 {
@@ -865,9 +727,6 @@
                 },
                 {
                   "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -900,16 +759,10 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"

--- a/test/data/manifestdb-light/centos_10-aarch64-image_installer-unattended_iso.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-image_installer-unattended_iso.json
@@ -1,0 +1,1698 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c"
+                },
+                {
+                  "id": "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:a788847c8c115aa9ae27ca92230418e77b3b36a6424f1d4f3436633864c93db9"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "anaconda-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:629e355a0345015e53cacd90ce641c7e2ef38405cd55e135f331a6303c51f509"
+                },
+                {
+                  "id": "sha256:1f2ce4e8c1aea4a2440b7e794e0440385f8e9c3f48b0fd65118f3dcdbca783bf"
+                },
+                {
+                  "id": "sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f"
+                },
+                {
+                  "id": "sha256:cd2c0f63ad37d585e77b3f1c584539e26bf7928710ac8fb19fd377f61b7326e6"
+                },
+                {
+                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
+                },
+                {
+                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
+                },
+                {
+                  "id": "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2"
+                },
+                {
+                  "id": "sha256:903be5b3913df555a8586e571d9016e1ac24eef2631a5d75b8c3f94c66f10955"
+                },
+                {
+                  "id": "sha256:b81f37a043a6f767e7c94d105f4bd31282f3ecc20680bb9d09bd93461cf4c863"
+                },
+                {
+                  "id": "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9"
+                },
+                {
+                  "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
+                },
+                {
+                  "id": "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c"
+                },
+                {
+                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
+                },
+                {
+                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
+                },
+                {
+                  "id": "sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112"
+                },
+                {
+                  "id": "sha256:5b8b6480d96480b779d6937e2d8694e03cdae14eb0664033ef24af50e1557726"
+                },
+                {
+                  "id": "sha256:75c008414c1be65c0e6954f74e1afdf3f706369f26899ea792b4ac0f31f287bc"
+                },
+                {
+                  "id": "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa"
+                },
+                {
+                  "id": "sha256:5e5d7e05a668f4ec5939a246b38d17cbb6ee83c0408ecbf584f6561a9d64a383"
+                },
+                {
+                  "id": "sha256:826c7f30d36dcc8cb4628bee44fc0e257a360eb06cfc31c49148a44b153e78ce"
+                },
+                {
+                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
+                },
+                {
+                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
+                },
+                {
+                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c"
+                },
+                {
+                  "id": "sha256:581265de790cf918fc770318449fe4cd07a18771c975d42867760b2e2f1bd18d"
+                },
+                {
+                  "id": "sha256:1f35e175b07fc080eb57fc9db22a3ce477d87bc5447466815f55864d3b6e6586"
+                },
+                {
+                  "id": "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31"
+                },
+                {
+                  "id": "sha256:9ac51bbcd5be0f507237b2d43367ad073eaf99398a65d26fa2a8fee5275f889b"
+                },
+                {
+                  "id": "sha256:f5f43514d2de810e4ea6d047203505e2e3c0c25f43941ec226968d17bb3aa1b5"
+                },
+                {
+                  "id": "sha256:24173b7985c9c52efc25b39e51f0fd41ac7b35e7031ed17da97788f293a3ce4e"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
+                },
+                {
+                  "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:9531c8584bbf61635c5c9b15733d9494cb6dd232a6eec85a946076c6c633e99f"
+                },
+                {
+                  "id": "sha256:5e4e6002bd0ef9491967c1f5f573b0c184ef5a41d165cff38c8c6c73606702cb"
+                },
+                {
+                  "id": "sha256:263acae321870b428781a1f4cb5e88740a897a4f9b614233a1798d295f805c54"
+                },
+                {
+                  "id": "sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1"
+                },
+                {
+                  "id": "sha256:8e901f9b6ca3996fe198c84d5f0a305b635bbaae54757fa84932ac52479c1efa"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111"
+                },
+                {
+                  "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:4ad76aeffa1e790eaf720b659f9860c50b6e0ba4787fa0a2d0e43dfa46193035"
+                },
+                {
+                  "id": "sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe"
+                },
+                {
+                  "id": "sha256:eeb3d09845f5cde069eeade2c4339532be58b6607120be00656123cc73ea727c"
+                },
+                {
+                  "id": "sha256:ce5b1962783aa6a9374a0a1b34941a112a799baac827c733bd28c78dbb4bcf36"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
+                },
+                {
+                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
+                },
+                {
+                  "id": "sha256:b498cfb546ddbfbd5953e28137e5b39a65ba6c7220bf4fe4c3cc9bcafc73c41b"
+                },
+                {
+                  "id": "sha256:f6453ebfd8ab070567bfcd4cda99cc41c2c849237745f24228c5f040cac5d562"
+                },
+                {
+                  "id": "sha256:f7f7a2e0133dfc81f9505bac28dfb7ee3398f3dc3b32c7682c86a9be5403bfee"
+                },
+                {
+                  "id": "sha256:cf732696c9aebd80fad833157535754f246445ad0fec66e918963443bd3cfb71"
+                },
+                {
+                  "id": "sha256:fe36b1d498f9c6057ed774ba5fb0a84c8592886c3a4c7c077ce7f41326373099"
+                },
+                {
+                  "id": "sha256:cb298bd94fae6f2f713a1108a16e0632f3a1e21820a288d7ea86c8b00a4d4fef"
+                },
+                {
+                  "id": "sha256:52999df2efd2afc3fcda19e416efb2d0f9b09562aa53331eaac2cde3c88ea207"
+                },
+                {
+                  "id": "sha256:b7110cc6e76089686855ae923d8e0212a0f067b8a48f3c96e8510d50c56061a7"
+                },
+                {
+                  "id": "sha256:2442f8197039e6fb34538a4651f00be2bcbaa8d2be3a15b734fa6ddf1bd8abba"
+                },
+                {
+                  "id": "sha256:a39d3ae3da34f2b4c01193e62202d5de0db79f800a039624b0f950734782b863"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686"
+                },
+                {
+                  "id": "sha256:316d18e697dfa41e92a9fe91d8d175629db5e330348a8adc1a5b43744d01d217"
+                },
+                {
+                  "id": "sha256:68d6e3ed85174ed856b83d5d1e16c23d5279cb5dc77915ae8570a768a5a65505"
+                },
+                {
+                  "id": "sha256:4381157a0ab3568cb31f727709b2edfca21522a8645e95c411f5798b8018393d"
+                },
+                {
+                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
+                },
+                {
+                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
+                },
+                {
+                  "id": "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a"
+                },
+                {
+                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
+                },
+                {
+                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
+                },
+                {
+                  "id": "sha256:500d641b95d95deab52480573126901d76d81dfe9fe0a5caf43445df38caad7b"
+                },
+                {
+                  "id": "sha256:5bc35fd09bee19e0dc22c7f7a731d1d8f4f68b81a3fd866e32273523eda30f9e"
+                },
+                {
+                  "id": "sha256:883642e660d2ef545d3d9f0cbd12790a99aea6358fb67c46664ff22fefa8b7df"
+                },
+                {
+                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
+                },
+                {
+                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
+                },
+                {
+                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
+                },
+                {
+                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
+                },
+                {
+                  "id": "sha256:990fde98d70a0a1a75bf55978f90138e8878a7f5cc1de475e03ee25b6744ee8a"
+                },
+                {
+                  "id": "sha256:95671115820a1fb4e74d1abed36bf069ce64a8233a3a37a8909cc62dffc57293"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
+                },
+                {
+                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
+                },
+                {
+                  "id": "sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:afed7d2fb0ea7b7e9d8dbcf1c1bb62ff53840c72d380cf165294a1eccb7fdeb1"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:cb6b44243b93acef33a5ee905d92203a2a55abdc6a3b7c446c8435a41a6ad137"
+                },
+                {
+                  "id": "sha256:61bfeb2957d080cbab70b332f16b482e1991b08e77ea7a8546b68b3cde90990c"
+                },
+                {
+                  "id": "sha256:28bdff3b22fe1fe1b18313472b2060d2706b9052cbabd91aaa7bed0c88c065de"
+                },
+                {
+                  "id": "sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a"
+                },
+                {
+                  "id": "sha256:85830c0611a0acd7053f7b3a29f52a0511acc3695f9c5ef39a29fcfb8b80e25b"
+                },
+                {
+                  "id": "sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d"
+                },
+                {
+                  "id": "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf"
+                },
+                {
+                  "id": "sha256:0a26024d87ac934c3aeca0ec8b27e579dfb6b268ac43f3a6f945579a54c46e6e"
+                },
+                {
+                  "id": "sha256:570e342d0e4708dab94b2025f6b928845b659b405872d824b45473c4635d7b1d"
+                },
+                {
+                  "id": "sha256:ce2b8ecf9afac9f546bdbbb0902afb6088fdcb8524269ad5b4adb9b9d4959b07"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.buildstamp",
+          "options": {
+            "arch": "aarch64",
+            "product": "CentOS Stream",
+            "version": "10-stream",
+            "final": true,
+            "variant": "",
+            "bugurl": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "en_GB.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+              "install": {
+                "uid": 0,
+                "gid": 0,
+                "home": "/root",
+                "shell": "/usr/libexec/anaconda/run-anaconda",
+                "password": ""
+              },
+              "root": {
+                "password": ""
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.anaconda",
+          "options": {
+            "activatable-modules": [
+              "org.fedoraproject.Anaconda.Modules.Localization",
+              "org.fedoraproject.Anaconda.Modules.Network",
+              "org.fedoraproject.Anaconda.Modules.Payloads",
+              "org.fedoraproject.Anaconda.Modules.Services",
+              "org.fedoraproject.Anaconda.Modules.Storage",
+              "org.fedoraproject.Anaconda.Modules.Users"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.lorax-script",
+          "options": {
+            "path": "99-generic/runtime-postinstall.tmpl",
+            "basearch": "aarch64",
+            "product": {
+              "name": "",
+              "version": ""
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.dracut",
+          "options": {
+            "kernel": [
+              "8-2.fk1.aarch64"
+            ],
+            "modules": [
+              "bash",
+              "systemd",
+              "fips",
+              "systemd-initrd",
+              "modsign",
+              "nss-softokn",
+              "i18n",
+              "convertfs",
+              "network-manager",
+              "network",
+              "url-lib",
+              "drm",
+              "plymouth",
+              "crypt",
+              "dm",
+              "dmsquash-live",
+              "kernel-modules",
+              "kernel-modules-extra",
+              "kernel-network-modules",
+              "livenet",
+              "lvm",
+              "mdraid",
+              "qemu",
+              "qemu-net",
+              "resume",
+              "rootfs-block",
+              "terminfo",
+              "udev-rules",
+              "dracut-systemd",
+              "pollcdrom",
+              "usrmount",
+              "base",
+              "fs-lib",
+              "img-lib",
+              "shutdown",
+              "uefi-lib",
+              "nvdimm",
+              "prefixdevname",
+              "prefixdevname-tools",
+              "net-lib",
+              "anaconda",
+              "rdma",
+              "rngd",
+              "multipath",
+              "fcoe",
+              "fcoe-uefi",
+              "iscsi",
+              "lunmask",
+              "nfs"
+            ],
+            "add_drivers": [
+              "ipmi_devintf",
+              "ipmi_msghandler"
+            ],
+            "install": [
+              "/.buildstamp"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux.config",
+          "options": {
+            "state": "permissive"
+          }
+        }
+      ]
+    },
+    {
+      "name": "efiboot-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.grub2.iso",
+          "options": {
+            "product": {
+              "name": "CentOS Stream",
+              "version": "10-stream"
+            },
+            "kernel": {
+              "dir": "/images/pxeboot",
+              "opts": [
+                "inst.stage2=hd:LABEL=CentOS-Stream-10-BaseOS-aarch64",
+                "inst.ks=hd:LABEL=CentOS-Stream-10-BaseOS-aarch64:/osbuild.ks"
+              ]
+            },
+            "isolabel": "CentOS-Stream-10-BaseOS-aarch64",
+            "architectures": [
+              "AA64"
+            ],
+            "vendor": "centos"
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111"
+                },
+                {
+                  "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd"
+                },
+                {
+                  "id": "sha256:d87d9e526f265be973fce2ba320c5ed3ae24f6c5560d816d0b9307d0ba4d357f"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "en_GB.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "uk"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "Europe/Berlin"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bootiso-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/images"
+              },
+              {
+                "path": "/images/pxeboot"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://tree/boot/vmlinuz-8-2.fk1.aarch64",
+                "to": "tree:///images/pxeboot/vmlinuz"
+              },
+              {
+                "from": "input://tree/boot/initramfs-8-2.fk1.aarch64.img",
+                "to": "tree:///images/pxeboot/initrd.img"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.squashfs",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "filename": "images/install.img",
+            "compression": {
+              "method": "xz",
+              "options": {
+                "bcj": "arm"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "images/efiboot.img",
+            "size": "20971520"
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "10486c41"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "images/efiboot.img",
+                "size": 40960,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:efiboot-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "images/efiboot.img",
+                "size": 40960
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.fat",
+              "source": "-",
+              "target": "/"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:efiboot-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/EFI",
+                "to": "tree:///"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "/liveimg.tar.gz"
+          }
+        },
+        {
+          "type": "org.osbuild.kickstart",
+          "options": {
+            "path": "/osbuild-base.ks",
+            "liveimg": {
+              "url": "file:///run/install/repo/liveimg.tar.gz"
+            },
+            "users": {
+              "osbuild": {
+                "groups": [
+                  "wheel"
+                ],
+                "key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNebAh6SjpAn8wB53K4695cGnHGuCtl4RdaX3futZgJUultHyzeYHnzMO7d4++qnRL+Rworew62LKP560uvtncc= github.com/osbuild/images"
+              }
+            },
+            "lang": "en_GB.UTF-8",
+            "keyboard": "uk",
+            "timezone": "Europe/Berlin",
+            "display_mode": "text",
+            "reboot": {
+              "eject": true
+            },
+            "rootpw": {
+              "lock": true
+            },
+            "zerombr": true,
+            "clearpart": {
+              "all": true,
+              "initlabel": true
+            },
+            "autopart": {
+              "type": "plain",
+              "fstype": "xfs",
+              "nohome": true
+            },
+            "network": [
+              {
+                "activate": true,
+                "bootproto": "dhcp",
+                "device": "link",
+                "onboot": "on"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434/sha256:ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434",
+                "to": "tree:///osbuild.ks",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.discinfo",
+          "options": {
+            "basearch": "aarch64",
+            "release": "CentOS Stream 10-stream"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bootiso",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.xorrisofs",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:bootiso-tree"
+              ]
+            }
+          },
+          "options": {
+            "filename": "installer.iso",
+            "volid": "CentOS-Stream-10-BaseOS-aarch64",
+            "sysid": "LINUX",
+            "efi": "images/efiboot.img",
+            "isolevel": 3
+          }
+        },
+        {
+          "type": "org.osbuild.implantisomd5",
+          "options": {
+            "filename": "installer.iso"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a": {
+          "url": "https://example.com/repo/packages/net-tools"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112": {
+          "url": "https://example.com/repo/packages/dbus-x11"
+        },
+        "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3": {
+          "url": "https://example.com/repo/packages/bzip2"
+        },
+        "sha256:0a26024d87ac934c3aeca0ec8b27e579dfb6b268ac43f3a6f945579a54c46e6e": {
+          "url": "https://example.com/repo/packages/volume_key"
+        },
+        "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1": {
+          "url": "https://example.com/repo/packages/initscripts"
+        },
+        "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa": {
+          "url": "https://example.com/repo/packages/iwl105-firmware"
+        },
+        "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9": {
+          "url": "https://example.com/repo/packages/bind-utils"
+        },
+        "sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe": {
+          "url": "https://example.com/repo/packages/kbd"
+        },
+        "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa": {
+          "url": "https://example.com/repo/packages/anaconda-dracut"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:1f2ce4e8c1aea4a2440b7e794e0440385f8e9c3f48b0fd65118f3dcdbca783bf": {
+          "url": "https://example.com/repo/packages/alsa-firmware"
+        },
+        "sha256:1f35e175b07fc080eb57fc9db22a3ce477d87bc5447466815f55864d3b6e6586": {
+          "url": "https://example.com/repo/packages/ftp"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:24173b7985c9c52efc25b39e51f0fd41ac7b35e7031ed17da97788f293a3ce4e": {
+          "url": "https://example.com/repo/packages/google-noto-sans-cjk-ttc-fonts"
+        },
+        "sha256:2442f8197039e6fb34538a4651f00be2bcbaa8d2be3a15b734fa6ddf1bd8abba": {
+          "url": "https://example.com/repo/packages/mt-st"
+        },
+        "sha256:263acae321870b428781a1f4cb5e88740a897a4f9b614233a1798d295f805c54": {
+          "url": "https://example.com/repo/packages/hdparm"
+        },
+        "sha256:28bdff3b22fe1fe1b18313472b2060d2706b9052cbabd91aaa7bed0c88c065de": {
+          "url": "https://example.com/repo/packages/spice-vdagent"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686": {
+          "url": "https://example.com/repo/packages/nm-connection-editor"
+        },
+        "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa": {
+          "url": "https://example.com/repo/packages/dejavu-sans-fonts"
+        },
+        "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc": {
+          "url": "https://example.com/repo/packages/dmidecode"
+        },
+        "sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f": {
+          "url": "https://example.com/repo/packages/alsa-tools-firmware"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:316d18e697dfa41e92a9fe91d8d175629db5e330348a8adc1a5b43744d01d217": {
+          "url": "https://example.com/repo/packages/nmap-ncat"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1": {
+          "url": "https://example.com/repo/packages/dnf"
+        },
+        "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0": {
+          "url": "https://example.com/repo/packages/curl"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:4381157a0ab3568cb31f727709b2edfca21522a8645e95c411f5798b8018393d": {
+          "url": "https://example.com/repo/packages/nss-tools"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64-cdboot"
+        },
+        "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce": {
+          "url": "https://example.com/repo/packages/iwl100-firmware"
+        },
+        "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674": {
+          "url": "https://example.com/repo/packages/iwl2030-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4ad76aeffa1e790eaf720b659f9860c50b6e0ba4787fa0a2d0e43dfa46193035": {
+          "url": "https://example.com/repo/packages/jomolhari-fonts"
+        },
+        "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d": {
+          "url": "https://example.com/repo/packages/less"
+        },
+        "sha256:500d641b95d95deab52480573126901d76d81dfe9fe0a5caf43445df38caad7b": {
+          "url": "https://example.com/repo/packages/pciutils"
+        },
+        "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2": {
+          "url": "https://example.com/repo/packages/anaconda-install-img-deps"
+        },
+        "sha256:52999df2efd2afc3fcda19e416efb2d0f9b09562aa53331eaac2cde3c88ea207": {
+          "url": "https://example.com/repo/packages/madan-fonts"
+        },
+        "sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781": {
+          "url": "https://example.com/repo/packages/xorriso"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:570e342d0e4708dab94b2025f6b928845b659b405872d824b45473c4635d7b1d": {
+          "url": "https://example.com/repo/packages/wget"
+        },
+        "sha256:581265de790cf918fc770318449fe4cd07a18771c975d42867760b2e2f1bd18d": {
+          "url": "https://example.com/repo/packages/fcoe-utils"
+        },
+        "sha256:5b8b6480d96480b779d6937e2d8694e03cdae14eb0664033ef24af50e1557726": {
+          "url": "https://example.com/repo/packages/default-fonts-core-sans"
+        },
+        "sha256:5bc35fd09bee19e0dc22c7f7a731d1d8f4f68b81a3fd866e32273523eda30f9e": {
+          "url": "https://example.com/repo/packages/perl-interpreter"
+        },
+        "sha256:5e4e6002bd0ef9491967c1f5f573b0c184ef5a41d165cff38c8c6c73606702cb": {
+          "url": "https://example.com/repo/packages/gsettings-desktop-schemas"
+        },
+        "sha256:5e5d7e05a668f4ec5939a246b38d17cbb6ee83c0408ecbf584f6561a9d64a383": {
+          "url": "https://example.com/repo/packages/dejavu-sans-mono-fonts"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:61bfeb2957d080cbab70b332f16b482e1991b08e77ea7a8546b68b3cde90990c": {
+          "url": "https://example.com/repo/packages/smartmontools"
+        },
+        "sha256:629e355a0345015e53cacd90ce641c7e2ef38405cd55e135f331a6303c51f509": {
+          "url": "https://example.com/repo/packages/@hardware-support"
+        },
+        "sha256:68d6e3ed85174ed856b83d5d1e16c23d5279cb5dc77915ae8570a768a5a65505": {
+          "url": "https://example.com/repo/packages/nss-softokn"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682": {
+          "url": "https://example.com/repo/packages/hostname"
+        },
+        "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393": {
+          "url": "https://example.com/repo/packages/grub2-tools-minimal"
+        },
+        "sha256:75c008414c1be65c0e6954f74e1afdf3f706369f26899ea792b4ac0f31f287bc": {
+          "url": "https://example.com/repo/packages/default-fonts-other-sans"
+        },
+        "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-baseos"
+        },
+        "sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18": {
+          "url": "https://example.com/repo/packages/strace"
+        },
+        "sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980": {
+          "url": "https://example.com/repo/packages/hexedit"
+        },
+        "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764": {
+          "url": "https://example.com/repo/packages/grub2-tools-extra"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5": {
+          "url": "https://example.com/repo/packages/firewalld"
+        },
+        "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a": {
+          "url": "https://example.com/repo/packages/openssh-server"
+        },
+        "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467": {
+          "url": "https://example.com/repo/packages/iwl6050-firmware"
+        },
+        "sha256:826c7f30d36dcc8cb4628bee44fc0e257a360eb06cfc31c49148a44b153e78ce": {
+          "url": "https://example.com/repo/packages/device-mapper-persistent-data"
+        },
+        "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0": {
+          "url": "https://example.com/repo/packages/ostree"
+        },
+        "sha256:85830c0611a0acd7053f7b3a29f52a0511acc3695f9c5ef39a29fcfb8b80e25b": {
+          "url": "https://example.com/repo/packages/udisks2-iscsi"
+        },
+        "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071": {
+          "url": "https://example.com/repo/packages/iwl5150-firmware"
+        },
+        "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714": {
+          "url": "https://example.com/repo/packages/iwl135-firmware"
+        },
+        "sha256:883642e660d2ef545d3d9f0cbd12790a99aea6358fb67c46664ff22fefa8b7df": {
+          "url": "https://example.com/repo/packages/pigz"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111": {
+          "url": "https://example.com/repo/packages/iwl6000g2a-firmware"
+        },
+        "sha256:8e901f9b6ca3996fe198c84d5f0a305b635bbaae54757fa84932ac52479c1efa": {
+          "url": "https://example.com/repo/packages/ipmitool"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:903be5b3913df555a8586e571d9016e1ac24eef2631a5d75b8c3f94c66f10955": {
+          "url": "https://example.com/repo/packages/anaconda-widgets"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9531c8584bbf61635c5c9b15733d9494cb6dd232a6eec85a946076c6c633e99f": {
+          "url": "https://example.com/repo/packages/grubby"
+        },
+        "sha256:95671115820a1fb4e74d1abed36bf069ce64a8233a3a37a8909cc62dffc57293": {
+          "url": "https://example.com/repo/packages/rdma-core"
+        },
+        "sha256:990fde98d70a0a1a75bf55978f90138e8878a7f5cc1de475e03ee25b6744ee8a": {
+          "url": "https://example.com/repo/packages/python3-pyatspi"
+        },
+        "sha256:9ac51bbcd5be0f507237b2d43367ad073eaf99398a65d26fa2a8fee5275f889b": {
+          "url": "https://example.com/repo/packages/glibc-all-langpacks"
+        },
+        "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd": {
+          "url": "https://example.com/repo/packages/prefixdevname"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a39d3ae3da34f2b4c01193e62202d5de0db79f800a039624b0f950734782b863": {
+          "url": "https://example.com/repo/packages/mtr"
+        },
+        "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53": {
+          "url": "https://example.com/repo/packages/plymouth"
+        },
+        "sha256:a788847c8c115aa9ae27ca92230418e77b3b36a6424f1d4f3436633864c93db9": {
+          "url": "https://example.com/repo/packages/squashfs-tools"
+        },
+        "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018": {
+          "url": "https://example.com/repo/packages/iwl3160-firmware"
+        },
+        "sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d": {
+          "url": "https://example.com/repo/packages/usbutils"
+        },
+        "sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a": {
+          "url": "https://example.com/repo/packages/udisks2"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14": {
+          "url": "https://example.com/repo/packages/sg3_utils"
+        },
+        "sha256:afed7d2fb0ea7b7e9d8dbcf1c1bb62ff53840c72d380cf165294a1eccb7fdeb1": {
+          "url": "https://example.com/repo/packages/rsyslog"
+        },
+        "sha256:b498cfb546ddbfbd5953e28137e5b39a65ba6c7220bf4fe4c3cc9bcafc73c41b": {
+          "url": "https://example.com/repo/packages/libblockdev-lvm-dbus"
+        },
+        "sha256:b7110cc6e76089686855ae923d8e0212a0f067b8a48f3c96e8510d50c56061a7": {
+          "url": "https://example.com/repo/packages/mdadm"
+        },
+        "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be": {
+          "url": "https://example.com/repo/packages/rpcbind"
+        },
+        "sha256:b81f37a043a6f767e7c94d105f4bd31282f3ecc20680bb9d09bd93461cf4c863": {
+          "url": "https://example.com/repo/packages/audit"
+        },
+        "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf": {
+          "url": "https://example.com/repo/packages/vim-minimal"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8": {
+          "url": "https://example.com/repo/packages/iwl2000-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0": {
+          "url": "https://example.com/repo/packages/iwl5000-firmware"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c": {
+          "url": "https://example.com/repo/packages/ethtool"
+        },
+        "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0": {
+          "url": "https://example.com/repo/packages/iwl1000-firmware"
+        },
+        "sha256:cb298bd94fae6f2f713a1108a16e0632f3a1e21820a288d7ea86c8b00a4d4fef": {
+          "url": "https://example.com/repo/packages/lsof"
+        },
+        "sha256:cb6b44243b93acef33a5ee905d92203a2a55abdc6a3b7c446c8435a41a6ad137": {
+          "url": "https://example.com/repo/packages/sil-padauk-fonts"
+        },
+        "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31": {
+          "url": "https://example.com/repo/packages/gdb-gdbserver"
+        },
+        "sha256:cd2c0f63ad37d585e77b3f1c584539e26bf7928710ac8fb19fd377f61b7326e6": {
+          "url": "https://example.com/repo/packages/anaconda"
+        },
+        "sha256:ce2b8ecf9afac9f546bdbbb0902afb6088fdcb8524269ad5b4adb9b9d4959b07": {
+          "url": "https://example.com/repo/packages/xfsdump"
+        },
+        "sha256:ce5b1962783aa6a9374a0a1b34941a112a799baac827c733bd28c78dbb4bcf36": {
+          "url": "https://example.com/repo/packages/kdump-anaconda-addon"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c": {
+          "url": "https://example.com/repo/packages/cryptsetup"
+        },
+        "sha256:cf732696c9aebd80fad833157535754f246445ad0fec66e918963443bd3cfb71": {
+          "url": "https://example.com/repo/packages/linux-firmware"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9": {
+          "url": "https://example.com/repo/packages/iwl6000g2b-firmware"
+        },
+        "sha256:d87d9e526f265be973fce2ba320c5ed3ae24f6c5560d816d0b9307d0ba4d357f": {
+          "url": "https://example.com/repo/packages/lorax-templates-rhel"
+        },
+        "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd": {
+          "url": "https://example.com/repo/packages/lorax-templates-generic"
+        },
+        "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9": {
+          "url": "https://example.com/repo/packages/openssh-clients"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-appstream"
+        },
+        "sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d": {
+          "url": "https://example.com/repo/packages/rpm-ostree"
+        },
+        "sha256:eeb3d09845f5cde069eeade2c4339532be58b6607120be00656123cc73ea727c": {
+          "url": "https://example.com/repo/packages/kbd-misc"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f5f43514d2de810e4ea6d047203505e2e3c0c25f43941ec226968d17bb3aa1b5": {
+          "url": "https://example.com/repo/packages/gnome-kiosk"
+        },
+        "sha256:f6453ebfd8ab070567bfcd4cda99cc41c2c849237745f24228c5f040cac5d562": {
+          "url": "https://example.com/repo/packages/libibverbs"
+        },
+        "sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c": {
+          "url": "https://example.com/repo/packages/isomd5sum"
+        },
+        "sha256:f7f7a2e0133dfc81f9505bac28dfb7ee3398f3dc3b32c7682c86a9be5403bfee": {
+          "url": "https://example.com/repo/packages/librsvg2"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23": {
+          "url": "https://example.com/repo/packages/dracut-network"
+        },
+        "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7": {
+          "url": "https://example.com/repo/packages/iwl7260-firmware"
+        },
+        "sha256:fe36b1d498f9c6057ed774ba5fb0a84c8592886c3a4c7c077ce7f41326373099": {
+          "url": "https://example.com/repo/packages/lldpad"
+        }
+      }
+    },
+    "org.osbuild.inline": {
+      "items": {
+        "sha256:ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434": {
+          "encoding": "base64",
+          "data": "JWluY2x1ZGUgL3J1bi9pbnN0YWxsL3JlcG8vb3NidWlsZC1iYXNlLmtzCgolcG9zdAplY2hvIC1lICIlc3Vkb1x0QUxMPShBTEwpXHROT1BBU1NXRDogQUxMIiA+ICIvZXRjL3N1ZG9lcnMuZC8lc3VkbyIKY2htb2QgMDQ0MCAvZXRjL3N1ZG9lcnMuZC8lc3VkbwplY2hvIC1lICIld2hlZWxcdEFMTD0oQUxMKVx0Tk9QQVNTV0Q6IEFMTCIgPiAiL2V0Yy9zdWRvZXJzLmQvJXdoZWVsIgpjaG1vZCAwNDQwIC9ldGMvc3Vkb2Vycy5kLyV3aGVlbApyZXN0b3JlY29uIC1ydkYgL2V0Yy9zdWRvZXJzLmQKJWVuZAo="
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-aarch64-qcow2-all_with_fips.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-qcow2-all_with_fips.json
@@ -19,22 +19,13 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
-                },
-                {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -49,22 +40,10 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -119,9 +98,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -135,9 +111,6 @@
                 },
                 {
                   "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
-                },
-                {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
@@ -315,9 +288,6 @@
                 },
                 {
                   "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
-                },
-                {
-                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
                 },
                 {
                   "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"

--- a/test/data/manifestdb-light/centos_10-aarch64-qcow2-all_with_fips.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-qcow2-all_with_fips.json
@@ -1,0 +1,1672 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "ec6f3143-3299-452c-a356-326e49db9dd9",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check debug fips=1 boot=UUID=ceeccf0b-0ca5-4de1-8e78-433b48376507"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3"
+                },
+                {
+                  "id": "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747"
+                },
+                {
+                  "id": "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280"
+                },
+                {
+                  "id": "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
+                },
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"
+                },
+                {
+                  "id": "sha256:52856879d4bfa1d564480850a56b0885e1c52a805af96fffe84122afc9b1c52b"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "el_CY.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "dvorak"
+          }
+        },
+        {
+          "type": "org.osbuild.hostname",
+          "options": {
+            "hostname": "my-host"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "Europe/London"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "time.example.com"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.groups",
+          "options": {
+            "groups": {
+              "group1": {
+                "gid": 1030
+              },
+              "group2": {
+                "gid": 1050
+              },
+              "user3": {
+                "gid": 1060
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+              "user1": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              },
+              "user2": {
+                "uid": 1020,
+                "gid": 1050,
+                "groups": [
+                  "group1"
+                ],
+                "description": "description 2",
+                "home": "/home/home2",
+                "shell": "/bin/sh",
+                "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              },
+              "user3": {
+                "uid": 1060,
+                "gid": 1060
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.yum.repos",
+          "options": {
+            "filename": "example.repo",
+            "repos": [
+              {
+                "id": "example",
+                "baseurl": [
+                  "https://example.com/download/yum"
+                ],
+                "enabled": true,
+                "gpgkey": [
+                  "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                ],
+                "name": "Example repo",
+                "gpgcheck": true,
+                "repo_gpgcheck": false
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dracut",
+          "options": {
+            "kernel": [
+              "8-2.fk1.aarch64"
+            ],
+            "add_modules": [
+              "fips"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "ec6f3143-3299-452c-a356-326e49db9dd9",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "ceeccf0b-0ca5-4de1-8e78-433b48376507",
+                "vfs_type": "xfs",
+                "path": "/boot",
+                "options": "defaults"
+              },
+              {
+                "uuid": "703a194a-05a9-4bd1-b95b-f0ab7334c44d",
+                "vfs_type": "xfs",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "69dcd89b-1260-4e7d-ac7b-082e9e3ced3a",
+                "vfs_type": "xfs",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "5e36c406-1d67-4da8-96a6-1d5c56fb3770",
+                "vfs_type": "xfs",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "061142c6-d09d-42ad-9645-0d6c4d0b4965",
+                "vfs_type": "xfs",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7de72734-1637-4cc4-a71d-249002b6d8e1",
+                "vfs_type": "xfs",
+                "path": "/mnt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "cedcec56-6ceb-420d-8076-2f760ad36893",
+                "vfs_type": "xfs",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "ecd1059a-9265-4c93-a0a2-f755e568ccf4",
+                "vfs_type": "xfs",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "e07fb247-9d0f-4338-b02b-dab58d46260c",
+                "vfs_type": "xfs",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "1e0f9868-a407-4a8f-8ed1-670cd90eae0b",
+                "vfs_type": "xfs",
+                "path": "/usr",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "ec6f3143-3299-452c-a356-326e49db9dd9",
+            "boot_fs_uuid": "ceeccf0b-0ca5-4de1-8e78-433b48376507",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check debug fips=1 boot=UUID=ceeccf0b-0ca5-4de1-8e78-433b48376507",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/etc/systemd/system/custom.service.d",
+                "exist_ok": true
+              },
+              {
+                "path": "/etc/custom_dir"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/custom_dir": {
+                "mode": "0770"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/custom_dir": {
+                "user": 1020,
+                "group": 1050
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e"
+                }
+              ]
+            },
+            "file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2"
+                }
+              ]
+            },
+            "file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258"
+                }
+              ]
+            },
+            "file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                }
+              ]
+            },
+            "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e/sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e",
+                "to": "tree:///etc/systemd/system/custom.service",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2/sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2",
+                "to": "tree:///etc/systemd/system/custom.service.d/override.conf",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258/sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258",
+                "to": "tree:///etc/custom_file.txt",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "to": "tree:///etc/empty_file.txt",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/custom_file.txt": {
+                "mode": "0644"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/custom_file.txt": {
+                "user": "root",
+                "group": "root"
+              },
+              "/etc/empty_file.txt": {
+                "user": 0,
+                "group": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd.service",
+              "custom.service"
+            ],
+            "disabled_services": [
+              "bluetooth.service"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.update-crypto-policies",
+          "options": {
+            "policy": "FIPS"
+          }
+        },
+        {
+          "type": "org.osbuild.dracut.conf",
+          "options": {
+            "filename": "40-fips.conf",
+            "config": {
+              "add_dracutmodules": [
+                "fips"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-03fc1d407d48fd091625350f6482676dd08ef587d24761c8e38a3c99e5497af9": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:03fc1d407d48fd091625350f6482676dd08ef587d24761c8e38a3c99e5497af9"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-03fc1d407d48fd091625350f6482676dd08ef587d24761c8e38a3c99e5497af9/sha256:03fc1d407d48fd091625350f6482676dd08ef587d24761c8e38a3c99e5497af9",
+                "to": "tree:///etc/system-fips",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/system-fips": {
+                "mode": "0644"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/system-fips": {
+                "user": "root",
+                "group": "root"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "16859004928"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 31467487,
+                "start": 1460224,
+                "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              },
+              {
+                "size": 1048576,
+                "start": 411648,
+                "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                "uuid": "e9974025-02c4-4130-addc-297524af2e1a"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.lvm2.create",
+          "options": {
+            "volumes": [
+              {
+                "name": "rootlv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "homelv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "home_shadowmanlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "foolv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "usrlv",
+                "size": "4294967296B"
+              },
+              {
+                "name": "optlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "medialv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "rootlv00",
+                "size": "1073741824B"
+              },
+              {
+                "name": "srvlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "mntlv",
+                "size": "1073741824B"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "ec6f3143-3299-452c-a356-326e49db9dd9",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "69dcd89b-1260-4e7d-ac7b-082e9e3ced3a"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "5e36c406-1d67-4da8-96a6-1d5c56fb3770"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "home_shadowmanlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "703a194a-05a9-4bd1-b95b-f0ab7334c44d"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "1e0f9868-a407-4a8f-8ed1-670cd90eae0b"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "cedcec56-6ceb-420d-8076-2f760ad36893"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "061142c6-d09d-42ad-9645-0d6c4d0b4965"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "ecd1059a-9265-4c93-a0a2-f755e568ccf4"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv00"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "e07fb247-9d0f-4338-b02b-dab58d46260c"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "7de72734-1637-4cc4-a71d-249002b6d8e1"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "mntlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "ceeccf0b-0ca5-4de1-8e78-433b48376507"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 411648,
+                "size": 1048576,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 411648,
+                "size": 1048576
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 409600
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "home_shadowmanlv"
+              }
+            },
+            "media": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "mnt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "mntlv"
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "root": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv00"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1460224,
+                "size": 31467487
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.xfs",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.xfs",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.xfs",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.xfs",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "mnt",
+              "type": "org.osbuild.xfs",
+              "source": "mnt",
+              "target": "/mnt"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.xfs",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.xfs",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.xfs",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.xfs",
+              "source": "usr",
+              "target": "/usr"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.lvm2.metadata",
+          "options": {
+            "vg_name": "rootvg"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "qcow2",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.qcow2",
+            "format": {
+              "type": "qcow2",
+              "compat": "1.1"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb": {
+          "url": "https://example.com/repo/packages/passwd"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98": {
+          "url": "https://example.com/repo/packages/exclude:fedora-repos"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b": {
+          "url": "https://example.com/repo/packages/exclude:udisks2"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2": {
+          "url": "https://example.com/repo/packages/bash"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:52856879d4bfa1d564480850a56b0885e1c52a805af96fffe84122afc9b1c52b": {
+          "url": "https://example.com/repo/packages/bluez"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1": {
+          "url": "https://example.com/repo/packages/shadow-utils"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-baseos"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747": {
+          "url": "https://example.com/repo/packages/exclude:fedora-release"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-en"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-*"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-appstream"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3": {
+          "url": "https://example.com/repo/packages/pam"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        }
+      }
+    },
+    "org.osbuild.inline": {
+      "items": {
+        "sha256:03fc1d407d48fd091625350f6482676dd08ef587d24761c8e38a3c99e5497af9": {
+          "encoding": "base64",
+          "data": "IyBGSVBTIG1vZHVsZSBpbnN0YWxsYXRpb24gY29tcGxldGUK"
+        },
+        "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+          "encoding": "base64",
+          "data": "W1VuaXRdCkRlc2NyaXB0aW9uPUN1c3RvbSBzZXJ2aWNlCgpbU2VydmljZV0KRXhlY1N0YXJ0PS91c3IvYmluL2ZhbHNlCgpbSW5zdGFsbF0KV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXQK"
+        },
+        "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+          "encoding": "base64",
+          "data": "W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NhdCAvZXRjL2N1c3RvbV9maWxlLnR4dAo="
+        },
+        "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+          "encoding": "base64",
+          "data": "aW1hZ2UgYnVpbGRlciBpcyB0aGUgYmVzdA=="
+        },
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+          "encoding": "base64",
+          "data": ""
+        },
+        "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+          "encoding": "base64",
+          "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-aarch64-qcow2-empty.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-qcow2-empty.json
@@ -19,16 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -43,22 +37,10 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -126,9 +108,6 @@
                 },
                 {
                   "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
-                },
-                {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"

--- a/test/data/manifestdb-light/centos_10-aarch64-qcow2-empty.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-qcow2-empty.json
@@ -1,0 +1,771 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "579db06d-1743-4c03-a0a3-e28c91048a1d",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747"
+                },
+                {
+                  "id": "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280"
+                },
+                {
+                  "id": "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "579db06d-1743-4c03-a0a3-e28c91048a1d",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "579db06d-1743-4c03-a0a3-e28c91048a1d",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20559839,
+                "start": 411648,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "579db06d-1743-4c03-a0a3-e28c91048a1d",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 411648,
+                "size": 20559839,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 411648,
+                "size": 20559839
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "qcow2",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.qcow2",
+            "format": {
+              "type": "qcow2",
+              "compat": "1.1"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98": {
+          "url": "https://example.com/repo/packages/exclude:fedora-repos"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b": {
+          "url": "https://example.com/repo/packages/exclude:udisks2"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-baseos"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747": {
+          "url": "https://example.com/repo/packages/exclude:fedora-release"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-en"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-*"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-appstream"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-aarch64-tar-empty.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-tar-empty.json
@@ -1,0 +1,209 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "archive",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "root.tar.xz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-baseos"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-appstream"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-aarch64-tar-empty.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-tar-empty.json
@@ -34,9 +34,6 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
                 },
                 {
@@ -81,9 +78,6 @@
               "references": [
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"

--- a/test/data/manifestdb-light/centos_10-aarch64-vhd-empty.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-vhd-empty.json
@@ -1,0 +1,1059 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "244c8347-24e2-42bc-9528-0e123e99de79",
+            "kernel_opts": "ro loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221"
+                },
+                {
+                  "id": "sha256:563a278902fa76bae3ec1833f24ff89abe26329b1d32af9aaa924d6fc6fd68aa"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:b6cae3a11438b4ec550ce10b73b35160fafbe9d436fdb4f81fea356fc5bb6fee"
+                },
+                {
+                  "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:79a583014c5150aac3a44a025229af2918d16d3f6f32d005bf5786f693d6b893"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:f48860f2daf7e7a03ab9827300ab91c865d446de1c12a279339a2fff75c00f4e"
+                },
+                {
+                  "id": "sha256:229b391b136444fc29f0a5b3a897222f8ff4ed2277427e68eeb13fccfe39905c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8e57cbb02cd20f0e373ae76a44d7ddd0125fe449db5dfc196b0920ef47ced56e"
+                },
+                {
+                  "id": "sha256:a4895eb44afc336fecbba6e520cd67e178dace0276655d102fceffa8e5f70570"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:75666699b77db631f576041e8102a55b46758c01b807eacae0f170930ab59b3d"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:01fdad2e9ee0a69f7e323ddb4258e2b0dbfaa242a21d7a8bfdfec04ebe8d3e86"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:81f29ed6c790aa976572770ecf7b6f0351da3c46c9558640c7a83896b6bf8e05"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:534994290b3914604921fc2c61852b7bb4c4d8fb947f057a6fb38a3a57835d9a"
+                },
+                {
+                  "id": "sha256:0ee8cf7e33852f80cd293a8fa8c371f888dc011984ff2836f1198bcdc552dc58"
+                },
+                {
+                  "id": "sha256:5f1e4685c9b4d243264d22fa24864335aab534815fcfe6c3a88eec83ee22354f"
+                },
+                {
+                  "id": "sha256:f3e607ceb5fd279c62a109d1bbb952cc44d7467266ef679a99fd0d9c02ce8d29"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:7913d978541704fb38f5f13a949811c80ed4a52b2514d4582fe3ccb8f5a04617"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:a76985e9146fec1e9fb00cc08d5e0a76eb7f47c10a7abbc4430f8ac235a8b1cd"
+                },
+                {
+                  "id": "sha256:141b56438fdc0208877397569000e1a5857ff57807ff3bbaf2622cc87901861d"
+                },
+                {
+                  "id": "sha256:725c887b1ebcd6be8eb9a0ef6b2c476ff6d2dd8f9cf622f8d60953a1f22c94c8"
+                },
+                {
+                  "id": "sha256:53d00356d82e89cbdf0f963060c58433f73e0b339ba9f63577bd7df44f78e051"
+                },
+                {
+                  "id": "sha256:f1d96d150523777accb14a93582922ded22aa868629c58c3cd49339952293327"
+                },
+                {
+                  "id": "sha256:840109e45bc2504c9f202410bd941dc430bcef1065e1c1a98e5d08506c0c91af"
+                },
+                {
+                  "id": "sha256:b1eb4c41592e8eb6f7f2c96cdda2162fe214f52f85b01e9b174aa81bf297e01a"
+                },
+                {
+                  "id": "sha256:590ef3ccd31b243b045e9c5f9268d1013b0960060366c76028a23b070b5fb7be"
+                },
+                {
+                  "id": "sha256:9fe43931a7b645b90921b9b72d836e9d06ececc0b3cca1376fa0a297b5f522a5"
+                },
+                {
+                  "id": "sha256:49ec7b34785f32ffd1f252d5cc9a0a015ca074f75c601d2272149a72d50d42df"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel-core"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "10-azure-kvp.cfg",
+            "config": {
+              "reporting": {
+                "logging": {
+                  "type": "log"
+                },
+                "telemetry": {
+                  "type": "hyperv"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "91-azure_datasource.cfg",
+            "config": {
+              "datasource": {
+                "Azure": {
+                  "apply_network_config": false
+                }
+              },
+              "datasource_list": [
+                "Azure"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-intel-cstate.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "intel_cstate"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-floppy.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "floppy"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              },
+              {
+                "command": "blacklist",
+                "modulename": "lbm-nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-skylake-edac.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "skx_edac"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-azure.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_AZURE",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "ClientAliveInterval": 180
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.pwquality.conf",
+          "options": {
+            "config": {
+              "minlen": 6,
+              "dcredit": 0,
+              "ucredit": 0,
+              "lcredit": 0,
+              "ocredit": 0,
+              "minclass": 3
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.waagent.conf",
+          "options": {
+            "config": {
+              "ResourceDisk.Format": false,
+              "ResourceDisk.EnableSwap": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.udev.rules",
+          "options": {
+            "filename": "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules",
+            "rules": [
+              {
+                "comment": [
+                  "Accelerated Networking on Azure exposes a new SRIOV interface to the VM.",
+                  "This interface is transparently bonded to the synthetic interface,",
+                  "so NetworkManager should just ignore any SRIOV interfaces."
+                ]
+              },
+              [
+                {
+                  "key": "SUBSYSTEM",
+                  "op": "==",
+                  "val": "net"
+                },
+                {
+                  "key": "DRIVERS",
+                  "op": "==",
+                  "val": "hv_pci"
+                },
+                {
+                  "key": "ACTION",
+                  "op": "==",
+                  "val": "add"
+                },
+                {
+                  "key": {
+                    "name": "ENV",
+                    "arg": "NM_UNMANAGED"
+                  },
+                  "op": "=",
+                  "val": "1"
+                }
+              ]
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "244c8347-24e2-42bc-9528-0e123e99de79",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "244c8347-24e2-42bc-9528-0e123e99de79",
+            "kernel_opts": "ro loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved",
+              "disable_recovery": true,
+              "disable_submenu": true,
+              "distributor": "$(sed 's, release .*$,,g' /etc/system-release)",
+              "terminal": [
+                "serial",
+                "console"
+              ],
+              "timeout": 10,
+              "timeout_style": "countdown",
+              "serial": "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "firewalld",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "sshd",
+              "waagent"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "4294967296"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 7976927,
+                "start": 411648,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "244c8347-24e2-42bc-9528-0e123e99de79",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 411648,
+                "size": 7976927,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 411648,
+                "size": 7976927
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "vpc",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.vhd",
+            "format": {
+              "type": "vpc"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:01fdad2e9ee0a69f7e323ddb4258e2b0dbfaa242a21d7a8bfdfec04ebe8d3e86": {
+          "url": "https://example.com/repo/packages/exclude:NetworkManager-config-server"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3": {
+          "url": "https://example.com/repo/packages/bzip2"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:0ee8cf7e33852f80cd293a8fa8c371f888dc011984ff2836f1198bcdc552dc58": {
+          "url": "https://example.com/repo/packages/exclude:buildah"
+        },
+        "sha256:141b56438fdc0208877397569000e1a5857ff57807ff3bbaf2622cc87901861d": {
+          "url": "https://example.com/repo/packages/exclude:python3-dnf-plugin-spacewalk"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:229b391b136444fc29f0a5b3a897222f8ff4ed2277427e68eeb13fccfe39905c": {
+          "url": "https://example.com/repo/packages/kernel-modules"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:49ec7b34785f32ffd1f252d5cc9a0a015ca074f75c601d2272149a72d50d42df": {
+          "url": "https://example.com/repo/packages/exclude:usb_modeswitch"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:534994290b3914604921fc2c61852b7bb4c4d8fb947f057a6fb38a3a57835d9a": {
+          "url": "https://example.com/repo/packages/exclude:bolt"
+        },
+        "sha256:53d00356d82e89cbdf0f963060c58433f73e0b339ba9f63577bd7df44f78e051": {
+          "url": "https://example.com/repo/packages/exclude:python3-rhnlib"
+        },
+        "sha256:563a278902fa76bae3ec1833f24ff89abe26329b1d32af9aaa924d6fc6fd68aa": {
+          "url": "https://example.com/repo/packages/NetworkManager"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:590ef3ccd31b243b045e9c5f9268d1013b0960060366c76028a23b070b5fb7be": {
+          "url": "https://example.com/repo/packages/exclude:rhnlib"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5f1e4685c9b4d243264d22fa24864335aab534815fcfe6c3a88eec83ee22354f": {
+          "url": "https://example.com/repo/packages/exclude:cockpit-podman"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221": {
+          "url": "https://example.com/repo/packages/@Server"
+        },
+        "sha256:725c887b1ebcd6be8eb9a0ef6b2c476ff6d2dd8f9cf622f8d60953a1f22c94c8": {
+          "url": "https://example.com/repo/packages/exclude:python3-hwdata"
+        },
+        "sha256:75666699b77db631f576041e8102a55b46758c01b807eacae0f170930ab59b3d": {
+          "url": "https://example.com/repo/packages/uuid"
+        },
+        "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-baseos"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7913d978541704fb38f5f13a949811c80ed4a52b2514d4582fe3ccb8f5a04617": {
+          "url": "https://example.com/repo/packages/exclude:glibc-all-langpacks"
+        },
+        "sha256:79a583014c5150aac3a44a025229af2918d16d3f6f32d005bf5786f693d6b893": {
+          "url": "https://example.com/repo/packages/hyperv-daemons"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:81f29ed6c790aa976572770ecf7b6f0351da3c46c9558640c7a83896b6bf8e05": {
+          "url": "https://example.com/repo/packages/exclude:alsa-sof-firmware"
+        },
+        "sha256:840109e45bc2504c9f202410bd941dc430bcef1065e1c1a98e5d08506c0c91af": {
+          "url": "https://example.com/repo/packages/exclude:rhn-client-tools"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8e57cbb02cd20f0e373ae76a44d7ddd0125fe449db5dfc196b0920ef47ced56e": {
+          "url": "https://example.com/repo/packages/nvme-cli"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:9fe43931a7b645b90921b9b72d836e9d06ececc0b3cca1376fa0a297b5f522a5": {
+          "url": "https://example.com/repo/packages/exclude:rhnsd"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a4895eb44afc336fecbba6e520cd67e178dace0276655d102fceffa8e5f70570": {
+          "url": "https://example.com/repo/packages/patch"
+        },
+        "sha256:a76985e9146fec1e9fb00cc08d5e0a76eb7f47c10a7abbc4430f8ac235a8b1cd": {
+          "url": "https://example.com/repo/packages/exclude:podman"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:b1eb4c41592e8eb6f7f2c96cdda2162fe214f52f85b01e9b174aa81bf297e01a": {
+          "url": "https://example.com/repo/packages/exclude:rhn-setup"
+        },
+        "sha256:b6cae3a11438b4ec550ce10b73b35160fafbe9d436fdb4f81fea356fc5bb6fee": {
+          "url": "https://example.com/repo/packages/WALinuxAgent"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-appstream"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f1d96d150523777accb14a93582922ded22aa868629c58c3cd49339952293327": {
+          "url": "https://example.com/repo/packages/exclude:rhn-check"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f3e607ceb5fd279c62a109d1bbb952cc44d7467266ef679a99fd0d9c02ce8d29": {
+          "url": "https://example.com/repo/packages/exclude:containernetworking-plugins"
+        },
+        "sha256:f48860f2daf7e7a03ab9827300ab91c865d446de1c12a279339a2fff75c00f4e": {
+          "url": "https://example.com/repo/packages/kernel-core"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-aarch64-vhd-empty.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-vhd-empty.json
@@ -19,16 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -40,31 +34,16 @@
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
                 },
                 {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -140,12 +119,6 @@
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
-                },
-                {
                   "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
                 },
                 {
@@ -156,9 +129,6 @@
                 },
                 {
                   "id": "sha256:79a583014c5150aac3a44a025229af2918d16d3f6f32d005bf5786f693d6b893"
-                },
-                {
-                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
                 },
                 {
                   "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
@@ -183,9 +153,6 @@
                 },
                 {
                   "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"

--- a/test/data/manifestdb-light/centos_10-aarch64-wsl-empty.json
+++ b/test/data/manifestdb-light/centos_10-aarch64-wsl-empty.json
@@ -1,0 +1,463 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:8a1eb106427026fd9f7daef2fbed09db45de687c264480f8d3945ff13bdd9fe6"
+                },
+                {
+                  "id": "sha256:8308da3588987ace3967a2eee85a70f8be6eca16320b1e235b636e1464bbad06"
+                },
+                {
+                  "id": "sha256:4f7872f3a4c4decf34923a48986e52563d2a58bc3225b1890b84b52e7defce09"
+                },
+                {
+                  "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"
+                },
+                {
+                  "id": "sha256:97e86df4b9e1385f56f5635f227cc75e5a59147a8d06d05d0c08241d7204a92d"
+                },
+                {
+                  "id": "sha256:839f835e4d4558140e9b92fd85c3f923b74b6220ba1ad86b9fe096b8b6305b86"
+                },
+                {
+                  "id": "sha256:1a36b318995f3383dfa35c283df090bde63776c52415a421ea201a9667f95ab3"
+                },
+                {
+                  "id": "sha256:32dcd32054ee4e9ae92eec040bc1385c94d74a0846bb0145b1bdf9958740200a"
+                },
+                {
+                  "id": "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:cbf61858f3260072d96d9b1d2e037fc35824944b9c94d0087b1a53385eccaead"
+                },
+                {
+                  "id": "sha256:5b0440b2a1ceb2db43e1832c91f96728c5fe59a1cd7b5d1f1b905bb0b2df3841"
+                },
+                {
+                  "id": "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31"
+                },
+                {
+                  "id": "sha256:f6fad119f40a1aae00b54c0de6a0fa24a1e35d4bf1284bffcfd7134bdbb837e1"
+                },
+                {
+                  "id": "sha256:cc0bbbee7c9dd4f3f30e01c7f1fcbeb839f30c47e3bcbf16db0d37789262cbb4"
+                },
+                {
+                  "id": "sha256:aa6d4532f128420f4d741f2834cd8d1d146bbbdc9554aef454b7adb8ff66f748"
+                },
+                {
+                  "id": "sha256:f8f6228d89c3de21a136641a6d66f8a393db4b9019b17e0bec92ffc88b393eb4"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:cfd4affb5ed7a688870bb3725e10cc066e63b2a94b5dd491cac681a3c2b17ca5"
+                },
+                {
+                  "id": "sha256:41ffca929b95c49690ab8815d1d1a134a5bcdd86bde407c0f46b90eabf556b05"
+                },
+                {
+                  "id": "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3"
+                },
+                {
+                  "id": "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb"
+                },
+                {
+                  "id": "sha256:5b0513b8ca5a7f03601efc10934409d271890e6ae7a3264445e7397233eac6f8"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:87f1c82f3d3b66f168e0673e4f4227a8a3fe53000bf342780424ee8e3344d591"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:e422e1641a99c5a045bc0b596ef5ce6429c8e7744f016444cedacd4eaf5d3e4c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:5f53b0a2be22e28dc4b056f663910c046a33f9b2d779eaf997ea771fe1881a13"
+                },
+                {
+                  "id": "sha256:8fb6d5f37e8055ce720bd0b1d56587f88c0071f285966ba17e72b2b12672aa73"
+                },
+                {
+                  "id": "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1"
+                },
+                {
+                  "id": "sha256:0652d77991ae054286ace9807d7b4b573b99e3be9be7ad126db8d197b5f22a68"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:ae5e2ad3b86239dbf500c630cf88d33d9775e9ce2e32d596910a07d682d97923"
+                },
+                {
+                  "id": "sha256:572d4fe95e2cfd3425b70544a829f39104cad64fb57cdc63a25f9e837fb79917"
+                },
+                {
+                  "id": "sha256:f486d76df6f0ea41b7d6acb72751d8eb4cc2a3f04e6273154fef5e76cab27e11"
+                },
+                {
+                  "id": "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf"
+                },
+                {
+                  "id": "sha256:809c2fb94fff223e96477a875bbc1b77e5b020262e8f959d4b49455100a7f9f7"
+                },
+                {
+                  "id": "sha256:6fd624e2ceb4409a98b06f7f6161a6259cc88a838b6f43454217ed5a0c18a547"
+                },
+                {
+                  "id": "sha256:2692c08277f40048982432ab907ab870ee677f69656d9a71a6f889cf03531eb4"
+                },
+                {
+                  "id": "sha256:a697ff6e769b4f3d7c9b05d77c96d575c5e001ef923a13395decbe00b7e461bb"
+                },
+                {
+                  "id": "sha256:7cb8f52fafc3465bc88412019948f599fa1217927861c07ac3f90628772efa55"
+                },
+                {
+                  "id": "sha256:10d1e54c16c491abf59ec796854ffa14563d54461ebb9092501da34f5a9184bc"
+                },
+                {
+                  "id": "sha256:c06dba625e4dfb0b49cb4013c2a82c8f314143c833c1306da12fa2d77a12e0c4"
+                },
+                {
+                  "id": "sha256:60e3d9a99e40010bb917f75d9ce99530d1f8b322d0b1aea07fe71257a369d943"
+                },
+                {
+                  "id": "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483"
+                },
+                {
+                  "id": "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.wsl.conf",
+          "options": {
+            "boot": {
+              "systemd": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "archive",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "disk.tar.gz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:0652d77991ae054286ace9807d7b4b573b99e3be9be7ad126db8d197b5f22a68": {
+          "url": "https://example.com/repo/packages/subscription-manager"
+        },
+        "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb": {
+          "url": "https://example.com/repo/packages/passwd"
+        },
+        "sha256:10d1e54c16c491abf59ec796854ffa14563d54461ebb9092501da34f5a9184bc": {
+          "url": "https://example.com/repo/packages/exclude:python-unversioned-command"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a36b318995f3383dfa35c283df090bde63776c52415a421ea201a9667f95ab3": {
+          "url": "https://example.com/repo/packages/crypto-policies-scripts"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:2692c08277f40048982432ab907ab870ee677f69656d9a71a6f889cf03531eb4": {
+          "url": "https://example.com/repo/packages/exclude:glibc-gconv-extra"
+        },
+        "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa": {
+          "url": "https://example.com/repo/packages/dejavu-sans-fonts"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:32dcd32054ee4e9ae92eec040bc1385c94d74a0846bb0145b1bdf9958740200a": {
+          "url": "https://example.com/repo/packages/curl-minimal"
+        },
+        "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2": {
+          "url": "https://example.com/repo/packages/bash"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1": {
+          "url": "https://example.com/repo/packages/dnf"
+        },
+        "sha256:41ffca929b95c49690ab8815d1d1a134a5bcdd86bde407c0f46b90eabf556b05": {
+          "url": "https://example.com/repo/packages/openssl"
+        },
+        "sha256:4f7872f3a4c4decf34923a48986e52563d2a58bc3225b1890b84b52e7defce09": {
+          "url": "https://example.com/repo/packages/basesystem"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:572d4fe95e2cfd3425b70544a829f39104cad64fb57cdc63a25f9e837fb79917": {
+          "url": "https://example.com/repo/packages/tzdata"
+        },
+        "sha256:5b0440b2a1ceb2db43e1832c91f96728c5fe59a1cd7b5d1f1b905bb0b2df3841": {
+          "url": "https://example.com/repo/packages/findutils"
+        },
+        "sha256:5b0513b8ca5a7f03601efc10934409d271890e6ae7a3264445e7397233eac6f8": {
+          "url": "https://example.com/repo/packages/procps-ng"
+        },
+        "sha256:5f53b0a2be22e28dc4b056f663910c046a33f9b2d779eaf997ea771fe1881a13": {
+          "url": "https://example.com/repo/packages/sed"
+        },
+        "sha256:60e3d9a99e40010bb917f75d9ce99530d1f8b322d0b1aea07fe71257a369d943": {
+          "url": "https://example.com/repo/packages/exclude:rpm-plugin-systemd-inhibit"
+        },
+        "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1": {
+          "url": "https://example.com/repo/packages/shadow-utils"
+        },
+        "sha256:6fd624e2ceb4409a98b06f7f6161a6259cc88a838b6f43454217ed5a0c18a547": {
+          "url": "https://example.com/repo/packages/exclude:gawk-all-langpacks"
+        },
+        "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682": {
+          "url": "https://example.com/repo/packages/hostname"
+        },
+        "sha256:75ee4dd98bcb88d11980402b6067195772aa8bad9550c15e640c07c6bee0963d": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-baseos"
+        },
+        "sha256:7cb8f52fafc3465bc88412019948f599fa1217927861c07ac3f90628772efa55": {
+          "url": "https://example.com/repo/packages/exclude:openssl-pkcs11"
+        },
+        "sha256:809c2fb94fff223e96477a875bbc1b77e5b020262e8f959d4b49455100a7f9f7": {
+          "url": "https://example.com/repo/packages/yum"
+        },
+        "sha256:8308da3588987ace3967a2eee85a70f8be6eca16320b1e235b636e1464bbad06": {
+          "url": "https://example.com/repo/packages/audit-libs"
+        },
+        "sha256:839f835e4d4558140e9b92fd85c3f923b74b6220ba1ad86b9fe096b8b6305b86": {
+          "url": "https://example.com/repo/packages/coreutils-single"
+        },
+        "sha256:87f1c82f3d3b66f168e0673e4f4227a8a3fe53000bf342780424ee8e3344d591": {
+          "url": "https://example.com/repo/packages/python3-inotify"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a1eb106427026fd9f7daef2fbed09db45de687c264480f8d3945ff13bdd9fe6": {
+          "url": "https://example.com/repo/packages/alternatives"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8fb6d5f37e8055ce720bd0b1d56587f88c0071f285966ba17e72b2b12672aa73": {
+          "url": "https://example.com/repo/packages/setup"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:97e86df4b9e1385f56f5635f227cc75e5a59147a8d06d05d0c08241d7204a92d": {
+          "url": "https://example.com/repo/packages/ca-certificates"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a697ff6e769b4f3d7c9b05d77c96d575c5e001ef923a13395decbe00b7e461bb": {
+          "url": "https://example.com/repo/packages/exclude:glibc-langpack-en"
+        },
+        "sha256:aa6d4532f128420f4d741f2834cd8d1d146bbbdc9554aef454b7adb8ff66f748": {
+          "url": "https://example.com/repo/packages/gnupg2"
+        },
+        "sha256:ae5e2ad3b86239dbf500c630cf88d33d9775e9ce2e32d596910a07d682d97923": {
+          "url": "https://example.com/repo/packages/tpm2-tss"
+        },
+        "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf": {
+          "url": "https://example.com/repo/packages/vim-minimal"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c06dba625e4dfb0b49cb4013c2a82c8f314143c833c1306da12fa2d77a12e0c4": {
+          "url": "https://example.com/repo/packages/exclude:redhat-release-eula"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31": {
+          "url": "https://example.com/repo/packages/gdb-gdbserver"
+        },
+        "sha256:cbf61858f3260072d96d9b1d2e037fc35824944b9c94d0087b1a53385eccaead": {
+          "url": "https://example.com/repo/packages/filesystem"
+        },
+        "sha256:cc0bbbee7c9dd4f3f30e01c7f1fcbeb839f30c47e3bcbf16db0d37789262cbb4": {
+          "url": "https://example.com/repo/packages/gmp"
+        },
+        "sha256:cfd4affb5ed7a688870bb3725e10cc066e63b2a94b5dd491cac681a3c2b17ca5": {
+          "url": "https://example.com/repo/packages/libcurl-minimal"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e422e1641a99c5a045bc0b596ef5ce6429c8e7744f016444cedacd4eaf5d3e4c": {
+          "url": "https://example.com/repo/packages/rootfiles"
+        },
+        "sha256:eb42f28cd1afdd4462364231eeb653aa9810e7a435f1c4eea4fe816d3dddd483": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el10/cs10-aarch64-appstream"
+        },
+        "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3": {
+          "url": "https://example.com/repo/packages/pam"
+        },
+        "sha256:f486d76df6f0ea41b7d6acb72751d8eb4cc2a3f04e6273154fef5e76cab27e11": {
+          "url": "https://example.com/repo/packages/util-linux"
+        },
+        "sha256:f6fad119f40a1aae00b54c0de6a0fa24a1e35d4bf1284bffcfd7134bdbb837e1": {
+          "url": "https://example.com/repo/packages/glibc-minimal-langpack"
+        },
+        "sha256:f8f6228d89c3de21a136641a6d66f8a393db4b9019b17e0bec92ffc88b393eb4": {
+          "url": "https://example.com/repo/packages/gobject-introspection"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-s390x-qcow2-all_with_fips.json
+++ b/test/data/manifestdb-light/centos_10-s390x-qcow2-all_with_fips.json
@@ -1,0 +1,1772 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
+                },
+                {
+                  "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:c8308558d3d8e8264bccc7a1001cc775e4443940dd58336cfb33cda237c65239"
+                },
+                {
+                  "id": "sha256:b919025f85505d5130821b55a6ff750d6cb3b2261f31b87d012c2542de11694e"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "732db7b2-c358-4ed7-8127-e425fabb19a8",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check debug fips=1 boot=UUID=cea25891-a7ab-43dc-9f77-089c62c81312"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3"
+                },
+                {
+                  "id": "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
+                },
+                {
+                  "id": "sha256:59731fa1fe190a4814aff005d6bd3383f1fc4a7e40afeaba7edef1c07dda6db8"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747"
+                },
+                {
+                  "id": "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280"
+                },
+                {
+                  "id": "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
+                },
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"
+                },
+                {
+                  "id": "sha256:52856879d4bfa1d564480850a56b0885e1c52a805af96fffe84122afc9b1c52b"
+                },
+                {
+                  "id": "sha256:c8308558d3d8e8264bccc7a1001cc775e4443940dd58336cfb33cda237c65239"
+                },
+                {
+                  "id": "sha256:b919025f85505d5130821b55a6ff750d6cb3b2261f31b87d012c2542de11694e"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "el_CY.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "dvorak"
+          }
+        },
+        {
+          "type": "org.osbuild.hostname",
+          "options": {
+            "hostname": "my-host"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "Europe/London"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "time.example.com"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.groups",
+          "options": {
+            "groups": {
+              "group1": {
+                "gid": 1030
+              },
+              "group2": {
+                "gid": 1050
+              },
+              "user3": {
+                "gid": 1060
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+              "user1": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              },
+              "user2": {
+                "uid": 1020,
+                "gid": 1050,
+                "groups": [
+                  "group1"
+                ],
+                "description": "description 2",
+                "home": "/home/home2",
+                "shell": "/bin/sh",
+                "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              },
+              "user3": {
+                "uid": 1060,
+                "gid": 1060
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.yum.repos",
+          "options": {
+            "filename": "example.repo",
+            "repos": [
+              {
+                "id": "example",
+                "baseurl": [
+                  "https://example.com/download/yum"
+                ],
+                "enabled": true,
+                "gpgkey": [
+                  "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                ],
+                "name": "Example repo",
+                "gpgcheck": true,
+                "repo_gpgcheck": false
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dracut",
+          "options": {
+            "kernel": [
+              "8-2.fk1.s390x"
+            ],
+            "add_modules": [
+              "fips"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "732db7b2-c358-4ed7-8127-e425fabb19a8",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "cea25891-a7ab-43dc-9f77-089c62c81312",
+                "vfs_type": "xfs",
+                "path": "/boot",
+                "options": "defaults"
+              },
+              {
+                "uuid": "816dceba-291f-4b9a-8095-1307ec4c5fd5",
+                "vfs_type": "xfs",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "0d871a7f-73d6-4ef3-85b3-07247e752d1b",
+                "vfs_type": "xfs",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "c35e3637-3a16-4f13-a078-f0127670fa58",
+                "vfs_type": "xfs",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "bbaeb862-8a5e-4e74-9d09-df25d6347385",
+                "vfs_type": "xfs",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "9d1a737f-869e-4337-9fdc-6e034d2be6e9",
+                "vfs_type": "xfs",
+                "path": "/mnt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "769ba012-a9c3-4d4c-a774-7ad8aad645e0",
+                "vfs_type": "xfs",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "b58e5f33-c143-41c5-ab5d-607f7726e40d",
+                "vfs_type": "xfs",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "e321f4af-09e7-4673-be0e-0343ba5d5288",
+                "vfs_type": "xfs",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "43113613-7413-4ca1-9a57-67ce5854b691",
+                "vfs_type": "xfs",
+                "path": "/usr",
+                "options": "defaults"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.zipl",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/etc/systemd/system/custom.service.d",
+                "exist_ok": true
+              },
+              {
+                "path": "/etc/custom_dir"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/custom_dir": {
+                "mode": "0770"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/custom_dir": {
+                "user": 1020,
+                "group": 1050
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e"
+                }
+              ]
+            },
+            "file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2"
+                }
+              ]
+            },
+            "file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258"
+                }
+              ]
+            },
+            "file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                }
+              ]
+            },
+            "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e/sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e",
+                "to": "tree:///etc/systemd/system/custom.service",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2/sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2",
+                "to": "tree:///etc/systemd/system/custom.service.d/override.conf",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258/sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258",
+                "to": "tree:///etc/custom_file.txt",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "to": "tree:///etc/empty_file.txt",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/custom_file.txt": {
+                "mode": "0644"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/custom_file.txt": {
+                "user": "root",
+                "group": "root"
+              },
+              "/etc/empty_file.txt": {
+                "user": 0,
+                "group": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd.service",
+              "custom.service"
+            ],
+            "disabled_services": [
+              "bluetooth.service"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.update-crypto-policies",
+          "options": {
+            "policy": "FIPS"
+          }
+        },
+        {
+          "type": "org.osbuild.dracut.conf",
+          "options": {
+            "filename": "40-fips.conf",
+            "config": {
+              "add_dracutmodules": [
+                "fips"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-03fc1d407d48fd091625350f6482676dd08ef587d24761c8e38a3c99e5497af9": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:03fc1d407d48fd091625350f6482676dd08ef587d24761c8e38a3c99e5497af9"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-03fc1d407d48fd091625350f6482676dd08ef587d24761c8e38a3c99e5497af9/sha256:03fc1d407d48fd091625350f6482676dd08ef587d24761c8e38a3c99e5497af9",
+                "to": "tree:///etc/system-fips",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/system-fips": {
+                "mode": "0644"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/system-fips": {
+                "user": "root",
+                "group": "root"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "16648241152"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "dos",
+            "uuid": "0x14fc63d2",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 31465472,
+                "start": 1050624,
+                "type": "8e"
+              },
+              {
+                "size": 1048576,
+                "start": 2048
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.lvm2.create",
+          "options": {
+            "volumes": [
+              {
+                "name": "rootlv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "homelv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "home_shadowmanlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "foolv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "usrlv",
+                "size": "4294967296B"
+              },
+              {
+                "name": "optlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "medialv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "rootlv00",
+                "size": "1073741824B"
+              },
+              {
+                "name": "srvlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "mntlv",
+                "size": "1073741824B"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1050624,
+                "size": 31465472,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "732db7b2-c358-4ed7-8127-e425fabb19a8"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1050624,
+                "size": 31465472,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "0d871a7f-73d6-4ef3-85b3-07247e752d1b"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1050624,
+                "size": 31465472,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "c35e3637-3a16-4f13-a078-f0127670fa58"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "home_shadowmanlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1050624,
+                "size": 31465472,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "816dceba-291f-4b9a-8095-1307ec4c5fd5"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1050624,
+                "size": 31465472,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "43113613-7413-4ca1-9a57-67ce5854b691"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1050624,
+                "size": 31465472,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "769ba012-a9c3-4d4c-a774-7ad8aad645e0"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1050624,
+                "size": 31465472,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "bbaeb862-8a5e-4e74-9d09-df25d6347385"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1050624,
+                "size": 31465472,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "b58e5f33-c143-41c5-ab5d-607f7726e40d"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv00"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1050624,
+                "size": 31465472,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "e321f4af-09e7-4673-be0e-0343ba5d5288"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1050624,
+                "size": 31465472,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "9d1a737f-869e-4337-9fdc-6e034d2be6e9"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "mntlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1050624,
+                "size": 31465472,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "cea25891-a7ab-43dc-9f77-089c62c81312"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 1048576,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 1048576
+              }
+            },
+            "disk": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img"
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "home_shadowmanlv"
+              }
+            },
+            "media": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "mnt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "mntlv"
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "root": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv00"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1050624,
+                "size": 31465472
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.xfs",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.xfs",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.xfs",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.xfs",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "mnt",
+              "type": "org.osbuild.xfs",
+              "source": "mnt",
+              "target": "/mnt"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.xfs",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.xfs",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.xfs",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.xfs",
+              "source": "usr",
+              "target": "/usr"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.lvm2.metadata",
+          "options": {
+            "vg_name": "rootvg"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1050624,
+                "size": 31465472,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.zipl.inst",
+          "options": {
+            "kernel": "8-2.fk1.s390x",
+            "location": 2048
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 1048576
+              }
+            },
+            "disk": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img"
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "home_shadowmanlv"
+              }
+            },
+            "media": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "mnt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "mntlv"
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "root": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv00"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1050624,
+                "size": 31465472
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.xfs",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.xfs",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.xfs",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.xfs",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "mnt",
+              "type": "org.osbuild.xfs",
+              "source": "mnt",
+              "target": "/mnt"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.xfs",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.xfs",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.xfs",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.xfs",
+              "source": "usr",
+              "target": "/usr"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "qcow2",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.qcow2",
+            "format": {
+              "type": "qcow2",
+              "compat": "1.1"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb": {
+          "url": "https://example.com/repo/packages/passwd"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98": {
+          "url": "https://example.com/repo/packages/exclude:fedora-repos"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b": {
+          "url": "https://example.com/repo/packages/exclude:udisks2"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2": {
+          "url": "https://example.com/repo/packages/bash"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:52856879d4bfa1d564480850a56b0885e1c52a805af96fffe84122afc9b1c52b": {
+          "url": "https://example.com/repo/packages/bluez"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:59731fa1fe190a4814aff005d6bd3383f1fc4a7e40afeaba7edef1c07dda6db8": {
+          "url": "https://example.com/repo/packages/s390utils-core"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1": {
+          "url": "https://example.com/repo/packages/shadow-utils"
+        },
+        "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca": {
+          "url": "https://example.com/repo/packages/s390utils-base"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747": {
+          "url": "https://example.com/repo/packages/exclude:fedora-release"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-en"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b919025f85505d5130821b55a6ff750d6cb3b2261f31b87d012c2542de11694e": {
+          "url": "https://example.com/passed-arch:s390x/passed-repo:/v2/mirror/public/el10/cs10-s390x-baseos"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c8308558d3d8e8264bccc7a1001cc775e4443940dd58336cfb33cda237c65239": {
+          "url": "https://example.com/passed-arch:s390x/passed-repo:/v2/mirror/public/el10/cs10-s390x-appstream"
+        },
+        "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-*"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3": {
+          "url": "https://example.com/repo/packages/pam"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        }
+      }
+    },
+    "org.osbuild.inline": {
+      "items": {
+        "sha256:03fc1d407d48fd091625350f6482676dd08ef587d24761c8e38a3c99e5497af9": {
+          "encoding": "base64",
+          "data": "IyBGSVBTIG1vZHVsZSBpbnN0YWxsYXRpb24gY29tcGxldGUK"
+        },
+        "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+          "encoding": "base64",
+          "data": "W1VuaXRdCkRlc2NyaXB0aW9uPUN1c3RvbSBzZXJ2aWNlCgpbU2VydmljZV0KRXhlY1N0YXJ0PS91c3IvYmluL2ZhbHNlCgpbSW5zdGFsbF0KV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXQK"
+        },
+        "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+          "encoding": "base64",
+          "data": "W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NhdCAvZXRjL2N1c3RvbV9maWxlLnR4dAo="
+        },
+        "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+          "encoding": "base64",
+          "data": "aW1hZ2UgYnVpbGRlciBpcyB0aGUgYmVzdA=="
+        },
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+          "encoding": "base64",
+          "data": ""
+        },
+        "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+          "encoding": "base64",
+          "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-s390x-qcow2-all_with_fips.json
+++ b/test/data/manifestdb-light/centos_10-s390x-qcow2-all_with_fips.json
@@ -22,13 +22,7 @@
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
-                },
-                {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -43,28 +37,13 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
                   "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
-                },
-                {
-                  "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -114,9 +93,6 @@
               "references": [
                 {
                   "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
-                },
-                {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
@@ -306,9 +282,6 @@
                 },
                 {
                   "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
-                },
-                {
-                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
                 },
                 {
                   "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"

--- a/test/data/manifestdb-light/centos_10-s390x-qcow2-empty.json
+++ b/test/data/manifestdb-light/centos_10-s390x-qcow2-empty.json
@@ -1,0 +1,735 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
+                },
+                {
+                  "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:c8308558d3d8e8264bccc7a1001cc775e4443940dd58336cfb33cda237c65239"
+                },
+                {
+                  "id": "sha256:b919025f85505d5130821b55a6ff750d6cb3b2261f31b87d012c2542de11694e"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "54f23a8f-8f49-4db0-9299-2c34d439ff38",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
+                },
+                {
+                  "id": "sha256:59731fa1fe190a4814aff005d6bd3383f1fc4a7e40afeaba7edef1c07dda6db8"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747"
+                },
+                {
+                  "id": "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280"
+                },
+                {
+                  "id": "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
+                },
+                {
+                  "id": "sha256:c8308558d3d8e8264bccc7a1001cc775e4443940dd58336cfb33cda237c65239"
+                },
+                {
+                  "id": "sha256:b919025f85505d5130821b55a6ff750d6cb3b2261f31b87d012c2542de11694e"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "54f23a8f-8f49-4db0-9299-2c34d439ff38",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.zipl",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "dos",
+            "uuid": "0x14fc63d2",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 20969472,
+                "start": 2048
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "54f23a8f-8f49-4db0-9299-2c34d439ff38"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 20969472,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 20969472
+              }
+            },
+            "disk": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.zipl.inst",
+          "options": {
+            "kernel": "8-2.fk1.s390x",
+            "location": 2048
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 20969472
+              }
+            },
+            "disk": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "qcow2",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.qcow2",
+            "format": {
+              "type": "qcow2",
+              "compat": "1.1"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98": {
+          "url": "https://example.com/repo/packages/exclude:fedora-repos"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b": {
+          "url": "https://example.com/repo/packages/exclude:udisks2"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:59731fa1fe190a4814aff005d6bd3383f1fc4a7e40afeaba7edef1c07dda6db8": {
+          "url": "https://example.com/repo/packages/s390utils-core"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca": {
+          "url": "https://example.com/repo/packages/s390utils-base"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747": {
+          "url": "https://example.com/repo/packages/exclude:fedora-release"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-en"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b919025f85505d5130821b55a6ff750d6cb3b2261f31b87d012c2542de11694e": {
+          "url": "https://example.com/passed-arch:s390x/passed-repo:/v2/mirror/public/el10/cs10-s390x-baseos"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c8308558d3d8e8264bccc7a1001cc775e4443940dd58336cfb33cda237c65239": {
+          "url": "https://example.com/passed-arch:s390x/passed-repo:/v2/mirror/public/el10/cs10-s390x-appstream"
+        },
+        "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-*"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-s390x-qcow2-empty.json
+++ b/test/data/manifestdb-light/centos_10-s390x-qcow2-empty.json
@@ -25,9 +25,6 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
@@ -37,28 +34,13 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
                   "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
-                },
-                {
-                  "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"

--- a/test/data/manifestdb-light/centos_10-s390x-tar-empty.json
+++ b/test/data/manifestdb-light/centos_10-s390x-tar-empty.json
@@ -34,9 +34,6 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
                 },
                 {
@@ -81,9 +78,6 @@
               "references": [
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"

--- a/test/data/manifestdb-light/centos_10-s390x-tar-empty.json
+++ b/test/data/manifestdb-light/centos_10-s390x-tar-empty.json
@@ -1,0 +1,209 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:c8308558d3d8e8264bccc7a1001cc775e4443940dd58336cfb33cda237c65239"
+                },
+                {
+                  "id": "sha256:b919025f85505d5130821b55a6ff750d6cb3b2261f31b87d012c2542de11694e"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:c8308558d3d8e8264bccc7a1001cc775e4443940dd58336cfb33cda237c65239"
+                },
+                {
+                  "id": "sha256:b919025f85505d5130821b55a6ff750d6cb3b2261f31b87d012c2542de11694e"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "archive",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "root.tar.xz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:b919025f85505d5130821b55a6ff750d6cb3b2261f31b87d012c2542de11694e": {
+          "url": "https://example.com/passed-arch:s390x/passed-repo:/v2/mirror/public/el10/cs10-s390x-baseos"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c8308558d3d8e8264bccc7a1001cc775e4443940dd58336cfb33cda237c65239": {
+          "url": "https://example.com/passed-arch:s390x/passed-repo:/v2/mirror/public/el10/cs10-s390x-appstream"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-x86_64-ami-all_customizations.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-ami-all_customizations.json
@@ -1,0 +1,1699 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "9004ccc7-ad39-4073-8a6d-c70a791e784d",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 debug"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3"
+                },
+                {
+                  "id": "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"
+                },
+                {
+                  "id": "sha256:52856879d4bfa1d564480850a56b0885e1c52a805af96fffe84122afc9b1c52b"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "el_CY.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "dvorak"
+          }
+        },
+        {
+          "type": "org.osbuild.hostname",
+          "options": {
+            "hostname": "my-host"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "Europe/London"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "time.example.com"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.groups",
+          "options": {
+            "groups": {
+              "group1": {
+                "gid": 1030
+              },
+              "group2": {
+                "gid": 1050
+              },
+              "user3": {
+                "gid": 1060
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+              "user1": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              },
+              "user2": {
+                "uid": 1020,
+                "gid": 1050,
+                "groups": [
+                  "group1"
+                ],
+                "description": "description 2",
+                "home": "/home/home2",
+                "shell": "/bin/sh",
+                "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              },
+              "user3": {
+                "uid": 1060,
+                "gid": 1060
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dracut.conf",
+          "options": {
+            "filename": "ec2.conf",
+            "config": {
+              "add_drivers": [
+                "nvme",
+                "xen-blkfront"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.yum.repos",
+          "options": {
+            "filename": "example.repo",
+            "repos": [
+              {
+                "id": "example",
+                "baseurl": [
+                  "https://example.com/download/yum"
+                ],
+                "enabled": true,
+                "gpgkey": [
+                  "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                ],
+                "name": "Example repo",
+                "gpgcheck": true,
+                "repo_gpgcheck": false
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "9004ccc7-ad39-4073-8a6d-c70a791e784d",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "c76485c5-d6f5-4528-815e-f0fb68ddfd24",
+                "vfs_type": "xfs",
+                "path": "/boot",
+                "options": "defaults"
+              },
+              {
+                "uuid": "6d07f61c-0574-46d3-9fe0-d51e1185516e",
+                "vfs_type": "xfs",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7ffbc402-3d55-459d-9557-4492c690f058",
+                "vfs_type": "xfs",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7d06de5d-736f-454b-895b-6238dbcfbac0",
+                "vfs_type": "xfs",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "78309ad1-5bd3-4737-9664-54cd691c1ffc",
+                "vfs_type": "xfs",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "5abe0083-174b-4f8a-9fc5-3054edc9e209",
+                "vfs_type": "xfs",
+                "path": "/mnt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "8c6d87a8-9c76-468b-b198-4c7e29389302",
+                "vfs_type": "xfs",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "2d663d76-d3b6-41a9-abf5-f6a05727844f",
+                "vfs_type": "xfs",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "018d69b6-a29b-4b2e-ab2c-228229f5c805",
+                "vfs_type": "xfs",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "1f1deded-380e-428a-b029-a077adcecf50",
+                "vfs_type": "xfs",
+                "path": "/usr",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "9004ccc7-ad39-4073-8a6d-c70a791e784d",
+            "boot_fs_uuid": "c76485c5-d6f5-4528-815e-f0fb68ddfd24",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 debug",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/etc/systemd/system/custom.service.d",
+                "exist_ok": true
+              },
+              {
+                "path": "/etc/custom_dir"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/custom_dir": {
+                "mode": "0770"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/custom_dir": {
+                "user": 1020,
+                "group": 1050
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e"
+                }
+              ]
+            },
+            "file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2"
+                }
+              ]
+            },
+            "file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258"
+                }
+              ]
+            },
+            "file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                }
+              ]
+            },
+            "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e/sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e",
+                "to": "tree:///etc/systemd/system/custom.service",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2/sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2",
+                "to": "tree:///etc/systemd/system/custom.service.d/override.conf",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258/sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258",
+                "to": "tree:///etc/custom_file.txt",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "to": "tree:///etc/empty_file.txt",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/custom_file.txt": {
+                "mode": "0644"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/custom_file.txt": {
+                "user": "root",
+                "group": "root"
+              },
+              "/etc/empty_file.txt": {
+                "user": 0,
+                "group": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned",
+              "sshd.service",
+              "custom.service"
+            ],
+            "disabled_services": [
+              "bluetooth.service"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c/sha256:4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c",
+                "to": "tree:///etc/pki/ca-trust/source/anchors/27894af897dd2423607045716438a725f28a6d0b.pem",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/pki/ca-trust/source/anchors/27894af897dd2423607045716438a725f28a6d0b.pem": {
+                "user": "root",
+                "group": "root"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.pki.update-ca-trust"
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "16860053504"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 31467487,
+                "start": 1462272,
+                "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              },
+              {
+                "size": 1048576,
+                "start": 413696,
+                "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                "uuid": "e596992b-d697-4fa7-aebb-fd651f4bbc45"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.lvm2.create",
+          "options": {
+            "volumes": [
+              {
+                "name": "rootlv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "homelv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "home_shadowmanlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "foolv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "usrlv",
+                "size": "4294967296B"
+              },
+              {
+                "name": "optlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "medialv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "rootlv00",
+                "size": "1073741824B"
+              },
+              {
+                "name": "srvlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "mntlv",
+                "size": "1073741824B"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "9004ccc7-ad39-4073-8a6d-c70a791e784d",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "7ffbc402-3d55-459d-9557-4492c690f058"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "7d06de5d-736f-454b-895b-6238dbcfbac0"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "home_shadowmanlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "6d07f61c-0574-46d3-9fe0-d51e1185516e"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "1f1deded-380e-428a-b029-a077adcecf50"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "8c6d87a8-9c76-468b-b198-4c7e29389302"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "78309ad1-5bd3-4737-9664-54cd691c1ffc"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "2d663d76-d3b6-41a9-abf5-f6a05727844f"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv00"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "018d69b6-a29b-4b2e-ab2c-228229f5c805"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "5abe0083-174b-4f8a-9fc5-3054edc9e209"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "mntlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "c76485c5-d6f5-4528-815e-f0fb68ddfd24"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 1048576,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 1048576
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "home_shadowmanlv"
+              }
+            },
+            "media": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "mnt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "mntlv"
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "root": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv00"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.xfs",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.xfs",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.xfs",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.xfs",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "mnt",
+              "type": "org.osbuild.xfs",
+              "source": "mnt",
+              "target": "/mnt"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.xfs",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.xfs",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.xfs",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.xfs",
+              "source": "usr",
+              "target": "/usr"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.lvm2.metadata",
+          "options": {
+            "vg_name": "rootvg"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "image.raw",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 3,
+              "path": "/grub2"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb": {
+          "url": "https://example.com/repo/packages/passwd"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2": {
+          "url": "https://example.com/repo/packages/bash"
+        },
+        "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-appstream"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:52856879d4bfa1d564480850a56b0885e1c52a805af96fffe84122afc9b1c52b": {
+          "url": "https://example.com/repo/packages/bluez"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1": {
+          "url": "https://example.com/repo/packages/shadow-utils"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-rt"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3": {
+          "url": "https://example.com/repo/packages/pam"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        },
+        "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-baseos"
+        }
+      }
+    },
+    "org.osbuild.inline": {
+      "items": {
+        "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+          "encoding": "base64",
+          "data": "W1VuaXRdCkRlc2NyaXB0aW9uPUN1c3RvbSBzZXJ2aWNlCgpbU2VydmljZV0KRXhlY1N0YXJ0PS91c3IvYmluL2ZhbHNlCgpbSW5zdGFsbF0KV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXQK"
+        },
+        "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+          "encoding": "base64",
+          "data": "W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NhdCAvZXRjL2N1c3RvbV9maWxlLnR4dAo="
+        },
+        "sha256:4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c": {
+          "encoding": "base64",
+          "data": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzekNDQXB1Z0F3SUJBZ0lVSjRsSytKZmRKQ05nY0VWeFpEaW5KZktLYlFzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2FERUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZRApWUVFIREFkU1lXeGxhV2RvTVJBd0RnWURWUVFLREFkU1pXUWdTR0YwTVJ3d0dnWURWUVFEREJOVVpYTjBJRU5CCklHWnZjaUJ2YzJKMWFXeGtNQ0FYRFRJME1Ea3dNekV6TWpreU1Gb1lEekl5T1Rnd05qRTRNVE15T1RJd1dqQm8KTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjTQpCMUpoYkdWcFoyZ3hFREFPQmdOVkJBb01CMUpsWkNCSVlYUXhIREFhQmdOVkJBTU1FMVJsYzNRZ1EwRWdabTl5CklHOXpZblZwYkdRd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURlQTdPY1dUclYKZ3N0b0JzVWFlSkttOG5lbGc3TGMwV05YSDZ5T1RMc3I0dGQ0eUhzMFlPdkZHd2dTZitmZlYzUkFHMW1ncW5NRwpNZ2tEMit6KzdRaEhiSEhzM3kwZDB6ZmhBMmJnMEtWdmZDV2s3Zk5SUEhZMFVPZVBwWGsyNDVCZnczRDBWVHBsCkY3bmVQazFJN1pZMDlzblBXVWViMnJqS1h6WWpLanpNMGgyNyt5a1Y4STgrRmJkeVBrL3BSOHdoeURxdEhMVWEKWGZGeTJURmxvRFNZTWtIS1ZkMzhCbkwwYmo5MXg1RitLc1prTjRIemZiWXd4TGJDUWZPU2d5N3E2VFdjZTlrcQpMbzZ0eWE5dnV2cFdGbTFkeWU3TCtCb2RBUUFxL2RJL0pNZUNmeVRiMGVGYit0eXpmcjVhVklvcXFETitwOWZ0CmN3NE9lZnBIYmh0TkFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUlYyQTlZbXVzZWtQenU1WWYwOGNWMG9QTDEKd2pBZkJnTlZIU01FR0RBV2dCUlYyQTlZbXVzZWtQenU1WWYwOGNWMG9QTDF3akFQQmdOVkhSTUJBZjhFQlRBRApBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFDZ1FaMlhmaitOeGFLQlpnbjJLTnhTME1UYmh6SFJ6NlJuCnFKcytoOE9VejJDcm1hZjZOK1JIbG1EUlpYVXJEalNIcHhWVDJMeEZ5N29mUnJMWUllekZEVVlmYjkyMFZra1YKU1ZjeGgxWURGUk9KYWxmTW9FNndkeVIvTG5LNE1KWlM5ZlVwZUNKSmMvQTBKKzlGSzlDd2N5VXJIZ0o4WGJKaApNS1l5UStjZjZPN3d6dXR1QnBNeVJxU0tTK2hWTTdCUVRtU0Z2djFlQUpsbzZrbEdBbW1LaVltQUV2Y1FhZEgxCmRqcnVqc0EzQ241dlgyTCsweXVpTEI1L3pveHF4NWNFeTk3VHVLVVlCOE9xTU11akFYTnpGNEwzSEpEVU5iYTIKQWhFa0Zvek1Yd1lYNzNUR2JHWjBtYXdQUzVEM3YzdFlURW1KRmY2U25WQ21VVzFmczU3ZwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        },
+        "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+          "encoding": "base64",
+          "data": "aW1hZ2UgYnVpbGRlciBpcyB0aGUgYmVzdA=="
+        },
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+          "encoding": "base64",
+          "data": ""
+        },
+        "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+          "encoding": "base64",
+          "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-x86_64-ami-all_customizations.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-ami-all_customizations.json
@@ -19,19 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
@@ -43,37 +34,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -134,9 +107,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -147,12 +117,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
@@ -300,9 +264,6 @@
                 },
                 {
                   "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
-                },
-                {
-                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
                 },
                 {
                   "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"

--- a/test/data/manifestdb-light/centos_10-x86_64-ami-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-ami-empty.json
@@ -1,0 +1,864 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "bb75155a-e793-4d15-a574-1e472a54ec62",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dracut.conf",
+          "options": {
+            "filename": "ec2.conf",
+            "config": {
+              "add_drivers": [
+                "nvme",
+                "xen-blkfront"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "bb75155a-e793-4d15-a574-1e472a54ec62",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "bb75155a-e793-4d15-a574-1e472a54ec62",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20557791,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "bb75155a-e793-4d15-a574-1e472a54ec62",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 20557791,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 20557791
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "image.raw",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-appstream"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-rt"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        },
+        "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-baseos"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-x86_64-ami-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-ami-empty.json
@@ -19,13 +19,7 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
@@ -37,37 +31,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -128,9 +104,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -141,12 +114,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/centos_10-x86_64-ami-partitioning_dos_lvm.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-ami-partitioning_dos_lvm.json
@@ -19,12 +19,6 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
-                },
-                {
                   "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
                 },
                 {
@@ -32,12 +26,6 @@
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
@@ -49,37 +37,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -140,9 +110,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -153,12 +120,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/centos_10-x86_64-ami-partitioning_dos_lvm.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-ami-partitioning_dos_lvm.json
@@ -1,0 +1,1397 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "55d98880-fc19-4445-bab2-b43c539294d8",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dracut.conf",
+          "options": {
+            "filename": "ec2.conf",
+            "config": {
+              "add_drivers": [
+                "nvme",
+                "xen-blkfront"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "55d98880-fc19-4445-bab2-b43c539294d8",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "cb72052c-096d-4523-8013-71cb88f22545",
+                "vfs_type": "xfs",
+                "path": "/boot",
+                "options": "defaults"
+              },
+              {
+                "uuid": "9d1b4085-a9c9-401e-9b40-f0f67f8d89b5",
+                "vfs_type": "ext4",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "b7ad9335-b453-476c-9b41-ddf8c2f8eabe",
+                "vfs_type": "ext4",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "f20f2c87-9ecb-46c0-91a9-1819559f5c32",
+                "vfs_type": "ext4",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "1762e8d0-8ccc-4d9e-b5e1-9f3726d39067",
+                "vfs_type": "ext4",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "68005bae-3c60-45cb-a89c-0c8062894a35",
+                "vfs_type": "ext4",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "d1009934-a733-4242-aaee-9d4ddb524c84",
+                "vfs_type": "ext4",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "2a7c9168-a978-46f2-b106-9ac8958d24c8",
+                "vfs_type": "ext4",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "85ad43f7-9809-4e4d-bacf-058b60222cd3",
+                "vfs_type": "ext4",
+                "path": "/usr",
+                "options": "defaults"
+              },
+              {
+                "uuid": "e7464c82-e5d0-40a5-b7dd-da9edbfe5238",
+                "vfs_type": "swap",
+                "path": "none",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "55d98880-fc19-4445-bab2-b43c539294d8",
+            "boot_fs_uuid": "cb72052c-096d-4523-8013-71cb88f22545",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "20080230400"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "dos",
+            "uuid": "f5ec7a6b-9b18-474e-b6d1-8bfbbd553759",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "00",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "ef",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 1048576,
+                "start": 413696,
+                "type": "83"
+              },
+              {
+                "size": 37756928,
+                "start": 1462272,
+                "type": "8e"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.lvm2.create",
+          "options": {
+            "volumes": [
+              {
+                "name": "homelv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "shadowmanlv",
+                "size": "5368709120B"
+              },
+              {
+                "name": "foolv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "usrlv",
+                "size": "4294967296B"
+              },
+              {
+                "name": "optlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "medialv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "roothomelv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "srvlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "swap-lv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "rootlv",
+                "size": "1073741824B"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "cb72052c-096d-4523-8013-71cb88f22545",
+            "label": "boot"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 1048576,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "b7ad9335-b453-476c-9b41-ddf8c2f8eabe",
+            "label": "home"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "f20f2c87-9ecb-46c0-91a9-1819559f5c32"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "shadowmanlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "9d1b4085-a9c9-401e-9b40-f0f67f8d89b5"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "85ad43f7-9809-4e4d-bacf-058b60222cd3"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "68005bae-3c60-45cb-a89c-0c8062894a35"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "1762e8d0-8ccc-4d9e-b5e1-9f3726d39067"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "d1009934-a733-4242-aaee-9d4ddb524c84"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "roothomelv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "2a7c9168-a978-46f2-b106-9ac8958d24c8"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkswap",
+          "options": {
+            "uuid": "e7464c82-e5d0-40a5-b7dd-da9edbfe5238"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "swap-lv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "55d98880-fc19-4445-bab2-b43c539294d8",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 1048576
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "shadowmanlv"
+              }
+            },
+            "media": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "root": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "roothomelv"
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 37756928
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.ext4",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.ext4",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.ext4",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.ext4",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.ext4",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.ext4",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.ext4",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.ext4",
+              "source": "usr",
+              "target": "/usr"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.lvm2.metadata",
+          "options": {
+            "vg_name": "testvg"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 37756928,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "image.raw",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "dos",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "dos",
+              "number": 2,
+              "path": "/grub2"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-appstream"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-rt"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        },
+        "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-baseos"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-x86_64-ami-partitioning_lvm.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-ami-partitioning_lvm.json
@@ -19,12 +19,6 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
-                },
-                {
                   "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
                 },
                 {
@@ -32,12 +26,6 @@
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
@@ -49,37 +37,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -140,9 +110,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -153,12 +120,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/centos_10-x86_64-ami-partitioning_lvm.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-ami-partitioning_lvm.json
@@ -1,0 +1,1443 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "692c4075-5a30-4814-85e3-f716db00a288",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dracut.conf",
+          "options": {
+            "filename": "ec2.conf",
+            "config": {
+              "add_drivers": [
+                "nvme",
+                "xen-blkfront"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "692c4075-5a30-4814-85e3-f716db00a288",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "dcd028ff-d9cd-4c2f-83d4-f8d305235718",
+                "vfs_type": "xfs",
+                "path": "/boot",
+                "options": "defaults"
+              },
+              {
+                "uuid": "748f1a41-e407-4b22-820e-cddb0e452801",
+                "vfs_type": "ext4",
+                "path": "/data",
+                "options": "defaults"
+              },
+              {
+                "uuid": "1ded4b82-180b-4cfd-b04a-df8e80ba3274",
+                "vfs_type": "ext4",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "2381b2fb-f501-475f-b15b-cda13c7d71a4",
+                "vfs_type": "ext4",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "fdcad9c7-6972-4e5a-a6ea-2336e0005a4a",
+                "vfs_type": "ext4",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "979015ed-5508-4fcf-933a-d8a0d29ef8a9",
+                "vfs_type": "ext4",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "21fed984-0bed-4cba-8af5-09657b914fc4",
+                "vfs_type": "ext4",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "60de9112-c3c6-4a85-b353-7e3376885560",
+                "vfs_type": "ext4",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "66743116-e6d3-4ed2-8ff3-9c7c44dc0ced",
+                "vfs_type": "ext4",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "bc9d7802-aba2-4368-8e1d-32414ab9dfb9",
+                "vfs_type": "ext4",
+                "path": "/usr",
+                "options": "defaults"
+              },
+              {
+                "uuid": "79437992-a597-4b15-923b-90357ae2e1fa",
+                "vfs_type": "swap",
+                "path": "none",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "692c4075-5a30-4814-85e3-f716db00a288",
+            "boot_fs_uuid": "dcd028ff-d9cd-4c2f-83d4-f8d305235718",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "21155020800"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "91e8e62e-4ba8-4190-b8fc-9ee6dd7a77e4",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 1048576,
+                "start": 413696,
+                "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                "uuid": "4ad0d098-3d85-4cf6-a236-6deff5a5b1fc"
+              },
+              {
+                "size": 2097152,
+                "start": 1462272,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "bdbb140e-c1ba-4ed7-a8fd-b02416db6eda"
+              },
+              {
+                "size": 37758943,
+                "start": 3559424,
+                "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+                "uuid": "8312ae61-c199-4ae2-8486-cc4ad34d7333"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.lvm2.create",
+          "options": {
+            "volumes": [
+              {
+                "name": "homelv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "shadowmanlv",
+                "size": "5368709120B"
+              },
+              {
+                "name": "foolv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "usrlv",
+                "size": "4294967296B"
+              },
+              {
+                "name": "optlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "medialv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "roothomelv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "srvlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "swap-lv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "rootlv",
+                "size": "1073741824B"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "dcd028ff-d9cd-4c2f-83d4-f8d305235718",
+            "label": "boot"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 1048576,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "748f1a41-e407-4b22-820e-cddb0e452801",
+            "label": "data"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "2381b2fb-f501-475f-b15b-cda13c7d71a4",
+            "label": "home"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "fdcad9c7-6972-4e5a-a6ea-2336e0005a4a"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "shadowmanlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "1ded4b82-180b-4cfd-b04a-df8e80ba3274"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "bc9d7802-aba2-4368-8e1d-32414ab9dfb9"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "21fed984-0bed-4cba-8af5-09657b914fc4"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "979015ed-5508-4fcf-933a-d8a0d29ef8a9"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "60de9112-c3c6-4a85-b353-7e3376885560"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "roothomelv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "66743116-e6d3-4ed2-8ff3-9c7c44dc0ced"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkswap",
+          "options": {
+            "uuid": "79437992-a597-4b15-923b-90357ae2e1fa"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "swap-lv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "692c4075-5a30-4814-85e3-f716db00a288",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 1048576
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600
+              }
+            },
+            "data": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 2097152
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "shadowmanlv"
+              }
+            },
+            "media": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "root": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "roothomelv"
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "data",
+              "type": "org.osbuild.ext4",
+              "source": "data",
+              "target": "/data"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.ext4",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.ext4",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.ext4",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.ext4",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.ext4",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.ext4",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.ext4",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.ext4",
+              "source": "usr",
+              "target": "/usr"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.lvm2.metadata",
+          "options": {
+            "vg_name": "testvg"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "image.raw",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/grub2"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-appstream"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-rt"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        },
+        "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-baseos"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-x86_64-ami-partitioning_plain.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-ami-partitioning_plain.json
@@ -1,0 +1,1293 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "524e2bcc-ca52-4376-bbe5-250ed503ca1d",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dracut.conf",
+          "options": {
+            "filename": "ec2.conf",
+            "config": {
+              "add_drivers": [
+                "nvme",
+                "xen-blkfront"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "524e2bcc-ca52-4376-bbe5-250ed503ca1d",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "08dae031-63d4-4095-9b98-b2e2242478a4",
+                "vfs_type": "ext4",
+                "path": "/data",
+                "options": "defaults"
+              },
+              {
+                "uuid": "e33a6dfa-27d4-4ebb-a2c3-68d19a2547f4",
+                "vfs_type": "ext4",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "b52f75fc-6c3c-439b-a26f-aad23eede09f",
+                "vfs_type": "ext4",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "f77e3b60-51ea-47bc-b5a7-3cfde4c2f9f7",
+                "vfs_type": "ext4",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "b0f4999a-a2d1-47fb-a838-977da8c6be51",
+                "vfs_type": "ext4",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "1543287c-6baf-48d8-9bc6-686a1168456e",
+                "vfs_type": "ext4",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "cad388c0-3b8d-4f83-ac54-fb21fba02cb6",
+                "vfs_type": "ext4",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "36494103-223c-4a3a-8249-f1e9867408e9",
+                "vfs_type": "xfs",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "318848c0-85c7-4e4e-a5c8-b670f3c44c78",
+                "vfs_type": "xfs",
+                "path": "/var",
+                "options": "defaults"
+              },
+              {
+                "uuid": "6b22f98b-9631-4f08-a455-368a064d41b5",
+                "vfs_type": "swap",
+                "path": "none",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "524e2bcc-ca52-4376-bbe5-250ed503ca1d",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "17917018112"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "5e2d8799-9009-4627-865d-7512361691ee",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 2097152,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "8c209fac-6ced-45fe-8158-c4b793c5ef17"
+              },
+              {
+                "size": 4194304,
+                "start": 2510848,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "2ab57a4c-1643-43bc-8a0f-4ee53ebd1684"
+              },
+              {
+                "size": 1024000,
+                "start": 6705152,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "7d15c378-7007-4836-9ecc-a32251d0093c"
+              },
+              {
+                "size": 2097152,
+                "start": 7729152,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "d1d0f6b2-2175-4268-8eaf-7fdaab0a8b2d"
+              },
+              {
+                "size": 8388608,
+                "start": 9826304,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "2f217e6b-a978-40a6-be7f-8fba6e88501d"
+              },
+              {
+                "size": 2097152,
+                "start": 18214912,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "435fcc28-5c0c-4409-abd7-b0ff689fcb6e"
+              },
+              {
+                "size": 2097152,
+                "start": 20312064,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "5db8e551-3d28-4600-97c6-b2a9190e1a44"
+              },
+              {
+                "size": 2097152,
+                "start": 22409216,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "9bfc9bae-590e-494e-9ac2-868fd14d181d"
+              },
+              {
+                "size": 2097152,
+                "start": 24506368,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "5015f3d2-c44c-4ec6-ba4d-c9ca64b342d7"
+              },
+              {
+                "size": 2097152,
+                "start": 26603520,
+                "type": "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F",
+                "uuid": "c86af325-424d-4596-966f-e08e5394dd1f"
+              },
+              {
+                "size": 6293471,
+                "start": 28700672,
+                "type": "4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709",
+                "uuid": "709f2c24-76f9-4bc3-81d2-329f7b235bab"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "08dae031-63d4-4095-9b98-b2e2242478a4"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "b52f75fc-6c3c-439b-a26f-aad23eede09f",
+            "label": "home"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2510848,
+                "size": 4194304,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "f77e3b60-51ea-47bc-b5a7-3cfde4c2f9f7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 6705152,
+                "size": 1024000,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "e33a6dfa-27d4-4ebb-a2c3-68d19a2547f4"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 7729152,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "318848c0-85c7-4e4e-a5c8-b670f3c44c78"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 9826304,
+                "size": 8388608,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "1543287c-6baf-48d8-9bc6-686a1168456e"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 18214912,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "b0f4999a-a2d1-47fb-a838-977da8c6be51"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 20312064,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "cad388c0-3b8d-4f83-ac54-fb21fba02cb6"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 22409216,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "36494103-223c-4a3a-8249-f1e9867408e9"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 24506368,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkswap",
+          "options": {
+            "uuid": "6b22f98b-9631-4f08-a455-368a064d41b5"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 26603520,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "524e2bcc-ca52-4376-bbe5-250ed503ca1d",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 28700672,
+                "size": 6293471,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 28700672,
+                "size": 6293471
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600
+              }
+            },
+            "data": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 2097152
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 7729152,
+                "size": 2097152
+              }
+            },
+            "home": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2510848,
+                "size": 4194304
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 6705152,
+                "size": 1024000
+              }
+            },
+            "media": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 20312064,
+                "size": 2097152
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 18214912,
+                "size": 2097152
+              }
+            },
+            "root": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 22409216,
+                "size": 2097152
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 24506368,
+                "size": 2097152
+              }
+            },
+            "var": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 9826304,
+                "size": 8388608
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "data",
+              "type": "org.osbuild.ext4",
+              "source": "data",
+              "target": "/data"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.ext4",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.ext4",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.ext4",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.ext4",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.ext4",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.ext4",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.xfs",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "var",
+              "type": "org.osbuild.xfs",
+              "source": "var",
+              "target": "/var"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "image.raw",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 12,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-appstream"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-rt"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        },
+        "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-baseos"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-x86_64-ami-partitioning_plain.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-ami-partitioning_plain.json
@@ -19,19 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
-                },
-                {
                   "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
                 },
                 {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
@@ -43,37 +34,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -134,9 +107,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -147,12 +117,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/centos_10-x86_64-gce-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-gce-empty.json
@@ -19,16 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -40,19 +34,7 @@
                   "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
                 },
                 {
-                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
@@ -62,9 +44,6 @@
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -127,9 +106,6 @@
                 },
                 {
                   "id": "sha256:9220e83cc1dd0cbbe1ca0da9b665f6f476f4f357b9d0f2e691d9fad55ab78305"
-                },
-                {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"

--- a/test/data/manifestdb-light/centos_10-x86_64-gce-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-gce-empty.json
@@ -1,0 +1,945 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                },
+                {
+                  "id": "sha256:843af58590dbafa56c89e30ffc6b01f0bd1d28770049ca9956e306165f286858"
+                },
+                {
+                  "id": "sha256:3e3779e71058c8a030a8ecfc8d94cdba7f3a53a1232159f79ef7a8d63cb88143"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "3dc01c89-60c1-47db-a069-7dd7f9ab42af",
+            "kernel_opts": "biosdevname=0 scsi_mod.use_blk_mq=Y console=ttyS0,38400n8d"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:9220e83cc1dd0cbbe1ca0da9b665f6f476f4f357b9d0f2e691d9fad55ab78305"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:4c8abe2beeae2af4a537a85ae9953e163af2c127991de913e075eda82046b3e4"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d3cf5271c662017c7fdae75c30437813922b84f8fd5329818fc4aa4fdb716cb0"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:af90238cff8047ed284dc33bb34f66b5639ebbc51b9c866631fb2ace4c83e328"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:0f2ed9e33d29ff4f3b0f664ca1e1dc3df1f8b9b315b2af284c6e0e3dc52be290"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:e1911163463de95ee97cf6485caa62dfc4406353719446fe1fe3d9a66387c849"
+                },
+                {
+                  "id": "sha256:59a4bad24de7614e18d9b453a6820ec59fcda49720aa8f16ef045f5665562de9"
+                },
+                {
+                  "id": "sha256:0c1406adec8def017eb397ea9b217e879db26a50384d91c6a6112f44d0d27799"
+                },
+                {
+                  "id": "sha256:30e24e8a39fbfc20c910b6249dd0eda191d24b6fb867e0f6a8b23b4d539371c3"
+                },
+                {
+                  "id": "sha256:5d9e8f5c8ecdfdab3de0380b628372e1cfaa2f9616f21274d3cabcc511d11ad7"
+                },
+                {
+                  "id": "sha256:bc8f1fdc6cba695a97446aed17e9205717b86b4899ffad52b5166cfe1f232165"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:b2a622322540941a2f49c7c8d6e8b98155b8f257a10eeb552993c5d210d957f6"
+                },
+                {
+                  "id": "sha256:9e99f61535d122942ad3cb6f1d1d2496b48913a48d7e76e7e93983c22a06f2c4"
+                },
+                {
+                  "id": "sha256:3e39dfe0fda6e3020d48b0d110ff8670187611a711de543a6692cf5519ece8da"
+                },
+                {
+                  "id": "sha256:9f242d5e9f0005c5120f17fc534c4e71cc5f9bfd59df1435a61c74d6ccc2846d"
+                },
+                {
+                  "id": "sha256:aa92be9c11e757dee72fd903a3d0b46daafb50027f30450ef892ac74f8b4e9f4"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:11bbcc61af43bebaad417d8b935a77f65c67225703ad1d94d58465a63831c05f"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:8e84e003f7afb133a9b5ea84d034af3610967afdebe0436a34ebd2e87ca2e34b"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:ce7b9745404d4f092712bfe05c7a4b64632dbd4fc194a2980912021901b9e985"
+                },
+                {
+                  "id": "sha256:5711028bfc9a0ba5752d3e32aca935f624a364c71c862e3b9a320f16ce0dc40d"
+                },
+                {
+                  "id": "sha256:d905e568721817dad5aad11910c1500d5b99695b6afcc415e47ed28767ec9364"
+                },
+                {
+                  "id": "sha256:a6505ee3dd72b373aefd0ab5a4632b855fa0b6dbf8facf5b554fc698bd59f37c"
+                },
+                {
+                  "id": "sha256:19413fb2096a9ff02d31dde255085eda820fead1c40697c119f6b88529d86e13"
+                },
+                {
+                  "id": "sha256:b63a75481268ddfefb9b0c01bd9c40ae60bb5a114a24a9595061dea7eea2b7b4"
+                },
+                {
+                  "id": "sha256:ba3b4980955962755c46bda6db09334a1bed64ab91f8a383e1c77bfa384f95f2"
+                },
+                {
+                  "id": "sha256:60597ea289d15efc9c36caa043e8ba904676646c7d919b4d220670c56e8d809c"
+                },
+                {
+                  "id": "sha256:4f3c2f44b48868bd3615aef61dd1ee9aa70c0d8051e3135cf6bcf441acb414a4"
+                },
+                {
+                  "id": "sha256:988a98f33b3157bfc52137cbc64b4753262effe649760c18cc7fbf3490debc32"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                },
+                {
+                  "id": "sha256:843af58590dbafa56c89e30ffc6b01f0bd1d28770049ca9956e306165f286858"
+                },
+                {
+                  "id": "sha256:3e3779e71058c8a030a8ecfc8d94cdba7f3a53a1232159f79ef7a8d63cb88143"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "metadata.google.internal"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.firewall",
+          "options": {
+            "default_zone": "trusted"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel-core"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-floppy.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "floppy"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dnf.config",
+          "options": {
+            "config": {
+              "main": {
+                "ip_resolve": "4"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.dnf-automatic.config",
+          "options": {
+            "config": {
+              "commands": {
+                "apply_updates": true,
+                "upgrade_type": "security"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.yum.repos",
+          "options": {
+            "filename": "google-cloud.repo",
+            "repos": [
+              {
+                "id": "google-compute-engine",
+                "baseurl": [
+                  "https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable"
+                ],
+                "enabled": true,
+                "gpgkey": [
+                  "https://packages.cloud.google.com/yum/doc/yum-key.gpg",
+                  "https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg"
+                ],
+                "name": "Google Compute Engine",
+                "gpgcheck": false,
+                "repo_gpgcheck": false
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.gcp.guest-agent.conf",
+          "options": {
+            "config_scope": "distro",
+            "config": {
+              "InstanceSetup": {
+                "set_boto_config": false
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false,
+              "ClientAliveInterval": 420,
+              "PermitRootLogin": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "3dc01c89-60c1-47db-a069-7dd7f9ab42af",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "3dc01c89-60c1-47db-a069-7dd7f9ab42af",
+            "kernel_opts": "biosdevname=0 scsi_mod.use_blk_mq=Y console=ttyS0,38400n8d",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "rngd",
+              "dnf-automatic.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final"
+            ],
+            "disabled_services": [
+              "sshd-keygen@",
+              "reboot.target"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.raw",
+            "size": "21474836480"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 41529311,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.raw",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "3dc01c89-60c1-47db-a069-7dd7f9ab42af",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.raw",
+                "start": 413696,
+                "size": 41529311,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.raw",
+                "start": 413696,
+                "size": 41529311
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.raw",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "archive",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:image"
+              ]
+            }
+          },
+          "options": {
+            "filename": "image.tar.gz",
+            "format": "oldgnu",
+            "acls": false,
+            "selinux": false,
+            "xattrs": false,
+            "root-node": "omit"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a": {
+          "url": "https://example.com/repo/packages/net-tools"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0c1406adec8def017eb397ea9b217e879db26a50384d91c6a6112f44d0d27799": {
+          "url": "https://example.com/repo/packages/exclude:b43-fwcutter"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:0f2ed9e33d29ff4f3b0f664ca1e1dc3df1f8b9b315b2af284c6e0e3dc52be290": {
+          "url": "https://example.com/repo/packages/vim"
+        },
+        "sha256:11bbcc61af43bebaad417d8b935a77f65c67225703ad1d94d58465a63831c05f": {
+          "url": "https://example.com/repo/packages/exclude:kernel-firmware"
+        },
+        "sha256:19413fb2096a9ff02d31dde255085eda820fead1c40697c119f6b88529d86e13": {
+          "url": "https://example.com/repo/packages/exclude:ql2500-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:30e24e8a39fbfc20c910b6249dd0eda191d24b6fb867e0f6a8b23b4d539371c3": {
+          "url": "https://example.com/repo/packages/exclude:b43-openfwwf"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-appstream"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3e3779e71058c8a030a8ecfc8d94cdba7f3a53a1232159f79ef7a8d63cb88143": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/el9-x86_64-google-cloud-sdk"
+        },
+        "sha256:3e39dfe0fda6e3020d48b0d110ff8670187611a711de543a6692cf5519ece8da": {
+          "url": "https://example.com/repo/packages/exclude:ipw2100-firmware"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4c8abe2beeae2af4a537a85ae9953e163af2c127991de913e075eda82046b3e4": {
+          "url": "https://example.com/repo/packages/dnf-automatic"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:4f3c2f44b48868bd3615aef61dd1ee9aa70c0d8051e3135cf6bcf441acb414a4": {
+          "url": "https://example.com/repo/packages/exclude:xorg-x11-drv-ati-firmware"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5711028bfc9a0ba5752d3e32aca935f624a364c71c862e3b9a320f16ce0dc40d": {
+          "url": "https://example.com/repo/packages/exclude:ql2200-firmware"
+        },
+        "sha256:59a4bad24de7614e18d9b453a6820ec59fcda49720aa8f16ef045f5665562de9": {
+          "url": "https://example.com/repo/packages/exclude:atmel-firmware"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5d9e8f5c8ecdfdab3de0380b628372e1cfaa2f9616f21274d3cabcc511d11ad7": {
+          "url": "https://example.com/repo/packages/exclude:bfa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:60597ea289d15efc9c36caa043e8ba904676646c7d919b4d220670c56e8d809c": {
+          "url": "https://example.com/repo/packages/exclude:smartmontools"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393": {
+          "url": "https://example.com/repo/packages/grub2-tools-minimal"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:843af58590dbafa56c89e30ffc6b01f0bd1d28770049ca9956e306165f286858": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/el9-x86_64-google-compute-engine"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8e84e003f7afb133a9b5ea84d034af3610967afdebe0436a34ebd2e87ca2e34b": {
+          "url": "https://example.com/repo/packages/exclude:microcode_ctl"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-rt"
+        },
+        "sha256:9220e83cc1dd0cbbe1ca0da9b665f6f476f4f357b9d0f2e691d9fad55ab78305": {
+          "url": "https://example.com/repo/packages/acpid"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:988a98f33b3157bfc52137cbc64b4753262effe649760c18cc7fbf3490debc32": {
+          "url": "https://example.com/repo/packages/exclude:zd1211-firmware"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:9e99f61535d122942ad3cb6f1d1d2496b48913a48d7e76e7e93983c22a06f2c4": {
+          "url": "https://example.com/repo/packages/exclude:gpm"
+        },
+        "sha256:9f242d5e9f0005c5120f17fc534c4e71cc5f9bfd59df1435a61c74d6ccc2846d": {
+          "url": "https://example.com/repo/packages/exclude:ipw2200-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a6505ee3dd72b373aefd0ab5a4632b855fa0b6dbf8facf5b554fc698bd59f37c": {
+          "url": "https://example.com/repo/packages/exclude:ql2400-firmware"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aa92be9c11e757dee72fd903a3d0b46daafb50027f30450ef892ac74f8b4e9f4": {
+          "url": "https://example.com/repo/packages/exclude:irqbalance"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:af90238cff8047ed284dc33bb34f66b5639ebbc51b9c866631fb2ace4c83e328": {
+          "url": "https://example.com/repo/packages/timedatex"
+        },
+        "sha256:b2a622322540941a2f49c7c8d6e8b98155b8f257a10eeb552993c5d210d957f6": {
+          "url": "https://example.com/repo/packages/exclude:eject"
+        },
+        "sha256:b63a75481268ddfefb9b0c01bd9c40ae60bb5a114a24a9595061dea7eea2b7b4": {
+          "url": "https://example.com/repo/packages/exclude:rt61pci-firmware"
+        },
+        "sha256:ba3b4980955962755c46bda6db09334a1bed64ab91f8a383e1c77bfa384f95f2": {
+          "url": "https://example.com/repo/packages/exclude:rt73usb-firmware"
+        },
+        "sha256:bc8f1fdc6cba695a97446aed17e9205717b86b4899ffad52b5166cfe1f232165": {
+          "url": "https://example.com/repo/packages/exclude:dmraid"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:ce7b9745404d4f092712bfe05c7a4b64632dbd4fc194a2980912021901b9e985": {
+          "url": "https://example.com/repo/packages/exclude:ql2100-firmware"
+        },
+        "sha256:d3cf5271c662017c7fdae75c30437813922b84f8fd5329818fc4aa4fdb716cb0": {
+          "url": "https://example.com/repo/packages/google-osconfig-agent"
+        },
+        "sha256:d905e568721817dad5aad11910c1500d5b99695b6afcc415e47ed28767ec9364": {
+          "url": "https://example.com/repo/packages/exclude:ql23xx-firmware"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e1911163463de95ee97cf6485caa62dfc4406353719446fe1fe3d9a66387c849": {
+          "url": "https://example.com/repo/packages/exclude:alsa-utils"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-baseos"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-x86_64-image_installer-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-image_installer-empty.json
@@ -1,0 +1,1783 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c"
+                },
+                {
+                  "id": "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:a788847c8c115aa9ae27ca92230418e77b3b36a6424f1d4f3436633864c93db9"
+                },
+                {
+                  "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
+                },
+                {
+                  "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "anaconda-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:629e355a0345015e53cacd90ce641c7e2ef38405cd55e135f331a6303c51f509"
+                },
+                {
+                  "id": "sha256:1f2ce4e8c1aea4a2440b7e794e0440385f8e9c3f48b0fd65118f3dcdbca783bf"
+                },
+                {
+                  "id": "sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f"
+                },
+                {
+                  "id": "sha256:cd2c0f63ad37d585e77b3f1c584539e26bf7928710ac8fb19fd377f61b7326e6"
+                },
+                {
+                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
+                },
+                {
+                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
+                },
+                {
+                  "id": "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2"
+                },
+                {
+                  "id": "sha256:903be5b3913df555a8586e571d9016e1ac24eef2631a5d75b8c3f94c66f10955"
+                },
+                {
+                  "id": "sha256:b81f37a043a6f767e7c94d105f4bd31282f3ecc20680bb9d09bd93461cf4c863"
+                },
+                {
+                  "id": "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9"
+                },
+                {
+                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
+                },
+                {
+                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
+                },
+                {
+                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
+                },
+                {
+                  "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
+                },
+                {
+                  "id": "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c"
+                },
+                {
+                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
+                },
+                {
+                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
+                },
+                {
+                  "id": "sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112"
+                },
+                {
+                  "id": "sha256:5b8b6480d96480b779d6937e2d8694e03cdae14eb0664033ef24af50e1557726"
+                },
+                {
+                  "id": "sha256:75c008414c1be65c0e6954f74e1afdf3f706369f26899ea792b4ac0f31f287bc"
+                },
+                {
+                  "id": "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa"
+                },
+                {
+                  "id": "sha256:5e5d7e05a668f4ec5939a246b38d17cbb6ee83c0408ecbf584f6561a9d64a383"
+                },
+                {
+                  "id": "sha256:826c7f30d36dcc8cb4628bee44fc0e257a360eb06cfc31c49148a44b153e78ce"
+                },
+                {
+                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
+                },
+                {
+                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
+                },
+                {
+                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c"
+                },
+                {
+                  "id": "sha256:581265de790cf918fc770318449fe4cd07a18771c975d42867760b2e2f1bd18d"
+                },
+                {
+                  "id": "sha256:1f35e175b07fc080eb57fc9db22a3ce477d87bc5447466815f55864d3b6e6586"
+                },
+                {
+                  "id": "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31"
+                },
+                {
+                  "id": "sha256:9ac51bbcd5be0f507237b2d43367ad073eaf99398a65d26fa2a8fee5275f889b"
+                },
+                {
+                  "id": "sha256:f5f43514d2de810e4ea6d047203505e2e3c0c25f43941ec226968d17bb3aa1b5"
+                },
+                {
+                  "id": "sha256:24173b7985c9c52efc25b39e51f0fd41ac7b35e7031ed17da97788f293a3ce4e"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
+                },
+                {
+                  "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
+                },
+                {
+                  "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:0d3ffa508f3c7375c05551af609738a9d474b3eab32cb2d2194b41870b37f1a9"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:9531c8584bbf61635c5c9b15733d9494cb6dd232a6eec85a946076c6c633e99f"
+                },
+                {
+                  "id": "sha256:5e4e6002bd0ef9491967c1f5f573b0c184ef5a41d165cff38c8c6c73606702cb"
+                },
+                {
+                  "id": "sha256:263acae321870b428781a1f4cb5e88740a897a4f9b614233a1798d295f805c54"
+                },
+                {
+                  "id": "sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1"
+                },
+                {
+                  "id": "sha256:8e901f9b6ca3996fe198c84d5f0a305b635bbaae54757fa84932ac52479c1efa"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111"
+                },
+                {
+                  "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:4ad76aeffa1e790eaf720b659f9860c50b6e0ba4787fa0a2d0e43dfa46193035"
+                },
+                {
+                  "id": "sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe"
+                },
+                {
+                  "id": "sha256:eeb3d09845f5cde069eeade2c4339532be58b6607120be00656123cc73ea727c"
+                },
+                {
+                  "id": "sha256:ce5b1962783aa6a9374a0a1b34941a112a799baac827c733bd28c78dbb4bcf36"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
+                },
+                {
+                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
+                },
+                {
+                  "id": "sha256:b498cfb546ddbfbd5953e28137e5b39a65ba6c7220bf4fe4c3cc9bcafc73c41b"
+                },
+                {
+                  "id": "sha256:f6453ebfd8ab070567bfcd4cda99cc41c2c849237745f24228c5f040cac5d562"
+                },
+                {
+                  "id": "sha256:f7f7a2e0133dfc81f9505bac28dfb7ee3398f3dc3b32c7682c86a9be5403bfee"
+                },
+                {
+                  "id": "sha256:cf732696c9aebd80fad833157535754f246445ad0fec66e918963443bd3cfb71"
+                },
+                {
+                  "id": "sha256:fe36b1d498f9c6057ed774ba5fb0a84c8592886c3a4c7c077ce7f41326373099"
+                },
+                {
+                  "id": "sha256:cb298bd94fae6f2f713a1108a16e0632f3a1e21820a288d7ea86c8b00a4d4fef"
+                },
+                {
+                  "id": "sha256:52999df2efd2afc3fcda19e416efb2d0f9b09562aa53331eaac2cde3c88ea207"
+                },
+                {
+                  "id": "sha256:b7110cc6e76089686855ae923d8e0212a0f067b8a48f3c96e8510d50c56061a7"
+                },
+                {
+                  "id": "sha256:eddfc611c4f74bed09b2ac20b714b54f2e47d9befc7cc8af98b4c679807ba573"
+                },
+                {
+                  "id": "sha256:2442f8197039e6fb34538a4651f00be2bcbaa8d2be3a15b734fa6ddf1bd8abba"
+                },
+                {
+                  "id": "sha256:a39d3ae3da34f2b4c01193e62202d5de0db79f800a039624b0f950734782b863"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686"
+                },
+                {
+                  "id": "sha256:316d18e697dfa41e92a9fe91d8d175629db5e330348a8adc1a5b43744d01d217"
+                },
+                {
+                  "id": "sha256:68d6e3ed85174ed856b83d5d1e16c23d5279cb5dc77915ae8570a768a5a65505"
+                },
+                {
+                  "id": "sha256:4381157a0ab3568cb31f727709b2edfca21522a8645e95c411f5798b8018393d"
+                },
+                {
+                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
+                },
+                {
+                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
+                },
+                {
+                  "id": "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a"
+                },
+                {
+                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
+                },
+                {
+                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
+                },
+                {
+                  "id": "sha256:500d641b95d95deab52480573126901d76d81dfe9fe0a5caf43445df38caad7b"
+                },
+                {
+                  "id": "sha256:5bc35fd09bee19e0dc22c7f7a731d1d8f4f68b81a3fd866e32273523eda30f9e"
+                },
+                {
+                  "id": "sha256:883642e660d2ef545d3d9f0cbd12790a99aea6358fb67c46664ff22fefa8b7df"
+                },
+                {
+                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
+                },
+                {
+                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
+                },
+                {
+                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
+                },
+                {
+                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
+                },
+                {
+                  "id": "sha256:990fde98d70a0a1a75bf55978f90138e8878a7f5cc1de475e03ee25b6744ee8a"
+                },
+                {
+                  "id": "sha256:95671115820a1fb4e74d1abed36bf069ce64a8233a3a37a8909cc62dffc57293"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
+                },
+                {
+                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
+                },
+                {
+                  "id": "sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:afed7d2fb0ea7b7e9d8dbcf1c1bb62ff53840c72d380cf165294a1eccb7fdeb1"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:cb6b44243b93acef33a5ee905d92203a2a55abdc6a3b7c446c8435a41a6ad137"
+                },
+                {
+                  "id": "sha256:61bfeb2957d080cbab70b332f16b482e1991b08e77ea7a8546b68b3cde90990c"
+                },
+                {
+                  "id": "sha256:28bdff3b22fe1fe1b18313472b2060d2706b9052cbabd91aaa7bed0c88c065de"
+                },
+                {
+                  "id": "sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18"
+                },
+                {
+                  "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
+                },
+                {
+                  "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
+                },
+                {
+                  "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
+                },
+                {
+                  "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a"
+                },
+                {
+                  "id": "sha256:85830c0611a0acd7053f7b3a29f52a0511acc3695f9c5ef39a29fcfb8b80e25b"
+                },
+                {
+                  "id": "sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d"
+                },
+                {
+                  "id": "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf"
+                },
+                {
+                  "id": "sha256:0a26024d87ac934c3aeca0ec8b27e579dfb6b268ac43f3a6f945579a54c46e6e"
+                },
+                {
+                  "id": "sha256:570e342d0e4708dab94b2025f6b928845b659b405872d824b45473c4635d7b1d"
+                },
+                {
+                  "id": "sha256:ce2b8ecf9afac9f546bdbbb0902afb6088fdcb8524269ad5b4adb9b9d4959b07"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.buildstamp",
+          "options": {
+            "arch": "x86_64",
+            "product": "CentOS Stream",
+            "version": "10-stream",
+            "final": true,
+            "variant": "",
+            "bugurl": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+              "install": {
+                "uid": 0,
+                "gid": 0,
+                "home": "/root",
+                "shell": "/usr/libexec/anaconda/run-anaconda",
+                "password": ""
+              },
+              "root": {
+                "password": ""
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.anaconda",
+          "options": {
+            "activatable-modules": [
+              "org.fedoraproject.Anaconda.Modules.Network",
+              "org.fedoraproject.Anaconda.Modules.Payloads",
+              "org.fedoraproject.Anaconda.Modules.Storage",
+              "org.fedoraproject.Anaconda.Modules.Users"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.lorax-script",
+          "options": {
+            "path": "99-generic/runtime-postinstall.tmpl",
+            "basearch": "x86_64",
+            "product": {
+              "name": "",
+              "version": ""
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.dracut",
+          "options": {
+            "kernel": [
+              "8-2.fk1.x86_64"
+            ],
+            "modules": [
+              "bash",
+              "systemd",
+              "fips",
+              "systemd-initrd",
+              "modsign",
+              "nss-softokn",
+              "i18n",
+              "convertfs",
+              "network-manager",
+              "network",
+              "url-lib",
+              "drm",
+              "plymouth",
+              "crypt",
+              "dm",
+              "dmsquash-live",
+              "kernel-modules",
+              "kernel-modules-extra",
+              "kernel-network-modules",
+              "livenet",
+              "lvm",
+              "mdraid",
+              "qemu",
+              "qemu-net",
+              "resume",
+              "rootfs-block",
+              "terminfo",
+              "udev-rules",
+              "dracut-systemd",
+              "pollcdrom",
+              "usrmount",
+              "base",
+              "fs-lib",
+              "img-lib",
+              "shutdown",
+              "uefi-lib",
+              "biosdevname",
+              "nvdimm",
+              "prefixdevname",
+              "prefixdevname-tools",
+              "net-lib",
+              "anaconda",
+              "rdma",
+              "rngd",
+              "multipath",
+              "fcoe",
+              "fcoe-uefi",
+              "iscsi",
+              "lunmask",
+              "nfs"
+            ],
+            "add_drivers": [
+              "ipmi_devintf",
+              "ipmi_msghandler"
+            ],
+            "install": [
+              "/.buildstamp"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux.config",
+          "options": {
+            "state": "permissive"
+          }
+        }
+      ]
+    },
+    {
+      "name": "efiboot-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.grub2.iso",
+          "options": {
+            "product": {
+              "name": "CentOS Stream",
+              "version": "10-stream"
+            },
+            "kernel": {
+              "dir": "/images/pxeboot",
+              "opts": [
+                "inst.stage2=hd:LABEL=CentOS-Stream-10-BaseOS-x86_64",
+                "inst.ks=hd:LABEL=CentOS-Stream-10-BaseOS-x86_64:/osbuild.ks"
+              ]
+            },
+            "isolabel": "CentOS-Stream-10-BaseOS-x86_64",
+            "architectures": [
+              "X64"
+            ],
+            "vendor": "centos"
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111"
+                },
+                {
+                  "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd"
+                },
+                {
+                  "id": "sha256:d87d9e526f265be973fce2ba320c5ed3ae24f6c5560d816d0b9307d0ba4d357f"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:674177213da94e10f7c2eb25574d59f64ab942abe4746b1eedf24bfd4dc17a76"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bootiso-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/images"
+              },
+              {
+                "path": "/images/pxeboot"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://tree/boot/vmlinuz-8-2.fk1.x86_64",
+                "to": "tree:///images/pxeboot/vmlinuz"
+              },
+              {
+                "from": "input://tree/boot/initramfs-8-2.fk1.x86_64.img",
+                "to": "tree:///images/pxeboot/initrd.img"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.squashfs",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "filename": "images/install.img",
+            "compression": {
+              "method": "xz",
+              "options": {
+                "bcj": "x86"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.isolinux",
+          "inputs": {
+            "data": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "product": {
+              "name": "CentOS Stream",
+              "version": "10-stream"
+            },
+            "kernel": {
+              "dir": "/images/pxeboot",
+              "opts": [
+                "inst.stage2=hd:LABEL=CentOS-Stream-10-BaseOS-x86_64",
+                "inst.ks=hd:LABEL=CentOS-Stream-10-BaseOS-x86_64:/osbuild.ks"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "images/efiboot.img",
+            "size": "20971520"
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "01fb0a1f"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "images/efiboot.img",
+                "size": 40960,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:efiboot-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "images/efiboot.img",
+                "size": 40960
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.fat",
+              "source": "-",
+              "target": "/"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:efiboot-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/EFI",
+                "to": "tree:///"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "/liveimg.tar.gz"
+          }
+        },
+        {
+          "type": "org.osbuild.kickstart",
+          "options": {
+            "path": "/osbuild.ks",
+            "liveimg": {
+              "url": "file:///run/install/repo/liveimg.tar.gz"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.discinfo",
+          "options": {
+            "basearch": "x86_64",
+            "release": "CentOS Stream 10-stream"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bootiso",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.xorrisofs",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:bootiso-tree"
+              ]
+            }
+          },
+          "options": {
+            "filename": "installer.iso",
+            "volid": "CentOS-Stream-10-BaseOS-x86_64",
+            "sysid": "LINUX",
+            "boot": {
+              "image": "isolinux/isolinux.bin",
+              "catalog": "isolinux/boot.cat"
+            },
+            "efi": "images/efiboot.img",
+            "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
+            "isolevel": 3
+          }
+        },
+        {
+          "type": "org.osbuild.implantisomd5",
+          "options": {
+            "filename": "installer.iso"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64-cdboot"
+        },
+        "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a": {
+          "url": "https://example.com/repo/packages/net-tools"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112": {
+          "url": "https://example.com/repo/packages/dbus-x11"
+        },
+        "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3": {
+          "url": "https://example.com/repo/packages/bzip2"
+        },
+        "sha256:0a26024d87ac934c3aeca0ec8b27e579dfb6b268ac43f3a6f945579a54c46e6e": {
+          "url": "https://example.com/repo/packages/volume_key"
+        },
+        "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1": {
+          "url": "https://example.com/repo/packages/initscripts"
+        },
+        "sha256:0d3ffa508f3c7375c05551af609738a9d474b3eab32cb2d2194b41870b37f1a9": {
+          "url": "https://example.com/repo/packages/grub2-tools-efi"
+        },
+        "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa": {
+          "url": "https://example.com/repo/packages/iwl105-firmware"
+        },
+        "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9": {
+          "url": "https://example.com/repo/packages/bind-utils"
+        },
+        "sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe": {
+          "url": "https://example.com/repo/packages/kbd"
+        },
+        "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa": {
+          "url": "https://example.com/repo/packages/anaconda-dracut"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:1f2ce4e8c1aea4a2440b7e794e0440385f8e9c3f48b0fd65118f3dcdbca783bf": {
+          "url": "https://example.com/repo/packages/alsa-firmware"
+        },
+        "sha256:1f35e175b07fc080eb57fc9db22a3ce477d87bc5447466815f55864d3b6e6586": {
+          "url": "https://example.com/repo/packages/ftp"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:24173b7985c9c52efc25b39e51f0fd41ac7b35e7031ed17da97788f293a3ce4e": {
+          "url": "https://example.com/repo/packages/google-noto-sans-cjk-ttc-fonts"
+        },
+        "sha256:2442f8197039e6fb34538a4651f00be2bcbaa8d2be3a15b734fa6ddf1bd8abba": {
+          "url": "https://example.com/repo/packages/mt-st"
+        },
+        "sha256:263acae321870b428781a1f4cb5e88740a897a4f9b614233a1798d295f805c54": {
+          "url": "https://example.com/repo/packages/hdparm"
+        },
+        "sha256:28bdff3b22fe1fe1b18313472b2060d2706b9052cbabd91aaa7bed0c88c065de": {
+          "url": "https://example.com/repo/packages/spice-vdagent"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686": {
+          "url": "https://example.com/repo/packages/nm-connection-editor"
+        },
+        "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa": {
+          "url": "https://example.com/repo/packages/dejavu-sans-fonts"
+        },
+        "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc": {
+          "url": "https://example.com/repo/packages/dmidecode"
+        },
+        "sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f": {
+          "url": "https://example.com/repo/packages/alsa-tools-firmware"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:316d18e697dfa41e92a9fe91d8d175629db5e330348a8adc1a5b43744d01d217": {
+          "url": "https://example.com/repo/packages/nmap-ncat"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-appstream"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1": {
+          "url": "https://example.com/repo/packages/dnf"
+        },
+        "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0": {
+          "url": "https://example.com/repo/packages/curl"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:4381157a0ab3568cb31f727709b2edfca21522a8645e95c411f5798b8018393d": {
+          "url": "https://example.com/repo/packages/nss-tools"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce": {
+          "url": "https://example.com/repo/packages/iwl100-firmware"
+        },
+        "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674": {
+          "url": "https://example.com/repo/packages/iwl2030-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4ad76aeffa1e790eaf720b659f9860c50b6e0ba4787fa0a2d0e43dfa46193035": {
+          "url": "https://example.com/repo/packages/jomolhari-fonts"
+        },
+        "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d": {
+          "url": "https://example.com/repo/packages/less"
+        },
+        "sha256:500d641b95d95deab52480573126901d76d81dfe9fe0a5caf43445df38caad7b": {
+          "url": "https://example.com/repo/packages/pciutils"
+        },
+        "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2": {
+          "url": "https://example.com/repo/packages/anaconda-install-img-deps"
+        },
+        "sha256:52999df2efd2afc3fcda19e416efb2d0f9b09562aa53331eaac2cde3c88ea207": {
+          "url": "https://example.com/repo/packages/madan-fonts"
+        },
+        "sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781": {
+          "url": "https://example.com/repo/packages/xorriso"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:570e342d0e4708dab94b2025f6b928845b659b405872d824b45473c4635d7b1d": {
+          "url": "https://example.com/repo/packages/wget"
+        },
+        "sha256:581265de790cf918fc770318449fe4cd07a18771c975d42867760b2e2f1bd18d": {
+          "url": "https://example.com/repo/packages/fcoe-utils"
+        },
+        "sha256:5b8b6480d96480b779d6937e2d8694e03cdae14eb0664033ef24af50e1557726": {
+          "url": "https://example.com/repo/packages/default-fonts-core-sans"
+        },
+        "sha256:5bc35fd09bee19e0dc22c7f7a731d1d8f4f68b81a3fd866e32273523eda30f9e": {
+          "url": "https://example.com/repo/packages/perl-interpreter"
+        },
+        "sha256:5e4e6002bd0ef9491967c1f5f573b0c184ef5a41d165cff38c8c6c73606702cb": {
+          "url": "https://example.com/repo/packages/gsettings-desktop-schemas"
+        },
+        "sha256:5e5d7e05a668f4ec5939a246b38d17cbb6ee83c0408ecbf584f6561a9d64a383": {
+          "url": "https://example.com/repo/packages/dejavu-sans-mono-fonts"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:61bfeb2957d080cbab70b332f16b482e1991b08e77ea7a8546b68b3cde90990c": {
+          "url": "https://example.com/repo/packages/smartmontools"
+        },
+        "sha256:629e355a0345015e53cacd90ce641c7e2ef38405cd55e135f331a6303c51f509": {
+          "url": "https://example.com/repo/packages/@hardware-support"
+        },
+        "sha256:674177213da94e10f7c2eb25574d59f64ab942abe4746b1eedf24bfd4dc17a76": {
+          "url": "https://example.com/repo/packages/microcode_ctl"
+        },
+        "sha256:68d6e3ed85174ed856b83d5d1e16c23d5279cb5dc77915ae8570a768a5a65505": {
+          "url": "https://example.com/repo/packages/nss-softokn"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682": {
+          "url": "https://example.com/repo/packages/hostname"
+        },
+        "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393": {
+          "url": "https://example.com/repo/packages/grub2-tools-minimal"
+        },
+        "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8": {
+          "url": "https://example.com/repo/packages/syslinux-nonlinux"
+        },
+        "sha256:75c008414c1be65c0e6954f74e1afdf3f706369f26899ea792b4ac0f31f287bc": {
+          "url": "https://example.com/repo/packages/default-fonts-other-sans"
+        },
+        "sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18": {
+          "url": "https://example.com/repo/packages/strace"
+        },
+        "sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980": {
+          "url": "https://example.com/repo/packages/hexedit"
+        },
+        "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764": {
+          "url": "https://example.com/repo/packages/grub2-tools-extra"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5": {
+          "url": "https://example.com/repo/packages/firewalld"
+        },
+        "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a": {
+          "url": "https://example.com/repo/packages/openssh-server"
+        },
+        "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467": {
+          "url": "https://example.com/repo/packages/iwl6050-firmware"
+        },
+        "sha256:826c7f30d36dcc8cb4628bee44fc0e257a360eb06cfc31c49148a44b153e78ce": {
+          "url": "https://example.com/repo/packages/device-mapper-persistent-data"
+        },
+        "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0": {
+          "url": "https://example.com/repo/packages/ostree"
+        },
+        "sha256:85830c0611a0acd7053f7b3a29f52a0511acc3695f9c5ef39a29fcfb8b80e25b": {
+          "url": "https://example.com/repo/packages/udisks2-iscsi"
+        },
+        "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071": {
+          "url": "https://example.com/repo/packages/iwl5150-firmware"
+        },
+        "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714": {
+          "url": "https://example.com/repo/packages/iwl135-firmware"
+        },
+        "sha256:883642e660d2ef545d3d9f0cbd12790a99aea6358fb67c46664ff22fefa8b7df": {
+          "url": "https://example.com/repo/packages/pigz"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111": {
+          "url": "https://example.com/repo/packages/iwl6000g2a-firmware"
+        },
+        "sha256:8e901f9b6ca3996fe198c84d5f0a305b635bbaae54757fa84932ac52479c1efa": {
+          "url": "https://example.com/repo/packages/ipmitool"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:903be5b3913df555a8586e571d9016e1ac24eef2631a5d75b8c3f94c66f10955": {
+          "url": "https://example.com/repo/packages/anaconda-widgets"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-rt"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9531c8584bbf61635c5c9b15733d9494cb6dd232a6eec85a946076c6c633e99f": {
+          "url": "https://example.com/repo/packages/grubby"
+        },
+        "sha256:95671115820a1fb4e74d1abed36bf069ce64a8233a3a37a8909cc62dffc57293": {
+          "url": "https://example.com/repo/packages/rdma-core"
+        },
+        "sha256:990fde98d70a0a1a75bf55978f90138e8878a7f5cc1de475e03ee25b6744ee8a": {
+          "url": "https://example.com/repo/packages/python3-pyatspi"
+        },
+        "sha256:9ac51bbcd5be0f507237b2d43367ad073eaf99398a65d26fa2a8fee5275f889b": {
+          "url": "https://example.com/repo/packages/glibc-all-langpacks"
+        },
+        "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd": {
+          "url": "https://example.com/repo/packages/prefixdevname"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a39d3ae3da34f2b4c01193e62202d5de0db79f800a039624b0f950734782b863": {
+          "url": "https://example.com/repo/packages/mtr"
+        },
+        "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53": {
+          "url": "https://example.com/repo/packages/plymouth"
+        },
+        "sha256:a788847c8c115aa9ae27ca92230418e77b3b36a6424f1d4f3436633864c93db9": {
+          "url": "https://example.com/repo/packages/squashfs-tools"
+        },
+        "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018": {
+          "url": "https://example.com/repo/packages/iwl3160-firmware"
+        },
+        "sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d": {
+          "url": "https://example.com/repo/packages/usbutils"
+        },
+        "sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a": {
+          "url": "https://example.com/repo/packages/udisks2"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14": {
+          "url": "https://example.com/repo/packages/sg3_utils"
+        },
+        "sha256:afed7d2fb0ea7b7e9d8dbcf1c1bb62ff53840c72d380cf165294a1eccb7fdeb1": {
+          "url": "https://example.com/repo/packages/rsyslog"
+        },
+        "sha256:b498cfb546ddbfbd5953e28137e5b39a65ba6c7220bf4fe4c3cc9bcafc73c41b": {
+          "url": "https://example.com/repo/packages/libblockdev-lvm-dbus"
+        },
+        "sha256:b7110cc6e76089686855ae923d8e0212a0f067b8a48f3c96e8510d50c56061a7": {
+          "url": "https://example.com/repo/packages/mdadm"
+        },
+        "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be": {
+          "url": "https://example.com/repo/packages/rpcbind"
+        },
+        "sha256:b81f37a043a6f767e7c94d105f4bd31282f3ecc20680bb9d09bd93461cf4c863": {
+          "url": "https://example.com/repo/packages/audit"
+        },
+        "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf": {
+          "url": "https://example.com/repo/packages/vim-minimal"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8": {
+          "url": "https://example.com/repo/packages/iwl2000-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0": {
+          "url": "https://example.com/repo/packages/iwl5000-firmware"
+        },
+        "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2": {
+          "url": "https://example.com/repo/packages/grub2-pc-modules"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c": {
+          "url": "https://example.com/repo/packages/ethtool"
+        },
+        "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0": {
+          "url": "https://example.com/repo/packages/iwl1000-firmware"
+        },
+        "sha256:cb298bd94fae6f2f713a1108a16e0632f3a1e21820a288d7ea86c8b00a4d4fef": {
+          "url": "https://example.com/repo/packages/lsof"
+        },
+        "sha256:cb6b44243b93acef33a5ee905d92203a2a55abdc6a3b7c446c8435a41a6ad137": {
+          "url": "https://example.com/repo/packages/sil-padauk-fonts"
+        },
+        "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31": {
+          "url": "https://example.com/repo/packages/gdb-gdbserver"
+        },
+        "sha256:cd2c0f63ad37d585e77b3f1c584539e26bf7928710ac8fb19fd377f61b7326e6": {
+          "url": "https://example.com/repo/packages/anaconda"
+        },
+        "sha256:ce2b8ecf9afac9f546bdbbb0902afb6088fdcb8524269ad5b4adb9b9d4959b07": {
+          "url": "https://example.com/repo/packages/xfsdump"
+        },
+        "sha256:ce5b1962783aa6a9374a0a1b34941a112a799baac827c733bd28c78dbb4bcf36": {
+          "url": "https://example.com/repo/packages/kdump-anaconda-addon"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c": {
+          "url": "https://example.com/repo/packages/cryptsetup"
+        },
+        "sha256:cf732696c9aebd80fad833157535754f246445ad0fec66e918963443bd3cfb71": {
+          "url": "https://example.com/repo/packages/linux-firmware"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9": {
+          "url": "https://example.com/repo/packages/iwl6000g2b-firmware"
+        },
+        "sha256:d87d9e526f265be973fce2ba320c5ed3ae24f6c5560d816d0b9307d0ba4d357f": {
+          "url": "https://example.com/repo/packages/lorax-templates-rhel"
+        },
+        "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd": {
+          "url": "https://example.com/repo/packages/lorax-templates-generic"
+        },
+        "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9": {
+          "url": "https://example.com/repo/packages/openssh-clients"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d": {
+          "url": "https://example.com/repo/packages/rpm-ostree"
+        },
+        "sha256:eddfc611c4f74bed09b2ac20b714b54f2e47d9befc7cc8af98b4c679807ba573": {
+          "url": "https://example.com/repo/packages/memtest86+"
+        },
+        "sha256:eeb3d09845f5cde069eeade2c4339532be58b6607120be00656123cc73ea727c": {
+          "url": "https://example.com/repo/packages/kbd-misc"
+        },
+        "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078": {
+          "url": "https://example.com/repo/packages/biosdevname"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f5f43514d2de810e4ea6d047203505e2e3c0c25f43941ec226968d17bb3aa1b5": {
+          "url": "https://example.com/repo/packages/gnome-kiosk"
+        },
+        "sha256:f6453ebfd8ab070567bfcd4cda99cc41c2c849237745f24228c5f040cac5d562": {
+          "url": "https://example.com/repo/packages/libibverbs"
+        },
+        "sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c": {
+          "url": "https://example.com/repo/packages/isomd5sum"
+        },
+        "sha256:f7f7a2e0133dfc81f9505bac28dfb7ee3398f3dc3b32c7682c86a9be5403bfee": {
+          "url": "https://example.com/repo/packages/librsvg2"
+        },
+        "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23": {
+          "url": "https://example.com/repo/packages/dracut-network"
+        },
+        "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7": {
+          "url": "https://example.com/repo/packages/iwl7260-firmware"
+        },
+        "sha256:fe36b1d498f9c6057ed774ba5fb0a84c8592886c3a4c7c077ce7f41326373099": {
+          "url": "https://example.com/repo/packages/lldpad"
+        },
+        "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a": {
+          "url": "https://example.com/repo/packages/syslinux"
+        },
+        "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-baseos"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-x86_64-image_installer-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-image_installer-empty.json
@@ -31,9 +31,6 @@
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
                   "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
                 },
                 {
@@ -62,12 +59,6 @@
                 },
                 {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
@@ -149,9 +140,6 @@
                   "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
                 },
                 {
-                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
-                },
-                {
                   "id": "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2"
                 },
                 {
@@ -167,19 +155,10 @@
                   "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
                 },
                 {
-                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
-                },
-                {
-                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
-                },
-                {
                   "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
                 },
                 {
                   "id": "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c"
-                },
-                {
-                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
                 },
                 {
                   "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
@@ -206,28 +185,13 @@
                   "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
                 },
                 {
-                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
-                },
-                {
                   "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
                   "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
-                },
-                {
-                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
                 },
                 {
                   "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
@@ -257,31 +221,13 @@
                   "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
                 },
                 {
-                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
-                },
-                {
-                  "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
-                },
-                {
                   "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
                   "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
-                },
-                {
-                  "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
-                },
-                {
-                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
-                },
-                {
-                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
                 },
                 {
                   "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
@@ -291,18 +237,6 @@
                 },
                 {
                   "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
-                },
-                {
-                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
                 },
                 {
                   "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
@@ -323,9 +257,6 @@
                   "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
                 },
                 {
-                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
-                },
-                {
                   "id": "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1"
                 },
                 {
@@ -335,16 +266,7 @@
                   "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
                 },
                 {
-                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
-                },
-                {
                   "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
-                },
-                {
-                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
-                },
-                {
-                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
                 },
                 {
                   "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
@@ -353,16 +275,7 @@
                   "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
                 },
                 {
-                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
-                },
-                {
                   "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
-                },
-                {
-                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
-                },
-                {
-                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
                 },
                 {
                   "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
@@ -371,16 +284,7 @@
                   "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
                 },
                 {
-                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
-                },
-                {
                   "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
                 },
                 {
                   "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
@@ -393,12 +297,6 @@
                 },
                 {
                   "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
-                },
-                {
-                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
-                },
-                {
-                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
                 },
                 {
                   "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
@@ -417,12 +315,6 @@
                 },
                 {
                   "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
-                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
-                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
                 },
                 {
                   "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
@@ -467,9 +359,6 @@
                   "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
                 },
                 {
-                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
-                },
-                {
                   "id": "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686"
                 },
                 {
@@ -485,13 +374,7 @@
                   "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
                 },
                 {
-                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
-                },
-                {
                   "id": "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a"
-                },
-                {
-                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
                 },
                 {
                   "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
@@ -509,12 +392,6 @@
                   "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
                 },
                 {
-                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
-                },
-                {
-                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
-                },
-                {
                   "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
                 },
                 {
@@ -528,12 +405,6 @@
                 },
                 {
                   "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
                 },
                 {
                   "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
@@ -551,13 +422,7 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14"
-                },
-                {
-                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
                 },
                 {
                   "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
@@ -578,22 +443,10 @@
                   "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
                 },
                 {
-                  "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
-                },
-                {
-                  "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
-                },
-                {
                   "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
@@ -621,12 +474,6 @@
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
                 },
                 {
                   "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
@@ -836,12 +683,6 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
@@ -863,16 +704,7 @@
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
                   "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
-                },
-                {
-                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
-                },
-                {
-                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
                 },
                 {
                   "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
@@ -881,16 +713,7 @@
                   "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
                 },
                 {
-                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
-                },
-                {
                   "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
-                },
-                {
-                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
-                },
-                {
-                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
                 },
                 {
                   "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
@@ -899,22 +722,10 @@
                   "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
                 },
                 {
-                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
-                },
-                {
-                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
-                },
-                {
                   "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
                 },
                 {
                   "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
                 },
                 {
                   "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
@@ -924,9 +735,6 @@
                 },
                 {
                   "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
-                },
-                {
-                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
                 },
                 {
                   "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
@@ -947,9 +755,6 @@
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
-                },
-                {
                   "id": "sha256:674177213da94e10f7c2eb25574d59f64ab942abe4746b1eedf24bfd4dc17a76"
                 },
                 {
@@ -963,9 +768,6 @@
                 },
                 {
                   "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -998,16 +800,10 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"

--- a/test/data/manifestdb-light/centos_10-x86_64-image_installer-unattended_iso.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-image_installer-unattended_iso.json
@@ -31,9 +31,6 @@
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
                   "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
                 },
                 {
@@ -62,12 +59,6 @@
                 },
                 {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
@@ -149,9 +140,6 @@
                   "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
                 },
                 {
-                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
-                },
-                {
                   "id": "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2"
                 },
                 {
@@ -167,19 +155,10 @@
                   "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
                 },
                 {
-                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
-                },
-                {
-                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
-                },
-                {
                   "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
                 },
                 {
                   "id": "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c"
-                },
-                {
-                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
                 },
                 {
                   "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
@@ -206,28 +185,13 @@
                   "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
                 },
                 {
-                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
-                },
-                {
                   "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
                   "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
-                },
-                {
-                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
                 },
                 {
                   "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
@@ -257,31 +221,13 @@
                   "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
                 },
                 {
-                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
-                },
-                {
-                  "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
-                },
-                {
                   "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
                   "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
-                },
-                {
-                  "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
-                },
-                {
-                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
-                },
-                {
-                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
                 },
                 {
                   "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
@@ -291,18 +237,6 @@
                 },
                 {
                   "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
-                },
-                {
-                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
                 },
                 {
                   "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
@@ -323,9 +257,6 @@
                   "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
                 },
                 {
-                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
-                },
-                {
                   "id": "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1"
                 },
                 {
@@ -335,16 +266,7 @@
                   "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
                 },
                 {
-                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
-                },
-                {
                   "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
-                },
-                {
-                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
-                },
-                {
-                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
                 },
                 {
                   "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
@@ -353,16 +275,7 @@
                   "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
                 },
                 {
-                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
-                },
-                {
                   "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
-                },
-                {
-                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
-                },
-                {
-                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
                 },
                 {
                   "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
@@ -371,16 +284,7 @@
                   "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
                 },
                 {
-                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
-                },
-                {
                   "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
                 },
                 {
                   "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
@@ -393,12 +297,6 @@
                 },
                 {
                   "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
-                },
-                {
-                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
-                },
-                {
-                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
                 },
                 {
                   "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
@@ -417,12 +315,6 @@
                 },
                 {
                   "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
-                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
-                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
                 },
                 {
                   "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
@@ -467,9 +359,6 @@
                   "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
                 },
                 {
-                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
-                },
-                {
                   "id": "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686"
                 },
                 {
@@ -485,13 +374,7 @@
                   "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
                 },
                 {
-                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
-                },
-                {
                   "id": "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a"
-                },
-                {
-                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
                 },
                 {
                   "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
@@ -509,12 +392,6 @@
                   "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
                 },
                 {
-                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
-                },
-                {
-                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
-                },
-                {
                   "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
                 },
                 {
@@ -528,12 +405,6 @@
                 },
                 {
                   "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
                 },
                 {
                   "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
@@ -551,13 +422,7 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14"
-                },
-                {
-                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
                 },
                 {
                   "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
@@ -578,22 +443,10 @@
                   "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
                 },
                 {
-                  "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
-                },
-                {
-                  "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
-                },
-                {
                   "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
@@ -621,12 +474,6 @@
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
                 },
                 {
                   "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
@@ -838,12 +685,6 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
@@ -865,16 +706,7 @@
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
                   "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
-                },
-                {
-                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
-                },
-                {
-                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
                 },
                 {
                   "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
@@ -883,16 +715,7 @@
                   "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
                 },
                 {
-                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
-                },
-                {
                   "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
-                },
-                {
-                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
-                },
-                {
-                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
                 },
                 {
                   "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
@@ -901,22 +724,10 @@
                   "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
                 },
                 {
-                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
-                },
-                {
-                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
-                },
-                {
                   "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
                 },
                 {
                   "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
                 },
                 {
                   "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
@@ -926,9 +737,6 @@
                 },
                 {
                   "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
-                },
-                {
-                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
                 },
                 {
                   "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
@@ -949,9 +757,6 @@
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
-                },
-                {
                   "id": "sha256:674177213da94e10f7c2eb25574d59f64ab942abe4746b1eedf24bfd4dc17a76"
                 },
                 {
@@ -965,9 +770,6 @@
                 },
                 {
                   "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -1000,16 +802,10 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"

--- a/test/data/manifestdb-light/centos_10-x86_64-image_installer-unattended_iso.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-image_installer-unattended_iso.json
@@ -1,0 +1,1858 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c"
+                },
+                {
+                  "id": "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:a788847c8c115aa9ae27ca92230418e77b3b36a6424f1d4f3436633864c93db9"
+                },
+                {
+                  "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
+                },
+                {
+                  "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "anaconda-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:629e355a0345015e53cacd90ce641c7e2ef38405cd55e135f331a6303c51f509"
+                },
+                {
+                  "id": "sha256:1f2ce4e8c1aea4a2440b7e794e0440385f8e9c3f48b0fd65118f3dcdbca783bf"
+                },
+                {
+                  "id": "sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f"
+                },
+                {
+                  "id": "sha256:cd2c0f63ad37d585e77b3f1c584539e26bf7928710ac8fb19fd377f61b7326e6"
+                },
+                {
+                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
+                },
+                {
+                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
+                },
+                {
+                  "id": "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2"
+                },
+                {
+                  "id": "sha256:903be5b3913df555a8586e571d9016e1ac24eef2631a5d75b8c3f94c66f10955"
+                },
+                {
+                  "id": "sha256:b81f37a043a6f767e7c94d105f4bd31282f3ecc20680bb9d09bd93461cf4c863"
+                },
+                {
+                  "id": "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9"
+                },
+                {
+                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
+                },
+                {
+                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
+                },
+                {
+                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
+                },
+                {
+                  "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
+                },
+                {
+                  "id": "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c"
+                },
+                {
+                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
+                },
+                {
+                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
+                },
+                {
+                  "id": "sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112"
+                },
+                {
+                  "id": "sha256:5b8b6480d96480b779d6937e2d8694e03cdae14eb0664033ef24af50e1557726"
+                },
+                {
+                  "id": "sha256:75c008414c1be65c0e6954f74e1afdf3f706369f26899ea792b4ac0f31f287bc"
+                },
+                {
+                  "id": "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa"
+                },
+                {
+                  "id": "sha256:5e5d7e05a668f4ec5939a246b38d17cbb6ee83c0408ecbf584f6561a9d64a383"
+                },
+                {
+                  "id": "sha256:826c7f30d36dcc8cb4628bee44fc0e257a360eb06cfc31c49148a44b153e78ce"
+                },
+                {
+                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
+                },
+                {
+                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
+                },
+                {
+                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c"
+                },
+                {
+                  "id": "sha256:581265de790cf918fc770318449fe4cd07a18771c975d42867760b2e2f1bd18d"
+                },
+                {
+                  "id": "sha256:1f35e175b07fc080eb57fc9db22a3ce477d87bc5447466815f55864d3b6e6586"
+                },
+                {
+                  "id": "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31"
+                },
+                {
+                  "id": "sha256:9ac51bbcd5be0f507237b2d43367ad073eaf99398a65d26fa2a8fee5275f889b"
+                },
+                {
+                  "id": "sha256:f5f43514d2de810e4ea6d047203505e2e3c0c25f43941ec226968d17bb3aa1b5"
+                },
+                {
+                  "id": "sha256:24173b7985c9c52efc25b39e51f0fd41ac7b35e7031ed17da97788f293a3ce4e"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
+                },
+                {
+                  "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
+                },
+                {
+                  "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:0d3ffa508f3c7375c05551af609738a9d474b3eab32cb2d2194b41870b37f1a9"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:9531c8584bbf61635c5c9b15733d9494cb6dd232a6eec85a946076c6c633e99f"
+                },
+                {
+                  "id": "sha256:5e4e6002bd0ef9491967c1f5f573b0c184ef5a41d165cff38c8c6c73606702cb"
+                },
+                {
+                  "id": "sha256:263acae321870b428781a1f4cb5e88740a897a4f9b614233a1798d295f805c54"
+                },
+                {
+                  "id": "sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1"
+                },
+                {
+                  "id": "sha256:8e901f9b6ca3996fe198c84d5f0a305b635bbaae54757fa84932ac52479c1efa"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111"
+                },
+                {
+                  "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:4ad76aeffa1e790eaf720b659f9860c50b6e0ba4787fa0a2d0e43dfa46193035"
+                },
+                {
+                  "id": "sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe"
+                },
+                {
+                  "id": "sha256:eeb3d09845f5cde069eeade2c4339532be58b6607120be00656123cc73ea727c"
+                },
+                {
+                  "id": "sha256:ce5b1962783aa6a9374a0a1b34941a112a799baac827c733bd28c78dbb4bcf36"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
+                },
+                {
+                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
+                },
+                {
+                  "id": "sha256:b498cfb546ddbfbd5953e28137e5b39a65ba6c7220bf4fe4c3cc9bcafc73c41b"
+                },
+                {
+                  "id": "sha256:f6453ebfd8ab070567bfcd4cda99cc41c2c849237745f24228c5f040cac5d562"
+                },
+                {
+                  "id": "sha256:f7f7a2e0133dfc81f9505bac28dfb7ee3398f3dc3b32c7682c86a9be5403bfee"
+                },
+                {
+                  "id": "sha256:cf732696c9aebd80fad833157535754f246445ad0fec66e918963443bd3cfb71"
+                },
+                {
+                  "id": "sha256:fe36b1d498f9c6057ed774ba5fb0a84c8592886c3a4c7c077ce7f41326373099"
+                },
+                {
+                  "id": "sha256:cb298bd94fae6f2f713a1108a16e0632f3a1e21820a288d7ea86c8b00a4d4fef"
+                },
+                {
+                  "id": "sha256:52999df2efd2afc3fcda19e416efb2d0f9b09562aa53331eaac2cde3c88ea207"
+                },
+                {
+                  "id": "sha256:b7110cc6e76089686855ae923d8e0212a0f067b8a48f3c96e8510d50c56061a7"
+                },
+                {
+                  "id": "sha256:eddfc611c4f74bed09b2ac20b714b54f2e47d9befc7cc8af98b4c679807ba573"
+                },
+                {
+                  "id": "sha256:2442f8197039e6fb34538a4651f00be2bcbaa8d2be3a15b734fa6ddf1bd8abba"
+                },
+                {
+                  "id": "sha256:a39d3ae3da34f2b4c01193e62202d5de0db79f800a039624b0f950734782b863"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686"
+                },
+                {
+                  "id": "sha256:316d18e697dfa41e92a9fe91d8d175629db5e330348a8adc1a5b43744d01d217"
+                },
+                {
+                  "id": "sha256:68d6e3ed85174ed856b83d5d1e16c23d5279cb5dc77915ae8570a768a5a65505"
+                },
+                {
+                  "id": "sha256:4381157a0ab3568cb31f727709b2edfca21522a8645e95c411f5798b8018393d"
+                },
+                {
+                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
+                },
+                {
+                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
+                },
+                {
+                  "id": "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a"
+                },
+                {
+                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
+                },
+                {
+                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
+                },
+                {
+                  "id": "sha256:500d641b95d95deab52480573126901d76d81dfe9fe0a5caf43445df38caad7b"
+                },
+                {
+                  "id": "sha256:5bc35fd09bee19e0dc22c7f7a731d1d8f4f68b81a3fd866e32273523eda30f9e"
+                },
+                {
+                  "id": "sha256:883642e660d2ef545d3d9f0cbd12790a99aea6358fb67c46664ff22fefa8b7df"
+                },
+                {
+                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
+                },
+                {
+                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
+                },
+                {
+                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
+                },
+                {
+                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
+                },
+                {
+                  "id": "sha256:990fde98d70a0a1a75bf55978f90138e8878a7f5cc1de475e03ee25b6744ee8a"
+                },
+                {
+                  "id": "sha256:95671115820a1fb4e74d1abed36bf069ce64a8233a3a37a8909cc62dffc57293"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
+                },
+                {
+                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
+                },
+                {
+                  "id": "sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:afed7d2fb0ea7b7e9d8dbcf1c1bb62ff53840c72d380cf165294a1eccb7fdeb1"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:cb6b44243b93acef33a5ee905d92203a2a55abdc6a3b7c446c8435a41a6ad137"
+                },
+                {
+                  "id": "sha256:61bfeb2957d080cbab70b332f16b482e1991b08e77ea7a8546b68b3cde90990c"
+                },
+                {
+                  "id": "sha256:28bdff3b22fe1fe1b18313472b2060d2706b9052cbabd91aaa7bed0c88c065de"
+                },
+                {
+                  "id": "sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18"
+                },
+                {
+                  "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
+                },
+                {
+                  "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
+                },
+                {
+                  "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
+                },
+                {
+                  "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a"
+                },
+                {
+                  "id": "sha256:85830c0611a0acd7053f7b3a29f52a0511acc3695f9c5ef39a29fcfb8b80e25b"
+                },
+                {
+                  "id": "sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d"
+                },
+                {
+                  "id": "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf"
+                },
+                {
+                  "id": "sha256:0a26024d87ac934c3aeca0ec8b27e579dfb6b268ac43f3a6f945579a54c46e6e"
+                },
+                {
+                  "id": "sha256:570e342d0e4708dab94b2025f6b928845b659b405872d824b45473c4635d7b1d"
+                },
+                {
+                  "id": "sha256:ce2b8ecf9afac9f546bdbbb0902afb6088fdcb8524269ad5b4adb9b9d4959b07"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.buildstamp",
+          "options": {
+            "arch": "x86_64",
+            "product": "CentOS Stream",
+            "version": "10-stream",
+            "final": true,
+            "variant": "",
+            "bugurl": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "en_GB.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+              "install": {
+                "uid": 0,
+                "gid": 0,
+                "home": "/root",
+                "shell": "/usr/libexec/anaconda/run-anaconda",
+                "password": ""
+              },
+              "root": {
+                "password": ""
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.anaconda",
+          "options": {
+            "activatable-modules": [
+              "org.fedoraproject.Anaconda.Modules.Localization",
+              "org.fedoraproject.Anaconda.Modules.Network",
+              "org.fedoraproject.Anaconda.Modules.Payloads",
+              "org.fedoraproject.Anaconda.Modules.Services",
+              "org.fedoraproject.Anaconda.Modules.Storage",
+              "org.fedoraproject.Anaconda.Modules.Users"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.lorax-script",
+          "options": {
+            "path": "99-generic/runtime-postinstall.tmpl",
+            "basearch": "x86_64",
+            "product": {
+              "name": "",
+              "version": ""
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.dracut",
+          "options": {
+            "kernel": [
+              "8-2.fk1.x86_64"
+            ],
+            "modules": [
+              "bash",
+              "systemd",
+              "fips",
+              "systemd-initrd",
+              "modsign",
+              "nss-softokn",
+              "i18n",
+              "convertfs",
+              "network-manager",
+              "network",
+              "url-lib",
+              "drm",
+              "plymouth",
+              "crypt",
+              "dm",
+              "dmsquash-live",
+              "kernel-modules",
+              "kernel-modules-extra",
+              "kernel-network-modules",
+              "livenet",
+              "lvm",
+              "mdraid",
+              "qemu",
+              "qemu-net",
+              "resume",
+              "rootfs-block",
+              "terminfo",
+              "udev-rules",
+              "dracut-systemd",
+              "pollcdrom",
+              "usrmount",
+              "base",
+              "fs-lib",
+              "img-lib",
+              "shutdown",
+              "uefi-lib",
+              "biosdevname",
+              "nvdimm",
+              "prefixdevname",
+              "prefixdevname-tools",
+              "net-lib",
+              "anaconda",
+              "rdma",
+              "rngd",
+              "multipath",
+              "fcoe",
+              "fcoe-uefi",
+              "iscsi",
+              "lunmask",
+              "nfs"
+            ],
+            "add_drivers": [
+              "ipmi_devintf",
+              "ipmi_msghandler"
+            ],
+            "install": [
+              "/.buildstamp"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux.config",
+          "options": {
+            "state": "permissive"
+          }
+        }
+      ]
+    },
+    {
+      "name": "efiboot-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.grub2.iso",
+          "options": {
+            "product": {
+              "name": "CentOS Stream",
+              "version": "10-stream"
+            },
+            "kernel": {
+              "dir": "/images/pxeboot",
+              "opts": [
+                "inst.stage2=hd:LABEL=CentOS-Stream-10-BaseOS-x86_64",
+                "inst.ks=hd:LABEL=CentOS-Stream-10-BaseOS-x86_64:/osbuild.ks"
+              ]
+            },
+            "isolabel": "CentOS-Stream-10-BaseOS-x86_64",
+            "architectures": [
+              "X64"
+            ],
+            "vendor": "centos"
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111"
+                },
+                {
+                  "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd"
+                },
+                {
+                  "id": "sha256:d87d9e526f265be973fce2ba320c5ed3ae24f6c5560d816d0b9307d0ba4d357f"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:674177213da94e10f7c2eb25574d59f64ab942abe4746b1eedf24bfd4dc17a76"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "en_GB.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "uk"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "Europe/Berlin"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bootiso-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/images"
+              },
+              {
+                "path": "/images/pxeboot"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://tree/boot/vmlinuz-8-2.fk1.x86_64",
+                "to": "tree:///images/pxeboot/vmlinuz"
+              },
+              {
+                "from": "input://tree/boot/initramfs-8-2.fk1.x86_64.img",
+                "to": "tree:///images/pxeboot/initrd.img"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.squashfs",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "filename": "images/install.img",
+            "compression": {
+              "method": "xz",
+              "options": {
+                "bcj": "x86"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.isolinux",
+          "inputs": {
+            "data": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "product": {
+              "name": "CentOS Stream",
+              "version": "10-stream"
+            },
+            "kernel": {
+              "dir": "/images/pxeboot",
+              "opts": [
+                "inst.stage2=hd:LABEL=CentOS-Stream-10-BaseOS-x86_64",
+                "inst.ks=hd:LABEL=CentOS-Stream-10-BaseOS-x86_64:/osbuild.ks"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "images/efiboot.img",
+            "size": "20971520"
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "cbbc4c9d"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "images/efiboot.img",
+                "size": 40960,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:efiboot-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "images/efiboot.img",
+                "size": 40960
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.fat",
+              "source": "-",
+              "target": "/"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:efiboot-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/EFI",
+                "to": "tree:///"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "/liveimg.tar.gz"
+          }
+        },
+        {
+          "type": "org.osbuild.kickstart",
+          "options": {
+            "path": "/osbuild-base.ks",
+            "liveimg": {
+              "url": "file:///run/install/repo/liveimg.tar.gz"
+            },
+            "users": {
+              "osbuild": {
+                "groups": [
+                  "wheel"
+                ],
+                "key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNebAh6SjpAn8wB53K4695cGnHGuCtl4RdaX3futZgJUultHyzeYHnzMO7d4++qnRL+Rworew62LKP560uvtncc= github.com/osbuild/images"
+              }
+            },
+            "lang": "en_GB.UTF-8",
+            "keyboard": "uk",
+            "timezone": "Europe/Berlin",
+            "display_mode": "text",
+            "reboot": {
+              "eject": true
+            },
+            "rootpw": {
+              "lock": true
+            },
+            "zerombr": true,
+            "clearpart": {
+              "all": true,
+              "initlabel": true
+            },
+            "autopart": {
+              "type": "plain",
+              "fstype": "xfs",
+              "nohome": true
+            },
+            "network": [
+              {
+                "activate": true,
+                "bootproto": "dhcp",
+                "device": "link",
+                "onboot": "on"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434/sha256:ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434",
+                "to": "tree:///osbuild.ks",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.discinfo",
+          "options": {
+            "basearch": "x86_64",
+            "release": "CentOS Stream 10-stream"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bootiso",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.xorrisofs",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:bootiso-tree"
+              ]
+            }
+          },
+          "options": {
+            "filename": "installer.iso",
+            "volid": "CentOS-Stream-10-BaseOS-x86_64",
+            "sysid": "LINUX",
+            "boot": {
+              "image": "isolinux/isolinux.bin",
+              "catalog": "isolinux/boot.cat"
+            },
+            "efi": "images/efiboot.img",
+            "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
+            "isolevel": 3
+          }
+        },
+        {
+          "type": "org.osbuild.implantisomd5",
+          "options": {
+            "filename": "installer.iso"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64-cdboot"
+        },
+        "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a": {
+          "url": "https://example.com/repo/packages/net-tools"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112": {
+          "url": "https://example.com/repo/packages/dbus-x11"
+        },
+        "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3": {
+          "url": "https://example.com/repo/packages/bzip2"
+        },
+        "sha256:0a26024d87ac934c3aeca0ec8b27e579dfb6b268ac43f3a6f945579a54c46e6e": {
+          "url": "https://example.com/repo/packages/volume_key"
+        },
+        "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1": {
+          "url": "https://example.com/repo/packages/initscripts"
+        },
+        "sha256:0d3ffa508f3c7375c05551af609738a9d474b3eab32cb2d2194b41870b37f1a9": {
+          "url": "https://example.com/repo/packages/grub2-tools-efi"
+        },
+        "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa": {
+          "url": "https://example.com/repo/packages/iwl105-firmware"
+        },
+        "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9": {
+          "url": "https://example.com/repo/packages/bind-utils"
+        },
+        "sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe": {
+          "url": "https://example.com/repo/packages/kbd"
+        },
+        "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa": {
+          "url": "https://example.com/repo/packages/anaconda-dracut"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:1f2ce4e8c1aea4a2440b7e794e0440385f8e9c3f48b0fd65118f3dcdbca783bf": {
+          "url": "https://example.com/repo/packages/alsa-firmware"
+        },
+        "sha256:1f35e175b07fc080eb57fc9db22a3ce477d87bc5447466815f55864d3b6e6586": {
+          "url": "https://example.com/repo/packages/ftp"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:24173b7985c9c52efc25b39e51f0fd41ac7b35e7031ed17da97788f293a3ce4e": {
+          "url": "https://example.com/repo/packages/google-noto-sans-cjk-ttc-fonts"
+        },
+        "sha256:2442f8197039e6fb34538a4651f00be2bcbaa8d2be3a15b734fa6ddf1bd8abba": {
+          "url": "https://example.com/repo/packages/mt-st"
+        },
+        "sha256:263acae321870b428781a1f4cb5e88740a897a4f9b614233a1798d295f805c54": {
+          "url": "https://example.com/repo/packages/hdparm"
+        },
+        "sha256:28bdff3b22fe1fe1b18313472b2060d2706b9052cbabd91aaa7bed0c88c065de": {
+          "url": "https://example.com/repo/packages/spice-vdagent"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686": {
+          "url": "https://example.com/repo/packages/nm-connection-editor"
+        },
+        "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa": {
+          "url": "https://example.com/repo/packages/dejavu-sans-fonts"
+        },
+        "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc": {
+          "url": "https://example.com/repo/packages/dmidecode"
+        },
+        "sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f": {
+          "url": "https://example.com/repo/packages/alsa-tools-firmware"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:316d18e697dfa41e92a9fe91d8d175629db5e330348a8adc1a5b43744d01d217": {
+          "url": "https://example.com/repo/packages/nmap-ncat"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-appstream"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1": {
+          "url": "https://example.com/repo/packages/dnf"
+        },
+        "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0": {
+          "url": "https://example.com/repo/packages/curl"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:4381157a0ab3568cb31f727709b2edfca21522a8645e95c411f5798b8018393d": {
+          "url": "https://example.com/repo/packages/nss-tools"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce": {
+          "url": "https://example.com/repo/packages/iwl100-firmware"
+        },
+        "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674": {
+          "url": "https://example.com/repo/packages/iwl2030-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4ad76aeffa1e790eaf720b659f9860c50b6e0ba4787fa0a2d0e43dfa46193035": {
+          "url": "https://example.com/repo/packages/jomolhari-fonts"
+        },
+        "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d": {
+          "url": "https://example.com/repo/packages/less"
+        },
+        "sha256:500d641b95d95deab52480573126901d76d81dfe9fe0a5caf43445df38caad7b": {
+          "url": "https://example.com/repo/packages/pciutils"
+        },
+        "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2": {
+          "url": "https://example.com/repo/packages/anaconda-install-img-deps"
+        },
+        "sha256:52999df2efd2afc3fcda19e416efb2d0f9b09562aa53331eaac2cde3c88ea207": {
+          "url": "https://example.com/repo/packages/madan-fonts"
+        },
+        "sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781": {
+          "url": "https://example.com/repo/packages/xorriso"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:570e342d0e4708dab94b2025f6b928845b659b405872d824b45473c4635d7b1d": {
+          "url": "https://example.com/repo/packages/wget"
+        },
+        "sha256:581265de790cf918fc770318449fe4cd07a18771c975d42867760b2e2f1bd18d": {
+          "url": "https://example.com/repo/packages/fcoe-utils"
+        },
+        "sha256:5b8b6480d96480b779d6937e2d8694e03cdae14eb0664033ef24af50e1557726": {
+          "url": "https://example.com/repo/packages/default-fonts-core-sans"
+        },
+        "sha256:5bc35fd09bee19e0dc22c7f7a731d1d8f4f68b81a3fd866e32273523eda30f9e": {
+          "url": "https://example.com/repo/packages/perl-interpreter"
+        },
+        "sha256:5e4e6002bd0ef9491967c1f5f573b0c184ef5a41d165cff38c8c6c73606702cb": {
+          "url": "https://example.com/repo/packages/gsettings-desktop-schemas"
+        },
+        "sha256:5e5d7e05a668f4ec5939a246b38d17cbb6ee83c0408ecbf584f6561a9d64a383": {
+          "url": "https://example.com/repo/packages/dejavu-sans-mono-fonts"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:61bfeb2957d080cbab70b332f16b482e1991b08e77ea7a8546b68b3cde90990c": {
+          "url": "https://example.com/repo/packages/smartmontools"
+        },
+        "sha256:629e355a0345015e53cacd90ce641c7e2ef38405cd55e135f331a6303c51f509": {
+          "url": "https://example.com/repo/packages/@hardware-support"
+        },
+        "sha256:674177213da94e10f7c2eb25574d59f64ab942abe4746b1eedf24bfd4dc17a76": {
+          "url": "https://example.com/repo/packages/microcode_ctl"
+        },
+        "sha256:68d6e3ed85174ed856b83d5d1e16c23d5279cb5dc77915ae8570a768a5a65505": {
+          "url": "https://example.com/repo/packages/nss-softokn"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682": {
+          "url": "https://example.com/repo/packages/hostname"
+        },
+        "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393": {
+          "url": "https://example.com/repo/packages/grub2-tools-minimal"
+        },
+        "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8": {
+          "url": "https://example.com/repo/packages/syslinux-nonlinux"
+        },
+        "sha256:75c008414c1be65c0e6954f74e1afdf3f706369f26899ea792b4ac0f31f287bc": {
+          "url": "https://example.com/repo/packages/default-fonts-other-sans"
+        },
+        "sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18": {
+          "url": "https://example.com/repo/packages/strace"
+        },
+        "sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980": {
+          "url": "https://example.com/repo/packages/hexedit"
+        },
+        "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764": {
+          "url": "https://example.com/repo/packages/grub2-tools-extra"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5": {
+          "url": "https://example.com/repo/packages/firewalld"
+        },
+        "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a": {
+          "url": "https://example.com/repo/packages/openssh-server"
+        },
+        "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467": {
+          "url": "https://example.com/repo/packages/iwl6050-firmware"
+        },
+        "sha256:826c7f30d36dcc8cb4628bee44fc0e257a360eb06cfc31c49148a44b153e78ce": {
+          "url": "https://example.com/repo/packages/device-mapper-persistent-data"
+        },
+        "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0": {
+          "url": "https://example.com/repo/packages/ostree"
+        },
+        "sha256:85830c0611a0acd7053f7b3a29f52a0511acc3695f9c5ef39a29fcfb8b80e25b": {
+          "url": "https://example.com/repo/packages/udisks2-iscsi"
+        },
+        "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071": {
+          "url": "https://example.com/repo/packages/iwl5150-firmware"
+        },
+        "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714": {
+          "url": "https://example.com/repo/packages/iwl135-firmware"
+        },
+        "sha256:883642e660d2ef545d3d9f0cbd12790a99aea6358fb67c46664ff22fefa8b7df": {
+          "url": "https://example.com/repo/packages/pigz"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111": {
+          "url": "https://example.com/repo/packages/iwl6000g2a-firmware"
+        },
+        "sha256:8e901f9b6ca3996fe198c84d5f0a305b635bbaae54757fa84932ac52479c1efa": {
+          "url": "https://example.com/repo/packages/ipmitool"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:903be5b3913df555a8586e571d9016e1ac24eef2631a5d75b8c3f94c66f10955": {
+          "url": "https://example.com/repo/packages/anaconda-widgets"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-rt"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9531c8584bbf61635c5c9b15733d9494cb6dd232a6eec85a946076c6c633e99f": {
+          "url": "https://example.com/repo/packages/grubby"
+        },
+        "sha256:95671115820a1fb4e74d1abed36bf069ce64a8233a3a37a8909cc62dffc57293": {
+          "url": "https://example.com/repo/packages/rdma-core"
+        },
+        "sha256:990fde98d70a0a1a75bf55978f90138e8878a7f5cc1de475e03ee25b6744ee8a": {
+          "url": "https://example.com/repo/packages/python3-pyatspi"
+        },
+        "sha256:9ac51bbcd5be0f507237b2d43367ad073eaf99398a65d26fa2a8fee5275f889b": {
+          "url": "https://example.com/repo/packages/glibc-all-langpacks"
+        },
+        "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd": {
+          "url": "https://example.com/repo/packages/prefixdevname"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a39d3ae3da34f2b4c01193e62202d5de0db79f800a039624b0f950734782b863": {
+          "url": "https://example.com/repo/packages/mtr"
+        },
+        "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53": {
+          "url": "https://example.com/repo/packages/plymouth"
+        },
+        "sha256:a788847c8c115aa9ae27ca92230418e77b3b36a6424f1d4f3436633864c93db9": {
+          "url": "https://example.com/repo/packages/squashfs-tools"
+        },
+        "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018": {
+          "url": "https://example.com/repo/packages/iwl3160-firmware"
+        },
+        "sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d": {
+          "url": "https://example.com/repo/packages/usbutils"
+        },
+        "sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a": {
+          "url": "https://example.com/repo/packages/udisks2"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14": {
+          "url": "https://example.com/repo/packages/sg3_utils"
+        },
+        "sha256:afed7d2fb0ea7b7e9d8dbcf1c1bb62ff53840c72d380cf165294a1eccb7fdeb1": {
+          "url": "https://example.com/repo/packages/rsyslog"
+        },
+        "sha256:b498cfb546ddbfbd5953e28137e5b39a65ba6c7220bf4fe4c3cc9bcafc73c41b": {
+          "url": "https://example.com/repo/packages/libblockdev-lvm-dbus"
+        },
+        "sha256:b7110cc6e76089686855ae923d8e0212a0f067b8a48f3c96e8510d50c56061a7": {
+          "url": "https://example.com/repo/packages/mdadm"
+        },
+        "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be": {
+          "url": "https://example.com/repo/packages/rpcbind"
+        },
+        "sha256:b81f37a043a6f767e7c94d105f4bd31282f3ecc20680bb9d09bd93461cf4c863": {
+          "url": "https://example.com/repo/packages/audit"
+        },
+        "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf": {
+          "url": "https://example.com/repo/packages/vim-minimal"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8": {
+          "url": "https://example.com/repo/packages/iwl2000-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0": {
+          "url": "https://example.com/repo/packages/iwl5000-firmware"
+        },
+        "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2": {
+          "url": "https://example.com/repo/packages/grub2-pc-modules"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c": {
+          "url": "https://example.com/repo/packages/ethtool"
+        },
+        "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0": {
+          "url": "https://example.com/repo/packages/iwl1000-firmware"
+        },
+        "sha256:cb298bd94fae6f2f713a1108a16e0632f3a1e21820a288d7ea86c8b00a4d4fef": {
+          "url": "https://example.com/repo/packages/lsof"
+        },
+        "sha256:cb6b44243b93acef33a5ee905d92203a2a55abdc6a3b7c446c8435a41a6ad137": {
+          "url": "https://example.com/repo/packages/sil-padauk-fonts"
+        },
+        "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31": {
+          "url": "https://example.com/repo/packages/gdb-gdbserver"
+        },
+        "sha256:cd2c0f63ad37d585e77b3f1c584539e26bf7928710ac8fb19fd377f61b7326e6": {
+          "url": "https://example.com/repo/packages/anaconda"
+        },
+        "sha256:ce2b8ecf9afac9f546bdbbb0902afb6088fdcb8524269ad5b4adb9b9d4959b07": {
+          "url": "https://example.com/repo/packages/xfsdump"
+        },
+        "sha256:ce5b1962783aa6a9374a0a1b34941a112a799baac827c733bd28c78dbb4bcf36": {
+          "url": "https://example.com/repo/packages/kdump-anaconda-addon"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c": {
+          "url": "https://example.com/repo/packages/cryptsetup"
+        },
+        "sha256:cf732696c9aebd80fad833157535754f246445ad0fec66e918963443bd3cfb71": {
+          "url": "https://example.com/repo/packages/linux-firmware"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9": {
+          "url": "https://example.com/repo/packages/iwl6000g2b-firmware"
+        },
+        "sha256:d87d9e526f265be973fce2ba320c5ed3ae24f6c5560d816d0b9307d0ba4d357f": {
+          "url": "https://example.com/repo/packages/lorax-templates-rhel"
+        },
+        "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd": {
+          "url": "https://example.com/repo/packages/lorax-templates-generic"
+        },
+        "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9": {
+          "url": "https://example.com/repo/packages/openssh-clients"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d": {
+          "url": "https://example.com/repo/packages/rpm-ostree"
+        },
+        "sha256:eddfc611c4f74bed09b2ac20b714b54f2e47d9befc7cc8af98b4c679807ba573": {
+          "url": "https://example.com/repo/packages/memtest86+"
+        },
+        "sha256:eeb3d09845f5cde069eeade2c4339532be58b6607120be00656123cc73ea727c": {
+          "url": "https://example.com/repo/packages/kbd-misc"
+        },
+        "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078": {
+          "url": "https://example.com/repo/packages/biosdevname"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f5f43514d2de810e4ea6d047203505e2e3c0c25f43941ec226968d17bb3aa1b5": {
+          "url": "https://example.com/repo/packages/gnome-kiosk"
+        },
+        "sha256:f6453ebfd8ab070567bfcd4cda99cc41c2c849237745f24228c5f040cac5d562": {
+          "url": "https://example.com/repo/packages/libibverbs"
+        },
+        "sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c": {
+          "url": "https://example.com/repo/packages/isomd5sum"
+        },
+        "sha256:f7f7a2e0133dfc81f9505bac28dfb7ee3398f3dc3b32c7682c86a9be5403bfee": {
+          "url": "https://example.com/repo/packages/librsvg2"
+        },
+        "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23": {
+          "url": "https://example.com/repo/packages/dracut-network"
+        },
+        "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7": {
+          "url": "https://example.com/repo/packages/iwl7260-firmware"
+        },
+        "sha256:fe36b1d498f9c6057ed774ba5fb0a84c8592886c3a4c7c077ce7f41326373099": {
+          "url": "https://example.com/repo/packages/lldpad"
+        },
+        "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a": {
+          "url": "https://example.com/repo/packages/syslinux"
+        },
+        "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-baseos"
+        }
+      }
+    },
+    "org.osbuild.inline": {
+      "items": {
+        "sha256:ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434": {
+          "encoding": "base64",
+          "data": "JWluY2x1ZGUgL3J1bi9pbnN0YWxsL3JlcG8vb3NidWlsZC1iYXNlLmtzCgolcG9zdAplY2hvIC1lICIlc3Vkb1x0QUxMPShBTEwpXHROT1BBU1NXRDogQUxMIiA+ICIvZXRjL3N1ZG9lcnMuZC8lc3VkbyIKY2htb2QgMDQ0MCAvZXRjL3N1ZG9lcnMuZC8lc3VkbwplY2hvIC1lICIld2hlZWxcdEFMTD0oQUxMKVx0Tk9QQVNTV0Q6IEFMTCIgPiAiL2V0Yy9zdWRvZXJzLmQvJXdoZWVsIgpjaG1vZCAwNDQwIC9ldGMvc3Vkb2Vycy5kLyV3aGVlbApyZXN0b3JlY29uIC1ydkYgL2V0Yy9zdWRvZXJzLmQKJWVuZAo="
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-x86_64-oci-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-oci-empty.json
@@ -1,0 +1,816 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "5d2622a9-83c4-4e9c-a692-decb4efc707f",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747"
+                },
+                {
+                  "id": "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280"
+                },
+                {
+                  "id": "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "5d2622a9-83c4-4e9c-a692-decb4efc707f",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "5d2622a9-83c4-4e9c-a692-decb4efc707f",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20557791,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "5d2622a9-83c4-4e9c-a692-decb4efc707f",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 20557791,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 20557791
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "qcow2",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.qcow2",
+            "format": {
+              "type": "qcow2",
+              "compat": "1.1"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98": {
+          "url": "https://example.com/repo/packages/exclude:fedora-repos"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b": {
+          "url": "https://example.com/repo/packages/exclude:udisks2"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-appstream"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747": {
+          "url": "https://example.com/repo/packages/exclude:fedora-release"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-en"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-rt"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-*"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-baseos"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-x86_64-oci-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-oci-empty.json
@@ -19,22 +19,13 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -49,22 +40,10 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -138,12 +117,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/centos_10-x86_64-ova-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-ova-empty.json
@@ -19,13 +19,7 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
@@ -37,28 +31,13 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
                 },
                 {
-                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
@@ -68,9 +47,6 @@
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -133,9 +109,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/centos_10-x86_64-ova-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-ova-empty.json
@@ -1,0 +1,612 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "a2d72001-423f-4ea2-9854-a3a4fc306314",
+            "kernel_opts": "ro"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:2ec46eb16ef55156c58b6348c9552f739a616fb6b4e22367486fe62442e3a9c4"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "a2d72001-423f-4ea2-9854-a3a4fc306314",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "a2d72001-423f-4ea2-9854-a3a4fc306314",
+            "kernel_opts": "ro",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "4294967296"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 7974879,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "a2d72001-423f-4ea2-9854-a3a4fc306314",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 7974879,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 7974879
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "vmdk",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "image.vmdk",
+            "format": {
+              "type": "vmdk",
+              "subformat": "streamOptimized"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "ovf",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "vmdk-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:vmdk"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://vmdk-tree/image.vmdk",
+                "to": "tree:///"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.ovf",
+          "options": {
+            "vmdk": "image.vmdk"
+          }
+        }
+      ]
+    },
+    {
+      "name": "archive",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:ovf"
+              ]
+            }
+          },
+          "options": {
+            "filename": "image.ova",
+            "format": "ustar",
+            "paths": [
+              "image.ovf",
+              "image.mf",
+              "image.vmdk"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2ec46eb16ef55156c58b6348c9552f739a616fb6b4e22367486fe62442e3a9c4": {
+          "url": "https://example.com/repo/packages/open-vm-tools"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-appstream"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5": {
+          "url": "https://example.com/repo/packages/firewalld"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-rt"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-baseos"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-x86_64-qcow2-all_with_fips.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-qcow2-all_with_fips.json
@@ -19,28 +19,16 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
-                },
-                {
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -55,22 +43,10 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -128,9 +104,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -147,12 +120,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
@@ -327,9 +294,6 @@
                 },
                 {
                   "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
-                },
-                {
-                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
                 },
                 {
                   "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"

--- a/test/data/manifestdb-light/centos_10-x86_64-qcow2-all_with_fips.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-qcow2-all_with_fips.json
@@ -1,0 +1,1717 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "d97a79d8-dcbe-4352-9e97-fe22a7fb539b",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check debug fips=1 boot=UUID=cca6f3b8-d6aa-4506-adf9-c70667b4c3e2"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3"
+                },
+                {
+                  "id": "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747"
+                },
+                {
+                  "id": "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280"
+                },
+                {
+                  "id": "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
+                },
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"
+                },
+                {
+                  "id": "sha256:52856879d4bfa1d564480850a56b0885e1c52a805af96fffe84122afc9b1c52b"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "el_CY.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "dvorak"
+          }
+        },
+        {
+          "type": "org.osbuild.hostname",
+          "options": {
+            "hostname": "my-host"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "Europe/London"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "time.example.com"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.groups",
+          "options": {
+            "groups": {
+              "group1": {
+                "gid": 1030
+              },
+              "group2": {
+                "gid": 1050
+              },
+              "user3": {
+                "gid": 1060
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+              "user1": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              },
+              "user2": {
+                "uid": 1020,
+                "gid": 1050,
+                "groups": [
+                  "group1"
+                ],
+                "description": "description 2",
+                "home": "/home/home2",
+                "shell": "/bin/sh",
+                "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              },
+              "user3": {
+                "uid": 1060,
+                "gid": 1060
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.yum.repos",
+          "options": {
+            "filename": "example.repo",
+            "repos": [
+              {
+                "id": "example",
+                "baseurl": [
+                  "https://example.com/download/yum"
+                ],
+                "enabled": true,
+                "gpgkey": [
+                  "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                ],
+                "name": "Example repo",
+                "gpgcheck": true,
+                "repo_gpgcheck": false
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dracut",
+          "options": {
+            "kernel": [
+              "8-2.fk1.x86_64"
+            ],
+            "add_modules": [
+              "fips"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "d97a79d8-dcbe-4352-9e97-fe22a7fb539b",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "cca6f3b8-d6aa-4506-adf9-c70667b4c3e2",
+                "vfs_type": "xfs",
+                "path": "/boot",
+                "options": "defaults"
+              },
+              {
+                "uuid": "6e76cde5-82f5-41b3-ba74-0f5d3f83ba33",
+                "vfs_type": "xfs",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "ca49279e-31ea-47d8-a639-aad9aa0702c6",
+                "vfs_type": "xfs",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "72e089ef-7330-4a8f-a75b-d143f9564e0f",
+                "vfs_type": "xfs",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "b7a8688b-afb5-4a18-a6cf-820f3c2c8439",
+                "vfs_type": "xfs",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "b7b734d2-06e3-46f2-8749-c759d329f152",
+                "vfs_type": "xfs",
+                "path": "/mnt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "2c161d02-7ceb-4dd5-a81a-7bc73665326b",
+                "vfs_type": "xfs",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "0cf92f83-27dc-4980-b637-df347cac2d33",
+                "vfs_type": "xfs",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "5b555334-2722-4c97-ba15-12f79cc9ee46",
+                "vfs_type": "xfs",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "6a778b9b-7156-44ef-9f21-5e7c7a001ccf",
+                "vfs_type": "xfs",
+                "path": "/usr",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "d97a79d8-dcbe-4352-9e97-fe22a7fb539b",
+            "boot_fs_uuid": "cca6f3b8-d6aa-4506-adf9-c70667b4c3e2",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check debug fips=1 boot=UUID=cca6f3b8-d6aa-4506-adf9-c70667b4c3e2",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/etc/systemd/system/custom.service.d",
+                "exist_ok": true
+              },
+              {
+                "path": "/etc/custom_dir"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/custom_dir": {
+                "mode": "0770"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/custom_dir": {
+                "user": 1020,
+                "group": 1050
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e"
+                }
+              ]
+            },
+            "file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2"
+                }
+              ]
+            },
+            "file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258"
+                }
+              ]
+            },
+            "file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                }
+              ]
+            },
+            "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e/sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e",
+                "to": "tree:///etc/systemd/system/custom.service",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2/sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2",
+                "to": "tree:///etc/systemd/system/custom.service.d/override.conf",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258/sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258",
+                "to": "tree:///etc/custom_file.txt",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "to": "tree:///etc/empty_file.txt",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/custom_file.txt": {
+                "mode": "0644"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/custom_file.txt": {
+                "user": "root",
+                "group": "root"
+              },
+              "/etc/empty_file.txt": {
+                "user": 0,
+                "group": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd.service",
+              "custom.service"
+            ],
+            "disabled_services": [
+              "bluetooth.service"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.update-crypto-policies",
+          "options": {
+            "policy": "FIPS"
+          }
+        },
+        {
+          "type": "org.osbuild.dracut.conf",
+          "options": {
+            "filename": "40-fips.conf",
+            "config": {
+              "add_dracutmodules": [
+                "fips"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-03fc1d407d48fd091625350f6482676dd08ef587d24761c8e38a3c99e5497af9": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:03fc1d407d48fd091625350f6482676dd08ef587d24761c8e38a3c99e5497af9"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-03fc1d407d48fd091625350f6482676dd08ef587d24761c8e38a3c99e5497af9/sha256:03fc1d407d48fd091625350f6482676dd08ef587d24761c8e38a3c99e5497af9",
+                "to": "tree:///etc/system-fips",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/system-fips": {
+                "mode": "0644"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/system-fips": {
+                "user": "root",
+                "group": "root"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "16860053504"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 31467487,
+                "start": 1462272,
+                "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              },
+              {
+                "size": 1048576,
+                "start": 413696,
+                "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                "uuid": "1ebb2d5b-8ac9-4e8a-b48c-35ca6ead5eab"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.lvm2.create",
+          "options": {
+            "volumes": [
+              {
+                "name": "rootlv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "homelv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "home_shadowmanlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "foolv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "usrlv",
+                "size": "4294967296B"
+              },
+              {
+                "name": "optlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "medialv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "rootlv00",
+                "size": "1073741824B"
+              },
+              {
+                "name": "srvlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "mntlv",
+                "size": "1073741824B"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "d97a79d8-dcbe-4352-9e97-fe22a7fb539b",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "ca49279e-31ea-47d8-a639-aad9aa0702c6"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "72e089ef-7330-4a8f-a75b-d143f9564e0f"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "home_shadowmanlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "6e76cde5-82f5-41b3-ba74-0f5d3f83ba33"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "6a778b9b-7156-44ef-9f21-5e7c7a001ccf"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "2c161d02-7ceb-4dd5-a81a-7bc73665326b"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "b7a8688b-afb5-4a18-a6cf-820f3c2c8439"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "0cf92f83-27dc-4980-b637-df347cac2d33"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv00"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "5b555334-2722-4c97-ba15-12f79cc9ee46"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "b7b734d2-06e3-46f2-8749-c759d329f152"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "mntlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "cca6f3b8-d6aa-4506-adf9-c70667b4c3e2"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 1048576,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 1048576
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "home_shadowmanlv"
+              }
+            },
+            "media": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "mnt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "mntlv"
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "root": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv00"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1462272,
+                "size": 31467487
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.xfs",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.xfs",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.xfs",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.xfs",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "mnt",
+              "type": "org.osbuild.xfs",
+              "source": "mnt",
+              "target": "/mnt"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.xfs",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.xfs",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.xfs",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.xfs",
+              "source": "usr",
+              "target": "/usr"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.lvm2.metadata",
+          "options": {
+            "vg_name": "rootvg"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 3,
+              "path": "/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "qcow2",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.qcow2",
+            "format": {
+              "type": "qcow2",
+              "compat": "1.1"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb": {
+          "url": "https://example.com/repo/packages/passwd"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98": {
+          "url": "https://example.com/repo/packages/exclude:fedora-repos"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b": {
+          "url": "https://example.com/repo/packages/exclude:udisks2"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2": {
+          "url": "https://example.com/repo/packages/bash"
+        },
+        "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-appstream"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:52856879d4bfa1d564480850a56b0885e1c52a805af96fffe84122afc9b1c52b": {
+          "url": "https://example.com/repo/packages/bluez"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1": {
+          "url": "https://example.com/repo/packages/shadow-utils"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747": {
+          "url": "https://example.com/repo/packages/exclude:fedora-release"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-en"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-rt"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-*"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3": {
+          "url": "https://example.com/repo/packages/pam"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-baseos"
+        }
+      }
+    },
+    "org.osbuild.inline": {
+      "items": {
+        "sha256:03fc1d407d48fd091625350f6482676dd08ef587d24761c8e38a3c99e5497af9": {
+          "encoding": "base64",
+          "data": "IyBGSVBTIG1vZHVsZSBpbnN0YWxsYXRpb24gY29tcGxldGUK"
+        },
+        "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+          "encoding": "base64",
+          "data": "W1VuaXRdCkRlc2NyaXB0aW9uPUN1c3RvbSBzZXJ2aWNlCgpbU2VydmljZV0KRXhlY1N0YXJ0PS91c3IvYmluL2ZhbHNlCgpbSW5zdGFsbF0KV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXQK"
+        },
+        "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+          "encoding": "base64",
+          "data": "W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NhdCAvZXRjL2N1c3RvbV9maWxlLnR4dAo="
+        },
+        "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+          "encoding": "base64",
+          "data": "aW1hZ2UgYnVpbGRlciBpcyB0aGUgYmVzdA=="
+        },
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+          "encoding": "base64",
+          "data": ""
+        },
+        "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+          "encoding": "base64",
+          "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-x86_64-qcow2-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-qcow2-empty.json
@@ -1,0 +1,816 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "dc1e3ab7-bc06-43b9-a331-f9b6fae303e5",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747"
+                },
+                {
+                  "id": "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280"
+                },
+                {
+                  "id": "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "dc1e3ab7-bc06-43b9-a331-f9b6fae303e5",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "dc1e3ab7-bc06-43b9-a331-f9b6fae303e5",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20557791,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "dc1e3ab7-bc06-43b9-a331-f9b6fae303e5",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 20557791,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 20557791
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "qcow2",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.qcow2",
+            "format": {
+              "type": "qcow2",
+              "compat": "1.1"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98": {
+          "url": "https://example.com/repo/packages/exclude:fedora-repos"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b": {
+          "url": "https://example.com/repo/packages/exclude:udisks2"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-appstream"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747": {
+          "url": "https://example.com/repo/packages/exclude:fedora-release"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-en"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-rt"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-*"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-baseos"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-x86_64-qcow2-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-qcow2-empty.json
@@ -19,22 +19,13 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -49,22 +40,10 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -138,12 +117,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/centos_10-x86_64-tar-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-tar-empty.json
@@ -1,0 +1,218 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "archive",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "root.tar.xz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-appstream"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-rt"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-baseos"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-x86_64-tar-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-tar-empty.json
@@ -34,9 +34,6 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
                 },
                 {
@@ -84,9 +81,6 @@
               "references": [
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"

--- a/test/data/manifestdb-light/centos_10-x86_64-vhd-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-vhd-empty.json
@@ -19,13 +19,7 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
@@ -37,13 +31,7 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
-                },
-                {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
@@ -55,22 +43,10 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -149,15 +125,6 @@
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
-                },
-                {
                   "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
                 },
                 {
@@ -168,9 +135,6 @@
                 },
                 {
                   "id": "sha256:79a583014c5150aac3a44a025229af2918d16d3f6f32d005bf5786f693d6b893"
-                },
-                {
-                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
                 },
                 {
                   "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
@@ -195,9 +159,6 @@
                 },
                 {
                   "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"

--- a/test/data/manifestdb-light/centos_10-x86_64-vhd-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-vhd-empty.json
@@ -1,0 +1,1104 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "229fb39f-1b23-4aef-9a42-66227b7c1833",
+            "kernel_opts": "ro loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221"
+                },
+                {
+                  "id": "sha256:563a278902fa76bae3ec1833f24ff89abe26329b1d32af9aaa924d6fc6fd68aa"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:b6cae3a11438b4ec550ce10b73b35160fafbe9d436fdb4f81fea356fc5bb6fee"
+                },
+                {
+                  "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:79a583014c5150aac3a44a025229af2918d16d3f6f32d005bf5786f693d6b893"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:f48860f2daf7e7a03ab9827300ab91c865d446de1c12a279339a2fff75c00f4e"
+                },
+                {
+                  "id": "sha256:229b391b136444fc29f0a5b3a897222f8ff4ed2277427e68eeb13fccfe39905c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8e57cbb02cd20f0e373ae76a44d7ddd0125fe449db5dfc196b0920ef47ced56e"
+                },
+                {
+                  "id": "sha256:a4895eb44afc336fecbba6e520cd67e178dace0276655d102fceffa8e5f70570"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:75666699b77db631f576041e8102a55b46758c01b807eacae0f170930ab59b3d"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:01fdad2e9ee0a69f7e323ddb4258e2b0dbfaa242a21d7a8bfdfec04ebe8d3e86"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:81f29ed6c790aa976572770ecf7b6f0351da3c46c9558640c7a83896b6bf8e05"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:534994290b3914604921fc2c61852b7bb4c4d8fb947f057a6fb38a3a57835d9a"
+                },
+                {
+                  "id": "sha256:0ee8cf7e33852f80cd293a8fa8c371f888dc011984ff2836f1198bcdc552dc58"
+                },
+                {
+                  "id": "sha256:5f1e4685c9b4d243264d22fa24864335aab534815fcfe6c3a88eec83ee22354f"
+                },
+                {
+                  "id": "sha256:f3e607ceb5fd279c62a109d1bbb952cc44d7467266ef679a99fd0d9c02ce8d29"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:7913d978541704fb38f5f13a949811c80ed4a52b2514d4582fe3ccb8f5a04617"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:a76985e9146fec1e9fb00cc08d5e0a76eb7f47c10a7abbc4430f8ac235a8b1cd"
+                },
+                {
+                  "id": "sha256:141b56438fdc0208877397569000e1a5857ff57807ff3bbaf2622cc87901861d"
+                },
+                {
+                  "id": "sha256:725c887b1ebcd6be8eb9a0ef6b2c476ff6d2dd8f9cf622f8d60953a1f22c94c8"
+                },
+                {
+                  "id": "sha256:53d00356d82e89cbdf0f963060c58433f73e0b339ba9f63577bd7df44f78e051"
+                },
+                {
+                  "id": "sha256:f1d96d150523777accb14a93582922ded22aa868629c58c3cd49339952293327"
+                },
+                {
+                  "id": "sha256:840109e45bc2504c9f202410bd941dc430bcef1065e1c1a98e5d08506c0c91af"
+                },
+                {
+                  "id": "sha256:b1eb4c41592e8eb6f7f2c96cdda2162fe214f52f85b01e9b174aa81bf297e01a"
+                },
+                {
+                  "id": "sha256:590ef3ccd31b243b045e9c5f9268d1013b0960060366c76028a23b070b5fb7be"
+                },
+                {
+                  "id": "sha256:9fe43931a7b645b90921b9b72d836e9d06ececc0b3cca1376fa0a297b5f522a5"
+                },
+                {
+                  "id": "sha256:49ec7b34785f32ffd1f252d5cc9a0a015ca074f75c601d2272149a72d50d42df"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel-core"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "10-azure-kvp.cfg",
+            "config": {
+              "reporting": {
+                "logging": {
+                  "type": "log"
+                },
+                "telemetry": {
+                  "type": "hyperv"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "91-azure_datasource.cfg",
+            "config": {
+              "datasource": {
+                "Azure": {
+                  "apply_network_config": false
+                }
+              },
+              "datasource_list": [
+                "Azure"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-intel-cstate.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "intel_cstate"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-floppy.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "floppy"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              },
+              {
+                "command": "blacklist",
+                "modulename": "lbm-nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-skylake-edac.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "skx_edac"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-azure.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_AZURE",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "ClientAliveInterval": 180
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.pwquality.conf",
+          "options": {
+            "config": {
+              "minlen": 6,
+              "dcredit": 0,
+              "ucredit": 0,
+              "lcredit": 0,
+              "ocredit": 0,
+              "minclass": 3
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.waagent.conf",
+          "options": {
+            "config": {
+              "ResourceDisk.Format": false,
+              "ResourceDisk.EnableSwap": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.udev.rules",
+          "options": {
+            "filename": "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules",
+            "rules": [
+              {
+                "comment": [
+                  "Accelerated Networking on Azure exposes a new SRIOV interface to the VM.",
+                  "This interface is transparently bonded to the synthetic interface,",
+                  "so NetworkManager should just ignore any SRIOV interfaces."
+                ]
+              },
+              [
+                {
+                  "key": "SUBSYSTEM",
+                  "op": "==",
+                  "val": "net"
+                },
+                {
+                  "key": "DRIVERS",
+                  "op": "==",
+                  "val": "hv_pci"
+                },
+                {
+                  "key": "ACTION",
+                  "op": "==",
+                  "val": "add"
+                },
+                {
+                  "key": {
+                    "name": "ENV",
+                    "arg": "NM_UNMANAGED"
+                  },
+                  "op": "=",
+                  "val": "1"
+                }
+              ]
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "229fb39f-1b23-4aef-9a42-66227b7c1833",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "229fb39f-1b23-4aef-9a42-66227b7c1833",
+            "kernel_opts": "ro loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved",
+              "disable_recovery": true,
+              "disable_submenu": true,
+              "distributor": "$(sed 's, release .*$,,g' /etc/system-release)",
+              "terminal": [
+                "serial",
+                "console"
+              ],
+              "timeout": 10,
+              "timeout_style": "countdown",
+              "serial": "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "firewalld",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "sshd",
+              "waagent"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "4294967296"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 7974879,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "229fb39f-1b23-4aef-9a42-66227b7c1833",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 7974879,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 7974879
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "vpc",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.vhd",
+            "format": {
+              "type": "vpc"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:01fdad2e9ee0a69f7e323ddb4258e2b0dbfaa242a21d7a8bfdfec04ebe8d3e86": {
+          "url": "https://example.com/repo/packages/exclude:NetworkManager-config-server"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3": {
+          "url": "https://example.com/repo/packages/bzip2"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:0ee8cf7e33852f80cd293a8fa8c371f888dc011984ff2836f1198bcdc552dc58": {
+          "url": "https://example.com/repo/packages/exclude:buildah"
+        },
+        "sha256:141b56438fdc0208877397569000e1a5857ff57807ff3bbaf2622cc87901861d": {
+          "url": "https://example.com/repo/packages/exclude:python3-dnf-plugin-spacewalk"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:229b391b136444fc29f0a5b3a897222f8ff4ed2277427e68eeb13fccfe39905c": {
+          "url": "https://example.com/repo/packages/kernel-modules"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-appstream"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:49ec7b34785f32ffd1f252d5cc9a0a015ca074f75c601d2272149a72d50d42df": {
+          "url": "https://example.com/repo/packages/exclude:usb_modeswitch"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:534994290b3914604921fc2c61852b7bb4c4d8fb947f057a6fb38a3a57835d9a": {
+          "url": "https://example.com/repo/packages/exclude:bolt"
+        },
+        "sha256:53d00356d82e89cbdf0f963060c58433f73e0b339ba9f63577bd7df44f78e051": {
+          "url": "https://example.com/repo/packages/exclude:python3-rhnlib"
+        },
+        "sha256:563a278902fa76bae3ec1833f24ff89abe26329b1d32af9aaa924d6fc6fd68aa": {
+          "url": "https://example.com/repo/packages/NetworkManager"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:590ef3ccd31b243b045e9c5f9268d1013b0960060366c76028a23b070b5fb7be": {
+          "url": "https://example.com/repo/packages/exclude:rhnlib"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5f1e4685c9b4d243264d22fa24864335aab534815fcfe6c3a88eec83ee22354f": {
+          "url": "https://example.com/repo/packages/exclude:cockpit-podman"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221": {
+          "url": "https://example.com/repo/packages/@Server"
+        },
+        "sha256:725c887b1ebcd6be8eb9a0ef6b2c476ff6d2dd8f9cf622f8d60953a1f22c94c8": {
+          "url": "https://example.com/repo/packages/exclude:python3-hwdata"
+        },
+        "sha256:75666699b77db631f576041e8102a55b46758c01b807eacae0f170930ab59b3d": {
+          "url": "https://example.com/repo/packages/uuid"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7913d978541704fb38f5f13a949811c80ed4a52b2514d4582fe3ccb8f5a04617": {
+          "url": "https://example.com/repo/packages/exclude:glibc-all-langpacks"
+        },
+        "sha256:79a583014c5150aac3a44a025229af2918d16d3f6f32d005bf5786f693d6b893": {
+          "url": "https://example.com/repo/packages/hyperv-daemons"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:81f29ed6c790aa976572770ecf7b6f0351da3c46c9558640c7a83896b6bf8e05": {
+          "url": "https://example.com/repo/packages/exclude:alsa-sof-firmware"
+        },
+        "sha256:840109e45bc2504c9f202410bd941dc430bcef1065e1c1a98e5d08506c0c91af": {
+          "url": "https://example.com/repo/packages/exclude:rhn-client-tools"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8e57cbb02cd20f0e373ae76a44d7ddd0125fe449db5dfc196b0920ef47ced56e": {
+          "url": "https://example.com/repo/packages/nvme-cli"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-rt"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:9fe43931a7b645b90921b9b72d836e9d06ececc0b3cca1376fa0a297b5f522a5": {
+          "url": "https://example.com/repo/packages/exclude:rhnsd"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a4895eb44afc336fecbba6e520cd67e178dace0276655d102fceffa8e5f70570": {
+          "url": "https://example.com/repo/packages/patch"
+        },
+        "sha256:a76985e9146fec1e9fb00cc08d5e0a76eb7f47c10a7abbc4430f8ac235a8b1cd": {
+          "url": "https://example.com/repo/packages/exclude:podman"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:b1eb4c41592e8eb6f7f2c96cdda2162fe214f52f85b01e9b174aa81bf297e01a": {
+          "url": "https://example.com/repo/packages/exclude:rhn-setup"
+        },
+        "sha256:b6cae3a11438b4ec550ce10b73b35160fafbe9d436fdb4f81fea356fc5bb6fee": {
+          "url": "https://example.com/repo/packages/WALinuxAgent"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f1d96d150523777accb14a93582922ded22aa868629c58c3cd49339952293327": {
+          "url": "https://example.com/repo/packages/exclude:rhn-check"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f3e607ceb5fd279c62a109d1bbb952cc44d7467266ef679a99fd0d9c02ce8d29": {
+          "url": "https://example.com/repo/packages/exclude:containernetworking-plugins"
+        },
+        "sha256:f48860f2daf7e7a03ab9827300ab91c865d446de1c12a279339a2fff75c00f4e": {
+          "url": "https://example.com/repo/packages/kernel-core"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        },
+        "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-baseos"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-x86_64-vmdk-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-vmdk-empty.json
@@ -1,0 +1,543 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "6a4a8351-ab04-4cfe-8406-b00afaf02579",
+            "kernel_opts": "ro"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:2ec46eb16ef55156c58b6348c9552f739a616fb6b4e22367486fe62442e3a9c4"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "6a4a8351-ab04-4cfe-8406-b00afaf02579",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "6a4a8351-ab04-4cfe-8406-b00afaf02579",
+            "kernel_opts": "ro",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "centos",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "4294967296"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 7974879,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "6a4a8351-ab04-4cfe-8406-b00afaf02579",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 7974879,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 7974879
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "vmdk",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.vmdk",
+            "format": {
+              "type": "vmdk",
+              "subformat": "streamOptimized"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2ec46eb16ef55156c58b6348c9552f739a616fb6b4e22367486fe62442e3a9c4": {
+          "url": "https://example.com/repo/packages/open-vm-tools"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-appstream"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5": {
+          "url": "https://example.com/repo/packages/firewalld"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-rt"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-baseos"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/centos_10-x86_64-vmdk-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-vmdk-empty.json
@@ -19,22 +19,13 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -49,22 +40,10 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -126,9 +105,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/centos_10-x86_64-wsl-empty.json
+++ b/test/data/manifestdb-light/centos_10-x86_64-wsl-empty.json
@@ -1,0 +1,472 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.centos10",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:8a1eb106427026fd9f7daef2fbed09db45de687c264480f8d3945ff13bdd9fe6"
+                },
+                {
+                  "id": "sha256:8308da3588987ace3967a2eee85a70f8be6eca16320b1e235b636e1464bbad06"
+                },
+                {
+                  "id": "sha256:4f7872f3a4c4decf34923a48986e52563d2a58bc3225b1890b84b52e7defce09"
+                },
+                {
+                  "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"
+                },
+                {
+                  "id": "sha256:97e86df4b9e1385f56f5635f227cc75e5a59147a8d06d05d0c08241d7204a92d"
+                },
+                {
+                  "id": "sha256:839f835e4d4558140e9b92fd85c3f923b74b6220ba1ad86b9fe096b8b6305b86"
+                },
+                {
+                  "id": "sha256:1a36b318995f3383dfa35c283df090bde63776c52415a421ea201a9667f95ab3"
+                },
+                {
+                  "id": "sha256:32dcd32054ee4e9ae92eec040bc1385c94d74a0846bb0145b1bdf9958740200a"
+                },
+                {
+                  "id": "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:cbf61858f3260072d96d9b1d2e037fc35824944b9c94d0087b1a53385eccaead"
+                },
+                {
+                  "id": "sha256:5b0440b2a1ceb2db43e1832c91f96728c5fe59a1cd7b5d1f1b905bb0b2df3841"
+                },
+                {
+                  "id": "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31"
+                },
+                {
+                  "id": "sha256:f6fad119f40a1aae00b54c0de6a0fa24a1e35d4bf1284bffcfd7134bdbb837e1"
+                },
+                {
+                  "id": "sha256:cc0bbbee7c9dd4f3f30e01c7f1fcbeb839f30c47e3bcbf16db0d37789262cbb4"
+                },
+                {
+                  "id": "sha256:aa6d4532f128420f4d741f2834cd8d1d146bbbdc9554aef454b7adb8ff66f748"
+                },
+                {
+                  "id": "sha256:f8f6228d89c3de21a136641a6d66f8a393db4b9019b17e0bec92ffc88b393eb4"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:cfd4affb5ed7a688870bb3725e10cc066e63b2a94b5dd491cac681a3c2b17ca5"
+                },
+                {
+                  "id": "sha256:41ffca929b95c49690ab8815d1d1a134a5bcdd86bde407c0f46b90eabf556b05"
+                },
+                {
+                  "id": "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3"
+                },
+                {
+                  "id": "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb"
+                },
+                {
+                  "id": "sha256:5b0513b8ca5a7f03601efc10934409d271890e6ae7a3264445e7397233eac6f8"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:87f1c82f3d3b66f168e0673e4f4227a8a3fe53000bf342780424ee8e3344d591"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:e422e1641a99c5a045bc0b596ef5ce6429c8e7744f016444cedacd4eaf5d3e4c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:5f53b0a2be22e28dc4b056f663910c046a33f9b2d779eaf997ea771fe1881a13"
+                },
+                {
+                  "id": "sha256:8fb6d5f37e8055ce720bd0b1d56587f88c0071f285966ba17e72b2b12672aa73"
+                },
+                {
+                  "id": "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1"
+                },
+                {
+                  "id": "sha256:0652d77991ae054286ace9807d7b4b573b99e3be9be7ad126db8d197b5f22a68"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:ae5e2ad3b86239dbf500c630cf88d33d9775e9ce2e32d596910a07d682d97923"
+                },
+                {
+                  "id": "sha256:572d4fe95e2cfd3425b70544a829f39104cad64fb57cdc63a25f9e837fb79917"
+                },
+                {
+                  "id": "sha256:f486d76df6f0ea41b7d6acb72751d8eb4cc2a3f04e6273154fef5e76cab27e11"
+                },
+                {
+                  "id": "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf"
+                },
+                {
+                  "id": "sha256:809c2fb94fff223e96477a875bbc1b77e5b020262e8f959d4b49455100a7f9f7"
+                },
+                {
+                  "id": "sha256:6fd624e2ceb4409a98b06f7f6161a6259cc88a838b6f43454217ed5a0c18a547"
+                },
+                {
+                  "id": "sha256:2692c08277f40048982432ab907ab870ee677f69656d9a71a6f889cf03531eb4"
+                },
+                {
+                  "id": "sha256:a697ff6e769b4f3d7c9b05d77c96d575c5e001ef923a13395decbe00b7e461bb"
+                },
+                {
+                  "id": "sha256:7cb8f52fafc3465bc88412019948f599fa1217927861c07ac3f90628772efa55"
+                },
+                {
+                  "id": "sha256:10d1e54c16c491abf59ec796854ffa14563d54461ebb9092501da34f5a9184bc"
+                },
+                {
+                  "id": "sha256:c06dba625e4dfb0b49cb4013c2a82c8f314143c833c1306da12fa2d77a12e0c4"
+                },
+                {
+                  "id": "sha256:60e3d9a99e40010bb917f75d9ce99530d1f8b322d0b1aea07fe71257a369d943"
+                },
+                {
+                  "id": "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8"
+                },
+                {
+                  "id": "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d"
+                },
+                {
+                  "id": "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740"
+                }
+              ]
+            }
+          },
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.wsl.conf",
+          "options": {
+            "boot": {
+              "systemd": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "archive",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "disk.tar.gz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:0652d77991ae054286ace9807d7b4b573b99e3be9be7ad126db8d197b5f22a68": {
+          "url": "https://example.com/repo/packages/subscription-manager"
+        },
+        "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb": {
+          "url": "https://example.com/repo/packages/passwd"
+        },
+        "sha256:10d1e54c16c491abf59ec796854ffa14563d54461ebb9092501da34f5a9184bc": {
+          "url": "https://example.com/repo/packages/exclude:python-unversioned-command"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a36b318995f3383dfa35c283df090bde63776c52415a421ea201a9667f95ab3": {
+          "url": "https://example.com/repo/packages/crypto-policies-scripts"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:2692c08277f40048982432ab907ab870ee677f69656d9a71a6f889cf03531eb4": {
+          "url": "https://example.com/repo/packages/exclude:glibc-gconv-extra"
+        },
+        "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa": {
+          "url": "https://example.com/repo/packages/dejavu-sans-fonts"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:32dcd32054ee4e9ae92eec040bc1385c94d74a0846bb0145b1bdf9958740200a": {
+          "url": "https://example.com/repo/packages/curl-minimal"
+        },
+        "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2": {
+          "url": "https://example.com/repo/packages/bash"
+        },
+        "sha256:3843603de61d3682536cc569e9ac20e52f5ed00adac5d182511bc452a575d5a8": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-appstream"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1": {
+          "url": "https://example.com/repo/packages/dnf"
+        },
+        "sha256:41ffca929b95c49690ab8815d1d1a134a5bcdd86bde407c0f46b90eabf556b05": {
+          "url": "https://example.com/repo/packages/openssl"
+        },
+        "sha256:4f7872f3a4c4decf34923a48986e52563d2a58bc3225b1890b84b52e7defce09": {
+          "url": "https://example.com/repo/packages/basesystem"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:572d4fe95e2cfd3425b70544a829f39104cad64fb57cdc63a25f9e837fb79917": {
+          "url": "https://example.com/repo/packages/tzdata"
+        },
+        "sha256:5b0440b2a1ceb2db43e1832c91f96728c5fe59a1cd7b5d1f1b905bb0b2df3841": {
+          "url": "https://example.com/repo/packages/findutils"
+        },
+        "sha256:5b0513b8ca5a7f03601efc10934409d271890e6ae7a3264445e7397233eac6f8": {
+          "url": "https://example.com/repo/packages/procps-ng"
+        },
+        "sha256:5f53b0a2be22e28dc4b056f663910c046a33f9b2d779eaf997ea771fe1881a13": {
+          "url": "https://example.com/repo/packages/sed"
+        },
+        "sha256:60e3d9a99e40010bb917f75d9ce99530d1f8b322d0b1aea07fe71257a369d943": {
+          "url": "https://example.com/repo/packages/exclude:rpm-plugin-systemd-inhibit"
+        },
+        "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1": {
+          "url": "https://example.com/repo/packages/shadow-utils"
+        },
+        "sha256:6fd624e2ceb4409a98b06f7f6161a6259cc88a838b6f43454217ed5a0c18a547": {
+          "url": "https://example.com/repo/packages/exclude:gawk-all-langpacks"
+        },
+        "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682": {
+          "url": "https://example.com/repo/packages/hostname"
+        },
+        "sha256:7cb8f52fafc3465bc88412019948f599fa1217927861c07ac3f90628772efa55": {
+          "url": "https://example.com/repo/packages/exclude:openssl-pkcs11"
+        },
+        "sha256:809c2fb94fff223e96477a875bbc1b77e5b020262e8f959d4b49455100a7f9f7": {
+          "url": "https://example.com/repo/packages/yum"
+        },
+        "sha256:8308da3588987ace3967a2eee85a70f8be6eca16320b1e235b636e1464bbad06": {
+          "url": "https://example.com/repo/packages/audit-libs"
+        },
+        "sha256:839f835e4d4558140e9b92fd85c3f923b74b6220ba1ad86b9fe096b8b6305b86": {
+          "url": "https://example.com/repo/packages/coreutils-single"
+        },
+        "sha256:87f1c82f3d3b66f168e0673e4f4227a8a3fe53000bf342780424ee8e3344d591": {
+          "url": "https://example.com/repo/packages/python3-inotify"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a1eb106427026fd9f7daef2fbed09db45de687c264480f8d3945ff13bdd9fe6": {
+          "url": "https://example.com/repo/packages/alternatives"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8fb6d5f37e8055ce720bd0b1d56587f88c0071f285966ba17e72b2b12672aa73": {
+          "url": "https://example.com/repo/packages/setup"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:91c11be0bd7ca8f5ef8cbe63f46c9298d3d3d0edc502ed071e9b4804bfdfb740": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-rt"
+        },
+        "sha256:97e86df4b9e1385f56f5635f227cc75e5a59147a8d06d05d0c08241d7204a92d": {
+          "url": "https://example.com/repo/packages/ca-certificates"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a697ff6e769b4f3d7c9b05d77c96d575c5e001ef923a13395decbe00b7e461bb": {
+          "url": "https://example.com/repo/packages/exclude:glibc-langpack-en"
+        },
+        "sha256:aa6d4532f128420f4d741f2834cd8d1d146bbbdc9554aef454b7adb8ff66f748": {
+          "url": "https://example.com/repo/packages/gnupg2"
+        },
+        "sha256:ae5e2ad3b86239dbf500c630cf88d33d9775e9ce2e32d596910a07d682d97923": {
+          "url": "https://example.com/repo/packages/tpm2-tss"
+        },
+        "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf": {
+          "url": "https://example.com/repo/packages/vim-minimal"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c06dba625e4dfb0b49cb4013c2a82c8f314143c833c1306da12fa2d77a12e0c4": {
+          "url": "https://example.com/repo/packages/exclude:redhat-release-eula"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31": {
+          "url": "https://example.com/repo/packages/gdb-gdbserver"
+        },
+        "sha256:cbf61858f3260072d96d9b1d2e037fc35824944b9c94d0087b1a53385eccaead": {
+          "url": "https://example.com/repo/packages/filesystem"
+        },
+        "sha256:cc0bbbee7c9dd4f3f30e01c7f1fcbeb839f30c47e3bcbf16db0d37789262cbb4": {
+          "url": "https://example.com/repo/packages/gmp"
+        },
+        "sha256:cfd4affb5ed7a688870bb3725e10cc066e63b2a94b5dd491cac681a3c2b17ca5": {
+          "url": "https://example.com/repo/packages/libcurl-minimal"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e422e1641a99c5a045bc0b596ef5ce6429c8e7744f016444cedacd4eaf5d3e4c": {
+          "url": "https://example.com/repo/packages/rootfiles"
+        },
+        "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3": {
+          "url": "https://example.com/repo/packages/pam"
+        },
+        "sha256:f486d76df6f0ea41b7d6acb72751d8eb4cc2a3f04e6273154fef5e76cab27e11": {
+          "url": "https://example.com/repo/packages/util-linux"
+        },
+        "sha256:f6fad119f40a1aae00b54c0de6a0fa24a1e35d4bf1284bffcfd7134bdbb837e1": {
+          "url": "https://example.com/repo/packages/glibc-minimal-langpack"
+        },
+        "sha256:f8f6228d89c3de21a136641a6d66f8a393db4b9019b17e0bec92ffc88b393eb4": {
+          "url": "https://example.com/repo/packages/gobject-introspection"
+        },
+        "sha256:ff6d66bf54dea8b742a0133b5d208f55c39ed16889bb87f98aed9359d76c872d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el10/cs10-x86_64-baseos"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-ami-all_customizations.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-ami-all_customizations.json
@@ -19,13 +19,7 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
@@ -37,37 +31,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -130,9 +106,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -143,9 +116,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
@@ -296,9 +266,6 @@
                 },
                 {
                   "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
-                },
-                {
-                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
                 },
                 {
                   "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-ami-all_customizations.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-ami-all_customizations.json
@@ -1,0 +1,1666 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "43b8c9e4-0d87-4a9f-9f75-b8a78f716ae5",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0 debug"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3"
+                },
+                {
+                  "id": "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"
+                },
+                {
+                  "id": "sha256:52856879d4bfa1d564480850a56b0885e1c52a805af96fffe84122afc9b1c52b"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "el_CY.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "dvorak"
+          }
+        },
+        {
+          "type": "org.osbuild.hostname",
+          "options": {
+            "hostname": "my-host"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "Europe/London"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "time.example.com"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.groups",
+          "options": {
+            "groups": {
+              "group1": {
+                "gid": 1030
+              },
+              "group2": {
+                "gid": 1050
+              },
+              "user3": {
+                "gid": 1060
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+              "user1": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              },
+              "user2": {
+                "uid": 1020,
+                "gid": 1050,
+                "groups": [
+                  "group1"
+                ],
+                "description": "description 2",
+                "home": "/home/home2",
+                "shell": "/bin/sh",
+                "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              },
+              "user3": {
+                "uid": 1060,
+                "gid": 1060
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.yum.repos",
+          "options": {
+            "filename": "example.repo",
+            "repos": [
+              {
+                "id": "example",
+                "baseurl": [
+                  "https://example.com/download/yum"
+                ],
+                "enabled": true,
+                "gpgkey": [
+                  "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                ],
+                "name": "Example repo",
+                "gpgcheck": true,
+                "repo_gpgcheck": false
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "43b8c9e4-0d87-4a9f-9f75-b8a78f716ae5",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "82051f3c-a505-4d7e-92ca-fd1ab85afac4",
+                "vfs_type": "xfs",
+                "path": "/boot",
+                "options": "defaults"
+              },
+              {
+                "uuid": "568a3547-05ce-4c1c-aeb1-9a631fa7e1a6",
+                "vfs_type": "xfs",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "dc95f230-c2d7-408b-9e27-b3fec92d5561",
+                "vfs_type": "xfs",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7674fe15-b70c-4ce9-a028-d8f40816248c",
+                "vfs_type": "xfs",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "93bf8666-0fc1-4e8f-a3a1-e6c0ab712e30",
+                "vfs_type": "xfs",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "d4fad186-ce7d-402b-a865-30983bad7033",
+                "vfs_type": "xfs",
+                "path": "/mnt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "9d37e1e9-54f1-4ef7-bb1e-9dd6b442b19e",
+                "vfs_type": "xfs",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "973ad7db-6530-423e-8653-199e027ef5e1",
+                "vfs_type": "xfs",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "256aef65-0cfa-4d1b-bd41-997e1521af68",
+                "vfs_type": "xfs",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "ba418cf9-1699-463c-b9d2-fc162714e27f",
+                "vfs_type": "xfs",
+                "path": "/usr",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "43b8c9e4-0d87-4a9f-9f75-b8a78f716ae5",
+            "boot_fs_uuid": "82051f3c-a505-4d7e-92ca-fd1ab85afac4",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0 debug",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/etc/systemd/system/custom.service.d",
+                "exist_ok": true
+              },
+              {
+                "path": "/etc/custom_dir"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/custom_dir": {
+                "mode": "0770"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/custom_dir": {
+                "user": 1020,
+                "group": 1050
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e"
+                }
+              ]
+            },
+            "file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2"
+                }
+              ]
+            },
+            "file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258"
+                }
+              ]
+            },
+            "file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                }
+              ]
+            },
+            "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e/sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e",
+                "to": "tree:///etc/systemd/system/custom.service",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2/sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2",
+                "to": "tree:///etc/systemd/system/custom.service.d/override.conf",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258/sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258",
+                "to": "tree:///etc/custom_file.txt",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "to": "tree:///etc/empty_file.txt",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/custom_file.txt": {
+                "mode": "0644"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/custom_file.txt": {
+                "user": "root",
+                "group": "root"
+              },
+              "/etc/empty_file.txt": {
+                "user": 0,
+                "group": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned",
+              "sshd.service",
+              "custom.service"
+            ],
+            "disabled_services": [
+              "bluetooth.service"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c/sha256:4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c",
+                "to": "tree:///etc/pki/ca-trust/source/anchors/27894af897dd2423607045716438a725f28a6d0b.pem",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/pki/ca-trust/source/anchors/27894af897dd2423607045716438a725f28a6d0b.pem": {
+                "user": "root",
+                "group": "root"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.pki.update-ca-trust"
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "16859004928"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 31467487,
+                "start": 1460224,
+                "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              },
+              {
+                "size": 1048576,
+                "start": 411648,
+                "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                "uuid": "17cec9f7-e1f8-45fc-9f0c-84d2f4e54d61"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.lvm2.create",
+          "options": {
+            "volumes": [
+              {
+                "name": "rootlv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "homelv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "home_shadowmanlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "foolv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "usrlv",
+                "size": "4294967296B"
+              },
+              {
+                "name": "optlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "medialv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "rootlv00",
+                "size": "1073741824B"
+              },
+              {
+                "name": "srvlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "mntlv",
+                "size": "1073741824B"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "43b8c9e4-0d87-4a9f-9f75-b8a78f716ae5",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "dc95f230-c2d7-408b-9e27-b3fec92d5561"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "7674fe15-b70c-4ce9-a028-d8f40816248c"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "home_shadowmanlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "568a3547-05ce-4c1c-aeb1-9a631fa7e1a6"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "ba418cf9-1699-463c-b9d2-fc162714e27f"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "9d37e1e9-54f1-4ef7-bb1e-9dd6b442b19e"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "93bf8666-0fc1-4e8f-a3a1-e6c0ab712e30"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "973ad7db-6530-423e-8653-199e027ef5e1"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv00"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "256aef65-0cfa-4d1b-bd41-997e1521af68"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "d4fad186-ce7d-402b-a865-30983bad7033"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "mntlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "82051f3c-a505-4d7e-92ca-fd1ab85afac4"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 1048576,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 1048576
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "home_shadowmanlv"
+              }
+            },
+            "media": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "mnt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "mntlv"
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "root": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv00"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.xfs",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.xfs",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.xfs",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.xfs",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "mnt",
+              "type": "org.osbuild.xfs",
+              "source": "mnt",
+              "target": "/mnt"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.xfs",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.xfs",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.xfs",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.xfs",
+              "source": "usr",
+              "target": "/usr"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.lvm2.metadata",
+          "options": {
+            "vg_name": "rootvg"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb": {
+          "url": "https://example.com/repo/packages/passwd"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2": {
+          "url": "https://example.com/repo/packages/bash"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:52856879d4bfa1d564480850a56b0885e1c52a805af96fffe84122afc9b1c52b": {
+          "url": "https://example.com/repo/packages/bluez"
+        },
+        "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-baseos-n10.0"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1": {
+          "url": "https://example.com/repo/packages/shadow-utils"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-appstream-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3": {
+          "url": "https://example.com/repo/packages/pam"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    },
+    "org.osbuild.inline": {
+      "items": {
+        "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+          "encoding": "base64",
+          "data": "W1VuaXRdCkRlc2NyaXB0aW9uPUN1c3RvbSBzZXJ2aWNlCgpbU2VydmljZV0KRXhlY1N0YXJ0PS91c3IvYmluL2ZhbHNlCgpbSW5zdGFsbF0KV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXQK"
+        },
+        "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+          "encoding": "base64",
+          "data": "W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NhdCAvZXRjL2N1c3RvbV9maWxlLnR4dAo="
+        },
+        "sha256:4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c": {
+          "encoding": "base64",
+          "data": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzekNDQXB1Z0F3SUJBZ0lVSjRsSytKZmRKQ05nY0VWeFpEaW5KZktLYlFzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2FERUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZRApWUVFIREFkU1lXeGxhV2RvTVJBd0RnWURWUVFLREFkU1pXUWdTR0YwTVJ3d0dnWURWUVFEREJOVVpYTjBJRU5CCklHWnZjaUJ2YzJKMWFXeGtNQ0FYRFRJME1Ea3dNekV6TWpreU1Gb1lEekl5T1Rnd05qRTRNVE15T1RJd1dqQm8KTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjTQpCMUpoYkdWcFoyZ3hFREFPQmdOVkJBb01CMUpsWkNCSVlYUXhIREFhQmdOVkJBTU1FMVJsYzNRZ1EwRWdabTl5CklHOXpZblZwYkdRd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURlQTdPY1dUclYKZ3N0b0JzVWFlSkttOG5lbGc3TGMwV05YSDZ5T1RMc3I0dGQ0eUhzMFlPdkZHd2dTZitmZlYzUkFHMW1ncW5NRwpNZ2tEMit6KzdRaEhiSEhzM3kwZDB6ZmhBMmJnMEtWdmZDV2s3Zk5SUEhZMFVPZVBwWGsyNDVCZnczRDBWVHBsCkY3bmVQazFJN1pZMDlzblBXVWViMnJqS1h6WWpLanpNMGgyNyt5a1Y4STgrRmJkeVBrL3BSOHdoeURxdEhMVWEKWGZGeTJURmxvRFNZTWtIS1ZkMzhCbkwwYmo5MXg1RitLc1prTjRIemZiWXd4TGJDUWZPU2d5N3E2VFdjZTlrcQpMbzZ0eWE5dnV2cFdGbTFkeWU3TCtCb2RBUUFxL2RJL0pNZUNmeVRiMGVGYit0eXpmcjVhVklvcXFETitwOWZ0CmN3NE9lZnBIYmh0TkFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUlYyQTlZbXVzZWtQenU1WWYwOGNWMG9QTDEKd2pBZkJnTlZIU01FR0RBV2dCUlYyQTlZbXVzZWtQenU1WWYwOGNWMG9QTDF3akFQQmdOVkhSTUJBZjhFQlRBRApBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFDZ1FaMlhmaitOeGFLQlpnbjJLTnhTME1UYmh6SFJ6NlJuCnFKcytoOE9VejJDcm1hZjZOK1JIbG1EUlpYVXJEalNIcHhWVDJMeEZ5N29mUnJMWUllekZEVVlmYjkyMFZra1YKU1ZjeGgxWURGUk9KYWxmTW9FNndkeVIvTG5LNE1KWlM5ZlVwZUNKSmMvQTBKKzlGSzlDd2N5VXJIZ0o4WGJKaApNS1l5UStjZjZPN3d6dXR1QnBNeVJxU0tTK2hWTTdCUVRtU0Z2djFlQUpsbzZrbEdBbW1LaVltQUV2Y1FhZEgxCmRqcnVqc0EzQ241dlgyTCsweXVpTEI1L3pveHF4NWNFeTk3VHVLVVlCOE9xTU11akFYTnpGNEwzSEpEVU5iYTIKQWhFa0Zvek1Yd1lYNzNUR2JHWjBtYXdQUzVEM3YzdFlURW1KRmY2U25WQ21VVzFmczU3ZwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        },
+        "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+          "encoding": "base64",
+          "data": "aW1hZ2UgYnVpbGRlciBpcyB0aGUgYmVzdA=="
+        },
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+          "encoding": "base64",
+          "data": ""
+        },
+        "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+          "encoding": "base64",
+          "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-ami-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-ami-empty.json
@@ -19,16 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -40,28 +34,13 @@
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -124,9 +103,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -137,9 +113,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-ami-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-ami-empty.json
@@ -1,0 +1,831 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "169c389c-a8cc-436c-b931-d970ebff69d5",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "169c389c-a8cc-436c-b931-d970ebff69d5",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "169c389c-a8cc-436c-b931-d970ebff69d5",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20559839,
+                "start": 411648,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "169c389c-a8cc-436c-b931-d970ebff69d5",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 20559839,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 20559839
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-baseos-n10.0"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-appstream-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-ami-oscap_rhel10.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-ami-oscap_rhel10.json
@@ -19,13 +19,7 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:ff58b2c2afc22d8027e46529b857d1fe24505d66e7205497bfdf89fa15dcd11f"
                 },
                 {
                   "id": "sha256:ff58b2c2afc22d8027e46529b857d1fe24505d66e7205497bfdf89fa15dcd11f"
@@ -37,37 +31,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -130,9 +106,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -143,9 +116,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-ami-oscap_rhel10.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-ami-oscap_rhel10.json
@@ -1,0 +1,908 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:ff58b2c2afc22d8027e46529b857d1fe24505d66e7205497bfdf89fa15dcd11f"
+                },
+                {
+                  "id": "sha256:ff58b2c2afc22d8027e46529b857d1fe24505d66e7205497bfdf89fa15dcd11f"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "6de66ba2-24ed-4b5b-924a-9dbf01a76d66",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:71c42066c0365a2fc8789ea3557b1d9cc02efaa38acf606a8721677e156bd135"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:0f916f1464ce623afcf1deea10887af956097e0ca395df2fd743787cba611e70"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:c84d384f2a25cca2a8fde5eb61b0f81f728e5f778a232211b176ea80143877bc"
+                },
+                {
+                  "id": "sha256:ff58b2c2afc22d8027e46529b857d1fe24505d66e7205497bfdf89fa15dcd11f"
+                },
+                {
+                  "id": "sha256:8dd09cdcaee28f7ebb491c23ae6afa1305f8be037ac3d5dc2e19196ded4eac57"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "6de66ba2-24ed-4b5b-924a-9dbf01a76d66",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "6de66ba2-24ed-4b5b-924a-9dbf01a76d66",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/oscap_data",
+                "parents": true,
+                "exist_ok": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.oscap.autotailor",
+          "options": {
+            "filepath": "/oscap_data/tailoring.xml",
+            "config": {
+              "new_profile": "xccdf_org.ssgproject.content_profile_cis_osbuild_tailoring",
+              "datastream": "/usr/share/xml/scap/ssg/content/ssg-rhel10-ds.xml",
+              "profile_id": "xccdf_org.ssgproject.content_profile_cis",
+              "unselected": [
+                "grub2_password"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.oscap.remediation",
+          "options": {
+            "data_dir": "/oscap_data",
+            "config": {
+              "datastream": "/usr/share/xml/scap/ssg/content/ssg-rhel10-ds.xml",
+              "profile_id": "xccdf_org.ssgproject.content_profile_cis_osbuild_tailoring",
+              "tailoring": "/oscap_data/tailoring.xml",
+              "compress_results": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20559839,
+                "start": 411648,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "6de66ba2-24ed-4b5b-924a-9dbf01a76d66",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 20559839,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 20559839
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:0f916f1464ce623afcf1deea10887af956097e0ca395df2fd743787cba611e70": {
+          "url": "https://example.com/repo/packages/scap-security-guide"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-baseos-n10.0"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:71c42066c0365a2fc8789ea3557b1d9cc02efaa38acf606a8721677e156bd135": {
+          "url": "https://example.com/repo/packages/openscap-scanner"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8dd09cdcaee28f7ebb491c23ae6afa1305f8be037ac3d5dc2e19196ded4eac57": {
+          "url": "https://example.com/repo/packages/xmlstarlet"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-appstream-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c84d384f2a25cca2a8fde5eb61b0f81f728e5f778a232211b176ea80143877bc": {
+          "url": "https://example.com/repo/packages/jq"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        },
+        "sha256:ff58b2c2afc22d8027e46529b857d1fe24505d66e7205497bfdf89fa15dcd11f": {
+          "url": "https://example.com/repo/packages/openscap-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-ami-partitioning_lvm.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-ami-partitioning_lvm.json
@@ -19,19 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
-                },
-                {
                   "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
                 },
                 {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
@@ -43,37 +34,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -136,9 +109,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -149,9 +119,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-ami-partitioning_lvm.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-ami-partitioning_lvm.json
@@ -1,0 +1,1410 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "38dfccf2-0c49-4849-802b-791e9b09aa12",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "38dfccf2-0c49-4849-802b-791e9b09aa12",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "8f7c85c2-b0be-466c-8e15-34af1bad86b2",
+                "vfs_type": "xfs",
+                "path": "/boot",
+                "options": "defaults"
+              },
+              {
+                "uuid": "1e3cd696-a764-4c56-9e39-5e40d9cc9a1a",
+                "vfs_type": "ext4",
+                "path": "/data",
+                "options": "defaults"
+              },
+              {
+                "uuid": "455ca625-c0fb-4f20-b119-f567e4f098fd",
+                "vfs_type": "ext4",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "643dbabf-3796-45a7-b8ec-c256b5f0c48f",
+                "vfs_type": "ext4",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "783f1006-1baa-4a51-8b0f-d794a92fbd44",
+                "vfs_type": "ext4",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "9dadfbce-5ff8-4824-b29e-fa58c8ce02ea",
+                "vfs_type": "ext4",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "b7913738-9dba-4b97-84a1-af7a8f82a78f",
+                "vfs_type": "ext4",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "0f6e4517-7649-4864-a402-66644937211b",
+                "vfs_type": "ext4",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "6a7a714d-d18f-4e8b-8ec8-fc09da7fa301",
+                "vfs_type": "ext4",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "62c505c5-8415-4ee7-b37f-ee147c1bdc0d",
+                "vfs_type": "ext4",
+                "path": "/usr",
+                "options": "defaults"
+              },
+              {
+                "uuid": "c93538d6-5bf0-4bff-af1f-4221f8982b17",
+                "vfs_type": "swap",
+                "path": "none",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "38dfccf2-0c49-4849-802b-791e9b09aa12",
+            "boot_fs_uuid": "8f7c85c2-b0be-466c-8e15-34af1bad86b2",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "21153972224"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "c3c89fe3-6393-4b4a-8675-ff0aad79cbac",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 1048576,
+                "start": 411648,
+                "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                "uuid": "c808852f-e1cd-4882-b93e-b0cf761f904d"
+              },
+              {
+                "size": 2097152,
+                "start": 1460224,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "e4b72067-bedb-4880-bbfb-a5c434cff443"
+              },
+              {
+                "size": 37758943,
+                "start": 3557376,
+                "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+                "uuid": "5cb7d8e6-baa9-4962-97ba-34a4d0a5fb93"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.lvm2.create",
+          "options": {
+            "volumes": [
+              {
+                "name": "homelv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "shadowmanlv",
+                "size": "5368709120B"
+              },
+              {
+                "name": "foolv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "usrlv",
+                "size": "4294967296B"
+              },
+              {
+                "name": "optlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "medialv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "roothomelv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "srvlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "swap-lv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "rootlv",
+                "size": "1073741824B"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "8f7c85c2-b0be-466c-8e15-34af1bad86b2",
+            "label": "boot"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 1048576,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "1e3cd696-a764-4c56-9e39-5e40d9cc9a1a",
+            "label": "data"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "643dbabf-3796-45a7-b8ec-c256b5f0c48f",
+            "label": "home"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "783f1006-1baa-4a51-8b0f-d794a92fbd44"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "shadowmanlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "455ca625-c0fb-4f20-b119-f567e4f098fd"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "62c505c5-8415-4ee7-b37f-ee147c1bdc0d"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "b7913738-9dba-4b97-84a1-af7a8f82a78f"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "9dadfbce-5ff8-4824-b29e-fa58c8ce02ea"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "0f6e4517-7649-4864-a402-66644937211b"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "roothomelv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "6a7a714d-d18f-4e8b-8ec8-fc09da7fa301"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkswap",
+          "options": {
+            "uuid": "c93538d6-5bf0-4bff-af1f-4221f8982b17"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "swap-lv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "38dfccf2-0c49-4849-802b-791e9b09aa12",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 1048576
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600
+              }
+            },
+            "data": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1460224,
+                "size": 2097152
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "shadowmanlv"
+              }
+            },
+            "media": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "root": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "roothomelv"
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "data",
+              "type": "org.osbuild.ext4",
+              "source": "data",
+              "target": "/data"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.ext4",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.ext4",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.ext4",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.ext4",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.ext4",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.ext4",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.ext4",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.ext4",
+              "source": "usr",
+              "target": "/usr"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.lvm2.metadata",
+          "options": {
+            "vg_name": "testvg"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3557376,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-baseos-n10.0"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-appstream-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-ami-partitioning_plain.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-ami-partitioning_plain.json
@@ -1,0 +1,1260 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "c0b4c5c3-b82c-496c-a7c3-5674b62b9f54",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "c0b4c5c3-b82c-496c-a7c3-5674b62b9f54",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "77bed9a9-4bc1-46ff-8c8f-1e7ce3e20a24",
+                "vfs_type": "ext4",
+                "path": "/data",
+                "options": "defaults"
+              },
+              {
+                "uuid": "24639e2f-be5a-4a59-a386-e83c40384ed7",
+                "vfs_type": "ext4",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "0c88d08e-3784-4ffb-b37a-f4ed41d578ae",
+                "vfs_type": "ext4",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "d412d84e-02ca-4f8e-844f-6564b8eae499",
+                "vfs_type": "ext4",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "c6a8f456-26bb-438a-ab5f-0e75e4d2e724",
+                "vfs_type": "ext4",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "d2b28bc8-b602-4f88-9f1b-390110a1dd3e",
+                "vfs_type": "ext4",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "d4d39d6c-522d-4698-8ef4-18860a70eaf5",
+                "vfs_type": "ext4",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "e5229df6-d586-4052-a082-f9f10b3095cc",
+                "vfs_type": "xfs",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "11fcc7fe-351f-44dd-8d0c-4b2ed48b96e1",
+                "vfs_type": "xfs",
+                "path": "/var",
+                "options": "defaults"
+              },
+              {
+                "uuid": "6db81ba1-8dfe-4c4b-8fc9-d4a1e44e0926",
+                "vfs_type": "swap",
+                "path": "none",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "c0b4c5c3-b82c-496c-a7c3-5674b62b9f54",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "17915969536"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "638b102d-5aad-4dad-8508-43cedae92d3f",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 2097152,
+                "start": 411648,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "5246514a-49ab-4501-a610-427ae7c8a8b3"
+              },
+              {
+                "size": 4194304,
+                "start": 2508800,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "57b75de3-6c6e-48f3-87e6-0652ffe4cde1"
+              },
+              {
+                "size": 1024000,
+                "start": 6703104,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "833da3d0-f86f-44e1-8dc6-9b45317b4016"
+              },
+              {
+                "size": 2097152,
+                "start": 7727104,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "fb68b23c-4747-4d5f-bb6c-6bcd6907e256"
+              },
+              {
+                "size": 8388608,
+                "start": 9824256,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "98d450af-64a3-4cc3-89f6-14643f3b44ed"
+              },
+              {
+                "size": 2097152,
+                "start": 18212864,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "211049a2-bc6a-462d-bdd2-ecf9284531ef"
+              },
+              {
+                "size": 2097152,
+                "start": 20310016,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "058649d4-4155-436a-bbda-8f57cb593ae7"
+              },
+              {
+                "size": 2097152,
+                "start": 22407168,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6a56fc61-e04a-406a-94d1-347e25e6c8b0"
+              },
+              {
+                "size": 2097152,
+                "start": 24504320,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "02f3412d-3f4c-4726-8df1-9f5bc5dbdc12"
+              },
+              {
+                "size": 2097152,
+                "start": 26601472,
+                "type": "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F",
+                "uuid": "64114e2e-d4ba-49a7-b101-d7325b02bb35"
+              },
+              {
+                "size": 6293471,
+                "start": 28698624,
+                "type": "B921B045-1DF0-41C3-AF44-4C6F280D3FAE",
+                "uuid": "b10157d8-62e8-402c-a014-8af3d15fba8f"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "77bed9a9-4bc1-46ff-8c8f-1e7ce3e20a24"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "0c88d08e-3784-4ffb-b37a-f4ed41d578ae",
+            "label": "home"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2508800,
+                "size": 4194304,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "d412d84e-02ca-4f8e-844f-6564b8eae499"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 6703104,
+                "size": 1024000,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "24639e2f-be5a-4a59-a386-e83c40384ed7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 7727104,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "11fcc7fe-351f-44dd-8d0c-4b2ed48b96e1"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 9824256,
+                "size": 8388608,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "d2b28bc8-b602-4f88-9f1b-390110a1dd3e"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 18212864,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "c6a8f456-26bb-438a-ab5f-0e75e4d2e724"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 20310016,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "d4d39d6c-522d-4698-8ef4-18860a70eaf5"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 22407168,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "e5229df6-d586-4052-a082-f9f10b3095cc"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 24504320,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkswap",
+          "options": {
+            "uuid": "6db81ba1-8dfe-4c4b-8fc9-d4a1e44e0926"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 26601472,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "c0b4c5c3-b82c-496c-a7c3-5674b62b9f54",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 28698624,
+                "size": 6293471,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 28698624,
+                "size": 6293471
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2048,
+                "size": 409600
+              }
+            },
+            "data": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 411648,
+                "size": 2097152
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 7727104,
+                "size": 2097152
+              }
+            },
+            "home": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2508800,
+                "size": 4194304
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 6703104,
+                "size": 1024000
+              }
+            },
+            "media": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 20310016,
+                "size": 2097152
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 18212864,
+                "size": 2097152
+              }
+            },
+            "root": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 22407168,
+                "size": 2097152
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 24504320,
+                "size": 2097152
+              }
+            },
+            "var": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 9824256,
+                "size": 8388608
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "data",
+              "type": "org.osbuild.ext4",
+              "source": "data",
+              "target": "/data"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.ext4",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.ext4",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.ext4",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.ext4",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.ext4",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.ext4",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.xfs",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "var",
+              "type": "org.osbuild.xfs",
+              "source": "var",
+              "target": "/var"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-baseos-n10.0"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-appstream-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-ami-partitioning_plain.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-ami-partitioning_plain.json
@@ -19,12 +19,6 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
-                },
-                {
                   "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
                 },
                 {
@@ -37,37 +31,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -130,9 +106,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -143,9 +116,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-azure_rhui-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-azure_rhui-empty.json
@@ -1,0 +1,1412 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "e0f7e382-fdb3-4b05-9bdb-a59dcd94b305",
+            "kernel_opts": "ro loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221"
+                },
+                {
+                  "id": "sha256:563a278902fa76bae3ec1833f24ff89abe26329b1d32af9aaa924d6fc6fd68aa"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:b6cae3a11438b4ec550ce10b73b35160fafbe9d436fdb4f81fea356fc5bb6fee"
+                },
+                {
+                  "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:79a583014c5150aac3a44a025229af2918d16d3f6f32d005bf5786f693d6b893"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:f48860f2daf7e7a03ab9827300ab91c865d446de1c12a279339a2fff75c00f4e"
+                },
+                {
+                  "id": "sha256:229b391b136444fc29f0a5b3a897222f8ff4ed2277427e68eeb13fccfe39905c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8e57cbb02cd20f0e373ae76a44d7ddd0125fe449db5dfc196b0920ef47ced56e"
+                },
+                {
+                  "id": "sha256:a4895eb44afc336fecbba6e520cd67e178dace0276655d102fceffa8e5f70570"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:75666699b77db631f576041e8102a55b46758c01b807eacae0f170930ab59b3d"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:01fdad2e9ee0a69f7e323ddb4258e2b0dbfaa242a21d7a8bfdfec04ebe8d3e86"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:81f29ed6c790aa976572770ecf7b6f0351da3c46c9558640c7a83896b6bf8e05"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:534994290b3914604921fc2c61852b7bb4c4d8fb947f057a6fb38a3a57835d9a"
+                },
+                {
+                  "id": "sha256:0ee8cf7e33852f80cd293a8fa8c371f888dc011984ff2836f1198bcdc552dc58"
+                },
+                {
+                  "id": "sha256:5f1e4685c9b4d243264d22fa24864335aab534815fcfe6c3a88eec83ee22354f"
+                },
+                {
+                  "id": "sha256:f3e607ceb5fd279c62a109d1bbb952cc44d7467266ef679a99fd0d9c02ce8d29"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:7913d978541704fb38f5f13a949811c80ed4a52b2514d4582fe3ccb8f5a04617"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:a76985e9146fec1e9fb00cc08d5e0a76eb7f47c10a7abbc4430f8ac235a8b1cd"
+                },
+                {
+                  "id": "sha256:141b56438fdc0208877397569000e1a5857ff57807ff3bbaf2622cc87901861d"
+                },
+                {
+                  "id": "sha256:725c887b1ebcd6be8eb9a0ef6b2c476ff6d2dd8f9cf622f8d60953a1f22c94c8"
+                },
+                {
+                  "id": "sha256:53d00356d82e89cbdf0f963060c58433f73e0b339ba9f63577bd7df44f78e051"
+                },
+                {
+                  "id": "sha256:f1d96d150523777accb14a93582922ded22aa868629c58c3cd49339952293327"
+                },
+                {
+                  "id": "sha256:840109e45bc2504c9f202410bd941dc430bcef1065e1c1a98e5d08506c0c91af"
+                },
+                {
+                  "id": "sha256:b1eb4c41592e8eb6f7f2c96cdda2162fe214f52f85b01e9b174aa81bf297e01a"
+                },
+                {
+                  "id": "sha256:590ef3ccd31b243b045e9c5f9268d1013b0960060366c76028a23b070b5fb7be"
+                },
+                {
+                  "id": "sha256:9fe43931a7b645b90921b9b72d836e9d06ececc0b3cca1376fa0a297b5f522a5"
+                },
+                {
+                  "id": "sha256:49ec7b34785f32ffd1f252d5cc9a0a015ca074f75c601d2272149a72d50d42df"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ],
+            "gpgkeys.fromtree": [
+              "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel-core"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "10-azure-kvp.cfg",
+            "config": {
+              "reporting": {
+                "logging": {
+                  "type": "log"
+                },
+                "telemetry": {
+                  "type": "hyperv"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "91-azure_datasource.cfg",
+            "config": {
+              "datasource": {
+                "Azure": {
+                  "apply_network_config": false
+                }
+              },
+              "datasource_list": [
+                "Azure"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-intel-cstate.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "intel_cstate"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-floppy.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "floppy"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              },
+              {
+                "command": "blacklist",
+                "modulename": "lbm-nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-skylake-edac.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "skx_edac"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-azure.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_AZURE",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "ClientAliveInterval": 180
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.pwquality.conf",
+          "options": {
+            "config": {
+              "minlen": 6,
+              "dcredit": 0,
+              "ucredit": 0,
+              "lcredit": 0,
+              "ocredit": 0,
+              "minclass": 3
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.waagent.conf",
+          "options": {
+            "config": {
+              "ResourceDisk.Format": false,
+              "ResourceDisk.EnableSwap": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.udev.rules",
+          "options": {
+            "filename": "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules",
+            "rules": [
+              {
+                "comment": [
+                  "Accelerated Networking on Azure exposes a new SRIOV interface to the VM.",
+                  "This interface is transparently bonded to the synthetic interface,",
+                  "so NetworkManager should just ignore any SRIOV interfaces."
+                ]
+              },
+              [
+                {
+                  "key": "SUBSYSTEM",
+                  "op": "==",
+                  "val": "net"
+                },
+                {
+                  "key": "DRIVERS",
+                  "op": "==",
+                  "val": "hv_pci"
+                },
+                {
+                  "key": "ACTION",
+                  "op": "==",
+                  "val": "add"
+                },
+                {
+                  "key": {
+                    "name": "ENV",
+                    "arg": "NM_UNMANAGED"
+                  },
+                  "op": "=",
+                  "val": "1"
+                }
+              ]
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "e0f7e382-fdb3-4b05-9bdb-a59dcd94b305",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "768a22f0-9054-4985-ac2d-ad88a8c676f2",
+                "vfs_type": "xfs",
+                "path": "/boot",
+                "options": "defaults"
+              },
+              {
+                "uuid": "d198cf19-0caa-476c-b4b8-2b588b31bfaf",
+                "vfs_type": "xfs",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "19b175ac-97d2-4d12-a3f3-6a63b7cde24e",
+                "vfs_type": "xfs",
+                "path": "/tmp",
+                "options": "defaults"
+              },
+              {
+                "uuid": "39245470-e702-4699-80d7-fb0a85461dbf",
+                "vfs_type": "xfs",
+                "path": "/usr",
+                "options": "defaults"
+              },
+              {
+                "uuid": "3f87e9d6-18f7-4bf5-8048-eacfa5c2331d",
+                "vfs_type": "xfs",
+                "path": "/var",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "e0f7e382-fdb3-4b05-9bdb-a59dcd94b305",
+            "boot_fs_uuid": "768a22f0-9054-4985-ac2d-ad88a8c676f2",
+            "kernel_opts": "ro loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved",
+              "disable_recovery": true,
+              "disable_submenu": true,
+              "distributor": "$(sed 's, release .*$,,g' /etc/system-release)",
+              "terminal": [
+                "serial",
+                "console"
+              ],
+              "timeout": 10,
+              "timeout_style": "countdown",
+              "serial": "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "firewalld",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "sshd",
+              "waagent"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "68719476736"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "size": 1024000,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 2097152,
+                "start": 1026048,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+              },
+              {
+                "size": 131094495,
+                "start": 3123200,
+                "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.lvm2.create",
+          "options": {
+            "volumes": [
+              {
+                "name": "homelv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "rootlv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "tmplv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "usrlv",
+                "size": "10737418240B"
+              },
+              {
+                "name": "varlv",
+                "size": "10737418240B"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3123200,
+                "size": 131094495,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 1024000,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "768a22f0-9054-4985-ac2d-ad88a8c676f2"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1026048,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "d198cf19-0caa-476c-b4b8-2b588b31bfaf",
+            "label": "home"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3123200,
+                "size": 131094495,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "e0f7e382-fdb3-4b05-9bdb-a59dcd94b305",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3123200,
+                "size": 131094495,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "19b175ac-97d2-4d12-a3f3-6a63b7cde24e",
+            "label": "tmp"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "tmplv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3123200,
+                "size": 131094495,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "39245470-e702-4699-80d7-fb0a85461dbf",
+            "label": "usr"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3123200,
+                "size": 131094495,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "3f87e9d6-18f7-4bf5-8048-eacfa5c2331d",
+            "label": "var"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "varlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3123200,
+                "size": 131094495,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1026048,
+                "size": 2097152
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 1024000
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3123200,
+                "size": 131094495
+              }
+            },
+            "tmp": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "tmplv"
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "var": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "varlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.xfs",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "tmp",
+              "type": "org.osbuild.xfs",
+              "source": "tmp",
+              "target": "/tmp"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.xfs",
+              "source": "usr",
+              "target": "/usr"
+            },
+            {
+              "name": "var",
+              "type": "org.osbuild.xfs",
+              "source": "var",
+              "target": "/var"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.lvm2.metadata",
+          "options": {
+            "vg_name": "rootvg"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3123200,
+                "size": 131094495,
+                "lock": true
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "vpc",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "image.vhd",
+            "format": {
+              "type": "vpc"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "xz",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.xz",
+          "inputs": {
+            "file": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:vpc": {
+                  "file": "image.vhd"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.vhd.xz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:01fdad2e9ee0a69f7e323ddb4258e2b0dbfaa242a21d7a8bfdfec04ebe8d3e86": {
+          "url": "https://example.com/repo/packages/exclude:NetworkManager-config-server"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3": {
+          "url": "https://example.com/repo/packages/bzip2"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:0ee8cf7e33852f80cd293a8fa8c371f888dc011984ff2836f1198bcdc552dc58": {
+          "url": "https://example.com/repo/packages/exclude:buildah"
+        },
+        "sha256:141b56438fdc0208877397569000e1a5857ff57807ff3bbaf2622cc87901861d": {
+          "url": "https://example.com/repo/packages/exclude:python3-dnf-plugin-spacewalk"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:229b391b136444fc29f0a5b3a897222f8ff4ed2277427e68eeb13fccfe39905c": {
+          "url": "https://example.com/repo/packages/kernel-modules"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:49ec7b34785f32ffd1f252d5cc9a0a015ca074f75c601d2272149a72d50d42df": {
+          "url": "https://example.com/repo/packages/exclude:usb_modeswitch"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:534994290b3914604921fc2c61852b7bb4c4d8fb947f057a6fb38a3a57835d9a": {
+          "url": "https://example.com/repo/packages/exclude:bolt"
+        },
+        "sha256:53d00356d82e89cbdf0f963060c58433f73e0b339ba9f63577bd7df44f78e051": {
+          "url": "https://example.com/repo/packages/exclude:python3-rhnlib"
+        },
+        "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-baseos-n10.0"
+        },
+        "sha256:563a278902fa76bae3ec1833f24ff89abe26329b1d32af9aaa924d6fc6fd68aa": {
+          "url": "https://example.com/repo/packages/NetworkManager"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:590ef3ccd31b243b045e9c5f9268d1013b0960060366c76028a23b070b5fb7be": {
+          "url": "https://example.com/repo/packages/exclude:rhnlib"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5f1e4685c9b4d243264d22fa24864335aab534815fcfe6c3a88eec83ee22354f": {
+          "url": "https://example.com/repo/packages/exclude:cockpit-podman"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221": {
+          "url": "https://example.com/repo/packages/@Server"
+        },
+        "sha256:725c887b1ebcd6be8eb9a0ef6b2c476ff6d2dd8f9cf622f8d60953a1f22c94c8": {
+          "url": "https://example.com/repo/packages/exclude:python3-hwdata"
+        },
+        "sha256:75666699b77db631f576041e8102a55b46758c01b807eacae0f170930ab59b3d": {
+          "url": "https://example.com/repo/packages/uuid"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7913d978541704fb38f5f13a949811c80ed4a52b2514d4582fe3ccb8f5a04617": {
+          "url": "https://example.com/repo/packages/exclude:glibc-all-langpacks"
+        },
+        "sha256:79a583014c5150aac3a44a025229af2918d16d3f6f32d005bf5786f693d6b893": {
+          "url": "https://example.com/repo/packages/hyperv-daemons"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:81f29ed6c790aa976572770ecf7b6f0351da3c46c9558640c7a83896b6bf8e05": {
+          "url": "https://example.com/repo/packages/exclude:alsa-sof-firmware"
+        },
+        "sha256:840109e45bc2504c9f202410bd941dc430bcef1065e1c1a98e5d08506c0c91af": {
+          "url": "https://example.com/repo/packages/exclude:rhn-client-tools"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8e57cbb02cd20f0e373ae76a44d7ddd0125fe449db5dfc196b0920ef47ced56e": {
+          "url": "https://example.com/repo/packages/nvme-cli"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:9fe43931a7b645b90921b9b72d836e9d06ececc0b3cca1376fa0a297b5f522a5": {
+          "url": "https://example.com/repo/packages/exclude:rhnsd"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a4895eb44afc336fecbba6e520cd67e178dace0276655d102fceffa8e5f70570": {
+          "url": "https://example.com/repo/packages/patch"
+        },
+        "sha256:a76985e9146fec1e9fb00cc08d5e0a76eb7f47c10a7abbc4430f8ac235a8b1cd": {
+          "url": "https://example.com/repo/packages/exclude:podman"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:b1eb4c41592e8eb6f7f2c96cdda2162fe214f52f85b01e9b174aa81bf297e01a": {
+          "url": "https://example.com/repo/packages/exclude:rhn-setup"
+        },
+        "sha256:b6cae3a11438b4ec550ce10b73b35160fafbe9d436fdb4f81fea356fc5bb6fee": {
+          "url": "https://example.com/repo/packages/WALinuxAgent"
+        },
+        "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-appstream-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f1d96d150523777accb14a93582922ded22aa868629c58c3cd49339952293327": {
+          "url": "https://example.com/repo/packages/exclude:rhn-check"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f3e607ceb5fd279c62a109d1bbb952cc44d7467266ef679a99fd0d9c02ce8d29": {
+          "url": "https://example.com/repo/packages/exclude:containernetworking-plugins"
+        },
+        "sha256:f48860f2daf7e7a03ab9827300ab91c865d446de1c12a279339a2fff75c00f4e": {
+          "url": "https://example.com/repo/packages/kernel-core"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-azure_rhui-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-azure_rhui-empty.json
@@ -19,13 +19,7 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
@@ -37,13 +31,7 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
-                },
-                {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
@@ -55,15 +43,6 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
@@ -71,12 +50,6 @@
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
                 },
                 {
                   "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
@@ -154,12 +127,6 @@
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
-                },
-                {
                   "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
                 },
                 {
@@ -178,9 +145,6 @@
                   "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
                 },
                 {
-                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
                   "id": "sha256:f48860f2daf7e7a03ab9827300ab91c865d446de1c12a279339a2fff75c00f4e"
                 },
                 {
@@ -193,9 +157,6 @@
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
-                },
-                {
                   "id": "sha256:8e57cbb02cd20f0e373ae76a44d7ddd0125fe449db5dfc196b0920ef47ced56e"
                 },
                 {
@@ -203,9 +164,6 @@
                 },
                 {
                   "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-ec2-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-ec2-empty.json
@@ -1,0 +1,857 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "739f781e-4370-4221-a05a-5db5efeab629",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "739f781e-4370-4221-a05a-5db5efeab629",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "739f781e-4370-4221-a05a-5db5efeab629",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 iommu.strict=0",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20559839,
+                "start": 411648,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "739f781e-4370-4221-a05a-5db5efeab629",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 411648,
+                "size": 20559839,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 411648,
+                "size": 20559839
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "xz",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.xz",
+          "inputs": {
+            "file": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "image.raw.xz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-baseos-n10.0"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-appstream-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-ec2-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-ec2-empty.json
@@ -19,16 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -40,19 +34,7 @@
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
@@ -62,12 +44,6 @@
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
                 },
                 {
                   "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
@@ -127,9 +103,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -140,9 +113,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-image_installer-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-image_installer-empty.json
@@ -55,12 +55,6 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
@@ -136,9 +130,6 @@
                   "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
                 },
                 {
-                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
-                },
-                {
                   "id": "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2"
                 },
                 {
@@ -155,9 +146,6 @@
                 },
                 {
                   "id": "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c"
-                },
-                {
-                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
                 },
                 {
                   "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
@@ -184,28 +172,13 @@
                   "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
                 },
                 {
-                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
-                },
-                {
                   "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
                   "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
-                },
-                {
-                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
                 },
                 {
                   "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
@@ -235,37 +208,13 @@
                   "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
                 },
                 {
-                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
-                },
-                {
-                  "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
-                },
-                {
                   "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
                 },
                 {
                   "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
                 },
                 {
-                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
-                },
-                {
-                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
-                },
-                {
                   "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
-                },
-                {
-                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
                 },
                 {
                   "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
@@ -286,9 +235,6 @@
                   "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
                 },
                 {
-                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
-                },
-                {
                   "id": "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1"
                 },
                 {
@@ -298,16 +244,7 @@
                   "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
                 },
                 {
-                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
-                },
-                {
                   "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
-                },
-                {
-                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
-                },
-                {
-                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
                 },
                 {
                   "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
@@ -316,16 +253,7 @@
                   "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
                 },
                 {
-                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
-                },
-                {
                   "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
-                },
-                {
-                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
-                },
-                {
-                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
                 },
                 {
                   "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
@@ -334,16 +262,7 @@
                   "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
                 },
                 {
-                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
-                },
-                {
                   "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
                 },
                 {
                   "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
@@ -356,12 +275,6 @@
                 },
                 {
                   "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
-                },
-                {
-                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
-                },
-                {
-                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
                 },
                 {
                   "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
@@ -380,12 +293,6 @@
                 },
                 {
                   "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
-                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
-                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
                 },
                 {
                   "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
@@ -427,9 +334,6 @@
                   "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
                 },
                 {
-                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
-                },
-                {
                   "id": "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686"
                 },
                 {
@@ -445,13 +349,7 @@
                   "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
                 },
                 {
-                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
-                },
-                {
                   "id": "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a"
-                },
-                {
-                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
                 },
                 {
                   "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
@@ -469,12 +367,6 @@
                   "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
                 },
                 {
-                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
-                },
-                {
-                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
-                },
-                {
                   "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
                 },
                 {
@@ -488,12 +380,6 @@
                 },
                 {
                   "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
                 },
                 {
                   "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
@@ -511,13 +397,7 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14"
-                },
-                {
-                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
                 },
                 {
                   "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
@@ -536,12 +416,6 @@
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
@@ -569,12 +443,6 @@
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
                 },
                 {
                   "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
@@ -785,9 +653,6 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
@@ -860,9 +725,6 @@
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
-                },
-                {
                   "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
                 },
                 {
@@ -873,9 +735,6 @@
                 },
                 {
                   "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -908,9 +767,6 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
                 },
                 {
@@ -918,9 +774,6 @@
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-image_installer-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-image_installer-empty.json
@@ -1,0 +1,1652 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c"
+                },
+                {
+                  "id": "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:a788847c8c115aa9ae27ca92230418e77b3b36a6424f1d4f3436633864c93db9"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "anaconda-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:629e355a0345015e53cacd90ce641c7e2ef38405cd55e135f331a6303c51f509"
+                },
+                {
+                  "id": "sha256:1f2ce4e8c1aea4a2440b7e794e0440385f8e9c3f48b0fd65118f3dcdbca783bf"
+                },
+                {
+                  "id": "sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f"
+                },
+                {
+                  "id": "sha256:cd2c0f63ad37d585e77b3f1c584539e26bf7928710ac8fb19fd377f61b7326e6"
+                },
+                {
+                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
+                },
+                {
+                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
+                },
+                {
+                  "id": "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2"
+                },
+                {
+                  "id": "sha256:903be5b3913df555a8586e571d9016e1ac24eef2631a5d75b8c3f94c66f10955"
+                },
+                {
+                  "id": "sha256:b81f37a043a6f767e7c94d105f4bd31282f3ecc20680bb9d09bd93461cf4c863"
+                },
+                {
+                  "id": "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9"
+                },
+                {
+                  "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
+                },
+                {
+                  "id": "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c"
+                },
+                {
+                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
+                },
+                {
+                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
+                },
+                {
+                  "id": "sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112"
+                },
+                {
+                  "id": "sha256:5b8b6480d96480b779d6937e2d8694e03cdae14eb0664033ef24af50e1557726"
+                },
+                {
+                  "id": "sha256:75c008414c1be65c0e6954f74e1afdf3f706369f26899ea792b4ac0f31f287bc"
+                },
+                {
+                  "id": "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa"
+                },
+                {
+                  "id": "sha256:5e5d7e05a668f4ec5939a246b38d17cbb6ee83c0408ecbf584f6561a9d64a383"
+                },
+                {
+                  "id": "sha256:826c7f30d36dcc8cb4628bee44fc0e257a360eb06cfc31c49148a44b153e78ce"
+                },
+                {
+                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
+                },
+                {
+                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
+                },
+                {
+                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c"
+                },
+                {
+                  "id": "sha256:581265de790cf918fc770318449fe4cd07a18771c975d42867760b2e2f1bd18d"
+                },
+                {
+                  "id": "sha256:1f35e175b07fc080eb57fc9db22a3ce477d87bc5447466815f55864d3b6e6586"
+                },
+                {
+                  "id": "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31"
+                },
+                {
+                  "id": "sha256:9ac51bbcd5be0f507237b2d43367ad073eaf99398a65d26fa2a8fee5275f889b"
+                },
+                {
+                  "id": "sha256:f5f43514d2de810e4ea6d047203505e2e3c0c25f43941ec226968d17bb3aa1b5"
+                },
+                {
+                  "id": "sha256:24173b7985c9c52efc25b39e51f0fd41ac7b35e7031ed17da97788f293a3ce4e"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
+                },
+                {
+                  "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:9531c8584bbf61635c5c9b15733d9494cb6dd232a6eec85a946076c6c633e99f"
+                },
+                {
+                  "id": "sha256:5e4e6002bd0ef9491967c1f5f573b0c184ef5a41d165cff38c8c6c73606702cb"
+                },
+                {
+                  "id": "sha256:263acae321870b428781a1f4cb5e88740a897a4f9b614233a1798d295f805c54"
+                },
+                {
+                  "id": "sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1"
+                },
+                {
+                  "id": "sha256:8e901f9b6ca3996fe198c84d5f0a305b635bbaae54757fa84932ac52479c1efa"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111"
+                },
+                {
+                  "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:4ad76aeffa1e790eaf720b659f9860c50b6e0ba4787fa0a2d0e43dfa46193035"
+                },
+                {
+                  "id": "sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe"
+                },
+                {
+                  "id": "sha256:eeb3d09845f5cde069eeade2c4339532be58b6607120be00656123cc73ea727c"
+                },
+                {
+                  "id": "sha256:ce5b1962783aa6a9374a0a1b34941a112a799baac827c733bd28c78dbb4bcf36"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
+                },
+                {
+                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
+                },
+                {
+                  "id": "sha256:b498cfb546ddbfbd5953e28137e5b39a65ba6c7220bf4fe4c3cc9bcafc73c41b"
+                },
+                {
+                  "id": "sha256:f6453ebfd8ab070567bfcd4cda99cc41c2c849237745f24228c5f040cac5d562"
+                },
+                {
+                  "id": "sha256:f7f7a2e0133dfc81f9505bac28dfb7ee3398f3dc3b32c7682c86a9be5403bfee"
+                },
+                {
+                  "id": "sha256:cf732696c9aebd80fad833157535754f246445ad0fec66e918963443bd3cfb71"
+                },
+                {
+                  "id": "sha256:fe36b1d498f9c6057ed774ba5fb0a84c8592886c3a4c7c077ce7f41326373099"
+                },
+                {
+                  "id": "sha256:cb298bd94fae6f2f713a1108a16e0632f3a1e21820a288d7ea86c8b00a4d4fef"
+                },
+                {
+                  "id": "sha256:52999df2efd2afc3fcda19e416efb2d0f9b09562aa53331eaac2cde3c88ea207"
+                },
+                {
+                  "id": "sha256:b7110cc6e76089686855ae923d8e0212a0f067b8a48f3c96e8510d50c56061a7"
+                },
+                {
+                  "id": "sha256:2442f8197039e6fb34538a4651f00be2bcbaa8d2be3a15b734fa6ddf1bd8abba"
+                },
+                {
+                  "id": "sha256:a39d3ae3da34f2b4c01193e62202d5de0db79f800a039624b0f950734782b863"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686"
+                },
+                {
+                  "id": "sha256:316d18e697dfa41e92a9fe91d8d175629db5e330348a8adc1a5b43744d01d217"
+                },
+                {
+                  "id": "sha256:68d6e3ed85174ed856b83d5d1e16c23d5279cb5dc77915ae8570a768a5a65505"
+                },
+                {
+                  "id": "sha256:4381157a0ab3568cb31f727709b2edfca21522a8645e95c411f5798b8018393d"
+                },
+                {
+                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
+                },
+                {
+                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
+                },
+                {
+                  "id": "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a"
+                },
+                {
+                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
+                },
+                {
+                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
+                },
+                {
+                  "id": "sha256:500d641b95d95deab52480573126901d76d81dfe9fe0a5caf43445df38caad7b"
+                },
+                {
+                  "id": "sha256:5bc35fd09bee19e0dc22c7f7a731d1d8f4f68b81a3fd866e32273523eda30f9e"
+                },
+                {
+                  "id": "sha256:883642e660d2ef545d3d9f0cbd12790a99aea6358fb67c46664ff22fefa8b7df"
+                },
+                {
+                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
+                },
+                {
+                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
+                },
+                {
+                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
+                },
+                {
+                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
+                },
+                {
+                  "id": "sha256:990fde98d70a0a1a75bf55978f90138e8878a7f5cc1de475e03ee25b6744ee8a"
+                },
+                {
+                  "id": "sha256:95671115820a1fb4e74d1abed36bf069ce64a8233a3a37a8909cc62dffc57293"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
+                },
+                {
+                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
+                },
+                {
+                  "id": "sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:afed7d2fb0ea7b7e9d8dbcf1c1bb62ff53840c72d380cf165294a1eccb7fdeb1"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:cb6b44243b93acef33a5ee905d92203a2a55abdc6a3b7c446c8435a41a6ad137"
+                },
+                {
+                  "id": "sha256:61bfeb2957d080cbab70b332f16b482e1991b08e77ea7a8546b68b3cde90990c"
+                },
+                {
+                  "id": "sha256:28bdff3b22fe1fe1b18313472b2060d2706b9052cbabd91aaa7bed0c88c065de"
+                },
+                {
+                  "id": "sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a"
+                },
+                {
+                  "id": "sha256:85830c0611a0acd7053f7b3a29f52a0511acc3695f9c5ef39a29fcfb8b80e25b"
+                },
+                {
+                  "id": "sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d"
+                },
+                {
+                  "id": "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf"
+                },
+                {
+                  "id": "sha256:0a26024d87ac934c3aeca0ec8b27e579dfb6b268ac43f3a6f945579a54c46e6e"
+                },
+                {
+                  "id": "sha256:570e342d0e4708dab94b2025f6b928845b659b405872d824b45473c4635d7b1d"
+                },
+                {
+                  "id": "sha256:ce2b8ecf9afac9f546bdbbb0902afb6088fdcb8524269ad5b4adb9b9d4959b07"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.buildstamp",
+          "options": {
+            "arch": "aarch64",
+            "product": "Red Hat Enterprise Linux",
+            "version": "10.0",
+            "final": true,
+            "variant": "",
+            "bugurl": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+              "install": {
+                "uid": 0,
+                "gid": 0,
+                "home": "/root",
+                "shell": "/usr/libexec/anaconda/run-anaconda",
+                "password": ""
+              },
+              "root": {
+                "password": ""
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.anaconda",
+          "options": {
+            "activatable-modules": [
+              "org.fedoraproject.Anaconda.Modules.Network",
+              "org.fedoraproject.Anaconda.Modules.Payloads",
+              "org.fedoraproject.Anaconda.Modules.Storage",
+              "org.fedoraproject.Anaconda.Modules.Users"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.lorax-script",
+          "options": {
+            "path": "99-generic/runtime-postinstall.tmpl",
+            "basearch": "aarch64",
+            "product": {
+              "name": "",
+              "version": ""
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.dracut",
+          "options": {
+            "kernel": [
+              "8-2.fk1.aarch64"
+            ],
+            "modules": [
+              "bash",
+              "systemd",
+              "fips",
+              "systemd-initrd",
+              "modsign",
+              "nss-softokn",
+              "i18n",
+              "convertfs",
+              "network-manager",
+              "network",
+              "url-lib",
+              "drm",
+              "plymouth",
+              "crypt",
+              "dm",
+              "dmsquash-live",
+              "kernel-modules",
+              "kernel-modules-extra",
+              "kernel-network-modules",
+              "livenet",
+              "lvm",
+              "mdraid",
+              "qemu",
+              "qemu-net",
+              "resume",
+              "rootfs-block",
+              "terminfo",
+              "udev-rules",
+              "dracut-systemd",
+              "pollcdrom",
+              "usrmount",
+              "base",
+              "fs-lib",
+              "img-lib",
+              "shutdown",
+              "uefi-lib",
+              "nvdimm",
+              "prefixdevname",
+              "prefixdevname-tools",
+              "net-lib",
+              "anaconda",
+              "rdma",
+              "rngd",
+              "multipath",
+              "fcoe",
+              "fcoe-uefi",
+              "iscsi",
+              "lunmask",
+              "nfs"
+            ],
+            "add_drivers": [
+              "ipmi_devintf",
+              "ipmi_msghandler"
+            ],
+            "install": [
+              "/.buildstamp"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux.config",
+          "options": {
+            "state": "permissive"
+          }
+        }
+      ]
+    },
+    {
+      "name": "efiboot-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.grub2.iso",
+          "options": {
+            "product": {
+              "name": "Red Hat Enterprise Linux",
+              "version": "10.0"
+            },
+            "kernel": {
+              "dir": "/images/pxeboot",
+              "opts": [
+                "inst.stage2=hd:LABEL=RHEL-10-0-0-BaseOS-aarch64",
+                "inst.ks=hd:LABEL=RHEL-10-0-0-BaseOS-aarch64:/osbuild.ks"
+              ]
+            },
+            "isolabel": "RHEL-10-0-0-BaseOS-aarch64",
+            "architectures": [
+              "AA64"
+            ],
+            "vendor": "redhat"
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111"
+                },
+                {
+                  "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd"
+                },
+                {
+                  "id": "sha256:d87d9e526f265be973fce2ba320c5ed3ae24f6c5560d816d0b9307d0ba4d357f"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bootiso-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/images"
+              },
+              {
+                "path": "/images/pxeboot"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://tree/boot/vmlinuz-8-2.fk1.aarch64",
+                "to": "tree:///images/pxeboot/vmlinuz"
+              },
+              {
+                "from": "input://tree/boot/initramfs-8-2.fk1.aarch64.img",
+                "to": "tree:///images/pxeboot/initrd.img"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.squashfs",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "filename": "images/install.img",
+            "compression": {
+              "method": "xz",
+              "options": {
+                "bcj": "arm"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "images/efiboot.img",
+            "size": "20971520"
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "96855a5e"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "images/efiboot.img",
+                "size": 40960,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:efiboot-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "images/efiboot.img",
+                "size": 40960
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.fat",
+              "source": "-",
+              "target": "/"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:efiboot-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/EFI",
+                "to": "tree:///"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "/liveimg.tar.gz"
+          }
+        },
+        {
+          "type": "org.osbuild.kickstart",
+          "options": {
+            "path": "/osbuild.ks",
+            "liveimg": {
+              "url": "file:///run/install/repo/liveimg.tar.gz"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.discinfo",
+          "options": {
+            "basearch": "aarch64",
+            "release": "Red Hat Enterprise Linux 10.0"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bootiso",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.xorrisofs",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:bootiso-tree"
+              ]
+            }
+          },
+          "options": {
+            "filename": "installer.iso",
+            "volid": "RHEL-10-0-0-BaseOS-aarch64",
+            "sysid": "LINUX",
+            "efi": "images/efiboot.img",
+            "isolevel": 3
+          }
+        },
+        {
+          "type": "org.osbuild.implantisomd5",
+          "options": {
+            "filename": "installer.iso"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a": {
+          "url": "https://example.com/repo/packages/net-tools"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112": {
+          "url": "https://example.com/repo/packages/dbus-x11"
+        },
+        "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3": {
+          "url": "https://example.com/repo/packages/bzip2"
+        },
+        "sha256:0a26024d87ac934c3aeca0ec8b27e579dfb6b268ac43f3a6f945579a54c46e6e": {
+          "url": "https://example.com/repo/packages/volume_key"
+        },
+        "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1": {
+          "url": "https://example.com/repo/packages/initscripts"
+        },
+        "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa": {
+          "url": "https://example.com/repo/packages/iwl105-firmware"
+        },
+        "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9": {
+          "url": "https://example.com/repo/packages/bind-utils"
+        },
+        "sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe": {
+          "url": "https://example.com/repo/packages/kbd"
+        },
+        "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa": {
+          "url": "https://example.com/repo/packages/anaconda-dracut"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:1f2ce4e8c1aea4a2440b7e794e0440385f8e9c3f48b0fd65118f3dcdbca783bf": {
+          "url": "https://example.com/repo/packages/alsa-firmware"
+        },
+        "sha256:1f35e175b07fc080eb57fc9db22a3ce477d87bc5447466815f55864d3b6e6586": {
+          "url": "https://example.com/repo/packages/ftp"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:24173b7985c9c52efc25b39e51f0fd41ac7b35e7031ed17da97788f293a3ce4e": {
+          "url": "https://example.com/repo/packages/google-noto-sans-cjk-ttc-fonts"
+        },
+        "sha256:2442f8197039e6fb34538a4651f00be2bcbaa8d2be3a15b734fa6ddf1bd8abba": {
+          "url": "https://example.com/repo/packages/mt-st"
+        },
+        "sha256:263acae321870b428781a1f4cb5e88740a897a4f9b614233a1798d295f805c54": {
+          "url": "https://example.com/repo/packages/hdparm"
+        },
+        "sha256:28bdff3b22fe1fe1b18313472b2060d2706b9052cbabd91aaa7bed0c88c065de": {
+          "url": "https://example.com/repo/packages/spice-vdagent"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686": {
+          "url": "https://example.com/repo/packages/nm-connection-editor"
+        },
+        "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa": {
+          "url": "https://example.com/repo/packages/dejavu-sans-fonts"
+        },
+        "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc": {
+          "url": "https://example.com/repo/packages/dmidecode"
+        },
+        "sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f": {
+          "url": "https://example.com/repo/packages/alsa-tools-firmware"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:316d18e697dfa41e92a9fe91d8d175629db5e330348a8adc1a5b43744d01d217": {
+          "url": "https://example.com/repo/packages/nmap-ncat"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1": {
+          "url": "https://example.com/repo/packages/dnf"
+        },
+        "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0": {
+          "url": "https://example.com/repo/packages/curl"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:4381157a0ab3568cb31f727709b2edfca21522a8645e95c411f5798b8018393d": {
+          "url": "https://example.com/repo/packages/nss-tools"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64-cdboot"
+        },
+        "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce": {
+          "url": "https://example.com/repo/packages/iwl100-firmware"
+        },
+        "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674": {
+          "url": "https://example.com/repo/packages/iwl2030-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4ad76aeffa1e790eaf720b659f9860c50b6e0ba4787fa0a2d0e43dfa46193035": {
+          "url": "https://example.com/repo/packages/jomolhari-fonts"
+        },
+        "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d": {
+          "url": "https://example.com/repo/packages/less"
+        },
+        "sha256:500d641b95d95deab52480573126901d76d81dfe9fe0a5caf43445df38caad7b": {
+          "url": "https://example.com/repo/packages/pciutils"
+        },
+        "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2": {
+          "url": "https://example.com/repo/packages/anaconda-install-img-deps"
+        },
+        "sha256:52999df2efd2afc3fcda19e416efb2d0f9b09562aa53331eaac2cde3c88ea207": {
+          "url": "https://example.com/repo/packages/madan-fonts"
+        },
+        "sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781": {
+          "url": "https://example.com/repo/packages/xorriso"
+        },
+        "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-baseos-n10.0"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:570e342d0e4708dab94b2025f6b928845b659b405872d824b45473c4635d7b1d": {
+          "url": "https://example.com/repo/packages/wget"
+        },
+        "sha256:581265de790cf918fc770318449fe4cd07a18771c975d42867760b2e2f1bd18d": {
+          "url": "https://example.com/repo/packages/fcoe-utils"
+        },
+        "sha256:5b8b6480d96480b779d6937e2d8694e03cdae14eb0664033ef24af50e1557726": {
+          "url": "https://example.com/repo/packages/default-fonts-core-sans"
+        },
+        "sha256:5bc35fd09bee19e0dc22c7f7a731d1d8f4f68b81a3fd866e32273523eda30f9e": {
+          "url": "https://example.com/repo/packages/perl-interpreter"
+        },
+        "sha256:5e4e6002bd0ef9491967c1f5f573b0c184ef5a41d165cff38c8c6c73606702cb": {
+          "url": "https://example.com/repo/packages/gsettings-desktop-schemas"
+        },
+        "sha256:5e5d7e05a668f4ec5939a246b38d17cbb6ee83c0408ecbf584f6561a9d64a383": {
+          "url": "https://example.com/repo/packages/dejavu-sans-mono-fonts"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:61bfeb2957d080cbab70b332f16b482e1991b08e77ea7a8546b68b3cde90990c": {
+          "url": "https://example.com/repo/packages/smartmontools"
+        },
+        "sha256:629e355a0345015e53cacd90ce641c7e2ef38405cd55e135f331a6303c51f509": {
+          "url": "https://example.com/repo/packages/@hardware-support"
+        },
+        "sha256:68d6e3ed85174ed856b83d5d1e16c23d5279cb5dc77915ae8570a768a5a65505": {
+          "url": "https://example.com/repo/packages/nss-softokn"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682": {
+          "url": "https://example.com/repo/packages/hostname"
+        },
+        "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393": {
+          "url": "https://example.com/repo/packages/grub2-tools-minimal"
+        },
+        "sha256:75c008414c1be65c0e6954f74e1afdf3f706369f26899ea792b4ac0f31f287bc": {
+          "url": "https://example.com/repo/packages/default-fonts-other-sans"
+        },
+        "sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18": {
+          "url": "https://example.com/repo/packages/strace"
+        },
+        "sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980": {
+          "url": "https://example.com/repo/packages/hexedit"
+        },
+        "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764": {
+          "url": "https://example.com/repo/packages/grub2-tools-extra"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5": {
+          "url": "https://example.com/repo/packages/firewalld"
+        },
+        "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a": {
+          "url": "https://example.com/repo/packages/openssh-server"
+        },
+        "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467": {
+          "url": "https://example.com/repo/packages/iwl6050-firmware"
+        },
+        "sha256:826c7f30d36dcc8cb4628bee44fc0e257a360eb06cfc31c49148a44b153e78ce": {
+          "url": "https://example.com/repo/packages/device-mapper-persistent-data"
+        },
+        "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0": {
+          "url": "https://example.com/repo/packages/ostree"
+        },
+        "sha256:85830c0611a0acd7053f7b3a29f52a0511acc3695f9c5ef39a29fcfb8b80e25b": {
+          "url": "https://example.com/repo/packages/udisks2-iscsi"
+        },
+        "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071": {
+          "url": "https://example.com/repo/packages/iwl5150-firmware"
+        },
+        "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714": {
+          "url": "https://example.com/repo/packages/iwl135-firmware"
+        },
+        "sha256:883642e660d2ef545d3d9f0cbd12790a99aea6358fb67c46664ff22fefa8b7df": {
+          "url": "https://example.com/repo/packages/pigz"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111": {
+          "url": "https://example.com/repo/packages/iwl6000g2a-firmware"
+        },
+        "sha256:8e901f9b6ca3996fe198c84d5f0a305b635bbaae54757fa84932ac52479c1efa": {
+          "url": "https://example.com/repo/packages/ipmitool"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:903be5b3913df555a8586e571d9016e1ac24eef2631a5d75b8c3f94c66f10955": {
+          "url": "https://example.com/repo/packages/anaconda-widgets"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9531c8584bbf61635c5c9b15733d9494cb6dd232a6eec85a946076c6c633e99f": {
+          "url": "https://example.com/repo/packages/grubby"
+        },
+        "sha256:95671115820a1fb4e74d1abed36bf069ce64a8233a3a37a8909cc62dffc57293": {
+          "url": "https://example.com/repo/packages/rdma-core"
+        },
+        "sha256:990fde98d70a0a1a75bf55978f90138e8878a7f5cc1de475e03ee25b6744ee8a": {
+          "url": "https://example.com/repo/packages/python3-pyatspi"
+        },
+        "sha256:9ac51bbcd5be0f507237b2d43367ad073eaf99398a65d26fa2a8fee5275f889b": {
+          "url": "https://example.com/repo/packages/glibc-all-langpacks"
+        },
+        "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd": {
+          "url": "https://example.com/repo/packages/prefixdevname"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a39d3ae3da34f2b4c01193e62202d5de0db79f800a039624b0f950734782b863": {
+          "url": "https://example.com/repo/packages/mtr"
+        },
+        "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53": {
+          "url": "https://example.com/repo/packages/plymouth"
+        },
+        "sha256:a788847c8c115aa9ae27ca92230418e77b3b36a6424f1d4f3436633864c93db9": {
+          "url": "https://example.com/repo/packages/squashfs-tools"
+        },
+        "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018": {
+          "url": "https://example.com/repo/packages/iwl3160-firmware"
+        },
+        "sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d": {
+          "url": "https://example.com/repo/packages/usbutils"
+        },
+        "sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a": {
+          "url": "https://example.com/repo/packages/udisks2"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14": {
+          "url": "https://example.com/repo/packages/sg3_utils"
+        },
+        "sha256:afed7d2fb0ea7b7e9d8dbcf1c1bb62ff53840c72d380cf165294a1eccb7fdeb1": {
+          "url": "https://example.com/repo/packages/rsyslog"
+        },
+        "sha256:b498cfb546ddbfbd5953e28137e5b39a65ba6c7220bf4fe4c3cc9bcafc73c41b": {
+          "url": "https://example.com/repo/packages/libblockdev-lvm-dbus"
+        },
+        "sha256:b7110cc6e76089686855ae923d8e0212a0f067b8a48f3c96e8510d50c56061a7": {
+          "url": "https://example.com/repo/packages/mdadm"
+        },
+        "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-appstream-n10.0"
+        },
+        "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be": {
+          "url": "https://example.com/repo/packages/rpcbind"
+        },
+        "sha256:b81f37a043a6f767e7c94d105f4bd31282f3ecc20680bb9d09bd93461cf4c863": {
+          "url": "https://example.com/repo/packages/audit"
+        },
+        "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf": {
+          "url": "https://example.com/repo/packages/vim-minimal"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8": {
+          "url": "https://example.com/repo/packages/iwl2000-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0": {
+          "url": "https://example.com/repo/packages/iwl5000-firmware"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c": {
+          "url": "https://example.com/repo/packages/ethtool"
+        },
+        "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0": {
+          "url": "https://example.com/repo/packages/iwl1000-firmware"
+        },
+        "sha256:cb298bd94fae6f2f713a1108a16e0632f3a1e21820a288d7ea86c8b00a4d4fef": {
+          "url": "https://example.com/repo/packages/lsof"
+        },
+        "sha256:cb6b44243b93acef33a5ee905d92203a2a55abdc6a3b7c446c8435a41a6ad137": {
+          "url": "https://example.com/repo/packages/sil-padauk-fonts"
+        },
+        "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31": {
+          "url": "https://example.com/repo/packages/gdb-gdbserver"
+        },
+        "sha256:cd2c0f63ad37d585e77b3f1c584539e26bf7928710ac8fb19fd377f61b7326e6": {
+          "url": "https://example.com/repo/packages/anaconda"
+        },
+        "sha256:ce2b8ecf9afac9f546bdbbb0902afb6088fdcb8524269ad5b4adb9b9d4959b07": {
+          "url": "https://example.com/repo/packages/xfsdump"
+        },
+        "sha256:ce5b1962783aa6a9374a0a1b34941a112a799baac827c733bd28c78dbb4bcf36": {
+          "url": "https://example.com/repo/packages/kdump-anaconda-addon"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c": {
+          "url": "https://example.com/repo/packages/cryptsetup"
+        },
+        "sha256:cf732696c9aebd80fad833157535754f246445ad0fec66e918963443bd3cfb71": {
+          "url": "https://example.com/repo/packages/linux-firmware"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9": {
+          "url": "https://example.com/repo/packages/iwl6000g2b-firmware"
+        },
+        "sha256:d87d9e526f265be973fce2ba320c5ed3ae24f6c5560d816d0b9307d0ba4d357f": {
+          "url": "https://example.com/repo/packages/lorax-templates-rhel"
+        },
+        "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd": {
+          "url": "https://example.com/repo/packages/lorax-templates-generic"
+        },
+        "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9": {
+          "url": "https://example.com/repo/packages/openssh-clients"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d": {
+          "url": "https://example.com/repo/packages/rpm-ostree"
+        },
+        "sha256:eeb3d09845f5cde069eeade2c4339532be58b6607120be00656123cc73ea727c": {
+          "url": "https://example.com/repo/packages/kbd-misc"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f5f43514d2de810e4ea6d047203505e2e3c0c25f43941ec226968d17bb3aa1b5": {
+          "url": "https://example.com/repo/packages/gnome-kiosk"
+        },
+        "sha256:f6453ebfd8ab070567bfcd4cda99cc41c2c849237745f24228c5f040cac5d562": {
+          "url": "https://example.com/repo/packages/libibverbs"
+        },
+        "sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c": {
+          "url": "https://example.com/repo/packages/isomd5sum"
+        },
+        "sha256:f7f7a2e0133dfc81f9505bac28dfb7ee3398f3dc3b32c7682c86a9be5403bfee": {
+          "url": "https://example.com/repo/packages/librsvg2"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654": {
+          "url": "https://example.com/repo/packages/subscription-manager-cockpit"
+        },
+        "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23": {
+          "url": "https://example.com/repo/packages/dracut-network"
+        },
+        "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7": {
+          "url": "https://example.com/repo/packages/iwl7260-firmware"
+        },
+        "sha256:fe36b1d498f9c6057ed774ba5fb0a84c8592886c3a4c7c077ce7f41326373099": {
+          "url": "https://example.com/repo/packages/lldpad"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-image_installer-unattended_iso.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-image_installer-unattended_iso.json
@@ -1,0 +1,1727 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c"
+                },
+                {
+                  "id": "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:a788847c8c115aa9ae27ca92230418e77b3b36a6424f1d4f3436633864c93db9"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "anaconda-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:629e355a0345015e53cacd90ce641c7e2ef38405cd55e135f331a6303c51f509"
+                },
+                {
+                  "id": "sha256:1f2ce4e8c1aea4a2440b7e794e0440385f8e9c3f48b0fd65118f3dcdbca783bf"
+                },
+                {
+                  "id": "sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f"
+                },
+                {
+                  "id": "sha256:cd2c0f63ad37d585e77b3f1c584539e26bf7928710ac8fb19fd377f61b7326e6"
+                },
+                {
+                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
+                },
+                {
+                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
+                },
+                {
+                  "id": "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2"
+                },
+                {
+                  "id": "sha256:903be5b3913df555a8586e571d9016e1ac24eef2631a5d75b8c3f94c66f10955"
+                },
+                {
+                  "id": "sha256:b81f37a043a6f767e7c94d105f4bd31282f3ecc20680bb9d09bd93461cf4c863"
+                },
+                {
+                  "id": "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9"
+                },
+                {
+                  "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
+                },
+                {
+                  "id": "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c"
+                },
+                {
+                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
+                },
+                {
+                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
+                },
+                {
+                  "id": "sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112"
+                },
+                {
+                  "id": "sha256:5b8b6480d96480b779d6937e2d8694e03cdae14eb0664033ef24af50e1557726"
+                },
+                {
+                  "id": "sha256:75c008414c1be65c0e6954f74e1afdf3f706369f26899ea792b4ac0f31f287bc"
+                },
+                {
+                  "id": "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa"
+                },
+                {
+                  "id": "sha256:5e5d7e05a668f4ec5939a246b38d17cbb6ee83c0408ecbf584f6561a9d64a383"
+                },
+                {
+                  "id": "sha256:826c7f30d36dcc8cb4628bee44fc0e257a360eb06cfc31c49148a44b153e78ce"
+                },
+                {
+                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
+                },
+                {
+                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
+                },
+                {
+                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c"
+                },
+                {
+                  "id": "sha256:581265de790cf918fc770318449fe4cd07a18771c975d42867760b2e2f1bd18d"
+                },
+                {
+                  "id": "sha256:1f35e175b07fc080eb57fc9db22a3ce477d87bc5447466815f55864d3b6e6586"
+                },
+                {
+                  "id": "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31"
+                },
+                {
+                  "id": "sha256:9ac51bbcd5be0f507237b2d43367ad073eaf99398a65d26fa2a8fee5275f889b"
+                },
+                {
+                  "id": "sha256:f5f43514d2de810e4ea6d047203505e2e3c0c25f43941ec226968d17bb3aa1b5"
+                },
+                {
+                  "id": "sha256:24173b7985c9c52efc25b39e51f0fd41ac7b35e7031ed17da97788f293a3ce4e"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
+                },
+                {
+                  "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:9531c8584bbf61635c5c9b15733d9494cb6dd232a6eec85a946076c6c633e99f"
+                },
+                {
+                  "id": "sha256:5e4e6002bd0ef9491967c1f5f573b0c184ef5a41d165cff38c8c6c73606702cb"
+                },
+                {
+                  "id": "sha256:263acae321870b428781a1f4cb5e88740a897a4f9b614233a1798d295f805c54"
+                },
+                {
+                  "id": "sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1"
+                },
+                {
+                  "id": "sha256:8e901f9b6ca3996fe198c84d5f0a305b635bbaae54757fa84932ac52479c1efa"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111"
+                },
+                {
+                  "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:4ad76aeffa1e790eaf720b659f9860c50b6e0ba4787fa0a2d0e43dfa46193035"
+                },
+                {
+                  "id": "sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe"
+                },
+                {
+                  "id": "sha256:eeb3d09845f5cde069eeade2c4339532be58b6607120be00656123cc73ea727c"
+                },
+                {
+                  "id": "sha256:ce5b1962783aa6a9374a0a1b34941a112a799baac827c733bd28c78dbb4bcf36"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
+                },
+                {
+                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
+                },
+                {
+                  "id": "sha256:b498cfb546ddbfbd5953e28137e5b39a65ba6c7220bf4fe4c3cc9bcafc73c41b"
+                },
+                {
+                  "id": "sha256:f6453ebfd8ab070567bfcd4cda99cc41c2c849237745f24228c5f040cac5d562"
+                },
+                {
+                  "id": "sha256:f7f7a2e0133dfc81f9505bac28dfb7ee3398f3dc3b32c7682c86a9be5403bfee"
+                },
+                {
+                  "id": "sha256:cf732696c9aebd80fad833157535754f246445ad0fec66e918963443bd3cfb71"
+                },
+                {
+                  "id": "sha256:fe36b1d498f9c6057ed774ba5fb0a84c8592886c3a4c7c077ce7f41326373099"
+                },
+                {
+                  "id": "sha256:cb298bd94fae6f2f713a1108a16e0632f3a1e21820a288d7ea86c8b00a4d4fef"
+                },
+                {
+                  "id": "sha256:52999df2efd2afc3fcda19e416efb2d0f9b09562aa53331eaac2cde3c88ea207"
+                },
+                {
+                  "id": "sha256:b7110cc6e76089686855ae923d8e0212a0f067b8a48f3c96e8510d50c56061a7"
+                },
+                {
+                  "id": "sha256:2442f8197039e6fb34538a4651f00be2bcbaa8d2be3a15b734fa6ddf1bd8abba"
+                },
+                {
+                  "id": "sha256:a39d3ae3da34f2b4c01193e62202d5de0db79f800a039624b0f950734782b863"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686"
+                },
+                {
+                  "id": "sha256:316d18e697dfa41e92a9fe91d8d175629db5e330348a8adc1a5b43744d01d217"
+                },
+                {
+                  "id": "sha256:68d6e3ed85174ed856b83d5d1e16c23d5279cb5dc77915ae8570a768a5a65505"
+                },
+                {
+                  "id": "sha256:4381157a0ab3568cb31f727709b2edfca21522a8645e95c411f5798b8018393d"
+                },
+                {
+                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
+                },
+                {
+                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
+                },
+                {
+                  "id": "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a"
+                },
+                {
+                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
+                },
+                {
+                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
+                },
+                {
+                  "id": "sha256:500d641b95d95deab52480573126901d76d81dfe9fe0a5caf43445df38caad7b"
+                },
+                {
+                  "id": "sha256:5bc35fd09bee19e0dc22c7f7a731d1d8f4f68b81a3fd866e32273523eda30f9e"
+                },
+                {
+                  "id": "sha256:883642e660d2ef545d3d9f0cbd12790a99aea6358fb67c46664ff22fefa8b7df"
+                },
+                {
+                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
+                },
+                {
+                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
+                },
+                {
+                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
+                },
+                {
+                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
+                },
+                {
+                  "id": "sha256:990fde98d70a0a1a75bf55978f90138e8878a7f5cc1de475e03ee25b6744ee8a"
+                },
+                {
+                  "id": "sha256:95671115820a1fb4e74d1abed36bf069ce64a8233a3a37a8909cc62dffc57293"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
+                },
+                {
+                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
+                },
+                {
+                  "id": "sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:afed7d2fb0ea7b7e9d8dbcf1c1bb62ff53840c72d380cf165294a1eccb7fdeb1"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:cb6b44243b93acef33a5ee905d92203a2a55abdc6a3b7c446c8435a41a6ad137"
+                },
+                {
+                  "id": "sha256:61bfeb2957d080cbab70b332f16b482e1991b08e77ea7a8546b68b3cde90990c"
+                },
+                {
+                  "id": "sha256:28bdff3b22fe1fe1b18313472b2060d2706b9052cbabd91aaa7bed0c88c065de"
+                },
+                {
+                  "id": "sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a"
+                },
+                {
+                  "id": "sha256:85830c0611a0acd7053f7b3a29f52a0511acc3695f9c5ef39a29fcfb8b80e25b"
+                },
+                {
+                  "id": "sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d"
+                },
+                {
+                  "id": "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf"
+                },
+                {
+                  "id": "sha256:0a26024d87ac934c3aeca0ec8b27e579dfb6b268ac43f3a6f945579a54c46e6e"
+                },
+                {
+                  "id": "sha256:570e342d0e4708dab94b2025f6b928845b659b405872d824b45473c4635d7b1d"
+                },
+                {
+                  "id": "sha256:ce2b8ecf9afac9f546bdbbb0902afb6088fdcb8524269ad5b4adb9b9d4959b07"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.buildstamp",
+          "options": {
+            "arch": "aarch64",
+            "product": "Red Hat Enterprise Linux",
+            "version": "10.0",
+            "final": true,
+            "variant": "",
+            "bugurl": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "en_GB.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+              "install": {
+                "uid": 0,
+                "gid": 0,
+                "home": "/root",
+                "shell": "/usr/libexec/anaconda/run-anaconda",
+                "password": ""
+              },
+              "root": {
+                "password": ""
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.anaconda",
+          "options": {
+            "activatable-modules": [
+              "org.fedoraproject.Anaconda.Modules.Localization",
+              "org.fedoraproject.Anaconda.Modules.Network",
+              "org.fedoraproject.Anaconda.Modules.Payloads",
+              "org.fedoraproject.Anaconda.Modules.Services",
+              "org.fedoraproject.Anaconda.Modules.Storage",
+              "org.fedoraproject.Anaconda.Modules.Users"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.lorax-script",
+          "options": {
+            "path": "99-generic/runtime-postinstall.tmpl",
+            "basearch": "aarch64",
+            "product": {
+              "name": "",
+              "version": ""
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.dracut",
+          "options": {
+            "kernel": [
+              "8-2.fk1.aarch64"
+            ],
+            "modules": [
+              "bash",
+              "systemd",
+              "fips",
+              "systemd-initrd",
+              "modsign",
+              "nss-softokn",
+              "i18n",
+              "convertfs",
+              "network-manager",
+              "network",
+              "url-lib",
+              "drm",
+              "plymouth",
+              "crypt",
+              "dm",
+              "dmsquash-live",
+              "kernel-modules",
+              "kernel-modules-extra",
+              "kernel-network-modules",
+              "livenet",
+              "lvm",
+              "mdraid",
+              "qemu",
+              "qemu-net",
+              "resume",
+              "rootfs-block",
+              "terminfo",
+              "udev-rules",
+              "dracut-systemd",
+              "pollcdrom",
+              "usrmount",
+              "base",
+              "fs-lib",
+              "img-lib",
+              "shutdown",
+              "uefi-lib",
+              "nvdimm",
+              "prefixdevname",
+              "prefixdevname-tools",
+              "net-lib",
+              "anaconda",
+              "rdma",
+              "rngd",
+              "multipath",
+              "fcoe",
+              "fcoe-uefi",
+              "iscsi",
+              "lunmask",
+              "nfs"
+            ],
+            "add_drivers": [
+              "ipmi_devintf",
+              "ipmi_msghandler"
+            ],
+            "install": [
+              "/.buildstamp"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux.config",
+          "options": {
+            "state": "permissive"
+          }
+        }
+      ]
+    },
+    {
+      "name": "efiboot-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.grub2.iso",
+          "options": {
+            "product": {
+              "name": "Red Hat Enterprise Linux",
+              "version": "10.0"
+            },
+            "kernel": {
+              "dir": "/images/pxeboot",
+              "opts": [
+                "inst.stage2=hd:LABEL=RHEL-10-0-0-BaseOS-aarch64",
+                "inst.ks=hd:LABEL=RHEL-10-0-0-BaseOS-aarch64:/osbuild.ks"
+              ]
+            },
+            "isolabel": "RHEL-10-0-0-BaseOS-aarch64",
+            "architectures": [
+              "AA64"
+            ],
+            "vendor": "redhat"
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111"
+                },
+                {
+                  "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd"
+                },
+                {
+                  "id": "sha256:d87d9e526f265be973fce2ba320c5ed3ae24f6c5560d816d0b9307d0ba4d357f"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "en_GB.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "uk"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "Europe/Berlin"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bootiso-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/images"
+              },
+              {
+                "path": "/images/pxeboot"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://tree/boot/vmlinuz-8-2.fk1.aarch64",
+                "to": "tree:///images/pxeboot/vmlinuz"
+              },
+              {
+                "from": "input://tree/boot/initramfs-8-2.fk1.aarch64.img",
+                "to": "tree:///images/pxeboot/initrd.img"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.squashfs",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "filename": "images/install.img",
+            "compression": {
+              "method": "xz",
+              "options": {
+                "bcj": "arm"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "images/efiboot.img",
+            "size": "20971520"
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "4e287955"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "images/efiboot.img",
+                "size": 40960,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:efiboot-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "images/efiboot.img",
+                "size": 40960
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.fat",
+              "source": "-",
+              "target": "/"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:efiboot-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/EFI",
+                "to": "tree:///"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "/liveimg.tar.gz"
+          }
+        },
+        {
+          "type": "org.osbuild.kickstart",
+          "options": {
+            "path": "/osbuild-base.ks",
+            "liveimg": {
+              "url": "file:///run/install/repo/liveimg.tar.gz"
+            },
+            "users": {
+              "osbuild": {
+                "groups": [
+                  "wheel"
+                ],
+                "key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNebAh6SjpAn8wB53K4695cGnHGuCtl4RdaX3futZgJUultHyzeYHnzMO7d4++qnRL+Rworew62LKP560uvtncc= github.com/osbuild/images"
+              }
+            },
+            "lang": "en_GB.UTF-8",
+            "keyboard": "uk",
+            "timezone": "Europe/Berlin",
+            "display_mode": "text",
+            "reboot": {
+              "eject": true
+            },
+            "rootpw": {
+              "lock": true
+            },
+            "zerombr": true,
+            "clearpart": {
+              "all": true,
+              "initlabel": true
+            },
+            "autopart": {
+              "type": "plain",
+              "fstype": "xfs",
+              "nohome": true
+            },
+            "network": [
+              {
+                "activate": true,
+                "bootproto": "dhcp",
+                "device": "link",
+                "onboot": "on"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434/sha256:ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434",
+                "to": "tree:///osbuild.ks",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.discinfo",
+          "options": {
+            "basearch": "aarch64",
+            "release": "Red Hat Enterprise Linux 10.0"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bootiso",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.xorrisofs",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:bootiso-tree"
+              ]
+            }
+          },
+          "options": {
+            "filename": "installer.iso",
+            "volid": "RHEL-10-0-0-BaseOS-aarch64",
+            "sysid": "LINUX",
+            "efi": "images/efiboot.img",
+            "isolevel": 3
+          }
+        },
+        {
+          "type": "org.osbuild.implantisomd5",
+          "options": {
+            "filename": "installer.iso"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a": {
+          "url": "https://example.com/repo/packages/net-tools"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112": {
+          "url": "https://example.com/repo/packages/dbus-x11"
+        },
+        "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3": {
+          "url": "https://example.com/repo/packages/bzip2"
+        },
+        "sha256:0a26024d87ac934c3aeca0ec8b27e579dfb6b268ac43f3a6f945579a54c46e6e": {
+          "url": "https://example.com/repo/packages/volume_key"
+        },
+        "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1": {
+          "url": "https://example.com/repo/packages/initscripts"
+        },
+        "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa": {
+          "url": "https://example.com/repo/packages/iwl105-firmware"
+        },
+        "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9": {
+          "url": "https://example.com/repo/packages/bind-utils"
+        },
+        "sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe": {
+          "url": "https://example.com/repo/packages/kbd"
+        },
+        "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa": {
+          "url": "https://example.com/repo/packages/anaconda-dracut"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:1f2ce4e8c1aea4a2440b7e794e0440385f8e9c3f48b0fd65118f3dcdbca783bf": {
+          "url": "https://example.com/repo/packages/alsa-firmware"
+        },
+        "sha256:1f35e175b07fc080eb57fc9db22a3ce477d87bc5447466815f55864d3b6e6586": {
+          "url": "https://example.com/repo/packages/ftp"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:24173b7985c9c52efc25b39e51f0fd41ac7b35e7031ed17da97788f293a3ce4e": {
+          "url": "https://example.com/repo/packages/google-noto-sans-cjk-ttc-fonts"
+        },
+        "sha256:2442f8197039e6fb34538a4651f00be2bcbaa8d2be3a15b734fa6ddf1bd8abba": {
+          "url": "https://example.com/repo/packages/mt-st"
+        },
+        "sha256:263acae321870b428781a1f4cb5e88740a897a4f9b614233a1798d295f805c54": {
+          "url": "https://example.com/repo/packages/hdparm"
+        },
+        "sha256:28bdff3b22fe1fe1b18313472b2060d2706b9052cbabd91aaa7bed0c88c065de": {
+          "url": "https://example.com/repo/packages/spice-vdagent"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686": {
+          "url": "https://example.com/repo/packages/nm-connection-editor"
+        },
+        "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa": {
+          "url": "https://example.com/repo/packages/dejavu-sans-fonts"
+        },
+        "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc": {
+          "url": "https://example.com/repo/packages/dmidecode"
+        },
+        "sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f": {
+          "url": "https://example.com/repo/packages/alsa-tools-firmware"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:316d18e697dfa41e92a9fe91d8d175629db5e330348a8adc1a5b43744d01d217": {
+          "url": "https://example.com/repo/packages/nmap-ncat"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1": {
+          "url": "https://example.com/repo/packages/dnf"
+        },
+        "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0": {
+          "url": "https://example.com/repo/packages/curl"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:4381157a0ab3568cb31f727709b2edfca21522a8645e95c411f5798b8018393d": {
+          "url": "https://example.com/repo/packages/nss-tools"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64-cdboot"
+        },
+        "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce": {
+          "url": "https://example.com/repo/packages/iwl100-firmware"
+        },
+        "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674": {
+          "url": "https://example.com/repo/packages/iwl2030-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4ad76aeffa1e790eaf720b659f9860c50b6e0ba4787fa0a2d0e43dfa46193035": {
+          "url": "https://example.com/repo/packages/jomolhari-fonts"
+        },
+        "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d": {
+          "url": "https://example.com/repo/packages/less"
+        },
+        "sha256:500d641b95d95deab52480573126901d76d81dfe9fe0a5caf43445df38caad7b": {
+          "url": "https://example.com/repo/packages/pciutils"
+        },
+        "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2": {
+          "url": "https://example.com/repo/packages/anaconda-install-img-deps"
+        },
+        "sha256:52999df2efd2afc3fcda19e416efb2d0f9b09562aa53331eaac2cde3c88ea207": {
+          "url": "https://example.com/repo/packages/madan-fonts"
+        },
+        "sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781": {
+          "url": "https://example.com/repo/packages/xorriso"
+        },
+        "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-baseos-n10.0"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:570e342d0e4708dab94b2025f6b928845b659b405872d824b45473c4635d7b1d": {
+          "url": "https://example.com/repo/packages/wget"
+        },
+        "sha256:581265de790cf918fc770318449fe4cd07a18771c975d42867760b2e2f1bd18d": {
+          "url": "https://example.com/repo/packages/fcoe-utils"
+        },
+        "sha256:5b8b6480d96480b779d6937e2d8694e03cdae14eb0664033ef24af50e1557726": {
+          "url": "https://example.com/repo/packages/default-fonts-core-sans"
+        },
+        "sha256:5bc35fd09bee19e0dc22c7f7a731d1d8f4f68b81a3fd866e32273523eda30f9e": {
+          "url": "https://example.com/repo/packages/perl-interpreter"
+        },
+        "sha256:5e4e6002bd0ef9491967c1f5f573b0c184ef5a41d165cff38c8c6c73606702cb": {
+          "url": "https://example.com/repo/packages/gsettings-desktop-schemas"
+        },
+        "sha256:5e5d7e05a668f4ec5939a246b38d17cbb6ee83c0408ecbf584f6561a9d64a383": {
+          "url": "https://example.com/repo/packages/dejavu-sans-mono-fonts"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:61bfeb2957d080cbab70b332f16b482e1991b08e77ea7a8546b68b3cde90990c": {
+          "url": "https://example.com/repo/packages/smartmontools"
+        },
+        "sha256:629e355a0345015e53cacd90ce641c7e2ef38405cd55e135f331a6303c51f509": {
+          "url": "https://example.com/repo/packages/@hardware-support"
+        },
+        "sha256:68d6e3ed85174ed856b83d5d1e16c23d5279cb5dc77915ae8570a768a5a65505": {
+          "url": "https://example.com/repo/packages/nss-softokn"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682": {
+          "url": "https://example.com/repo/packages/hostname"
+        },
+        "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393": {
+          "url": "https://example.com/repo/packages/grub2-tools-minimal"
+        },
+        "sha256:75c008414c1be65c0e6954f74e1afdf3f706369f26899ea792b4ac0f31f287bc": {
+          "url": "https://example.com/repo/packages/default-fonts-other-sans"
+        },
+        "sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18": {
+          "url": "https://example.com/repo/packages/strace"
+        },
+        "sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980": {
+          "url": "https://example.com/repo/packages/hexedit"
+        },
+        "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764": {
+          "url": "https://example.com/repo/packages/grub2-tools-extra"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5": {
+          "url": "https://example.com/repo/packages/firewalld"
+        },
+        "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a": {
+          "url": "https://example.com/repo/packages/openssh-server"
+        },
+        "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467": {
+          "url": "https://example.com/repo/packages/iwl6050-firmware"
+        },
+        "sha256:826c7f30d36dcc8cb4628bee44fc0e257a360eb06cfc31c49148a44b153e78ce": {
+          "url": "https://example.com/repo/packages/device-mapper-persistent-data"
+        },
+        "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0": {
+          "url": "https://example.com/repo/packages/ostree"
+        },
+        "sha256:85830c0611a0acd7053f7b3a29f52a0511acc3695f9c5ef39a29fcfb8b80e25b": {
+          "url": "https://example.com/repo/packages/udisks2-iscsi"
+        },
+        "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071": {
+          "url": "https://example.com/repo/packages/iwl5150-firmware"
+        },
+        "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714": {
+          "url": "https://example.com/repo/packages/iwl135-firmware"
+        },
+        "sha256:883642e660d2ef545d3d9f0cbd12790a99aea6358fb67c46664ff22fefa8b7df": {
+          "url": "https://example.com/repo/packages/pigz"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111": {
+          "url": "https://example.com/repo/packages/iwl6000g2a-firmware"
+        },
+        "sha256:8e901f9b6ca3996fe198c84d5f0a305b635bbaae54757fa84932ac52479c1efa": {
+          "url": "https://example.com/repo/packages/ipmitool"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:903be5b3913df555a8586e571d9016e1ac24eef2631a5d75b8c3f94c66f10955": {
+          "url": "https://example.com/repo/packages/anaconda-widgets"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9531c8584bbf61635c5c9b15733d9494cb6dd232a6eec85a946076c6c633e99f": {
+          "url": "https://example.com/repo/packages/grubby"
+        },
+        "sha256:95671115820a1fb4e74d1abed36bf069ce64a8233a3a37a8909cc62dffc57293": {
+          "url": "https://example.com/repo/packages/rdma-core"
+        },
+        "sha256:990fde98d70a0a1a75bf55978f90138e8878a7f5cc1de475e03ee25b6744ee8a": {
+          "url": "https://example.com/repo/packages/python3-pyatspi"
+        },
+        "sha256:9ac51bbcd5be0f507237b2d43367ad073eaf99398a65d26fa2a8fee5275f889b": {
+          "url": "https://example.com/repo/packages/glibc-all-langpacks"
+        },
+        "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd": {
+          "url": "https://example.com/repo/packages/prefixdevname"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a39d3ae3da34f2b4c01193e62202d5de0db79f800a039624b0f950734782b863": {
+          "url": "https://example.com/repo/packages/mtr"
+        },
+        "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53": {
+          "url": "https://example.com/repo/packages/plymouth"
+        },
+        "sha256:a788847c8c115aa9ae27ca92230418e77b3b36a6424f1d4f3436633864c93db9": {
+          "url": "https://example.com/repo/packages/squashfs-tools"
+        },
+        "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018": {
+          "url": "https://example.com/repo/packages/iwl3160-firmware"
+        },
+        "sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d": {
+          "url": "https://example.com/repo/packages/usbutils"
+        },
+        "sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a": {
+          "url": "https://example.com/repo/packages/udisks2"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14": {
+          "url": "https://example.com/repo/packages/sg3_utils"
+        },
+        "sha256:afed7d2fb0ea7b7e9d8dbcf1c1bb62ff53840c72d380cf165294a1eccb7fdeb1": {
+          "url": "https://example.com/repo/packages/rsyslog"
+        },
+        "sha256:b498cfb546ddbfbd5953e28137e5b39a65ba6c7220bf4fe4c3cc9bcafc73c41b": {
+          "url": "https://example.com/repo/packages/libblockdev-lvm-dbus"
+        },
+        "sha256:b7110cc6e76089686855ae923d8e0212a0f067b8a48f3c96e8510d50c56061a7": {
+          "url": "https://example.com/repo/packages/mdadm"
+        },
+        "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-appstream-n10.0"
+        },
+        "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be": {
+          "url": "https://example.com/repo/packages/rpcbind"
+        },
+        "sha256:b81f37a043a6f767e7c94d105f4bd31282f3ecc20680bb9d09bd93461cf4c863": {
+          "url": "https://example.com/repo/packages/audit"
+        },
+        "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf": {
+          "url": "https://example.com/repo/packages/vim-minimal"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8": {
+          "url": "https://example.com/repo/packages/iwl2000-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0": {
+          "url": "https://example.com/repo/packages/iwl5000-firmware"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c": {
+          "url": "https://example.com/repo/packages/ethtool"
+        },
+        "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0": {
+          "url": "https://example.com/repo/packages/iwl1000-firmware"
+        },
+        "sha256:cb298bd94fae6f2f713a1108a16e0632f3a1e21820a288d7ea86c8b00a4d4fef": {
+          "url": "https://example.com/repo/packages/lsof"
+        },
+        "sha256:cb6b44243b93acef33a5ee905d92203a2a55abdc6a3b7c446c8435a41a6ad137": {
+          "url": "https://example.com/repo/packages/sil-padauk-fonts"
+        },
+        "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31": {
+          "url": "https://example.com/repo/packages/gdb-gdbserver"
+        },
+        "sha256:cd2c0f63ad37d585e77b3f1c584539e26bf7928710ac8fb19fd377f61b7326e6": {
+          "url": "https://example.com/repo/packages/anaconda"
+        },
+        "sha256:ce2b8ecf9afac9f546bdbbb0902afb6088fdcb8524269ad5b4adb9b9d4959b07": {
+          "url": "https://example.com/repo/packages/xfsdump"
+        },
+        "sha256:ce5b1962783aa6a9374a0a1b34941a112a799baac827c733bd28c78dbb4bcf36": {
+          "url": "https://example.com/repo/packages/kdump-anaconda-addon"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c": {
+          "url": "https://example.com/repo/packages/cryptsetup"
+        },
+        "sha256:cf732696c9aebd80fad833157535754f246445ad0fec66e918963443bd3cfb71": {
+          "url": "https://example.com/repo/packages/linux-firmware"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9": {
+          "url": "https://example.com/repo/packages/iwl6000g2b-firmware"
+        },
+        "sha256:d87d9e526f265be973fce2ba320c5ed3ae24f6c5560d816d0b9307d0ba4d357f": {
+          "url": "https://example.com/repo/packages/lorax-templates-rhel"
+        },
+        "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd": {
+          "url": "https://example.com/repo/packages/lorax-templates-generic"
+        },
+        "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9": {
+          "url": "https://example.com/repo/packages/openssh-clients"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d": {
+          "url": "https://example.com/repo/packages/rpm-ostree"
+        },
+        "sha256:eeb3d09845f5cde069eeade2c4339532be58b6607120be00656123cc73ea727c": {
+          "url": "https://example.com/repo/packages/kbd-misc"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f5f43514d2de810e4ea6d047203505e2e3c0c25f43941ec226968d17bb3aa1b5": {
+          "url": "https://example.com/repo/packages/gnome-kiosk"
+        },
+        "sha256:f6453ebfd8ab070567bfcd4cda99cc41c2c849237745f24228c5f040cac5d562": {
+          "url": "https://example.com/repo/packages/libibverbs"
+        },
+        "sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c": {
+          "url": "https://example.com/repo/packages/isomd5sum"
+        },
+        "sha256:f7f7a2e0133dfc81f9505bac28dfb7ee3398f3dc3b32c7682c86a9be5403bfee": {
+          "url": "https://example.com/repo/packages/librsvg2"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654": {
+          "url": "https://example.com/repo/packages/subscription-manager-cockpit"
+        },
+        "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23": {
+          "url": "https://example.com/repo/packages/dracut-network"
+        },
+        "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7": {
+          "url": "https://example.com/repo/packages/iwl7260-firmware"
+        },
+        "sha256:fe36b1d498f9c6057ed774ba5fb0a84c8592886c3a4c7c077ce7f41326373099": {
+          "url": "https://example.com/repo/packages/lldpad"
+        }
+      }
+    },
+    "org.osbuild.inline": {
+      "items": {
+        "sha256:ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434": {
+          "encoding": "base64",
+          "data": "JWluY2x1ZGUgL3J1bi9pbnN0YWxsL3JlcG8vb3NidWlsZC1iYXNlLmtzCgolcG9zdAplY2hvIC1lICIlc3Vkb1x0QUxMPShBTEwpXHROT1BBU1NXRDogQUxMIiA+ICIvZXRjL3N1ZG9lcnMuZC8lc3VkbyIKY2htb2QgMDQ0MCAvZXRjL3N1ZG9lcnMuZC8lc3VkbwplY2hvIC1lICIld2hlZWxcdEFMTD0oQUxMKVx0Tk9QQVNTV0Q6IEFMTCIgPiAiL2V0Yy9zdWRvZXJzLmQvJXdoZWVsIgpjaG1vZCAwNDQwIC9ldGMvc3Vkb2Vycy5kLyV3aGVlbApyZXN0b3JlY29uIC1ydkYgL2V0Yy9zdWRvZXJzLmQKJWVuZAo="
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-image_installer-unattended_iso.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-image_installer-unattended_iso.json
@@ -55,12 +55,6 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
@@ -136,9 +130,6 @@
                   "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
                 },
                 {
-                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
-                },
-                {
                   "id": "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2"
                 },
                 {
@@ -155,9 +146,6 @@
                 },
                 {
                   "id": "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c"
-                },
-                {
-                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
                 },
                 {
                   "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
@@ -184,28 +172,13 @@
                   "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
                 },
                 {
-                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
-                },
-                {
                   "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
                   "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
-                },
-                {
-                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
                 },
                 {
                   "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
@@ -235,37 +208,13 @@
                   "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
                 },
                 {
-                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
-                },
-                {
-                  "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
-                },
-                {
                   "id": "sha256:453b08cf296f59502866517a4e8b9305ba6d0bdbb455928d427711821a634527"
                 },
                 {
                   "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
                 },
                 {
-                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
-                },
-                {
-                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
-                },
-                {
                   "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
-                },
-                {
-                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
                 },
                 {
                   "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
@@ -286,9 +235,6 @@
                   "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
                 },
                 {
-                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
-                },
-                {
                   "id": "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1"
                 },
                 {
@@ -298,16 +244,7 @@
                   "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
                 },
                 {
-                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
-                },
-                {
                   "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
-                },
-                {
-                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
-                },
-                {
-                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
                 },
                 {
                   "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
@@ -316,16 +253,7 @@
                   "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
                 },
                 {
-                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
-                },
-                {
                   "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
-                },
-                {
-                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
-                },
-                {
-                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
                 },
                 {
                   "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
@@ -334,16 +262,7 @@
                   "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
                 },
                 {
-                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
-                },
-                {
                   "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
                 },
                 {
                   "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
@@ -356,12 +275,6 @@
                 },
                 {
                   "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
-                },
-                {
-                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
-                },
-                {
-                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
                 },
                 {
                   "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
@@ -380,12 +293,6 @@
                 },
                 {
                   "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
-                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
-                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
                 },
                 {
                   "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
@@ -427,9 +334,6 @@
                   "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
                 },
                 {
-                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
-                },
-                {
                   "id": "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686"
                 },
                 {
@@ -445,13 +349,7 @@
                   "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
                 },
                 {
-                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
-                },
-                {
                   "id": "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a"
-                },
-                {
-                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
                 },
                 {
                   "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
@@ -469,12 +367,6 @@
                   "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
                 },
                 {
-                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
-                },
-                {
-                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
-                },
-                {
                   "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
                 },
                 {
@@ -488,12 +380,6 @@
                 },
                 {
                   "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
                 },
                 {
                   "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
@@ -511,13 +397,7 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14"
-                },
-                {
-                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
                 },
                 {
                   "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
@@ -536,12 +416,6 @@
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
@@ -569,12 +443,6 @@
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
                 },
                 {
                   "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
@@ -787,9 +655,6 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
@@ -862,9 +727,6 @@
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
-                },
-                {
                   "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
                 },
                 {
@@ -875,9 +737,6 @@
                 },
                 {
                   "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -910,9 +769,6 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
                 },
                 {
@@ -920,9 +776,6 @@
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-qcow2-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-qcow2-empty.json
@@ -19,16 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -40,31 +34,16 @@
                   "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
                 },
                 {
-                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
-                },
-                {
                   "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
                 },
                 {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -137,9 +116,6 @@
                 },
                 {
                   "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
-                },
-                {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-qcow2-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-qcow2-empty.json
@@ -1,0 +1,823 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "7e2765eb-4a66-4e93-9c7a-e7c609cbaf02",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747"
+                },
+                {
+                  "id": "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280"
+                },
+                {
+                  "id": "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm",
+          "options": {
+            "dnf-plugins": {
+              "product-id": {
+                "enabled": false
+              },
+              "subscription-manager": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "7e2765eb-4a66-4e93-9c7a-e7c609cbaf02",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "7e2765eb-4a66-4e93-9c7a-e7c609cbaf02",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20559839,
+                "start": 411648,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "7e2765eb-4a66-4e93-9c7a-e7c609cbaf02",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 411648,
+                "size": 20559839,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 411648,
+                "size": 20559839
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "qcow2",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.qcow2",
+            "format": {
+              "type": "qcow2",
+              "compat": "1.1"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98": {
+          "url": "https://example.com/repo/packages/exclude:fedora-repos"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b": {
+          "url": "https://example.com/repo/packages/exclude:udisks2"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-baseos-n10.0"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747": {
+          "url": "https://example.com/repo/packages/exclude:fedora-release"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-en"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-appstream-n10.0"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-*"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654": {
+          "url": "https://example.com/repo/packages/subscription-manager-cockpit"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-qcow2-rhsm.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-qcow2-rhsm.json
@@ -19,16 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -40,31 +34,16 @@
                   "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
                 },
                 {
-                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
-                },
-                {
                   "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
                 },
                 {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -137,9 +116,6 @@
                 },
                 {
                   "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
-                },
-                {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-qcow2-rhsm.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-qcow2-rhsm.json
@@ -1,0 +1,831 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "900e7e0b-bc74-4c06-9552-ebdbdbb7d69b",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747"
+                },
+                {
+                  "id": "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280"
+                },
+                {
+                  "id": "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm",
+          "options": {
+            "dnf-plugins": {
+              "product-id": {
+                "enabled": true
+              },
+              "subscription-manager": {
+                "enabled": true
+              }
+            },
+            "subscription-manager": {
+              "rhsm": {
+                "manage_repos": true
+              },
+              "rhsmcertd": {
+                "auto_registration": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "900e7e0b-bc74-4c06-9552-ebdbdbb7d69b",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "900e7e0b-bc74-4c06-9552-ebdbdbb7d69b",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20559839,
+                "start": 411648,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "900e7e0b-bc74-4c06-9552-ebdbdbb7d69b",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 411648,
+                "size": 20559839,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 411648,
+                "size": 20559839
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "qcow2",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.qcow2",
+            "format": {
+              "type": "qcow2",
+              "compat": "1.1"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98": {
+          "url": "https://example.com/repo/packages/exclude:fedora-repos"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b": {
+          "url": "https://example.com/repo/packages/exclude:udisks2"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-baseos-n10.0"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747": {
+          "url": "https://example.com/repo/packages/exclude:fedora-release"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-en"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-appstream-n10.0"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-*"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654": {
+          "url": "https://example.com/repo/packages/subscription-manager-cockpit"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-tar-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-tar-empty.json
@@ -1,0 +1,227 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "archive",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "root.tar.xz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-baseos-n10.0"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-appstream-n10.0"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-tar-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-tar-empty.json
@@ -34,9 +34,6 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
                 },
                 {
@@ -86,9 +83,6 @@
               "references": [
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-vhd-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-vhd-empty.json
@@ -19,16 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -40,31 +34,16 @@
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
                 },
                 {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -145,12 +124,6 @@
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
-                },
-                {
                   "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
                 },
                 {
@@ -164,9 +137,6 @@
                 },
                 {
                   "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
-                },
-                {
-                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
                 },
                 {
                   "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
@@ -191,9 +161,6 @@
                 },
                 {
                   "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-vhd-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-vhd-empty.json
@@ -1,0 +1,1086 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "44b251b4-960d-4a03-81a0-56cfb56debad",
+            "kernel_opts": "ro loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221"
+                },
+                {
+                  "id": "sha256:563a278902fa76bae3ec1833f24ff89abe26329b1d32af9aaa924d6fc6fd68aa"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:b6cae3a11438b4ec550ce10b73b35160fafbe9d436fdb4f81fea356fc5bb6fee"
+                },
+                {
+                  "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:79a583014c5150aac3a44a025229af2918d16d3f6f32d005bf5786f693d6b893"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:f48860f2daf7e7a03ab9827300ab91c865d446de1c12a279339a2fff75c00f4e"
+                },
+                {
+                  "id": "sha256:229b391b136444fc29f0a5b3a897222f8ff4ed2277427e68eeb13fccfe39905c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8e57cbb02cd20f0e373ae76a44d7ddd0125fe449db5dfc196b0920ef47ced56e"
+                },
+                {
+                  "id": "sha256:a4895eb44afc336fecbba6e520cd67e178dace0276655d102fceffa8e5f70570"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f"
+                },
+                {
+                  "id": "sha256:75666699b77db631f576041e8102a55b46758c01b807eacae0f170930ab59b3d"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:01fdad2e9ee0a69f7e323ddb4258e2b0dbfaa242a21d7a8bfdfec04ebe8d3e86"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:81f29ed6c790aa976572770ecf7b6f0351da3c46c9558640c7a83896b6bf8e05"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:534994290b3914604921fc2c61852b7bb4c4d8fb947f057a6fb38a3a57835d9a"
+                },
+                {
+                  "id": "sha256:0ee8cf7e33852f80cd293a8fa8c371f888dc011984ff2836f1198bcdc552dc58"
+                },
+                {
+                  "id": "sha256:5f1e4685c9b4d243264d22fa24864335aab534815fcfe6c3a88eec83ee22354f"
+                },
+                {
+                  "id": "sha256:f3e607ceb5fd279c62a109d1bbb952cc44d7467266ef679a99fd0d9c02ce8d29"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:7913d978541704fb38f5f13a949811c80ed4a52b2514d4582fe3ccb8f5a04617"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:a76985e9146fec1e9fb00cc08d5e0a76eb7f47c10a7abbc4430f8ac235a8b1cd"
+                },
+                {
+                  "id": "sha256:141b56438fdc0208877397569000e1a5857ff57807ff3bbaf2622cc87901861d"
+                },
+                {
+                  "id": "sha256:725c887b1ebcd6be8eb9a0ef6b2c476ff6d2dd8f9cf622f8d60953a1f22c94c8"
+                },
+                {
+                  "id": "sha256:53d00356d82e89cbdf0f963060c58433f73e0b339ba9f63577bd7df44f78e051"
+                },
+                {
+                  "id": "sha256:f1d96d150523777accb14a93582922ded22aa868629c58c3cd49339952293327"
+                },
+                {
+                  "id": "sha256:840109e45bc2504c9f202410bd941dc430bcef1065e1c1a98e5d08506c0c91af"
+                },
+                {
+                  "id": "sha256:b1eb4c41592e8eb6f7f2c96cdda2162fe214f52f85b01e9b174aa81bf297e01a"
+                },
+                {
+                  "id": "sha256:590ef3ccd31b243b045e9c5f9268d1013b0960060366c76028a23b070b5fb7be"
+                },
+                {
+                  "id": "sha256:9fe43931a7b645b90921b9b72d836e9d06ececc0b3cca1376fa0a297b5f522a5"
+                },
+                {
+                  "id": "sha256:49ec7b34785f32ffd1f252d5cc9a0a015ca074f75c601d2272149a72d50d42df"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ],
+            "gpgkeys.fromtree": [
+              "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel-core"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "10-azure-kvp.cfg",
+            "config": {
+              "reporting": {
+                "logging": {
+                  "type": "log"
+                },
+                "telemetry": {
+                  "type": "hyperv"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "91-azure_datasource.cfg",
+            "config": {
+              "datasource": {
+                "Azure": {
+                  "apply_network_config": false
+                }
+              },
+              "datasource_list": [
+                "Azure"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-intel-cstate.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "intel_cstate"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-floppy.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "floppy"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              },
+              {
+                "command": "blacklist",
+                "modulename": "lbm-nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-skylake-edac.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "skx_edac"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-azure.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_AZURE",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "ClientAliveInterval": 180
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.pwquality.conf",
+          "options": {
+            "config": {
+              "minlen": 6,
+              "dcredit": 0,
+              "ucredit": 0,
+              "lcredit": 0,
+              "ocredit": 0,
+              "minclass": 3
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.waagent.conf",
+          "options": {
+            "config": {
+              "ResourceDisk.Format": false,
+              "ResourceDisk.EnableSwap": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.udev.rules",
+          "options": {
+            "filename": "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules",
+            "rules": [
+              {
+                "comment": [
+                  "Accelerated Networking on Azure exposes a new SRIOV interface to the VM.",
+                  "This interface is transparently bonded to the synthetic interface,",
+                  "so NetworkManager should just ignore any SRIOV interfaces."
+                ]
+              },
+              [
+                {
+                  "key": "SUBSYSTEM",
+                  "op": "==",
+                  "val": "net"
+                },
+                {
+                  "key": "DRIVERS",
+                  "op": "==",
+                  "val": "hv_pci"
+                },
+                {
+                  "key": "ACTION",
+                  "op": "==",
+                  "val": "add"
+                },
+                {
+                  "key": {
+                    "name": "ENV",
+                    "arg": "NM_UNMANAGED"
+                  },
+                  "op": "=",
+                  "val": "1"
+                }
+              ]
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "44b251b4-960d-4a03-81a0-56cfb56debad",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "44b251b4-960d-4a03-81a0-56cfb56debad",
+            "kernel_opts": "ro loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved",
+              "disable_recovery": true,
+              "disable_submenu": true,
+              "distributor": "$(sed 's, release .*$,,g' /etc/system-release)",
+              "terminal": [
+                "serial",
+                "console"
+              ],
+              "timeout": 10,
+              "timeout_style": "countdown",
+              "serial": "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "firewalld",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "sshd",
+              "waagent"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "4294967296"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "size": 409600,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 7976927,
+                "start": 411648,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "44b251b4-960d-4a03-81a0-56cfb56debad",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 411648,
+                "size": 7976927,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 411648,
+                "size": 7976927
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "vpc",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.vhd",
+            "format": {
+              "type": "vpc"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:01fdad2e9ee0a69f7e323ddb4258e2b0dbfaa242a21d7a8bfdfec04ebe8d3e86": {
+          "url": "https://example.com/repo/packages/exclude:NetworkManager-config-server"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3": {
+          "url": "https://example.com/repo/packages/bzip2"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:0ee8cf7e33852f80cd293a8fa8c371f888dc011984ff2836f1198bcdc552dc58": {
+          "url": "https://example.com/repo/packages/exclude:buildah"
+        },
+        "sha256:141b56438fdc0208877397569000e1a5857ff57807ff3bbaf2622cc87901861d": {
+          "url": "https://example.com/repo/packages/exclude:python3-dnf-plugin-spacewalk"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387": {
+          "url": "https://example.com/repo/packages/grub2-efi-aa64"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:229b391b136444fc29f0a5b3a897222f8ff4ed2277427e68eeb13fccfe39905c": {
+          "url": "https://example.com/repo/packages/kernel-modules"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:49ec7b34785f32ffd1f252d5cc9a0a015ca074f75c601d2272149a72d50d42df": {
+          "url": "https://example.com/repo/packages/exclude:usb_modeswitch"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:534994290b3914604921fc2c61852b7bb4c4d8fb947f057a6fb38a3a57835d9a": {
+          "url": "https://example.com/repo/packages/exclude:bolt"
+        },
+        "sha256:53d00356d82e89cbdf0f963060c58433f73e0b339ba9f63577bd7df44f78e051": {
+          "url": "https://example.com/repo/packages/exclude:python3-rhnlib"
+        },
+        "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-baseos-n10.0"
+        },
+        "sha256:563a278902fa76bae3ec1833f24ff89abe26329b1d32af9aaa924d6fc6fd68aa": {
+          "url": "https://example.com/repo/packages/NetworkManager"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:590ef3ccd31b243b045e9c5f9268d1013b0960060366c76028a23b070b5fb7be": {
+          "url": "https://example.com/repo/packages/exclude:rhnlib"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5f1e4685c9b4d243264d22fa24864335aab534815fcfe6c3a88eec83ee22354f": {
+          "url": "https://example.com/repo/packages/exclude:cockpit-podman"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221": {
+          "url": "https://example.com/repo/packages/@Server"
+        },
+        "sha256:725c887b1ebcd6be8eb9a0ef6b2c476ff6d2dd8f9cf622f8d60953a1f22c94c8": {
+          "url": "https://example.com/repo/packages/exclude:python3-hwdata"
+        },
+        "sha256:75666699b77db631f576041e8102a55b46758c01b807eacae0f170930ab59b3d": {
+          "url": "https://example.com/repo/packages/uuid"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7913d978541704fb38f5f13a949811c80ed4a52b2514d4582fe3ccb8f5a04617": {
+          "url": "https://example.com/repo/packages/exclude:glibc-all-langpacks"
+        },
+        "sha256:79a583014c5150aac3a44a025229af2918d16d3f6f32d005bf5786f693d6b893": {
+          "url": "https://example.com/repo/packages/hyperv-daemons"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:81f29ed6c790aa976572770ecf7b6f0351da3c46c9558640c7a83896b6bf8e05": {
+          "url": "https://example.com/repo/packages/exclude:alsa-sof-firmware"
+        },
+        "sha256:840109e45bc2504c9f202410bd941dc430bcef1065e1c1a98e5d08506c0c91af": {
+          "url": "https://example.com/repo/packages/exclude:rhn-client-tools"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8e57cbb02cd20f0e373ae76a44d7ddd0125fe449db5dfc196b0920ef47ced56e": {
+          "url": "https://example.com/repo/packages/nvme-cli"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:9fe43931a7b645b90921b9b72d836e9d06ececc0b3cca1376fa0a297b5f522a5": {
+          "url": "https://example.com/repo/packages/exclude:rhnsd"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a4895eb44afc336fecbba6e520cd67e178dace0276655d102fceffa8e5f70570": {
+          "url": "https://example.com/repo/packages/patch"
+        },
+        "sha256:a76985e9146fec1e9fb00cc08d5e0a76eb7f47c10a7abbc4430f8ac235a8b1cd": {
+          "url": "https://example.com/repo/packages/exclude:podman"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:b1eb4c41592e8eb6f7f2c96cdda2162fe214f52f85b01e9b174aa81bf297e01a": {
+          "url": "https://example.com/repo/packages/exclude:rhn-setup"
+        },
+        "sha256:b6cae3a11438b4ec550ce10b73b35160fafbe9d436fdb4f81fea356fc5bb6fee": {
+          "url": "https://example.com/repo/packages/WALinuxAgent"
+        },
+        "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-appstream-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f1d96d150523777accb14a93582922ded22aa868629c58c3cd49339952293327": {
+          "url": "https://example.com/repo/packages/exclude:rhn-check"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f3e607ceb5fd279c62a109d1bbb952cc44d7467266ef679a99fd0d9c02ce8d29": {
+          "url": "https://example.com/repo/packages/exclude:containernetworking-plugins"
+        },
+        "sha256:f48860f2daf7e7a03ab9827300ab91c865d446de1c12a279339a2fff75c00f4e": {
+          "url": "https://example.com/repo/packages/kernel-core"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f": {
+          "url": "https://example.com/repo/packages/shim-aa64"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-aarch64-wsl-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-aarch64-wsl-empty.json
@@ -1,0 +1,481 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:8a1eb106427026fd9f7daef2fbed09db45de687c264480f8d3945ff13bdd9fe6"
+                },
+                {
+                  "id": "sha256:8308da3588987ace3967a2eee85a70f8be6eca16320b1e235b636e1464bbad06"
+                },
+                {
+                  "id": "sha256:4f7872f3a4c4decf34923a48986e52563d2a58bc3225b1890b84b52e7defce09"
+                },
+                {
+                  "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"
+                },
+                {
+                  "id": "sha256:97e86df4b9e1385f56f5635f227cc75e5a59147a8d06d05d0c08241d7204a92d"
+                },
+                {
+                  "id": "sha256:839f835e4d4558140e9b92fd85c3f923b74b6220ba1ad86b9fe096b8b6305b86"
+                },
+                {
+                  "id": "sha256:1a36b318995f3383dfa35c283df090bde63776c52415a421ea201a9667f95ab3"
+                },
+                {
+                  "id": "sha256:32dcd32054ee4e9ae92eec040bc1385c94d74a0846bb0145b1bdf9958740200a"
+                },
+                {
+                  "id": "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:cbf61858f3260072d96d9b1d2e037fc35824944b9c94d0087b1a53385eccaead"
+                },
+                {
+                  "id": "sha256:5b0440b2a1ceb2db43e1832c91f96728c5fe59a1cd7b5d1f1b905bb0b2df3841"
+                },
+                {
+                  "id": "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31"
+                },
+                {
+                  "id": "sha256:f6fad119f40a1aae00b54c0de6a0fa24a1e35d4bf1284bffcfd7134bdbb837e1"
+                },
+                {
+                  "id": "sha256:cc0bbbee7c9dd4f3f30e01c7f1fcbeb839f30c47e3bcbf16db0d37789262cbb4"
+                },
+                {
+                  "id": "sha256:aa6d4532f128420f4d741f2834cd8d1d146bbbdc9554aef454b7adb8ff66f748"
+                },
+                {
+                  "id": "sha256:f8f6228d89c3de21a136641a6d66f8a393db4b9019b17e0bec92ffc88b393eb4"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:cfd4affb5ed7a688870bb3725e10cc066e63b2a94b5dd491cac681a3c2b17ca5"
+                },
+                {
+                  "id": "sha256:41ffca929b95c49690ab8815d1d1a134a5bcdd86bde407c0f46b90eabf556b05"
+                },
+                {
+                  "id": "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3"
+                },
+                {
+                  "id": "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb"
+                },
+                {
+                  "id": "sha256:5b0513b8ca5a7f03601efc10934409d271890e6ae7a3264445e7397233eac6f8"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:87f1c82f3d3b66f168e0673e4f4227a8a3fe53000bf342780424ee8e3344d591"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:e422e1641a99c5a045bc0b596ef5ce6429c8e7744f016444cedacd4eaf5d3e4c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:5f53b0a2be22e28dc4b056f663910c046a33f9b2d779eaf997ea771fe1881a13"
+                },
+                {
+                  "id": "sha256:8fb6d5f37e8055ce720bd0b1d56587f88c0071f285966ba17e72b2b12672aa73"
+                },
+                {
+                  "id": "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1"
+                },
+                {
+                  "id": "sha256:0652d77991ae054286ace9807d7b4b573b99e3be9be7ad126db8d197b5f22a68"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:ae5e2ad3b86239dbf500c630cf88d33d9775e9ce2e32d596910a07d682d97923"
+                },
+                {
+                  "id": "sha256:572d4fe95e2cfd3425b70544a829f39104cad64fb57cdc63a25f9e837fb79917"
+                },
+                {
+                  "id": "sha256:f486d76df6f0ea41b7d6acb72751d8eb4cc2a3f04e6273154fef5e76cab27e11"
+                },
+                {
+                  "id": "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf"
+                },
+                {
+                  "id": "sha256:809c2fb94fff223e96477a875bbc1b77e5b020262e8f959d4b49455100a7f9f7"
+                },
+                {
+                  "id": "sha256:6fd624e2ceb4409a98b06f7f6161a6259cc88a838b6f43454217ed5a0c18a547"
+                },
+                {
+                  "id": "sha256:2692c08277f40048982432ab907ab870ee677f69656d9a71a6f889cf03531eb4"
+                },
+                {
+                  "id": "sha256:a697ff6e769b4f3d7c9b05d77c96d575c5e001ef923a13395decbe00b7e461bb"
+                },
+                {
+                  "id": "sha256:7cb8f52fafc3465bc88412019948f599fa1217927861c07ac3f90628772efa55"
+                },
+                {
+                  "id": "sha256:10d1e54c16c491abf59ec796854ffa14563d54461ebb9092501da34f5a9184bc"
+                },
+                {
+                  "id": "sha256:c06dba625e4dfb0b49cb4013c2a82c8f314143c833c1306da12fa2d77a12e0c4"
+                },
+                {
+                  "id": "sha256:60e3d9a99e40010bb917f75d9ce99530d1f8b322d0b1aea07fe71257a369d943"
+                },
+                {
+                  "id": "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069"
+                },
+                {
+                  "id": "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.wsl.conf",
+          "options": {
+            "boot": {
+              "systemd": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "archive",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "disk.tar.gz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:0652d77991ae054286ace9807d7b4b573b99e3be9be7ad126db8d197b5f22a68": {
+          "url": "https://example.com/repo/packages/subscription-manager"
+        },
+        "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb": {
+          "url": "https://example.com/repo/packages/passwd"
+        },
+        "sha256:10d1e54c16c491abf59ec796854ffa14563d54461ebb9092501da34f5a9184bc": {
+          "url": "https://example.com/repo/packages/exclude:python-unversioned-command"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a36b318995f3383dfa35c283df090bde63776c52415a421ea201a9667f95ab3": {
+          "url": "https://example.com/repo/packages/crypto-policies-scripts"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:2692c08277f40048982432ab907ab870ee677f69656d9a71a6f889cf03531eb4": {
+          "url": "https://example.com/repo/packages/exclude:glibc-gconv-extra"
+        },
+        "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa": {
+          "url": "https://example.com/repo/packages/dejavu-sans-fonts"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:32dcd32054ee4e9ae92eec040bc1385c94d74a0846bb0145b1bdf9958740200a": {
+          "url": "https://example.com/repo/packages/curl-minimal"
+        },
+        "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2": {
+          "url": "https://example.com/repo/packages/bash"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1": {
+          "url": "https://example.com/repo/packages/dnf"
+        },
+        "sha256:41ffca929b95c49690ab8815d1d1a134a5bcdd86bde407c0f46b90eabf556b05": {
+          "url": "https://example.com/repo/packages/openssl"
+        },
+        "sha256:4f7872f3a4c4decf34923a48986e52563d2a58bc3225b1890b84b52e7defce09": {
+          "url": "https://example.com/repo/packages/basesystem"
+        },
+        "sha256:54f524f7058cc10b16137ed8cd2cc9531d8bba28574f1509cf1ee7a99327f069": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-baseos-n10.0"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:572d4fe95e2cfd3425b70544a829f39104cad64fb57cdc63a25f9e837fb79917": {
+          "url": "https://example.com/repo/packages/tzdata"
+        },
+        "sha256:5b0440b2a1ceb2db43e1832c91f96728c5fe59a1cd7b5d1f1b905bb0b2df3841": {
+          "url": "https://example.com/repo/packages/findutils"
+        },
+        "sha256:5b0513b8ca5a7f03601efc10934409d271890e6ae7a3264445e7397233eac6f8": {
+          "url": "https://example.com/repo/packages/procps-ng"
+        },
+        "sha256:5f53b0a2be22e28dc4b056f663910c046a33f9b2d779eaf997ea771fe1881a13": {
+          "url": "https://example.com/repo/packages/sed"
+        },
+        "sha256:60e3d9a99e40010bb917f75d9ce99530d1f8b322d0b1aea07fe71257a369d943": {
+          "url": "https://example.com/repo/packages/exclude:rpm-plugin-systemd-inhibit"
+        },
+        "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1": {
+          "url": "https://example.com/repo/packages/shadow-utils"
+        },
+        "sha256:6fd624e2ceb4409a98b06f7f6161a6259cc88a838b6f43454217ed5a0c18a547": {
+          "url": "https://example.com/repo/packages/exclude:gawk-all-langpacks"
+        },
+        "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682": {
+          "url": "https://example.com/repo/packages/hostname"
+        },
+        "sha256:7cb8f52fafc3465bc88412019948f599fa1217927861c07ac3f90628772efa55": {
+          "url": "https://example.com/repo/packages/exclude:openssl-pkcs11"
+        },
+        "sha256:809c2fb94fff223e96477a875bbc1b77e5b020262e8f959d4b49455100a7f9f7": {
+          "url": "https://example.com/repo/packages/yum"
+        },
+        "sha256:8308da3588987ace3967a2eee85a70f8be6eca16320b1e235b636e1464bbad06": {
+          "url": "https://example.com/repo/packages/audit-libs"
+        },
+        "sha256:839f835e4d4558140e9b92fd85c3f923b74b6220ba1ad86b9fe096b8b6305b86": {
+          "url": "https://example.com/repo/packages/coreutils-single"
+        },
+        "sha256:87f1c82f3d3b66f168e0673e4f4227a8a3fe53000bf342780424ee8e3344d591": {
+          "url": "https://example.com/repo/packages/python3-inotify"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a1eb106427026fd9f7daef2fbed09db45de687c264480f8d3945ff13bdd9fe6": {
+          "url": "https://example.com/repo/packages/alternatives"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8fb6d5f37e8055ce720bd0b1d56587f88c0071f285966ba17e72b2b12672aa73": {
+          "url": "https://example.com/repo/packages/setup"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:97e86df4b9e1385f56f5635f227cc75e5a59147a8d06d05d0c08241d7204a92d": {
+          "url": "https://example.com/repo/packages/ca-certificates"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a697ff6e769b4f3d7c9b05d77c96d575c5e001ef923a13395decbe00b7e461bb": {
+          "url": "https://example.com/repo/packages/exclude:glibc-langpack-en"
+        },
+        "sha256:aa6d4532f128420f4d741f2834cd8d1d146bbbdc9554aef454b7adb8ff66f748": {
+          "url": "https://example.com/repo/packages/gnupg2"
+        },
+        "sha256:ae5e2ad3b86239dbf500c630cf88d33d9775e9ce2e32d596910a07d682d97923": {
+          "url": "https://example.com/repo/packages/tpm2-tss"
+        },
+        "sha256:b73d01aa5aad1cf8f57ced67bd4d3e555f52a868b0f35e672cbab53587cd5376": {
+          "url": "https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/rhvpn/el10/el10-aarch64-appstream-n10.0"
+        },
+        "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf": {
+          "url": "https://example.com/repo/packages/vim-minimal"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c06dba625e4dfb0b49cb4013c2a82c8f314143c833c1306da12fa2d77a12e0c4": {
+          "url": "https://example.com/repo/packages/exclude:redhat-release-eula"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31": {
+          "url": "https://example.com/repo/packages/gdb-gdbserver"
+        },
+        "sha256:cbf61858f3260072d96d9b1d2e037fc35824944b9c94d0087b1a53385eccaead": {
+          "url": "https://example.com/repo/packages/filesystem"
+        },
+        "sha256:cc0bbbee7c9dd4f3f30e01c7f1fcbeb839f30c47e3bcbf16db0d37789262cbb4": {
+          "url": "https://example.com/repo/packages/gmp"
+        },
+        "sha256:cfd4affb5ed7a688870bb3725e10cc066e63b2a94b5dd491cac681a3c2b17ca5": {
+          "url": "https://example.com/repo/packages/libcurl-minimal"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e422e1641a99c5a045bc0b596ef5ce6429c8e7744f016444cedacd4eaf5d3e4c": {
+          "url": "https://example.com/repo/packages/rootfiles"
+        },
+        "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3": {
+          "url": "https://example.com/repo/packages/pam"
+        },
+        "sha256:f486d76df6f0ea41b7d6acb72751d8eb4cc2a3f04e6273154fef5e76cab27e11": {
+          "url": "https://example.com/repo/packages/util-linux"
+        },
+        "sha256:f6fad119f40a1aae00b54c0de6a0fa24a1e35d4bf1284bffcfd7134bdbb837e1": {
+          "url": "https://example.com/repo/packages/glibc-minimal-langpack"
+        },
+        "sha256:f8f6228d89c3de21a136641a6d66f8a393db4b9019b17e0bec92ffc88b393eb4": {
+          "url": "https://example.com/repo/packages/gobject-introspection"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-s390x-qcow2-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-s390x-qcow2-empty.json
@@ -1,0 +1,787 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
+                },
+                {
+                  "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:9d0275d1dbfeeed443f1053120599adcb0017bc3c87060a67ea30c89a90bf606"
+                },
+                {
+                  "id": "sha256:51d36393d1638ba9899883ccdf2262c4495e356a8e8771b4806a56ee3a2805cc"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "61861115-5c53-4c5c-96c4-24d718400e8c",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
+                },
+                {
+                  "id": "sha256:59731fa1fe190a4814aff005d6bd3383f1fc4a7e40afeaba7edef1c07dda6db8"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747"
+                },
+                {
+                  "id": "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280"
+                },
+                {
+                  "id": "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
+                },
+                {
+                  "id": "sha256:9d0275d1dbfeeed443f1053120599adcb0017bc3c87060a67ea30c89a90bf606"
+                },
+                {
+                  "id": "sha256:51d36393d1638ba9899883ccdf2262c4495e356a8e8771b4806a56ee3a2805cc"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm",
+          "options": {
+            "dnf-plugins": {
+              "product-id": {
+                "enabled": false
+              },
+              "subscription-manager": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "61861115-5c53-4c5c-96c4-24d718400e8c",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.zipl",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "dos",
+            "uuid": "0x14fc63d2",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 20969472,
+                "start": 2048
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "61861115-5c53-4c5c-96c4-24d718400e8c"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 20969472,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 20969472
+              }
+            },
+            "disk": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.zipl.inst",
+          "options": {
+            "kernel": "8-2.fk1.s390x",
+            "location": 2048
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 20969472
+              }
+            },
+            "disk": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "qcow2",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.qcow2",
+            "format": {
+              "type": "qcow2",
+              "compat": "1.1"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98": {
+          "url": "https://example.com/repo/packages/exclude:fedora-repos"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b": {
+          "url": "https://example.com/repo/packages/exclude:udisks2"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:51d36393d1638ba9899883ccdf2262c4495e356a8e8771b4806a56ee3a2805cc": {
+          "url": "https://example.com/passed-arch:s390x/passed-repo:/v2/mirror/rhvpn/el10/el10-s390x-appstream-n10.0"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:59731fa1fe190a4814aff005d6bd3383f1fc4a7e40afeaba7edef1c07dda6db8": {
+          "url": "https://example.com/repo/packages/s390utils-core"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca": {
+          "url": "https://example.com/repo/packages/s390utils-base"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747": {
+          "url": "https://example.com/repo/packages/exclude:fedora-release"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-en"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9d0275d1dbfeeed443f1053120599adcb0017bc3c87060a67ea30c89a90bf606": {
+          "url": "https://example.com/passed-arch:s390x/passed-repo:/v2/mirror/rhvpn/el10/el10-s390x-baseos-n10.0"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-*"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654": {
+          "url": "https://example.com/repo/packages/subscription-manager-cockpit"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-s390x-qcow2-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-s390x-qcow2-empty.json
@@ -25,13 +25,7 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
-                },
-                {
-                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
                 },
                 {
                   "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
@@ -43,28 +37,13 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
                   "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
-                },
-                {
-                  "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"

--- a/test/data/manifestdb-light/rhel_10.0-s390x-qcow2-rhsm.json
+++ b/test/data/manifestdb-light/rhel_10.0-s390x-qcow2-rhsm.json
@@ -25,13 +25,7 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
-                },
-                {
-                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
                 },
                 {
                   "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
@@ -43,28 +37,13 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
                   "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
-                },
-                {
-                  "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"

--- a/test/data/manifestdb-light/rhel_10.0-s390x-qcow2-rhsm.json
+++ b/test/data/manifestdb-light/rhel_10.0-s390x-qcow2-rhsm.json
@@ -1,0 +1,795 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
+                },
+                {
+                  "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:9d0275d1dbfeeed443f1053120599adcb0017bc3c87060a67ea30c89a90bf606"
+                },
+                {
+                  "id": "sha256:51d36393d1638ba9899883ccdf2262c4495e356a8e8771b4806a56ee3a2805cc"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "ee519559-a824-4118-8c24-6740ecb81c03",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca"
+                },
+                {
+                  "id": "sha256:59731fa1fe190a4814aff005d6bd3383f1fc4a7e40afeaba7edef1c07dda6db8"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747"
+                },
+                {
+                  "id": "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280"
+                },
+                {
+                  "id": "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
+                },
+                {
+                  "id": "sha256:9d0275d1dbfeeed443f1053120599adcb0017bc3c87060a67ea30c89a90bf606"
+                },
+                {
+                  "id": "sha256:51d36393d1638ba9899883ccdf2262c4495e356a8e8771b4806a56ee3a2805cc"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm",
+          "options": {
+            "dnf-plugins": {
+              "product-id": {
+                "enabled": true
+              },
+              "subscription-manager": {
+                "enabled": true
+              }
+            },
+            "subscription-manager": {
+              "rhsm": {
+                "manage_repos": true
+              },
+              "rhsmcertd": {
+                "auto_registration": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "ee519559-a824-4118-8c24-6740ecb81c03",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.zipl",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "dos",
+            "uuid": "0x14fc63d2",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 20969472,
+                "start": 2048
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "ee519559-a824-4118-8c24-6740ecb81c03"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 20969472,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 20969472
+              }
+            },
+            "disk": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.zipl.inst",
+          "options": {
+            "kernel": "8-2.fk1.s390x",
+            "location": 2048
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 20969472
+              }
+            },
+            "disk": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "qcow2",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.qcow2",
+            "format": {
+              "type": "qcow2",
+              "compat": "1.1"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98": {
+          "url": "https://example.com/repo/packages/exclude:fedora-repos"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b": {
+          "url": "https://example.com/repo/packages/exclude:udisks2"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:51d36393d1638ba9899883ccdf2262c4495e356a8e8771b4806a56ee3a2805cc": {
+          "url": "https://example.com/passed-arch:s390x/passed-repo:/v2/mirror/rhvpn/el10/el10-s390x-appstream-n10.0"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:59731fa1fe190a4814aff005d6bd3383f1fc4a7e40afeaba7edef1c07dda6db8": {
+          "url": "https://example.com/repo/packages/s390utils-core"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:66f0e74f653a23298ed6565b8e09dff590f42202c50b6f0ebc4032a775dfc8ca": {
+          "url": "https://example.com/repo/packages/s390utils-base"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747": {
+          "url": "https://example.com/repo/packages/exclude:fedora-release"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-en"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9d0275d1dbfeeed443f1053120599adcb0017bc3c87060a67ea30c89a90bf606": {
+          "url": "https://example.com/passed-arch:s390x/passed-repo:/v2/mirror/rhvpn/el10/el10-s390x-baseos-n10.0"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-*"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654": {
+          "url": "https://example.com/repo/packages/subscription-manager-cockpit"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-s390x-tar-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-s390x-tar-empty.json
@@ -1,0 +1,227 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:9d0275d1dbfeeed443f1053120599adcb0017bc3c87060a67ea30c89a90bf606"
+                },
+                {
+                  "id": "sha256:51d36393d1638ba9899883ccdf2262c4495e356a8e8771b4806a56ee3a2805cc"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:9d0275d1dbfeeed443f1053120599adcb0017bc3c87060a67ea30c89a90bf606"
+                },
+                {
+                  "id": "sha256:51d36393d1638ba9899883ccdf2262c4495e356a8e8771b4806a56ee3a2805cc"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "archive",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "root.tar.xz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:51d36393d1638ba9899883ccdf2262c4495e356a8e8771b4806a56ee3a2805cc": {
+          "url": "https://example.com/passed-arch:s390x/passed-repo:/v2/mirror/rhvpn/el10/el10-s390x-appstream-n10.0"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9d0275d1dbfeeed443f1053120599adcb0017bc3c87060a67ea30c89a90bf606": {
+          "url": "https://example.com/passed-arch:s390x/passed-repo:/v2/mirror/rhvpn/el10/el10-s390x-baseos-n10.0"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-s390x-tar-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-s390x-tar-empty.json
@@ -34,9 +34,6 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
                 },
                 {
@@ -86,9 +83,6 @@
               "references": [
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ami-all_customizations.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ami-all_customizations.json
@@ -1,0 +1,1714 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "a275bc3e-57e2-4eaa-a726-f6e8a38bccdd",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 debug"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3"
+                },
+                {
+                  "id": "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"
+                },
+                {
+                  "id": "sha256:52856879d4bfa1d564480850a56b0885e1c52a805af96fffe84122afc9b1c52b"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "el_CY.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "dvorak"
+          }
+        },
+        {
+          "type": "org.osbuild.hostname",
+          "options": {
+            "hostname": "my-host"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "Europe/London"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "time.example.com"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.groups",
+          "options": {
+            "groups": {
+              "group1": {
+                "gid": 1030
+              },
+              "group2": {
+                "gid": 1050
+              },
+              "user3": {
+                "gid": 1060
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+              "user1": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              },
+              "user2": {
+                "uid": 1020,
+                "gid": 1050,
+                "groups": [
+                  "group1"
+                ],
+                "description": "description 2",
+                "home": "/home/home2",
+                "shell": "/bin/sh",
+                "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              },
+              "user3": {
+                "uid": 1060,
+                "gid": 1060
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dracut.conf",
+          "options": {
+            "filename": "ec2.conf",
+            "config": {
+              "add_drivers": [
+                "nvme",
+                "xen-blkfront"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.yum.repos",
+          "options": {
+            "filename": "example.repo",
+            "repos": [
+              {
+                "id": "example",
+                "baseurl": [
+                  "https://example.com/download/yum"
+                ],
+                "enabled": true,
+                "gpgkey": [
+                  "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                ],
+                "name": "Example repo",
+                "gpgcheck": true,
+                "repo_gpgcheck": false
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "a275bc3e-57e2-4eaa-a726-f6e8a38bccdd",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "92f2d535-f4f3-4c5e-99a3-1dc62db47ba5",
+                "vfs_type": "xfs",
+                "path": "/boot",
+                "options": "defaults"
+              },
+              {
+                "uuid": "5149d962-e14f-4eb1-b07e-b9a4dc1a7360",
+                "vfs_type": "xfs",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "86493d66-39a7-4f5c-a06c-2bfc9b5f2cd0",
+                "vfs_type": "xfs",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7c989e76-a365-4a5e-9a3b-37b7f4b84c37",
+                "vfs_type": "xfs",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "c85f3d00-e8bd-4890-9596-65661565df46",
+                "vfs_type": "xfs",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "b2626ffb-731b-484a-bb27-0efdd70b5649",
+                "vfs_type": "xfs",
+                "path": "/mnt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "3727d716-fb4d-46da-bd7a-d0fd6d77e46e",
+                "vfs_type": "xfs",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "e91577f5-012b-4903-bf1a-efee54792d6d",
+                "vfs_type": "xfs",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "d36c0788-abf4-4567-a5ef-ea9da8781d42",
+                "vfs_type": "xfs",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "b30835b8-60cf-4e5f-bd61-6198ddc5eeea",
+                "vfs_type": "xfs",
+                "path": "/usr",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "a275bc3e-57e2-4eaa-a726-f6e8a38bccdd",
+            "boot_fs_uuid": "92f2d535-f4f3-4c5e-99a3-1dc62db47ba5",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 debug",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/etc/systemd/system/custom.service.d",
+                "exist_ok": true
+              },
+              {
+                "path": "/etc/custom_dir"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/custom_dir": {
+                "mode": "0770"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/custom_dir": {
+                "user": 1020,
+                "group": 1050
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e"
+                }
+              ]
+            },
+            "file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2"
+                }
+              ]
+            },
+            "file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258"
+                }
+              ]
+            },
+            "file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                }
+              ]
+            },
+            "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e/sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e",
+                "to": "tree:///etc/systemd/system/custom.service",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2/sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2",
+                "to": "tree:///etc/systemd/system/custom.service.d/override.conf",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258/sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258",
+                "to": "tree:///etc/custom_file.txt",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "to": "tree:///etc/empty_file.txt",
+                "remove_destination": true
+              },
+              {
+                "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chmod",
+          "options": {
+            "items": {
+              "/etc/custom_file.txt": {
+                "mode": "0644"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/custom_file.txt": {
+                "user": "root",
+                "group": "root"
+              },
+              "/etc/empty_file.txt": {
+                "user": 0,
+                "group": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned",
+              "sshd.service",
+              "custom.service"
+            ],
+            "disabled_services": [
+              "bluetooth.service"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c/sha256:4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c",
+                "to": "tree:///etc/pki/ca-trust/source/anchors/27894af897dd2423607045716438a725f28a6d0b.pem",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.chown",
+          "options": {
+            "items": {
+              "/etc/pki/ca-trust/source/anchors/27894af897dd2423607045716438a725f28a6d0b.pem": {
+                "user": "root",
+                "group": "root"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.pki.update-ca-trust"
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "16860053504"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 31467487,
+                "start": 1462272,
+                "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              },
+              {
+                "size": 1048576,
+                "start": 413696,
+                "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                "uuid": "a0c73b62-be5f-4f62-8dae-07cd17a06901"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.lvm2.create",
+          "options": {
+            "volumes": [
+              {
+                "name": "rootlv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "homelv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "home_shadowmanlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "foolv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "usrlv",
+                "size": "4294967296B"
+              },
+              {
+                "name": "optlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "medialv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "rootlv00",
+                "size": "1073741824B"
+              },
+              {
+                "name": "srvlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "mntlv",
+                "size": "1073741824B"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "a275bc3e-57e2-4eaa-a726-f6e8a38bccdd",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "86493d66-39a7-4f5c-a06c-2bfc9b5f2cd0"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "7c989e76-a365-4a5e-9a3b-37b7f4b84c37"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "home_shadowmanlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "5149d962-e14f-4eb1-b07e-b9a4dc1a7360"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "b30835b8-60cf-4e5f-bd61-6198ddc5eeea"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "3727d716-fb4d-46da-bd7a-d0fd6d77e46e"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "c85f3d00-e8bd-4890-9596-65661565df46"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "e91577f5-012b-4903-bf1a-efee54792d6d"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv00"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "d36c0788-abf4-4567-a5ef-ea9da8781d42"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "b2626ffb-731b-484a-bb27-0efdd70b5649"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "mntlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "92f2d535-f4f3-4c5e-99a3-1dc62db47ba5"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 1048576,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 1048576
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "home_shadowmanlv"
+              }
+            },
+            "media": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "mnt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "mntlv"
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "root": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv00"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.xfs",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.xfs",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.xfs",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.xfs",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "mnt",
+              "type": "org.osbuild.xfs",
+              "source": "mnt",
+              "target": "/mnt"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.xfs",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.xfs",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.xfs",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.xfs",
+              "source": "usr",
+              "target": "/usr"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.lvm2.metadata",
+          "options": {
+            "vg_name": "rootvg"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 31467487,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "image.raw",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 3,
+              "path": "/grub2"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb": {
+          "url": "https://example.com/repo/packages/passwd"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2": {
+          "url": "https://example.com/repo/packages/bash"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:52856879d4bfa1d564480850a56b0885e1c52a805af96fffe84122afc9b1c52b": {
+          "url": "https://example.com/repo/packages/bluez"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1": {
+          "url": "https://example.com/repo/packages/shadow-utils"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3": {
+          "url": "https://example.com/repo/packages/pam"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    },
+    "org.osbuild.inline": {
+      "items": {
+        "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+          "encoding": "base64",
+          "data": "W1VuaXRdCkRlc2NyaXB0aW9uPUN1c3RvbSBzZXJ2aWNlCgpbU2VydmljZV0KRXhlY1N0YXJ0PS91c3IvYmluL2ZhbHNlCgpbSW5zdGFsbF0KV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXQK"
+        },
+        "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+          "encoding": "base64",
+          "data": "W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NhdCAvZXRjL2N1c3RvbV9maWxlLnR4dAo="
+        },
+        "sha256:4c4e8c734e4ee3a117ca8f9363ba7b706d02bfc8f297c00b02ce02babddef51c": {
+          "encoding": "base64",
+          "data": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzekNDQXB1Z0F3SUJBZ0lVSjRsSytKZmRKQ05nY0VWeFpEaW5KZktLYlFzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2FERUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZRApWUVFIREFkU1lXeGxhV2RvTVJBd0RnWURWUVFLREFkU1pXUWdTR0YwTVJ3d0dnWURWUVFEREJOVVpYTjBJRU5CCklHWnZjaUJ2YzJKMWFXeGtNQ0FYRFRJME1Ea3dNekV6TWpreU1Gb1lEekl5T1Rnd05qRTRNVE15T1RJd1dqQm8KTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjTQpCMUpoYkdWcFoyZ3hFREFPQmdOVkJBb01CMUpsWkNCSVlYUXhIREFhQmdOVkJBTU1FMVJsYzNRZ1EwRWdabTl5CklHOXpZblZwYkdRd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURlQTdPY1dUclYKZ3N0b0JzVWFlSkttOG5lbGc3TGMwV05YSDZ5T1RMc3I0dGQ0eUhzMFlPdkZHd2dTZitmZlYzUkFHMW1ncW5NRwpNZ2tEMit6KzdRaEhiSEhzM3kwZDB6ZmhBMmJnMEtWdmZDV2s3Zk5SUEhZMFVPZVBwWGsyNDVCZnczRDBWVHBsCkY3bmVQazFJN1pZMDlzblBXVWViMnJqS1h6WWpLanpNMGgyNyt5a1Y4STgrRmJkeVBrL3BSOHdoeURxdEhMVWEKWGZGeTJURmxvRFNZTWtIS1ZkMzhCbkwwYmo5MXg1RitLc1prTjRIemZiWXd4TGJDUWZPU2d5N3E2VFdjZTlrcQpMbzZ0eWE5dnV2cFdGbTFkeWU3TCtCb2RBUUFxL2RJL0pNZUNmeVRiMGVGYit0eXpmcjVhVklvcXFETitwOWZ0CmN3NE9lZnBIYmh0TkFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUlYyQTlZbXVzZWtQenU1WWYwOGNWMG9QTDEKd2pBZkJnTlZIU01FR0RBV2dCUlYyQTlZbXVzZWtQenU1WWYwOGNWMG9QTDF3akFQQmdOVkhSTUJBZjhFQlRBRApBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFDZ1FaMlhmaitOeGFLQlpnbjJLTnhTME1UYmh6SFJ6NlJuCnFKcytoOE9VejJDcm1hZjZOK1JIbG1EUlpYVXJEalNIcHhWVDJMeEZ5N29mUnJMWUllekZEVVlmYjkyMFZra1YKU1ZjeGgxWURGUk9KYWxmTW9FNndkeVIvTG5LNE1KWlM5ZlVwZUNKSmMvQTBKKzlGSzlDd2N5VXJIZ0o4WGJKaApNS1l5UStjZjZPN3d6dXR1QnBNeVJxU0tTK2hWTTdCUVRtU0Z2djFlQUpsbzZrbEdBbW1LaVltQUV2Y1FhZEgxCmRqcnVqc0EzQ241dlgyTCsweXVpTEI1L3pveHF4NWNFeTk3VHVLVVlCOE9xTU11akFYTnpGNEwzSEpEVU5iYTIKQWhFa0Zvek1Yd1lYNzNUR2JHWjBtYXdQUzVEM3YzdFlURW1KRmY2U25WQ21VVzFmczU3ZwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        },
+        "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+          "encoding": "base64",
+          "data": "aW1hZ2UgYnVpbGRlciBpcyB0aGUgYmVzdA=="
+        },
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+          "encoding": "base64",
+          "data": ""
+        },
+        "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+          "encoding": "base64",
+          "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ami-all_customizations.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ami-all_customizations.json
@@ -19,19 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
@@ -43,37 +34,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -136,9 +109,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -149,12 +119,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
@@ -305,9 +269,6 @@
                 },
                 {
                   "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
-                },
-                {
-                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
                 },
                 {
                   "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ami-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ami-empty.json
@@ -19,13 +19,7 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
@@ -37,37 +31,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -130,9 +106,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -143,12 +116,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ami-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ami-empty.json
@@ -1,0 +1,879 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "bf244126-091b-4e52-8139-8c51acf8fc08",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dracut.conf",
+          "options": {
+            "filename": "ec2.conf",
+            "config": {
+              "add_drivers": [
+                "nvme",
+                "xen-blkfront"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "bf244126-091b-4e52-8139-8c51acf8fc08",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "bf244126-091b-4e52-8139-8c51acf8fc08",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20557791,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "bf244126-091b-4e52-8139-8c51acf8fc08",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 20557791,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 20557791
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "image.raw",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ami-oscap_rhel10.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ami-oscap_rhel10.json
@@ -1,0 +1,956 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:ff58b2c2afc22d8027e46529b857d1fe24505d66e7205497bfdf89fa15dcd11f"
+                },
+                {
+                  "id": "sha256:ff58b2c2afc22d8027e46529b857d1fe24505d66e7205497bfdf89fa15dcd11f"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "e3dc08d3-0c07-4187-b459-2caec6fb74f8",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:71c42066c0365a2fc8789ea3557b1d9cc02efaa38acf606a8721677e156bd135"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:0f916f1464ce623afcf1deea10887af956097e0ca395df2fd743787cba611e70"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:c84d384f2a25cca2a8fde5eb61b0f81f728e5f778a232211b176ea80143877bc"
+                },
+                {
+                  "id": "sha256:ff58b2c2afc22d8027e46529b857d1fe24505d66e7205497bfdf89fa15dcd11f"
+                },
+                {
+                  "id": "sha256:8dd09cdcaee28f7ebb491c23ae6afa1305f8be037ac3d5dc2e19196ded4eac57"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dracut.conf",
+          "options": {
+            "filename": "ec2.conf",
+            "config": {
+              "add_drivers": [
+                "nvme",
+                "xen-blkfront"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "e3dc08d3-0c07-4187-b459-2caec6fb74f8",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "e3dc08d3-0c07-4187-b459-2caec6fb74f8",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/oscap_data",
+                "parents": true,
+                "exist_ok": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.oscap.autotailor",
+          "options": {
+            "filepath": "/oscap_data/tailoring.xml",
+            "config": {
+              "new_profile": "xccdf_org.ssgproject.content_profile_cis_osbuild_tailoring",
+              "datastream": "/usr/share/xml/scap/ssg/content/ssg-rhel10-ds.xml",
+              "profile_id": "xccdf_org.ssgproject.content_profile_cis",
+              "unselected": [
+                "grub2_password"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.oscap.remediation",
+          "options": {
+            "data_dir": "/oscap_data",
+            "config": {
+              "datastream": "/usr/share/xml/scap/ssg/content/ssg-rhel10-ds.xml",
+              "profile_id": "xccdf_org.ssgproject.content_profile_cis_osbuild_tailoring",
+              "tailoring": "/oscap_data/tailoring.xml",
+              "compress_results": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20557791,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "e3dc08d3-0c07-4187-b459-2caec6fb74f8",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 20557791,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 20557791
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "image.raw",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:0f916f1464ce623afcf1deea10887af956097e0ca395df2fd743787cba611e70": {
+          "url": "https://example.com/repo/packages/scap-security-guide"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:71c42066c0365a2fc8789ea3557b1d9cc02efaa38acf606a8721677e156bd135": {
+          "url": "https://example.com/repo/packages/openscap-scanner"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8dd09cdcaee28f7ebb491c23ae6afa1305f8be037ac3d5dc2e19196ded4eac57": {
+          "url": "https://example.com/repo/packages/xmlstarlet"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:c84d384f2a25cca2a8fde5eb61b0f81f728e5f778a232211b176ea80143877bc": {
+          "url": "https://example.com/repo/packages/jq"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        },
+        "sha256:ff58b2c2afc22d8027e46529b857d1fe24505d66e7205497bfdf89fa15dcd11f": {
+          "url": "https://example.com/repo/packages/openscap-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ami-oscap_rhel10.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ami-oscap_rhel10.json
@@ -19,19 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:ff58b2c2afc22d8027e46529b857d1fe24505d66e7205497bfdf89fa15dcd11f"
                 },
                 {
                   "id": "sha256:ff58b2c2afc22d8027e46529b857d1fe24505d66e7205497bfdf89fa15dcd11f"
@@ -43,37 +34,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -136,9 +109,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -149,12 +119,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ami-partitioning_lvm.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ami-partitioning_lvm.json
@@ -19,12 +19,6 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
-                },
-                {
                   "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
                 },
                 {
@@ -32,12 +26,6 @@
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
@@ -49,37 +37,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -142,9 +112,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -155,12 +122,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ami-partitioning_lvm.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ami-partitioning_lvm.json
@@ -1,0 +1,1458 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "833a7770-9259-4e71-9aa1-0b57472eccd1",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dracut.conf",
+          "options": {
+            "filename": "ec2.conf",
+            "config": {
+              "add_drivers": [
+                "nvme",
+                "xen-blkfront"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "833a7770-9259-4e71-9aa1-0b57472eccd1",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "e3ad7c7d-99ba-451e-9433-1a1cf97e33be",
+                "vfs_type": "xfs",
+                "path": "/boot",
+                "options": "defaults"
+              },
+              {
+                "uuid": "3ea4e66d-7944-4e9c-8049-2171808a0598",
+                "vfs_type": "ext4",
+                "path": "/data",
+                "options": "defaults"
+              },
+              {
+                "uuid": "1e9d73cd-9833-4a62-9c17-c55d072b29ff",
+                "vfs_type": "ext4",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "a7803dad-4186-4e08-888b-07f80ebc2187",
+                "vfs_type": "ext4",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "ec06b849-96fa-4de1-af33-6d7396dfab06",
+                "vfs_type": "ext4",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "802cc4be-f9af-4f12-98cb-5a0ef8cb1abd",
+                "vfs_type": "ext4",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7d788775-83b8-47d3-abb9-b5dce4094493",
+                "vfs_type": "ext4",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "a1b3e246-2743-4334-9da6-2242e52d21a9",
+                "vfs_type": "ext4",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "fb1ad7e1-8c6c-4f93-a22e-3a0da7326d29",
+                "vfs_type": "ext4",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "e23a9de7-1036-4535-8443-b7705a043b20",
+                "vfs_type": "ext4",
+                "path": "/usr",
+                "options": "defaults"
+              },
+              {
+                "uuid": "e3244a0d-e565-4d47-8ff6-e0c559f28ad8",
+                "vfs_type": "swap",
+                "path": "none",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "833a7770-9259-4e71-9aa1-0b57472eccd1",
+            "boot_fs_uuid": "e3ad7c7d-99ba-451e-9433-1a1cf97e33be",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "21155020800"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "a0bd2dc6-63cd-42b6-a9fd-17ed63aaf218",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 1048576,
+                "start": 413696,
+                "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                "uuid": "507d4b82-bb70-4772-81f4-06f02024aa46"
+              },
+              {
+                "size": 2097152,
+                "start": 1462272,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "d107f174-8ab1-4b37-a376-819392ae3445"
+              },
+              {
+                "size": 37758943,
+                "start": 3559424,
+                "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+                "uuid": "10fab746-07c2-438e-b126-8b35c2b555e2"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.lvm2.create",
+          "options": {
+            "volumes": [
+              {
+                "name": "homelv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "shadowmanlv",
+                "size": "5368709120B"
+              },
+              {
+                "name": "foolv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "usrlv",
+                "size": "4294967296B"
+              },
+              {
+                "name": "optlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "medialv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "roothomelv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "srvlv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "swap-lv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "rootlv",
+                "size": "1073741824B"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "e3ad7c7d-99ba-451e-9433-1a1cf97e33be",
+            "label": "boot"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 1048576,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "3ea4e66d-7944-4e9c-8049-2171808a0598",
+            "label": "data"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "a7803dad-4186-4e08-888b-07f80ebc2187",
+            "label": "home"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "ec06b849-96fa-4de1-af33-6d7396dfab06"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "shadowmanlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "1e9d73cd-9833-4a62-9c17-c55d072b29ff"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "e23a9de7-1036-4535-8443-b7705a043b20"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "7d788775-83b8-47d3-abb9-b5dce4094493"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "802cc4be-f9af-4f12-98cb-5a0ef8cb1abd"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "a1b3e246-2743-4334-9da6-2242e52d21a9"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "roothomelv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "fb1ad7e1-8c6c-4f93-a22e-3a0da7326d29"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkswap",
+          "options": {
+            "uuid": "e3244a0d-e565-4d47-8ff6-e0c559f28ad8"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "swap-lv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "833a7770-9259-4e71-9aa1-0b57472eccd1",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 1048576
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600
+              }
+            },
+            "data": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 1462272,
+                "size": 2097152
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "foolv"
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "shadowmanlv"
+              }
+            },
+            "media": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "medialv"
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "optlv"
+              }
+            },
+            "root": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "roothomelv"
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "srvlv"
+              }
+            },
+            "testvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "testvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "data",
+              "type": "org.osbuild.ext4",
+              "source": "data",
+              "target": "/data"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.ext4",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.ext4",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.ext4",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.ext4",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.ext4",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.ext4",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.ext4",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.ext4",
+              "source": "usr",
+              "target": "/usr"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.lvm2.metadata",
+          "options": {
+            "vg_name": "testvg"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 3559424,
+                "size": 37758943,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "image.raw",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/grub2"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ami-partitioning_plain.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ami-partitioning_plain.json
@@ -1,0 +1,1308 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "72d3a9d0-c39d-4934-9973-0bb146b82478",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dracut.conf",
+          "options": {
+            "filename": "ec2.conf",
+            "config": {
+              "add_drivers": [
+                "nvme",
+                "xen-blkfront"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "72d3a9d0-c39d-4934-9973-0bb146b82478",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "f11208af-0190-4bfb-b6c0-dd23fff3e685",
+                "vfs_type": "ext4",
+                "path": "/data",
+                "options": "defaults"
+              },
+              {
+                "uuid": "5bfde3bb-8f97-4b8d-9323-7297dbadee05",
+                "vfs_type": "ext4",
+                "path": "/foo",
+                "options": "defaults"
+              },
+              {
+                "uuid": "6641a47d-fc0b-4243-81bc-437c003b0daf",
+                "vfs_type": "ext4",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "b1b9d69f-e9ab-4da5-bbda-4f776737b9b9",
+                "vfs_type": "ext4",
+                "path": "/home/shadowman",
+                "options": "defaults"
+              },
+              {
+                "uuid": "16d072a1-c912-420e-a171-9bdb9183a5b6",
+                "vfs_type": "ext4",
+                "path": "/media",
+                "options": "defaults"
+              },
+              {
+                "uuid": "8876c2e3-b596-47b6-8457-40d8b2551852",
+                "vfs_type": "ext4",
+                "path": "/opt",
+                "options": "defaults"
+              },
+              {
+                "uuid": "b4740598-6492-4a61-b29e-68e196c0b2a5",
+                "vfs_type": "ext4",
+                "path": "/root",
+                "options": "defaults"
+              },
+              {
+                "uuid": "9bc5a07a-9882-4484-a36f-0a92106b88d1",
+                "vfs_type": "xfs",
+                "path": "/srv",
+                "options": "defaults"
+              },
+              {
+                "uuid": "eee579f8-87f0-4368-94d2-b13abe64c38b",
+                "vfs_type": "xfs",
+                "path": "/var",
+                "options": "defaults"
+              },
+              {
+                "uuid": "e30d6ddb-73e4-40f4-8c23-cc42bc1965da",
+                "vfs_type": "swap",
+                "path": "none",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "72d3a9d0-c39d-4934-9973-0bb146b82478",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "image.raw",
+            "size": "17917018112"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "5c9f6b12-8032-4d0a-9413-7fabd0cc503f",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 2097152,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "2ea073e8-0704-40d5-b07f-5a9793d3d584"
+              },
+              {
+                "size": 4194304,
+                "start": 2510848,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "bc993449-e8cc-422c-b7b6-83cd2b3243cf"
+              },
+              {
+                "size": 1024000,
+                "start": 6705152,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "42dbd29f-08a2-4ae0-b267-cd13c8c9b977"
+              },
+              {
+                "size": 2097152,
+                "start": 7729152,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "9a6ada12-0a0e-4d04-95dd-ed8f07ea53ee"
+              },
+              {
+                "size": 8388608,
+                "start": 9826304,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "8a9bde41-dd47-4088-999b-721cde429b8c"
+              },
+              {
+                "size": 2097152,
+                "start": 18214912,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "54f0bd3a-4ff5-426c-9770-2b150e3a97d6"
+              },
+              {
+                "size": 2097152,
+                "start": 20312064,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "5a82241a-a666-48d9-babf-726618023798"
+              },
+              {
+                "size": 2097152,
+                "start": 22409216,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "599a0f82-86d6-4022-89a7-31ba5ab7aded"
+              },
+              {
+                "size": 2097152,
+                "start": 24506368,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "b5276eee-5f78-491f-a9a0-435774a8bb7d"
+              },
+              {
+                "size": 2097152,
+                "start": 26603520,
+                "type": "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F",
+                "uuid": "51956b71-a42a-47d3-ac6e-113c1dc6c38e"
+              },
+              {
+                "size": 6293471,
+                "start": 28700672,
+                "type": "4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709",
+                "uuid": "c208844f-bd3e-48ec-a7de-5dd3b80a1834"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "f11208af-0190-4bfb-b6c0-dd23fff3e685"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "6641a47d-fc0b-4243-81bc-437c003b0daf",
+            "label": "home"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2510848,
+                "size": 4194304,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "b1b9d69f-e9ab-4da5-bbda-4f776737b9b9"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 6705152,
+                "size": 1024000,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "5bfde3bb-8f97-4b8d-9323-7297dbadee05"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 7729152,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "eee579f8-87f0-4368-94d2-b13abe64c38b"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 9826304,
+                "size": 8388608,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "8876c2e3-b596-47b6-8457-40d8b2551852"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 18214912,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "16d072a1-c912-420e-a171-9bdb9183a5b6"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 20312064,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "options": {
+            "uuid": "b4740598-6492-4a61-b29e-68e196c0b2a5"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 22409216,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "9bc5a07a-9882-4484-a36f-0a92106b88d1"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 24506368,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkswap",
+          "options": {
+            "uuid": "e30d6ddb-73e4-40f4-8c23-cc42bc1965da"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 26603520,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "72d3a9d0-c39d-4934-9973-0bb146b82478",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 28700672,
+                "size": 6293471,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 28700672,
+                "size": 6293471
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 4096,
+                "size": 409600
+              }
+            },
+            "data": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 413696,
+                "size": 2097152
+              }
+            },
+            "foo": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 7729152,
+                "size": 2097152
+              }
+            },
+            "home": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 2510848,
+                "size": 4194304
+              }
+            },
+            "home-shadowman": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 6705152,
+                "size": 1024000
+              }
+            },
+            "media": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 20312064,
+                "size": 2097152
+              }
+            },
+            "opt": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 18214912,
+                "size": 2097152
+              }
+            },
+            "root": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 22409216,
+                "size": 2097152
+              }
+            },
+            "srv": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 24506368,
+                "size": 2097152
+              }
+            },
+            "var": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "image.raw",
+                "start": 9826304,
+                "size": 8388608
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "data",
+              "type": "org.osbuild.ext4",
+              "source": "data",
+              "target": "/data"
+            },
+            {
+              "name": "foo",
+              "type": "org.osbuild.ext4",
+              "source": "foo",
+              "target": "/foo"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.ext4",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "home-shadowman",
+              "type": "org.osbuild.ext4",
+              "source": "home-shadowman",
+              "target": "/home/shadowman"
+            },
+            {
+              "name": "media",
+              "type": "org.osbuild.ext4",
+              "source": "media",
+              "target": "/media"
+            },
+            {
+              "name": "opt",
+              "type": "org.osbuild.ext4",
+              "source": "opt",
+              "target": "/opt"
+            },
+            {
+              "name": "root",
+              "type": "org.osbuild.ext4",
+              "source": "root",
+              "target": "/root"
+            },
+            {
+              "name": "srv",
+              "type": "org.osbuild.xfs",
+              "source": "srv",
+              "target": "/srv"
+            },
+            {
+              "name": "var",
+              "type": "org.osbuild.xfs",
+              "source": "var",
+              "target": "/var"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "image.raw",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 12,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ami-partitioning_plain.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ami-partitioning_plain.json
@@ -19,19 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
-                },
-                {
                   "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
                 },
                 {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
@@ -43,37 +34,19 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -136,9 +109,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -149,12 +119,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-azure_rhui-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-azure_rhui-empty.json
@@ -1,0 +1,1448 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "fa872b0d-ac39-421c-9d1e-04d52d67b14a",
+            "kernel_opts": "ro loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221"
+                },
+                {
+                  "id": "sha256:563a278902fa76bae3ec1833f24ff89abe26329b1d32af9aaa924d6fc6fd68aa"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:b6cae3a11438b4ec550ce10b73b35160fafbe9d436fdb4f81fea356fc5bb6fee"
+                },
+                {
+                  "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:79a583014c5150aac3a44a025229af2918d16d3f6f32d005bf5786f693d6b893"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:f48860f2daf7e7a03ab9827300ab91c865d446de1c12a279339a2fff75c00f4e"
+                },
+                {
+                  "id": "sha256:229b391b136444fc29f0a5b3a897222f8ff4ed2277427e68eeb13fccfe39905c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8e57cbb02cd20f0e373ae76a44d7ddd0125fe449db5dfc196b0920ef47ced56e"
+                },
+                {
+                  "id": "sha256:a4895eb44afc336fecbba6e520cd67e178dace0276655d102fceffa8e5f70570"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:75666699b77db631f576041e8102a55b46758c01b807eacae0f170930ab59b3d"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:01fdad2e9ee0a69f7e323ddb4258e2b0dbfaa242a21d7a8bfdfec04ebe8d3e86"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:81f29ed6c790aa976572770ecf7b6f0351da3c46c9558640c7a83896b6bf8e05"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:534994290b3914604921fc2c61852b7bb4c4d8fb947f057a6fb38a3a57835d9a"
+                },
+                {
+                  "id": "sha256:0ee8cf7e33852f80cd293a8fa8c371f888dc011984ff2836f1198bcdc552dc58"
+                },
+                {
+                  "id": "sha256:5f1e4685c9b4d243264d22fa24864335aab534815fcfe6c3a88eec83ee22354f"
+                },
+                {
+                  "id": "sha256:f3e607ceb5fd279c62a109d1bbb952cc44d7467266ef679a99fd0d9c02ce8d29"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:7913d978541704fb38f5f13a949811c80ed4a52b2514d4582fe3ccb8f5a04617"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:a76985e9146fec1e9fb00cc08d5e0a76eb7f47c10a7abbc4430f8ac235a8b1cd"
+                },
+                {
+                  "id": "sha256:141b56438fdc0208877397569000e1a5857ff57807ff3bbaf2622cc87901861d"
+                },
+                {
+                  "id": "sha256:725c887b1ebcd6be8eb9a0ef6b2c476ff6d2dd8f9cf622f8d60953a1f22c94c8"
+                },
+                {
+                  "id": "sha256:53d00356d82e89cbdf0f963060c58433f73e0b339ba9f63577bd7df44f78e051"
+                },
+                {
+                  "id": "sha256:f1d96d150523777accb14a93582922ded22aa868629c58c3cd49339952293327"
+                },
+                {
+                  "id": "sha256:840109e45bc2504c9f202410bd941dc430bcef1065e1c1a98e5d08506c0c91af"
+                },
+                {
+                  "id": "sha256:b1eb4c41592e8eb6f7f2c96cdda2162fe214f52f85b01e9b174aa81bf297e01a"
+                },
+                {
+                  "id": "sha256:590ef3ccd31b243b045e9c5f9268d1013b0960060366c76028a23b070b5fb7be"
+                },
+                {
+                  "id": "sha256:9fe43931a7b645b90921b9b72d836e9d06ececc0b3cca1376fa0a297b5f522a5"
+                },
+                {
+                  "id": "sha256:49ec7b34785f32ffd1f252d5cc9a0a015ca074f75c601d2272149a72d50d42df"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ],
+            "gpgkeys.fromtree": [
+              "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel-core"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "10-azure-kvp.cfg",
+            "config": {
+              "reporting": {
+                "logging": {
+                  "type": "log"
+                },
+                "telemetry": {
+                  "type": "hyperv"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "91-azure_datasource.cfg",
+            "config": {
+              "datasource": {
+                "Azure": {
+                  "apply_network_config": false
+                }
+              },
+              "datasource_list": [
+                "Azure"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-intel-cstate.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "intel_cstate"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-floppy.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "floppy"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              },
+              {
+                "command": "blacklist",
+                "modulename": "lbm-nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-skylake-edac.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "skx_edac"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-azure.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_AZURE",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "ClientAliveInterval": 180
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.pwquality.conf",
+          "options": {
+            "config": {
+              "minlen": 6,
+              "dcredit": 0,
+              "ucredit": 0,
+              "lcredit": 0,
+              "ocredit": 0,
+              "minclass": 3
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.waagent.conf",
+          "options": {
+            "config": {
+              "ResourceDisk.Format": false,
+              "ResourceDisk.EnableSwap": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.udev.rules",
+          "options": {
+            "filename": "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules",
+            "rules": [
+              {
+                "comment": [
+                  "Accelerated Networking on Azure exposes a new SRIOV interface to the VM.",
+                  "This interface is transparently bonded to the synthetic interface,",
+                  "so NetworkManager should just ignore any SRIOV interfaces."
+                ]
+              },
+              [
+                {
+                  "key": "SUBSYSTEM",
+                  "op": "==",
+                  "val": "net"
+                },
+                {
+                  "key": "DRIVERS",
+                  "op": "==",
+                  "val": "hv_pci"
+                },
+                {
+                  "key": "ACTION",
+                  "op": "==",
+                  "val": "add"
+                },
+                {
+                  "key": {
+                    "name": "ENV",
+                    "arg": "NM_UNMANAGED"
+                  },
+                  "op": "=",
+                  "val": "1"
+                }
+              ]
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "fa872b0d-ac39-421c-9d1e-04d52d67b14a",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "ee295b84-13e4-4ae8-82d3-78fb2a7448cc",
+                "vfs_type": "xfs",
+                "path": "/boot",
+                "options": "defaults"
+              },
+              {
+                "uuid": "ca7e6803-80c6-49f7-95d2-6b68be7b998b",
+                "vfs_type": "xfs",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "f3328c9b-eb33-4441-bf35-c0c4b7141777",
+                "vfs_type": "xfs",
+                "path": "/tmp",
+                "options": "defaults"
+              },
+              {
+                "uuid": "ab9470ba-4fd2-4c9e-850f-538ea3433579",
+                "vfs_type": "xfs",
+                "path": "/usr",
+                "options": "defaults"
+              },
+              {
+                "uuid": "583f5aaa-5902-4c5b-b082-c94208c61306",
+                "vfs_type": "xfs",
+                "path": "/var",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "fa872b0d-ac39-421c-9d1e-04d52d67b14a",
+            "boot_fs_uuid": "ee295b84-13e4-4ae8-82d3-78fb2a7448cc",
+            "kernel_opts": "ro loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved",
+              "disable_recovery": true,
+              "disable_submenu": true,
+              "distributor": "$(sed 's, release .*$,,g' /etc/system-release)",
+              "terminal": [
+                "serial",
+                "console"
+              ],
+              "timeout": 10,
+              "timeout_style": "countdown",
+              "serial": "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "firewalld",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "sshd",
+              "waagent"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "68719476736"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "size": 1024000,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 2097152,
+                "start": 1026048,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+              },
+              {
+                "bootable": true,
+                "size": 4096,
+                "start": 3123200,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 131090399,
+                "start": 3127296,
+                "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.lvm2.create",
+          "options": {
+            "volumes": [
+              {
+                "name": "homelv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "rootlv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "tmplv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "usrlv",
+                "size": "10737418240B"
+              },
+              {
+                "name": "varlv",
+                "size": "10737418240B"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3127296,
+                "size": 131090399,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 1024000,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "ee295b84-13e4-4ae8-82d3-78fb2a7448cc"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1026048,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "ca7e6803-80c6-49f7-95d2-6b68be7b998b",
+            "label": "home"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3127296,
+                "size": 131090399,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "fa872b0d-ac39-421c-9d1e-04d52d67b14a",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3127296,
+                "size": 131090399,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "f3328c9b-eb33-4441-bf35-c0c4b7141777",
+            "label": "tmp"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "tmplv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3127296,
+                "size": 131090399,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "ab9470ba-4fd2-4c9e-850f-538ea3433579",
+            "label": "usr"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3127296,
+                "size": 131090399,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "583f5aaa-5902-4c5b-b082-c94208c61306",
+            "label": "var"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "varlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3127296,
+                "size": 131090399,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1026048,
+                "size": 2097152
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 1024000
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3127296,
+                "size": 131090399
+              }
+            },
+            "tmp": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "tmplv"
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "var": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "varlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.xfs",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "tmp",
+              "type": "org.osbuild.xfs",
+              "source": "tmp",
+              "target": "/tmp"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.xfs",
+              "source": "usr",
+              "target": "/usr"
+            },
+            {
+              "name": "var",
+              "type": "org.osbuild.xfs",
+              "source": "var",
+              "target": "/var"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.lvm2.metadata",
+          "options": {
+            "vg_name": "rootvg"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3127296,
+                "size": 131090399,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 3123200,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 1,
+              "path": "/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "vpc",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "image.vhd",
+            "format": {
+              "type": "vpc"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "xz",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.xz",
+          "inputs": {
+            "file": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:vpc": {
+                  "file": "image.vhd"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.vhd.xz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:01fdad2e9ee0a69f7e323ddb4258e2b0dbfaa242a21d7a8bfdfec04ebe8d3e86": {
+          "url": "https://example.com/repo/packages/exclude:NetworkManager-config-server"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3": {
+          "url": "https://example.com/repo/packages/bzip2"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:0ee8cf7e33852f80cd293a8fa8c371f888dc011984ff2836f1198bcdc552dc58": {
+          "url": "https://example.com/repo/packages/exclude:buildah"
+        },
+        "sha256:141b56438fdc0208877397569000e1a5857ff57807ff3bbaf2622cc87901861d": {
+          "url": "https://example.com/repo/packages/exclude:python3-dnf-plugin-spacewalk"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:229b391b136444fc29f0a5b3a897222f8ff4ed2277427e68eeb13fccfe39905c": {
+          "url": "https://example.com/repo/packages/kernel-modules"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:49ec7b34785f32ffd1f252d5cc9a0a015ca074f75c601d2272149a72d50d42df": {
+          "url": "https://example.com/repo/packages/exclude:usb_modeswitch"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:534994290b3914604921fc2c61852b7bb4c4d8fb947f057a6fb38a3a57835d9a": {
+          "url": "https://example.com/repo/packages/exclude:bolt"
+        },
+        "sha256:53d00356d82e89cbdf0f963060c58433f73e0b339ba9f63577bd7df44f78e051": {
+          "url": "https://example.com/repo/packages/exclude:python3-rhnlib"
+        },
+        "sha256:563a278902fa76bae3ec1833f24ff89abe26329b1d32af9aaa924d6fc6fd68aa": {
+          "url": "https://example.com/repo/packages/NetworkManager"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:590ef3ccd31b243b045e9c5f9268d1013b0960060366c76028a23b070b5fb7be": {
+          "url": "https://example.com/repo/packages/exclude:rhnlib"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5f1e4685c9b4d243264d22fa24864335aab534815fcfe6c3a88eec83ee22354f": {
+          "url": "https://example.com/repo/packages/exclude:cockpit-podman"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221": {
+          "url": "https://example.com/repo/packages/@Server"
+        },
+        "sha256:725c887b1ebcd6be8eb9a0ef6b2c476ff6d2dd8f9cf622f8d60953a1f22c94c8": {
+          "url": "https://example.com/repo/packages/exclude:python3-hwdata"
+        },
+        "sha256:75666699b77db631f576041e8102a55b46758c01b807eacae0f170930ab59b3d": {
+          "url": "https://example.com/repo/packages/uuid"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7913d978541704fb38f5f13a949811c80ed4a52b2514d4582fe3ccb8f5a04617": {
+          "url": "https://example.com/repo/packages/exclude:glibc-all-langpacks"
+        },
+        "sha256:79a583014c5150aac3a44a025229af2918d16d3f6f32d005bf5786f693d6b893": {
+          "url": "https://example.com/repo/packages/hyperv-daemons"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:81f29ed6c790aa976572770ecf7b6f0351da3c46c9558640c7a83896b6bf8e05": {
+          "url": "https://example.com/repo/packages/exclude:alsa-sof-firmware"
+        },
+        "sha256:840109e45bc2504c9f202410bd941dc430bcef1065e1c1a98e5d08506c0c91af": {
+          "url": "https://example.com/repo/packages/exclude:rhn-client-tools"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8e57cbb02cd20f0e373ae76a44d7ddd0125fe449db5dfc196b0920ef47ced56e": {
+          "url": "https://example.com/repo/packages/nvme-cli"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:9fe43931a7b645b90921b9b72d836e9d06ececc0b3cca1376fa0a297b5f522a5": {
+          "url": "https://example.com/repo/packages/exclude:rhnsd"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a4895eb44afc336fecbba6e520cd67e178dace0276655d102fceffa8e5f70570": {
+          "url": "https://example.com/repo/packages/patch"
+        },
+        "sha256:a76985e9146fec1e9fb00cc08d5e0a76eb7f47c10a7abbc4430f8ac235a8b1cd": {
+          "url": "https://example.com/repo/packages/exclude:podman"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:b1eb4c41592e8eb6f7f2c96cdda2162fe214f52f85b01e9b174aa81bf297e01a": {
+          "url": "https://example.com/repo/packages/exclude:rhn-setup"
+        },
+        "sha256:b6cae3a11438b4ec550ce10b73b35160fafbe9d436fdb4f81fea356fc5bb6fee": {
+          "url": "https://example.com/repo/packages/WALinuxAgent"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f1d96d150523777accb14a93582922ded22aa868629c58c3cd49339952293327": {
+          "url": "https://example.com/repo/packages/exclude:rhn-check"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f3e607ceb5fd279c62a109d1bbb952cc44d7467266ef679a99fd0d9c02ce8d29": {
+          "url": "https://example.com/repo/packages/exclude:containernetworking-plugins"
+        },
+        "sha256:f48860f2daf7e7a03ab9827300ab91c865d446de1c12a279339a2fff75c00f4e": {
+          "url": "https://example.com/repo/packages/kernel-core"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-azure_rhui-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-azure_rhui-empty.json
@@ -19,19 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
@@ -43,13 +34,7 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
-                },
-                {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
@@ -61,15 +46,6 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
@@ -77,12 +53,6 @@
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
                 },
                 {
                   "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
@@ -160,15 +130,6 @@
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
-                },
-                {
                   "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
                 },
                 {
@@ -187,9 +148,6 @@
                   "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
                 },
                 {
-                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
                   "id": "sha256:f48860f2daf7e7a03ab9827300ab91c865d446de1c12a279339a2fff75c00f4e"
                 },
                 {
@@ -202,9 +160,6 @@
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
-                },
-                {
                   "id": "sha256:8e57cbb02cd20f0e373ae76a44d7ddd0125fe449db5dfc196b0920ef47ced56e"
                 },
                 {
@@ -212,9 +167,6 @@
                 },
                 {
                   "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-azure_sap_rhui-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-azure_sap_rhui-empty.json
@@ -1,0 +1,1757 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                },
+                {
+                  "id": "sha256:59716846a2af6e6e9f7a7e9137c6cbab4657ebe349933bb2125d0f3af3decdb4"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "bfb00913-00cb-4f36-9b98-2de92945b607",
+            "kernel_opts": "ro loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221"
+                },
+                {
+                  "id": "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221"
+                },
+                {
+                  "id": "sha256:563a278902fa76bae3ec1833f24ff89abe26329b1d32af9aaa924d6fc6fd68aa"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:834f527ab85c15604413cc1eb324e1f81fdf942278b8bf165ae2fd3f716c21df"
+                },
+                {
+                  "id": "sha256:b6cae3a11438b4ec550ce10b73b35160fafbe9d436fdb4f81fea356fc5bb6fee"
+                },
+                {
+                  "id": "sha256:d4863d84f2eb146989bdb811f122e1f53b45a5337e8a40df1e783660b8ee52d8"
+                },
+                {
+                  "id": "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9"
+                },
+                {
+                  "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
+                },
+                {
+                  "id": "sha256:6d2805b8ba496887d08f75abd6607637a1213e60f259faa429fdb2d8585f9c5b"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:77f2f036726eaa17f75c9a6bdd9f613862b1a17951469921026e482e66ea046a"
+                },
+                {
+                  "id": "sha256:74a87c2b6b9cca8b666883b7127bc2f6715bb86a0ac03520e4b7ffdb5db2a76c"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:79a583014c5150aac3a44a025229af2918d16d3f6f32d005bf5786f693d6b893"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:34d7b8e4cd882ba2f57a00eb8be3f26a3d203dd40174405e005b43c39c05c5d8"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:f48860f2daf7e7a03ab9827300ab91c865d446de1c12a279339a2fff75c00f4e"
+                },
+                {
+                  "id": "sha256:229b391b136444fc29f0a5b3a897222f8ff4ed2277427e68eeb13fccfe39905c"
+                },
+                {
+                  "id": "sha256:39db58014d5ba260ea83f4f8c9dfd0d789722ac05fde12238f6ed166d34c928e"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:b080217d85602fdf61ee847c411d818127551d1761f49c45949d94b5725f8b19"
+                },
+                {
+                  "id": "sha256:a2ba66ebd54a9c316c59a10e13fe8a1afd7c563927139326d96981a8bef54b3e"
+                },
+                {
+                  "id": "sha256:daf9a1c9f76bfb1b9541dbd858b6eb0f21d705a74e2da9b20401f2404edb9b3f"
+                },
+                {
+                  "id": "sha256:a046b7832c1d515eb937980b7a4cf7c86362960f0636a91adef2a9e8ca56ae9b"
+                },
+                {
+                  "id": "sha256:3fa869ab63df319a2e0e289023b85e0e3d93ff573a1576846a2e920e35a2f674"
+                },
+                {
+                  "id": "sha256:4d8490e1592ba5e4ebb7529515110486da610c7a8a8c797149c7cb48a13a0509"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:0d5ffd33e266114c137b134adc8880f17a2c3490cb94d45a56c85a7d49e2229d"
+                },
+                {
+                  "id": "sha256:8e57cbb02cd20f0e373ae76a44d7ddd0125fe449db5dfc196b0920ef47ced56e"
+                },
+                {
+                  "id": "sha256:a4895eb44afc336fecbba6e520cd67e178dace0276655d102fceffa8e5f70570"
+                },
+                {
+                  "id": "sha256:df43c1675a244126841088b3e1805d572dbc129899bf1de5e5d8b99a792a9c9b"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:84ae9d32172ed31ea84c69effbe49349cd7a3efdc58a3b75070b27de89610fc6"
+                },
+                {
+                  "id": "sha256:2a9bf79a706b4cb8b373a7c502092cf45c72d89dc46c4918f97436f91ab0a86e"
+                },
+                {
+                  "id": "sha256:75666699b77db631f576041e8102a55b46758c01b807eacae0f170930ab59b3d"
+                },
+                {
+                  "id": "sha256:1718e9ae08aa8be533a767ff50d322f545633c41d5c6cf23491aac7b80858721"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:5542be8c0fada990e1c18e62c1a903b38ca5404e9def0c2e83badd344fc6fc57"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:01fdad2e9ee0a69f7e323ddb4258e2b0dbfaa242a21d7a8bfdfec04ebe8d3e86"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:81f29ed6c790aa976572770ecf7b6f0351da3c46c9558640c7a83896b6bf8e05"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:534994290b3914604921fc2c61852b7bb4c4d8fb947f057a6fb38a3a57835d9a"
+                },
+                {
+                  "id": "sha256:0ee8cf7e33852f80cd293a8fa8c371f888dc011984ff2836f1198bcdc552dc58"
+                },
+                {
+                  "id": "sha256:5f1e4685c9b4d243264d22fa24864335aab534815fcfe6c3a88eec83ee22354f"
+                },
+                {
+                  "id": "sha256:f3e607ceb5fd279c62a109d1bbb952cc44d7467266ef679a99fd0d9c02ce8d29"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:7913d978541704fb38f5f13a949811c80ed4a52b2514d4582fe3ccb8f5a04617"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:a76985e9146fec1e9fb00cc08d5e0a76eb7f47c10a7abbc4430f8ac235a8b1cd"
+                },
+                {
+                  "id": "sha256:141b56438fdc0208877397569000e1a5857ff57807ff3bbaf2622cc87901861d"
+                },
+                {
+                  "id": "sha256:725c887b1ebcd6be8eb9a0ef6b2c476ff6d2dd8f9cf622f8d60953a1f22c94c8"
+                },
+                {
+                  "id": "sha256:53d00356d82e89cbdf0f963060c58433f73e0b339ba9f63577bd7df44f78e051"
+                },
+                {
+                  "id": "sha256:f1d96d150523777accb14a93582922ded22aa868629c58c3cd49339952293327"
+                },
+                {
+                  "id": "sha256:840109e45bc2504c9f202410bd941dc430bcef1065e1c1a98e5d08506c0c91af"
+                },
+                {
+                  "id": "sha256:b1eb4c41592e8eb6f7f2c96cdda2162fe214f52f85b01e9b174aa81bf297e01a"
+                },
+                {
+                  "id": "sha256:590ef3ccd31b243b045e9c5f9268d1013b0960060366c76028a23b070b5fb7be"
+                },
+                {
+                  "id": "sha256:9fe43931a7b645b90921b9b72d836e9d06ececc0b3cca1376fa0a297b5f522a5"
+                },
+                {
+                  "id": "sha256:49ec7b34785f32ffd1f252d5cc9a0a015ca074f75c601d2272149a72d50d42df"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                },
+                {
+                  "id": "sha256:59716846a2af6e6e9f7a7e9137c6cbab4657ebe349933bb2125d0f3af3decdb4"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ],
+            "gpgkeys.fromtree": [
+              "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel-core"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "10-azure-kvp.cfg",
+            "config": {
+              "reporting": {
+                "logging": {
+                  "type": "log"
+                },
+                "telemetry": {
+                  "type": "hyperv"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "91-azure_datasource.cfg",
+            "config": {
+              "datasource": {
+                "Azure": {
+                  "apply_network_config": false
+                }
+              },
+              "datasource_list": [
+                "Azure"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-intel-cstate.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "intel_cstate"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-floppy.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "floppy"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              },
+              {
+                "command": "blacklist",
+                "modulename": "lbm-nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-skylake-edac.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "skx_edac"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-azure.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_AZURE",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux.config",
+          "options": {
+            "state": "permissive"
+          }
+        },
+        {
+          "type": "org.osbuild.tuned",
+          "options": {
+            "profiles": [
+              "sap-hana"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.tmpfilesd",
+          "options": {
+            "filename": "sap.conf",
+            "config": [
+              {
+                "type": "x",
+                "path": "/tmp/.sap*"
+              },
+              {
+                "type": "x",
+                "path": "/tmp/.hdb*lock"
+              },
+              {
+                "type": "x",
+                "path": "/tmp/.trex*lock"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.pam.limits.conf",
+          "options": {
+            "filename": "99-sap.conf",
+            "config": [
+              {
+                "domain": "@sapsys",
+                "type": "hard",
+                "item": "nofile",
+                "value": 1048576
+              },
+              {
+                "domain": "@sapsys",
+                "type": "soft",
+                "item": "nofile",
+                "value": 1048576
+              },
+              {
+                "domain": "@dba",
+                "type": "hard",
+                "item": "nofile",
+                "value": 1048576
+              },
+              {
+                "domain": "@dba",
+                "type": "soft",
+                "item": "nofile",
+                "value": 1048576
+              },
+              {
+                "domain": "@sapsys",
+                "type": "hard",
+                "item": "nproc",
+                "value": "unlimited"
+              },
+              {
+                "domain": "@sapsys",
+                "type": "soft",
+                "item": "nproc",
+                "value": "unlimited"
+              },
+              {
+                "domain": "@dba",
+                "type": "hard",
+                "item": "nproc",
+                "value": "unlimited"
+              },
+              {
+                "domain": "@dba",
+                "type": "soft",
+                "item": "nproc",
+                "value": "unlimited"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.sysctld",
+          "options": {
+            "filename": "sap.conf",
+            "config": [
+              {
+                "key": "kernel.pid_max",
+                "value": "4194304"
+              },
+              {
+                "key": "vm.max_map_count",
+                "value": "2147483647"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dnf.config",
+          "options": {
+            "variables": [
+              {
+                "name": "releasever",
+                "value": "10.0"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "ClientAliveInterval": 180
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.pwquality.conf",
+          "options": {
+            "config": {
+              "minlen": 6,
+              "dcredit": 0,
+              "ucredit": 0,
+              "lcredit": 0,
+              "ocredit": 0,
+              "minclass": 3
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.waagent.conf",
+          "options": {
+            "config": {
+              "ResourceDisk.Format": false,
+              "ResourceDisk.EnableSwap": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.udev.rules",
+          "options": {
+            "filename": "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules",
+            "rules": [
+              {
+                "comment": [
+                  "Accelerated Networking on Azure exposes a new SRIOV interface to the VM.",
+                  "This interface is transparently bonded to the synthetic interface,",
+                  "so NetworkManager should just ignore any SRIOV interfaces."
+                ]
+              },
+              [
+                {
+                  "key": "SUBSYSTEM",
+                  "op": "==",
+                  "val": "net"
+                },
+                {
+                  "key": "DRIVERS",
+                  "op": "==",
+                  "val": "hv_pci"
+                },
+                {
+                  "key": "ACTION",
+                  "op": "==",
+                  "val": "add"
+                },
+                {
+                  "key": {
+                    "name": "ENV",
+                    "arg": "NM_UNMANAGED"
+                  },
+                  "op": "=",
+                  "val": "1"
+                }
+              ]
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "bfb00913-00cb-4f36-9b98-2de92945b607",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "5fb1fba2-b45d-45a8-98e8-6ae6d330dccd",
+                "vfs_type": "xfs",
+                "path": "/boot",
+                "options": "defaults"
+              },
+              {
+                "uuid": "bb605f60-9d11-46a7-a12f-b33d04a83437",
+                "vfs_type": "xfs",
+                "path": "/home",
+                "options": "defaults"
+              },
+              {
+                "uuid": "5331aa5c-a6a6-4769-b0a3-9f7448184209",
+                "vfs_type": "xfs",
+                "path": "/tmp",
+                "options": "defaults"
+              },
+              {
+                "uuid": "1015b8ea-3968-48ca-bc6c-515a409e05b7",
+                "vfs_type": "xfs",
+                "path": "/usr",
+                "options": "defaults"
+              },
+              {
+                "uuid": "55b562e3-829f-4f1c-9c50-8f30f07d5222",
+                "vfs_type": "xfs",
+                "path": "/var",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "bfb00913-00cb-4f36-9b98-2de92945b607",
+            "boot_fs_uuid": "5fb1fba2-b45d-45a8-98e8-6ae6d330dccd",
+            "kernel_opts": "ro loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved",
+              "disable_recovery": true,
+              "disable_submenu": true,
+              "distributor": "$(sed 's, release .*$,,g' /etc/system-release)",
+              "terminal": [
+                "serial",
+                "console"
+              ],
+              "timeout": 10,
+              "timeout_style": "countdown",
+              "serial": "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "firewalld",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "sshd",
+              "waagent"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "68719476736"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "size": 1024000,
+                "start": 2048,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 2097152,
+                "start": 1026048,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+              },
+              {
+                "bootable": true,
+                "size": 4096,
+                "start": 3123200,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 131090399,
+                "start": 3127296,
+                "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.lvm2.create",
+          "options": {
+            "volumes": [
+              {
+                "name": "homelv",
+                "size": "1073741824B"
+              },
+              {
+                "name": "rootlv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "tmplv",
+                "size": "2147483648B"
+              },
+              {
+                "name": "usrlv",
+                "size": "10737418240B"
+              },
+              {
+                "name": "varlv",
+                "size": "10737418240B"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3127296,
+                "size": 131090399,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 1024000,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "5fb1fba2-b45d-45a8-98e8-6ae6d330dccd"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1026048,
+                "size": 2097152,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "bb605f60-9d11-46a7-a12f-b33d04a83437",
+            "label": "home"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3127296,
+                "size": 131090399,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "bfb00913-00cb-4f36-9b98-2de92945b607",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3127296,
+                "size": 131090399,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "5331aa5c-a6a6-4769-b0a3-9f7448184209",
+            "label": "tmp"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "tmplv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3127296,
+                "size": 131090399,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "1015b8ea-3968-48ca-bc6c-515a409e05b7",
+            "label": "usr"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3127296,
+                "size": 131090399,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "55b562e3-829f-4f1c-9c50-8f30f07d5222",
+            "label": "var"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "varlv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3127296,
+                "size": 131090399,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "rootlv"
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 1026048,
+                "size": 2097152
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 2048,
+                "size": 1024000
+              }
+            },
+            "home": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "homelv"
+              }
+            },
+            "rootvg": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3127296,
+                "size": 131090399
+              }
+            },
+            "tmp": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "tmplv"
+              }
+            },
+            "usr": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "usrlv"
+              }
+            },
+            "var": {
+              "type": "org.osbuild.lvm2.lv",
+              "parent": "rootvg",
+              "options": {
+                "volume": "varlv"
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.xfs",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            },
+            {
+              "name": "home",
+              "type": "org.osbuild.xfs",
+              "source": "home",
+              "target": "/home"
+            },
+            {
+              "name": "tmp",
+              "type": "org.osbuild.xfs",
+              "source": "tmp",
+              "target": "/tmp"
+            },
+            {
+              "name": "usr",
+              "type": "org.osbuild.xfs",
+              "source": "usr",
+              "target": "/usr"
+            },
+            {
+              "name": "var",
+              "type": "org.osbuild.xfs",
+              "source": "var",
+              "target": "/var"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.lvm2.metadata",
+          "options": {
+            "vg_name": "rootvg"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 3127296,
+                "size": 131090399,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 3123200,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 1,
+              "path": "/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "vpc",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "image.vhd",
+            "format": {
+              "type": "vpc"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "xz",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.xz",
+          "inputs": {
+            "file": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:vpc": {
+                  "file": "image.vhd"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.vhd.xz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:01fdad2e9ee0a69f7e323ddb4258e2b0dbfaa242a21d7a8bfdfec04ebe8d3e86": {
+          "url": "https://example.com/repo/packages/exclude:NetworkManager-config-server"
+        },
+        "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a": {
+          "url": "https://example.com/repo/packages/net-tools"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3": {
+          "url": "https://example.com/repo/packages/bzip2"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0d5ffd33e266114c137b134adc8880f17a2c3490cb94d45a56c85a7d49e2229d": {
+          "url": "https://example.com/repo/packages/numactl"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:0ee8cf7e33852f80cd293a8fa8c371f888dc011984ff2836f1198bcdc552dc58": {
+          "url": "https://example.com/repo/packages/exclude:buildah"
+        },
+        "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9": {
+          "url": "https://example.com/repo/packages/bind-utils"
+        },
+        "sha256:141b56438fdc0208877397569000e1a5857ff57807ff3bbaf2622cc87901861d": {
+          "url": "https://example.com/repo/packages/exclude:python3-dnf-plugin-spacewalk"
+        },
+        "sha256:1718e9ae08aa8be533a767ff50d322f545633c41d5c6cf23491aac7b80858721": {
+          "url": "https://example.com/repo/packages/uuidd"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:229b391b136444fc29f0a5b3a897222f8ff4ed2277427e68eeb13fccfe39905c": {
+          "url": "https://example.com/repo/packages/kernel-modules"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2a9bf79a706b4cb8b373a7c502092cf45c72d89dc46c4918f97436f91ab0a86e": {
+          "url": "https://example.com/repo/packages/tuned-profiles-sap-hana"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:34d7b8e4cd882ba2f57a00eb8be3f26a3d203dd40174405e005b43c39c05c5d8": {
+          "url": "https://example.com/repo/packages/iptraf-ng"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:39db58014d5ba260ea83f4f8c9dfd0d789722ac05fde12238f6ed166d34c928e": {
+          "url": "https://example.com/repo/packages/krb5-workstation"
+        },
+        "sha256:3fa869ab63df319a2e0e289023b85e0e3d93ff573a1576846a2e920e35a2f674": {
+          "url": "https://example.com/repo/packages/libtool-ltdl"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:49ec7b34785f32ffd1f252d5cc9a0a015ca074f75c601d2272149a72d50d42df": {
+          "url": "https://example.com/repo/packages/exclude:usb_modeswitch"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4d8490e1592ba5e4ebb7529515110486da610c7a8a8c797149c7cb48a13a0509": {
+          "url": "https://example.com/repo/packages/lm_sensors"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:534994290b3914604921fc2c61852b7bb4c4d8fb947f057a6fb38a3a57835d9a": {
+          "url": "https://example.com/repo/packages/exclude:bolt"
+        },
+        "sha256:53d00356d82e89cbdf0f963060c58433f73e0b339ba9f63577bd7df44f78e051": {
+          "url": "https://example.com/repo/packages/exclude:python3-rhnlib"
+        },
+        "sha256:5542be8c0fada990e1c18e62c1a903b38ca5404e9def0c2e83badd344fc6fc57": {
+          "url": "https://example.com/repo/packages/xorg-x11-xauth"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:563a278902fa76bae3ec1833f24ff89abe26329b1d32af9aaa924d6fc6fd68aa": {
+          "url": "https://example.com/repo/packages/NetworkManager"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:590ef3ccd31b243b045e9c5f9268d1013b0960060366c76028a23b070b5fb7be": {
+          "url": "https://example.com/repo/packages/exclude:rhnlib"
+        },
+        "sha256:59716846a2af6e6e9f7a7e9137c6cbab4657ebe349933bb2125d0f3af3decdb4": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-saphana-n10.0"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5f1e4685c9b4d243264d22fa24864335aab534815fcfe6c3a88eec83ee22354f": {
+          "url": "https://example.com/repo/packages/exclude:cockpit-podman"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:6d2805b8ba496887d08f75abd6607637a1213e60f259faa429fdb2d8585f9c5b": {
+          "url": "https://example.com/repo/packages/cairo"
+        },
+        "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221": {
+          "url": "https://example.com/repo/packages/@Server"
+        },
+        "sha256:725c887b1ebcd6be8eb9a0ef6b2c476ff6d2dd8f9cf622f8d60953a1f22c94c8": {
+          "url": "https://example.com/repo/packages/exclude:python3-hwdata"
+        },
+        "sha256:74a87c2b6b9cca8b666883b7127bc2f6715bb86a0ac03520e4b7ffdb5db2a76c": {
+          "url": "https://example.com/repo/packages/graphviz"
+        },
+        "sha256:75666699b77db631f576041e8102a55b46758c01b807eacae0f170930ab59b3d": {
+          "url": "https://example.com/repo/packages/uuid"
+        },
+        "sha256:77f2f036726eaa17f75c9a6bdd9f613862b1a17951469921026e482e66ea046a": {
+          "url": "https://example.com/repo/packages/expect"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7913d978541704fb38f5f13a949811c80ed4a52b2514d4582fe3ccb8f5a04617": {
+          "url": "https://example.com/repo/packages/exclude:glibc-all-langpacks"
+        },
+        "sha256:79a583014c5150aac3a44a025229af2918d16d3f6f32d005bf5786f693d6b893": {
+          "url": "https://example.com/repo/packages/hyperv-daemons"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:81f29ed6c790aa976572770ecf7b6f0351da3c46c9558640c7a83896b6bf8e05": {
+          "url": "https://example.com/repo/packages/exclude:alsa-sof-firmware"
+        },
+        "sha256:834f527ab85c15604413cc1eb324e1f81fdf942278b8bf165ae2fd3f716c21df": {
+          "url": "https://example.com/repo/packages/PackageKit-gtk3-module"
+        },
+        "sha256:840109e45bc2504c9f202410bd941dc430bcef1065e1c1a98e5d08506c0c91af": {
+          "url": "https://example.com/repo/packages/exclude:rhn-client-tools"
+        },
+        "sha256:84ae9d32172ed31ea84c69effbe49349cd7a3efdc58a3b75070b27de89610fc6": {
+          "url": "https://example.com/repo/packages/tcsh"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8e57cbb02cd20f0e373ae76a44d7ddd0125fe449db5dfc196b0920ef47ced56e": {
+          "url": "https://example.com/repo/packages/nvme-cli"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:9fe43931a7b645b90921b9b72d836e9d06ececc0b3cca1376fa0a297b5f522a5": {
+          "url": "https://example.com/repo/packages/exclude:rhnsd"
+        },
+        "sha256:a046b7832c1d515eb937980b7a4cf7c86362960f0636a91adef2a9e8ca56ae9b": {
+          "url": "https://example.com/repo/packages/libnsl"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2ba66ebd54a9c316c59a10e13fe8a1afd7c563927139326d96981a8bef54b3e": {
+          "url": "https://example.com/repo/packages/libatomic"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a4895eb44afc336fecbba6e520cd67e178dace0276655d102fceffa8e5f70570": {
+          "url": "https://example.com/repo/packages/patch"
+        },
+        "sha256:a76985e9146fec1e9fb00cc08d5e0a76eb7f47c10a7abbc4430f8ac235a8b1cd": {
+          "url": "https://example.com/repo/packages/exclude:podman"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:b080217d85602fdf61ee847c411d818127551d1761f49c45949d94b5725f8b19": {
+          "url": "https://example.com/repo/packages/libaio"
+        },
+        "sha256:b1eb4c41592e8eb6f7f2c96cdda2162fe214f52f85b01e9b174aa81bf297e01a": {
+          "url": "https://example.com/repo/packages/exclude:rhn-setup"
+        },
+        "sha256:b6cae3a11438b4ec550ce10b73b35160fafbe9d436fdb4f81fea356fc5bb6fee": {
+          "url": "https://example.com/repo/packages/WALinuxAgent"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d4863d84f2eb146989bdb811f122e1f53b45a5337e8a40df1e783660b8ee52d8": {
+          "url": "https://example.com/repo/packages/ansible-core"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:daf9a1c9f76bfb1b9541dbd858b6eb0f21d705a74e2da9b20401f2404edb9b3f": {
+          "url": "https://example.com/repo/packages/libicu"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:df43c1675a244126841088b3e1805d572dbc129899bf1de5e5d8b99a792a9c9b": {
+          "url": "https://example.com/repo/packages/rhel-system-roles-sap"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f1d96d150523777accb14a93582922ded22aa868629c58c3cd49339952293327": {
+          "url": "https://example.com/repo/packages/exclude:rhn-check"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f3e607ceb5fd279c62a109d1bbb952cc44d7467266ef679a99fd0d9c02ce8d29": {
+          "url": "https://example.com/repo/packages/exclude:containernetworking-plugins"
+        },
+        "sha256:f48860f2daf7e7a03ab9827300ab91c865d446de1c12a279339a2fff75c00f4e": {
+          "url": "https://example.com/repo/packages/kernel-core"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-azure_sap_rhui-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-azure_sap_rhui-empty.json
@@ -19,19 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
@@ -43,19 +34,10 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
-                },
-                {
-                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
-                },
-                {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
@@ -67,15 +49,6 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
@@ -83,12 +56,6 @@
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
                 },
                 {
                   "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
@@ -145,9 +112,6 @@
                   "id": "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221"
                 },
                 {
-                  "id": "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221"
-                },
-                {
                   "id": "sha256:563a278902fa76bae3ec1833f24ff89abe26329b1d32af9aaa924d6fc6fd68aa"
                 },
                 {
@@ -184,15 +148,6 @@
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
-                },
-                {
                   "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
                 },
                 {
@@ -215,9 +170,6 @@
                 },
                 {
                   "id": "sha256:34d7b8e4cd882ba2f57a00eb8be3f26a3d203dd40174405e005b43c39c05c5d8"
-                },
-                {
-                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
                 },
                 {
                   "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
@@ -256,9 +208,6 @@
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
-                },
-                {
                   "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
                 },
                 {
@@ -278,9 +227,6 @@
                 },
                 {
                   "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
@@ -361,16 +307,7 @@
                   "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
                 },
                 {
-                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
-                },
-                {
                   "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
-                },
-                {
-                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
-                },
-                {
-                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
                 },
                 {
                   "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
@@ -379,22 +316,10 @@
                   "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
                 },
                 {
-                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
-                },
-                {
-                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
-                },
-                {
                   "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
                 },
                 {
                   "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
-                },
-                {
-                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
-                },
-                {
-                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
                 },
                 {
                   "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
@@ -409,12 +334,6 @@
                   "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
                 },
                 {
-                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
-                },
-                {
-                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
-                },
-                {
                   "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
                 },
                 {
@@ -424,22 +343,10 @@
                   "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
                 },
                 {
-                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
-                },
-                {
-                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
-                },
-                {
                   "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
                 },
                 {
                   "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
-                },
-                {
-                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
-                },
-                {
-                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
                 },
                 {
                   "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ec2-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ec2-empty.json
@@ -19,13 +19,7 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
@@ -37,28 +31,13 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
@@ -68,12 +47,6 @@
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
                 },
                 {
                   "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
@@ -133,9 +106,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -146,12 +116,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ec2-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ec2-empty.json
@@ -1,0 +1,905 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "d98c773b-d6e9-4a08-8e16-01b86370eede",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dracut.conf",
+          "options": {
+            "filename": "ec2.conf",
+            "config": {
+              "add_drivers": [
+                "nvme",
+                "xen-blkfront"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "d98c773b-d6e9-4a08-8e16-01b86370eede",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "d98c773b-d6e9-4a08-8e16-01b86370eede",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20557791,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "d98c773b-d6e9-4a08-8e16-01b86370eede",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 20557791,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 20557791
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "xz",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.xz",
+          "inputs": {
+            "file": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "image.raw.xz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ec2_ha-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ec2_ha-empty.json
@@ -1,0 +1,932 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                },
+                {
+                  "id": "sha256:1b103e3c5e7c6d0aac527370f790f515769e74f906ab14b2f690b35caa57467e"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "27cf1a36-c4c4-4eac-8a3d-731bb07d711f",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:9aaa5698395c58dd8eb97e3e4724e89216394f461c948b73af5f72877d1a7a78"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:8984d95fce49d9983a84b80017427efcb36b646c277f7a3792930481501f460c"
+                },
+                {
+                  "id": "sha256:d7d4f59db48fb4b8d9fe1fe1b7ec5bff489fc305e0ce38500bbb4acc2166e4ca"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                },
+                {
+                  "id": "sha256:1b103e3c5e7c6d0aac527370f790f515769e74f906ab14b2f690b35caa57467e"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dracut.conf",
+          "options": {
+            "filename": "ec2.conf",
+            "config": {
+              "add_drivers": [
+                "nvme",
+                "xen-blkfront"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "27cf1a36-c4c4-4eac-8a3d-731bb07d711f",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "27cf1a36-c4c4-4eac-8a3d-731bb07d711f",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20557791,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "27cf1a36-c4c4-4eac-8a3d-731bb07d711f",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 20557791,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 20557791
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "xz",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.xz",
+          "inputs": {
+            "file": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "image.raw.xz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b103e3c5e7c6d0aac527370f790f515769e74f906ab14b2f690b35caa57467e": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-ha-n10.0"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8984d95fce49d9983a84b80017427efcb36b646c277f7a3792930481501f460c": {
+          "url": "https://example.com/repo/packages/pacemaker"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9aaa5698395c58dd8eb97e3e4724e89216394f461c948b73af5f72877d1a7a78": {
+          "url": "https://example.com/repo/packages/fence-agents-all"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d7d4f59db48fb4b8d9fe1fe1b7ec5bff489fc305e0ce38500bbb4acc2166e4ca": {
+          "url": "https://example.com/repo/packages/pcs"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ec2_ha-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ec2_ha-empty.json
@@ -19,13 +19,7 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
@@ -37,28 +31,13 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
@@ -68,12 +47,6 @@
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
                 },
                 {
                   "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
@@ -136,9 +109,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -149,12 +119,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ec2_sap-ec2_sap_empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ec2_sap-ec2_sap_empty.json
@@ -19,13 +19,7 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
@@ -37,34 +31,16 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
                 },
                 {
-                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
-                },
-                {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
-                },
-                {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
@@ -74,12 +50,6 @@
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
                 },
                 {
                   "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
@@ -163,9 +133,6 @@
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
-                },
-                {
                   "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
                 },
                 {
@@ -176,12 +143,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
@@ -316,16 +277,7 @@
                   "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
                 },
                 {
-                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
-                },
-                {
                   "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
-                },
-                {
-                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
-                },
-                {
-                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
                 },
                 {
                   "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
@@ -334,22 +286,10 @@
                   "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
                 },
                 {
-                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
-                },
-                {
-                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
-                },
-                {
                   "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
                 },
                 {
                   "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
-                },
-                {
-                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
-                },
-                {
-                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
                 },
                 {
                   "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
@@ -364,12 +304,6 @@
                   "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
                 },
                 {
-                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
-                },
-                {
-                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
-                },
-                {
                   "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
                 },
                 {
@@ -379,22 +313,10 @@
                   "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
                 },
                 {
-                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
-                },
-                {
-                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
-                },
-                {
                   "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
                 },
                 {
                   "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
-                },
-                {
-                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
-                },
-                {
-                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
                 },
                 {
                   "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ec2_sap-ec2_sap_empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ec2_sap-ec2_sap_empty.json
@@ -1,0 +1,1235 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                },
+                {
+                  "id": "sha256:1b103e3c5e7c6d0aac527370f790f515769e74f906ab14b2f690b35caa57467e"
+                },
+                {
+                  "id": "sha256:fca613500bd69c612e1fdfb2a9594d22e32ba862ec32af72b6c053ad67f10b45"
+                },
+                {
+                  "id": "sha256:59716846a2af6e6e9f7a7e9137c6cbab4657ebe349933bb2125d0f3af3decdb4"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "58e003f8-a1a8-4ce6-8185-4989345ff113",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 processor.max_cstate=1 intel_idle.max_cstate=1"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221"
+                },
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:834f527ab85c15604413cc1eb324e1f81fdf942278b8bf165ae2fd3f716c21df"
+                },
+                {
+                  "id": "sha256:d4863d84f2eb146989bdb811f122e1f53b45a5337e8a40df1e783660b8ee52d8"
+                },
+                {
+                  "id": "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9"
+                },
+                {
+                  "id": "sha256:6d2805b8ba496887d08f75abd6607637a1213e60f259faa429fdb2d8585f9c5b"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:77f2f036726eaa17f75c9a6bdd9f613862b1a17951469921026e482e66ea046a"
+                },
+                {
+                  "id": "sha256:74a87c2b6b9cca8b666883b7127bc2f6715bb86a0ac03520e4b7ffdb5db2a76c"
+                },
+                {
+                  "id": "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:34d7b8e4cd882ba2f57a00eb8be3f26a3d203dd40174405e005b43c39c05c5d8"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:39db58014d5ba260ea83f4f8c9dfd0d789722ac05fde12238f6ed166d34c928e"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:b080217d85602fdf61ee847c411d818127551d1761f49c45949d94b5725f8b19"
+                },
+                {
+                  "id": "sha256:a2ba66ebd54a9c316c59a10e13fe8a1afd7c563927139326d96981a8bef54b3e"
+                },
+                {
+                  "id": "sha256:daf9a1c9f76bfb1b9541dbd858b6eb0f21d705a74e2da9b20401f2404edb9b3f"
+                },
+                {
+                  "id": "sha256:a046b7832c1d515eb937980b7a4cf7c86362960f0636a91adef2a9e8ca56ae9b"
+                },
+                {
+                  "id": "sha256:3fa869ab63df319a2e0e289023b85e0e3d93ff573a1576846a2e920e35a2f674"
+                },
+                {
+                  "id": "sha256:4d8490e1592ba5e4ebb7529515110486da610c7a8a8c797149c7cb48a13a0509"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:0d5ffd33e266114c137b134adc8880f17a2c3490cb94d45a56c85a7d49e2229d"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:df43c1675a244126841088b3e1805d572dbc129899bf1de5e5d8b99a792a9c9b"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:84ae9d32172ed31ea84c69effbe49349cd7a3efdc58a3b75070b27de89610fc6"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:2a9bf79a706b4cb8b373a7c502092cf45c72d89dc46c4918f97436f91ab0a86e"
+                },
+                {
+                  "id": "sha256:1718e9ae08aa8be533a767ff50d322f545633c41d5c6cf23491aac7b80858721"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:5542be8c0fada990e1c18e62c1a903b38ca5404e9def0c2e83badd344fc6fc57"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                },
+                {
+                  "id": "sha256:1b103e3c5e7c6d0aac527370f790f515769e74f906ab14b2f690b35caa57467e"
+                },
+                {
+                  "id": "sha256:fca613500bd69c612e1fdfb2a9594d22e32ba862ec32af72b6c053ad67f10b45"
+                },
+                {
+                  "id": "sha256:59716846a2af6e6e9f7a7e9137c6cbab4657ebe349933bb2125d0f3af3decdb4"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "169.254.169.123",
+                "minpoll": 4,
+                "maxpoll": 4,
+                "iburst": true,
+                "prefer": true
+              }
+            ],
+            "leapsectz": ""
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd-logind",
+          "options": {
+            "filename": "00-getty-fixes.conf",
+            "config": {
+              "Login": {
+                "NAutoVTs": 0
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "00-rhel-default-user.cfg",
+            "config": {
+              "system_info": {
+                "default_user": {
+                  "name": "ec2-user"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dracut.conf",
+          "options": {
+            "filename": "ec2.conf",
+            "config": {
+              "add_drivers": [
+                "nvme",
+                "xen-blkfront"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-ec2.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_EC2",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.authselect",
+          "options": {
+            "profile": "sssd"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux.config",
+          "options": {
+            "state": "permissive"
+          }
+        },
+        {
+          "type": "org.osbuild.tuned",
+          "options": {
+            "profiles": [
+              "sap-hana"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.tmpfilesd",
+          "options": {
+            "filename": "sap.conf",
+            "config": [
+              {
+                "type": "x",
+                "path": "/tmp/.sap*"
+              },
+              {
+                "type": "x",
+                "path": "/tmp/.hdb*lock"
+              },
+              {
+                "type": "x",
+                "path": "/tmp/.trex*lock"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.pam.limits.conf",
+          "options": {
+            "filename": "99-sap.conf",
+            "config": [
+              {
+                "domain": "@sapsys",
+                "type": "hard",
+                "item": "nofile",
+                "value": 1048576
+              },
+              {
+                "domain": "@sapsys",
+                "type": "soft",
+                "item": "nofile",
+                "value": 1048576
+              },
+              {
+                "domain": "@dba",
+                "type": "hard",
+                "item": "nofile",
+                "value": 1048576
+              },
+              {
+                "domain": "@dba",
+                "type": "soft",
+                "item": "nofile",
+                "value": 1048576
+              },
+              {
+                "domain": "@sapsys",
+                "type": "hard",
+                "item": "nproc",
+                "value": "unlimited"
+              },
+              {
+                "domain": "@sapsys",
+                "type": "soft",
+                "item": "nproc",
+                "value": "unlimited"
+              },
+              {
+                "domain": "@dba",
+                "type": "hard",
+                "item": "nproc",
+                "value": "unlimited"
+              },
+              {
+                "domain": "@dba",
+                "type": "soft",
+                "item": "nproc",
+                "value": "unlimited"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.sysctld",
+          "options": {
+            "filename": "sap.conf",
+            "config": [
+              {
+                "key": "kernel.pid_max",
+                "value": "4194304"
+              },
+              {
+                "key": "vm.max_map_count",
+                "value": "2147483647"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dnf.config",
+          "options": {
+            "variables": [
+              {
+                "name": "releasever",
+                "value": "10.0"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "58e003f8-a1a8-4ce6-8185-4989345ff113",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "58e003f8-a1a8-4ce6-8185-4989345ff113",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 processor.max_cstate=1 intel_idle.max_cstate=1",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "NetworkManager",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final",
+              "reboot.target",
+              "tuned"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20557791,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "58e003f8-a1a8-4ce6-8185-4989345ff113",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 20557791,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 20557791
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "xz",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.xz",
+          "inputs": {
+            "file": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "image.raw.xz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a": {
+          "url": "https://example.com/repo/packages/net-tools"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0d5ffd33e266114c137b134adc8880f17a2c3490cb94d45a56c85a7d49e2229d": {
+          "url": "https://example.com/repo/packages/numactl"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9": {
+          "url": "https://example.com/repo/packages/bind-utils"
+        },
+        "sha256:1718e9ae08aa8be533a767ff50d322f545633c41d5c6cf23491aac7b80858721": {
+          "url": "https://example.com/repo/packages/uuidd"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b103e3c5e7c6d0aac527370f790f515769e74f906ab14b2f690b35caa57467e": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-ha-n10.0"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2a9bf79a706b4cb8b373a7c502092cf45c72d89dc46c4918f97436f91ab0a86e": {
+          "url": "https://example.com/repo/packages/tuned-profiles-sap-hana"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:34d7b8e4cd882ba2f57a00eb8be3f26a3d203dd40174405e005b43c39c05c5d8": {
+          "url": "https://example.com/repo/packages/iptraf-ng"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:39db58014d5ba260ea83f4f8c9dfd0d789722ac05fde12238f6ed166d34c928e": {
+          "url": "https://example.com/repo/packages/krb5-workstation"
+        },
+        "sha256:3fa869ab63df319a2e0e289023b85e0e3d93ff573a1576846a2e920e35a2f674": {
+          "url": "https://example.com/repo/packages/libtool-ltdl"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4d8490e1592ba5e4ebb7529515110486da610c7a8a8c797149c7cb48a13a0509": {
+          "url": "https://example.com/repo/packages/lm_sensors"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:5542be8c0fada990e1c18e62c1a903b38ca5404e9def0c2e83badd344fc6fc57": {
+          "url": "https://example.com/repo/packages/xorg-x11-xauth"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:59716846a2af6e6e9f7a7e9137c6cbab4657ebe349933bb2125d0f3af3decdb4": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-saphana-n10.0"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:6d2805b8ba496887d08f75abd6607637a1213e60f259faa429fdb2d8585f9c5b": {
+          "url": "https://example.com/repo/packages/cairo"
+        },
+        "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221": {
+          "url": "https://example.com/repo/packages/@Server"
+        },
+        "sha256:74a87c2b6b9cca8b666883b7127bc2f6715bb86a0ac03520e4b7ffdb5db2a76c": {
+          "url": "https://example.com/repo/packages/graphviz"
+        },
+        "sha256:77f2f036726eaa17f75c9a6bdd9f613862b1a17951469921026e482e66ea046a": {
+          "url": "https://example.com/repo/packages/expect"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:834f527ab85c15604413cc1eb324e1f81fdf942278b8bf165ae2fd3f716c21df": {
+          "url": "https://example.com/repo/packages/PackageKit-gtk3-module"
+        },
+        "sha256:84ae9d32172ed31ea84c69effbe49349cd7a3efdc58a3b75070b27de89610fc6": {
+          "url": "https://example.com/repo/packages/tcsh"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a046b7832c1d515eb937980b7a4cf7c86362960f0636a91adef2a9e8ca56ae9b": {
+          "url": "https://example.com/repo/packages/libnsl"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2ba66ebd54a9c316c59a10e13fe8a1afd7c563927139326d96981a8bef54b3e": {
+          "url": "https://example.com/repo/packages/libatomic"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b080217d85602fdf61ee847c411d818127551d1761f49c45949d94b5725f8b19": {
+          "url": "https://example.com/repo/packages/libaio"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d4863d84f2eb146989bdb811f122e1f53b45a5337e8a40df1e783660b8ee52d8": {
+          "url": "https://example.com/repo/packages/ansible-core"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a": {
+          "url": "https://example.com/repo/packages/grub2"
+        },
+        "sha256:daf9a1c9f76bfb1b9541dbd858b6eb0f21d705a74e2da9b20401f2404edb9b3f": {
+          "url": "https://example.com/repo/packages/libicu"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:df43c1675a244126841088b3e1805d572dbc129899bf1de5e5d8b99a792a9c9b": {
+          "url": "https://example.com/repo/packages/rhel-system-roles-sap"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:e6af7cd461c636ed1330dfd460b246e169abd6ce75d5afc1ca94948f9c853df9": {
+          "url": "https://example.com/repo/packages/dhcpcd"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fca613500bd69c612e1fdfb2a9594d22e32ba862ec32af72b6c053ad67f10b45": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-sap-n10.0"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-gce-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-gce-empty.json
@@ -19,16 +19,10 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -40,19 +34,7 @@
                   "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
                 },
                 {
-                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
@@ -62,9 +44,6 @@
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -129,9 +108,6 @@
                 },
                 {
                   "id": "sha256:9220e83cc1dd0cbbe1ca0da9b665f6f476f4f357b9d0f2e691d9fad55ab78305"
-                },
-                {
-                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
                 },
                 {
                   "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-gce-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-gce-empty.json
@@ -1,0 +1,960 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                },
+                {
+                  "id": "sha256:843af58590dbafa56c89e30ffc6b01f0bd1d28770049ca9956e306165f286858"
+                },
+                {
+                  "id": "sha256:3e3779e71058c8a030a8ecfc8d94cdba7f3a53a1232159f79ef7a8d63cb88143"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "510ddb8f-4fb6-42dd-926f-eab4aec9ddc9",
+            "kernel_opts": "biosdevname=0 scsi_mod.use_blk_mq=Y console=ttyS0,38400n8d"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:9220e83cc1dd0cbbe1ca0da9b665f6f476f4f357b9d0f2e691d9fad55ab78305"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:4c8abe2beeae2af4a537a85ae9953e163af2c127991de913e075eda82046b3e4"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:d3cf5271c662017c7fdae75c30437813922b84f8fd5329818fc4aa4fdb716cb0"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:af90238cff8047ed284dc33bb34f66b5639ebbc51b9c866631fb2ace4c83e328"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:0f2ed9e33d29ff4f3b0f664ca1e1dc3df1f8b9b315b2af284c6e0e3dc52be290"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:e1911163463de95ee97cf6485caa62dfc4406353719446fe1fe3d9a66387c849"
+                },
+                {
+                  "id": "sha256:59a4bad24de7614e18d9b453a6820ec59fcda49720aa8f16ef045f5665562de9"
+                },
+                {
+                  "id": "sha256:0c1406adec8def017eb397ea9b217e879db26a50384d91c6a6112f44d0d27799"
+                },
+                {
+                  "id": "sha256:30e24e8a39fbfc20c910b6249dd0eda191d24b6fb867e0f6a8b23b4d539371c3"
+                },
+                {
+                  "id": "sha256:5d9e8f5c8ecdfdab3de0380b628372e1cfaa2f9616f21274d3cabcc511d11ad7"
+                },
+                {
+                  "id": "sha256:bc8f1fdc6cba695a97446aed17e9205717b86b4899ffad52b5166cfe1f232165"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:b2a622322540941a2f49c7c8d6e8b98155b8f257a10eeb552993c5d210d957f6"
+                },
+                {
+                  "id": "sha256:9e99f61535d122942ad3cb6f1d1d2496b48913a48d7e76e7e93983c22a06f2c4"
+                },
+                {
+                  "id": "sha256:3e39dfe0fda6e3020d48b0d110ff8670187611a711de543a6692cf5519ece8da"
+                },
+                {
+                  "id": "sha256:9f242d5e9f0005c5120f17fc534c4e71cc5f9bfd59df1435a61c74d6ccc2846d"
+                },
+                {
+                  "id": "sha256:aa92be9c11e757dee72fd903a3d0b46daafb50027f30450ef892ac74f8b4e9f4"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:11bbcc61af43bebaad417d8b935a77f65c67225703ad1d94d58465a63831c05f"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:8e84e003f7afb133a9b5ea84d034af3610967afdebe0436a34ebd2e87ca2e34b"
+                },
+                {
+                  "id": "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c"
+                },
+                {
+                  "id": "sha256:ce7b9745404d4f092712bfe05c7a4b64632dbd4fc194a2980912021901b9e985"
+                },
+                {
+                  "id": "sha256:5711028bfc9a0ba5752d3e32aca935f624a364c71c862e3b9a320f16ce0dc40d"
+                },
+                {
+                  "id": "sha256:d905e568721817dad5aad11910c1500d5b99695b6afcc415e47ed28767ec9364"
+                },
+                {
+                  "id": "sha256:a6505ee3dd72b373aefd0ab5a4632b855fa0b6dbf8facf5b554fc698bd59f37c"
+                },
+                {
+                  "id": "sha256:19413fb2096a9ff02d31dde255085eda820fead1c40697c119f6b88529d86e13"
+                },
+                {
+                  "id": "sha256:b63a75481268ddfefb9b0c01bd9c40ae60bb5a114a24a9595061dea7eea2b7b4"
+                },
+                {
+                  "id": "sha256:ba3b4980955962755c46bda6db09334a1bed64ab91f8a383e1c77bfa384f95f2"
+                },
+                {
+                  "id": "sha256:60597ea289d15efc9c36caa043e8ba904676646c7d919b4d220670c56e8d809c"
+                },
+                {
+                  "id": "sha256:4f3c2f44b48868bd3615aef61dd1ee9aa70c0d8051e3135cf6bcf441acb414a4"
+                },
+                {
+                  "id": "sha256:988a98f33b3157bfc52137cbc64b4753262effe649760c18cc7fbf3490debc32"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                },
+                {
+                  "id": "sha256:843af58590dbafa56c89e30ffc6b01f0bd1d28770049ca9956e306165f286858"
+                },
+                {
+                  "id": "sha256:3e3779e71058c8a030a8ecfc8d94cdba7f3a53a1232159f79ef7a8d63cb88143"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.chrony",
+          "options": {
+            "servers": [
+              {
+                "hostname": "metadata.google.internal"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.firewall",
+          "options": {
+            "default_zone": "trusted"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel-core"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-floppy.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "floppy"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.dnf.config",
+          "options": {
+            "config": {
+              "main": {
+                "ip_resolve": "4"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.dnf-automatic.config",
+          "options": {
+            "config": {
+              "commands": {
+                "apply_updates": true,
+                "upgrade_type": "security"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.yum.repos",
+          "options": {
+            "filename": "google-cloud.repo",
+            "repos": [
+              {
+                "id": "google-compute-engine",
+                "baseurl": [
+                  "https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable"
+                ],
+                "enabled": true,
+                "gpgkey": [
+                  "https://packages.cloud.google.com/yum/doc/yum-key.gpg",
+                  "https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg"
+                ],
+                "name": "Google Compute Engine",
+                "gpgcheck": false,
+                "repo_gpgcheck": false
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.gcp.guest-agent.conf",
+          "options": {
+            "config_scope": "distro",
+            "config": {
+              "InstanceSetup": {
+                "set_boto_config": false
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "PasswordAuthentication": false,
+              "ClientAliveInterval": 420,
+              "PermitRootLogin": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "510ddb8f-4fb6-42dd-926f-eab4aec9ddc9",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "510ddb8f-4fb6-42dd-926f-eab4aec9ddc9",
+            "kernel_opts": "biosdevname=0 scsi_mod.use_blk_mq=Y console=ttyS0,38400n8d",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "rngd",
+              "dnf-automatic.timer",
+              "cloud-init",
+              "cloud-init-local",
+              "cloud-config",
+              "cloud-final"
+            ],
+            "disabled_services": [
+              "sshd-keygen@",
+              "reboot.target"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.raw",
+            "size": "21474836480"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 41529311,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.raw",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.raw",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "510ddb8f-4fb6-42dd-926f-eab4aec9ddc9",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.raw",
+                "start": 413696,
+                "size": 41529311,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.raw",
+                "start": 413696,
+                "size": 41529311
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.raw",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "archive",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:image"
+              ]
+            }
+          },
+          "options": {
+            "filename": "image.tar.gz",
+            "format": "oldgnu",
+            "acls": false,
+            "selinux": false,
+            "xattrs": false,
+            "root-node": "omit"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a": {
+          "url": "https://example.com/repo/packages/net-tools"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0c1406adec8def017eb397ea9b217e879db26a50384d91c6a6112f44d0d27799": {
+          "url": "https://example.com/repo/packages/exclude:b43-fwcutter"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:0f2ed9e33d29ff4f3b0f664ca1e1dc3df1f8b9b315b2af284c6e0e3dc52be290": {
+          "url": "https://example.com/repo/packages/vim"
+        },
+        "sha256:11bbcc61af43bebaad417d8b935a77f65c67225703ad1d94d58465a63831c05f": {
+          "url": "https://example.com/repo/packages/exclude:kernel-firmware"
+        },
+        "sha256:19413fb2096a9ff02d31dde255085eda820fead1c40697c119f6b88529d86e13": {
+          "url": "https://example.com/repo/packages/exclude:ql2500-firmware"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:30e24e8a39fbfc20c910b6249dd0eda191d24b6fb867e0f6a8b23b4d539371c3": {
+          "url": "https://example.com/repo/packages/exclude:b43-openfwwf"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3e3779e71058c8a030a8ecfc8d94cdba7f3a53a1232159f79ef7a8d63cb88143": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/el9-x86_64-google-cloud-sdk"
+        },
+        "sha256:3e39dfe0fda6e3020d48b0d110ff8670187611a711de543a6692cf5519ece8da": {
+          "url": "https://example.com/repo/packages/exclude:ipw2100-firmware"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4c8abe2beeae2af4a537a85ae9953e163af2c127991de913e075eda82046b3e4": {
+          "url": "https://example.com/repo/packages/dnf-automatic"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:4f3c2f44b48868bd3615aef61dd1ee9aa70c0d8051e3135cf6bcf441acb414a4": {
+          "url": "https://example.com/repo/packages/exclude:xorg-x11-drv-ati-firmware"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5711028bfc9a0ba5752d3e32aca935f624a364c71c862e3b9a320f16ce0dc40d": {
+          "url": "https://example.com/repo/packages/exclude:ql2200-firmware"
+        },
+        "sha256:59a4bad24de7614e18d9b453a6820ec59fcda49720aa8f16ef045f5665562de9": {
+          "url": "https://example.com/repo/packages/exclude:atmel-firmware"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5d9e8f5c8ecdfdab3de0380b628372e1cfaa2f9616f21274d3cabcc511d11ad7": {
+          "url": "https://example.com/repo/packages/exclude:bfa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:60597ea289d15efc9c36caa043e8ba904676646c7d919b4d220670c56e8d809c": {
+          "url": "https://example.com/repo/packages/exclude:smartmontools"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393": {
+          "url": "https://example.com/repo/packages/grub2-tools-minimal"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:843af58590dbafa56c89e30ffc6b01f0bd1d28770049ca9956e306165f286858": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/el9-x86_64-google-compute-engine"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8e84e003f7afb133a9b5ea84d034af3610967afdebe0436a34ebd2e87ca2e34b": {
+          "url": "https://example.com/repo/packages/exclude:microcode_ctl"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:9220e83cc1dd0cbbe1ca0da9b665f6f476f4f357b9d0f2e691d9fad55ab78305": {
+          "url": "https://example.com/repo/packages/acpid"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:988a98f33b3157bfc52137cbc64b4753262effe649760c18cc7fbf3490debc32": {
+          "url": "https://example.com/repo/packages/exclude:zd1211-firmware"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:9e99f61535d122942ad3cb6f1d1d2496b48913a48d7e76e7e93983c22a06f2c4": {
+          "url": "https://example.com/repo/packages/exclude:gpm"
+        },
+        "sha256:9f242d5e9f0005c5120f17fc534c4e71cc5f9bfd59df1435a61c74d6ccc2846d": {
+          "url": "https://example.com/repo/packages/exclude:ipw2200-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a6505ee3dd72b373aefd0ab5a4632b855fa0b6dbf8facf5b554fc698bd59f37c": {
+          "url": "https://example.com/repo/packages/exclude:ql2400-firmware"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aa92be9c11e757dee72fd903a3d0b46daafb50027f30450ef892ac74f8b4e9f4": {
+          "url": "https://example.com/repo/packages/exclude:irqbalance"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:af90238cff8047ed284dc33bb34f66b5639ebbc51b9c866631fb2ace4c83e328": {
+          "url": "https://example.com/repo/packages/timedatex"
+        },
+        "sha256:b2a622322540941a2f49c7c8d6e8b98155b8f257a10eeb552993c5d210d957f6": {
+          "url": "https://example.com/repo/packages/exclude:eject"
+        },
+        "sha256:b63a75481268ddfefb9b0c01bd9c40ae60bb5a114a24a9595061dea7eea2b7b4": {
+          "url": "https://example.com/repo/packages/exclude:rt61pci-firmware"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:ba3b4980955962755c46bda6db09334a1bed64ab91f8a383e1c77bfa384f95f2": {
+          "url": "https://example.com/repo/packages/exclude:rt73usb-firmware"
+        },
+        "sha256:bc8f1fdc6cba695a97446aed17e9205717b86b4899ffad52b5166cfe1f232165": {
+          "url": "https://example.com/repo/packages/exclude:dmraid"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:ce7b9745404d4f092712bfe05c7a4b64632dbd4fc194a2980912021901b9e985": {
+          "url": "https://example.com/repo/packages/exclude:ql2100-firmware"
+        },
+        "sha256:d3cf5271c662017c7fdae75c30437813922b84f8fd5329818fc4aa4fdb716cb0": {
+          "url": "https://example.com/repo/packages/google-osconfig-agent"
+        },
+        "sha256:d905e568721817dad5aad11910c1500d5b99695b6afcc415e47ed28767ec9364": {
+          "url": "https://example.com/repo/packages/exclude:ql23xx-firmware"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c": {
+          "url": "https://example.com/repo/packages/exclude:qemu-guest-agent"
+        },
+        "sha256:e1911163463de95ee97cf6485caa62dfc4406353719446fe1fe3d9a66387c849": {
+          "url": "https://example.com/repo/packages/exclude:alsa-utils"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-image_installer-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-image_installer-empty.json
@@ -31,9 +31,6 @@
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
                   "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
                 },
                 {
@@ -62,12 +59,6 @@
                 },
                 {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
@@ -151,9 +142,6 @@
                   "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
                 },
                 {
-                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
-                },
-                {
                   "id": "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2"
                 },
                 {
@@ -169,19 +157,10 @@
                   "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
                 },
                 {
-                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
-                },
-                {
-                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
-                },
-                {
                   "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
                 },
                 {
                   "id": "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c"
-                },
-                {
-                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
                 },
                 {
                   "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
@@ -208,28 +187,13 @@
                   "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
                 },
                 {
-                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
-                },
-                {
                   "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
                   "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
-                },
-                {
-                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
                 },
                 {
                   "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
@@ -259,31 +223,13 @@
                   "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
                 },
                 {
-                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
-                },
-                {
-                  "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
-                },
-                {
                   "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
                   "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
-                },
-                {
-                  "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
-                },
-                {
-                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
-                },
-                {
-                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
                 },
                 {
                   "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
@@ -293,18 +239,6 @@
                 },
                 {
                   "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
-                },
-                {
-                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
                 },
                 {
                   "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
@@ -325,9 +259,6 @@
                   "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
                 },
                 {
-                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
-                },
-                {
                   "id": "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1"
                 },
                 {
@@ -337,16 +268,7 @@
                   "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
                 },
                 {
-                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
-                },
-                {
                   "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
-                },
-                {
-                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
-                },
-                {
-                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
                 },
                 {
                   "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
@@ -355,16 +277,7 @@
                   "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
                 },
                 {
-                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
-                },
-                {
                   "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
-                },
-                {
-                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
-                },
-                {
-                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
                 },
                 {
                   "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
@@ -373,16 +286,7 @@
                   "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
                 },
                 {
-                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
-                },
-                {
                   "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
                 },
                 {
                   "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
@@ -395,12 +299,6 @@
                 },
                 {
                   "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
-                },
-                {
-                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
-                },
-                {
-                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
                 },
                 {
                   "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
@@ -419,12 +317,6 @@
                 },
                 {
                   "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
-                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
-                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
                 },
                 {
                   "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
@@ -469,9 +361,6 @@
                   "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
                 },
                 {
-                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
-                },
-                {
                   "id": "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686"
                 },
                 {
@@ -487,13 +376,7 @@
                   "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
                 },
                 {
-                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
-                },
-                {
                   "id": "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a"
-                },
-                {
-                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
                 },
                 {
                   "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
@@ -511,12 +394,6 @@
                   "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
                 },
                 {
-                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
-                },
-                {
-                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
-                },
-                {
                   "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
                 },
                 {
@@ -530,12 +407,6 @@
                 },
                 {
                   "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
                 },
                 {
                   "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
@@ -553,13 +424,7 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14"
-                },
-                {
-                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
                 },
                 {
                   "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
@@ -580,22 +445,10 @@
                   "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
                 },
                 {
-                  "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
-                },
-                {
-                  "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
-                },
-                {
                   "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
@@ -623,12 +476,6 @@
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
                 },
                 {
                   "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
@@ -840,12 +687,6 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
@@ -867,16 +708,7 @@
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
                   "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
-                },
-                {
-                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
-                },
-                {
-                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
                 },
                 {
                   "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
@@ -885,16 +717,7 @@
                   "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
                 },
                 {
-                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
-                },
-                {
                   "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
-                },
-                {
-                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
-                },
-                {
-                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
                 },
                 {
                   "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
@@ -903,22 +726,10 @@
                   "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
                 },
                 {
-                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
-                },
-                {
-                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
-                },
-                {
                   "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
                 },
                 {
                   "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
                 },
                 {
                   "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
@@ -928,9 +739,6 @@
                 },
                 {
                   "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
-                },
-                {
-                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
                 },
                 {
                   "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
@@ -951,9 +759,6 @@
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
-                },
-                {
                   "id": "sha256:674177213da94e10f7c2eb25574d59f64ab942abe4746b1eedf24bfd4dc17a76"
                 },
                 {
@@ -967,9 +772,6 @@
                 },
                 {
                   "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -1002,9 +804,6 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
                 },
                 {
@@ -1012,9 +811,6 @@
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-image_installer-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-image_installer-empty.json
@@ -1,0 +1,1800 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c"
+                },
+                {
+                  "id": "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:a788847c8c115aa9ae27ca92230418e77b3b36a6424f1d4f3436633864c93db9"
+                },
+                {
+                  "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
+                },
+                {
+                  "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "anaconda-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:629e355a0345015e53cacd90ce641c7e2ef38405cd55e135f331a6303c51f509"
+                },
+                {
+                  "id": "sha256:1f2ce4e8c1aea4a2440b7e794e0440385f8e9c3f48b0fd65118f3dcdbca783bf"
+                },
+                {
+                  "id": "sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f"
+                },
+                {
+                  "id": "sha256:cd2c0f63ad37d585e77b3f1c584539e26bf7928710ac8fb19fd377f61b7326e6"
+                },
+                {
+                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
+                },
+                {
+                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
+                },
+                {
+                  "id": "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2"
+                },
+                {
+                  "id": "sha256:903be5b3913df555a8586e571d9016e1ac24eef2631a5d75b8c3f94c66f10955"
+                },
+                {
+                  "id": "sha256:b81f37a043a6f767e7c94d105f4bd31282f3ecc20680bb9d09bd93461cf4c863"
+                },
+                {
+                  "id": "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9"
+                },
+                {
+                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
+                },
+                {
+                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
+                },
+                {
+                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
+                },
+                {
+                  "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
+                },
+                {
+                  "id": "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c"
+                },
+                {
+                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
+                },
+                {
+                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
+                },
+                {
+                  "id": "sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112"
+                },
+                {
+                  "id": "sha256:5b8b6480d96480b779d6937e2d8694e03cdae14eb0664033ef24af50e1557726"
+                },
+                {
+                  "id": "sha256:75c008414c1be65c0e6954f74e1afdf3f706369f26899ea792b4ac0f31f287bc"
+                },
+                {
+                  "id": "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa"
+                },
+                {
+                  "id": "sha256:5e5d7e05a668f4ec5939a246b38d17cbb6ee83c0408ecbf584f6561a9d64a383"
+                },
+                {
+                  "id": "sha256:826c7f30d36dcc8cb4628bee44fc0e257a360eb06cfc31c49148a44b153e78ce"
+                },
+                {
+                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
+                },
+                {
+                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
+                },
+                {
+                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c"
+                },
+                {
+                  "id": "sha256:581265de790cf918fc770318449fe4cd07a18771c975d42867760b2e2f1bd18d"
+                },
+                {
+                  "id": "sha256:1f35e175b07fc080eb57fc9db22a3ce477d87bc5447466815f55864d3b6e6586"
+                },
+                {
+                  "id": "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31"
+                },
+                {
+                  "id": "sha256:9ac51bbcd5be0f507237b2d43367ad073eaf99398a65d26fa2a8fee5275f889b"
+                },
+                {
+                  "id": "sha256:f5f43514d2de810e4ea6d047203505e2e3c0c25f43941ec226968d17bb3aa1b5"
+                },
+                {
+                  "id": "sha256:24173b7985c9c52efc25b39e51f0fd41ac7b35e7031ed17da97788f293a3ce4e"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
+                },
+                {
+                  "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
+                },
+                {
+                  "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:0d3ffa508f3c7375c05551af609738a9d474b3eab32cb2d2194b41870b37f1a9"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:9531c8584bbf61635c5c9b15733d9494cb6dd232a6eec85a946076c6c633e99f"
+                },
+                {
+                  "id": "sha256:5e4e6002bd0ef9491967c1f5f573b0c184ef5a41d165cff38c8c6c73606702cb"
+                },
+                {
+                  "id": "sha256:263acae321870b428781a1f4cb5e88740a897a4f9b614233a1798d295f805c54"
+                },
+                {
+                  "id": "sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1"
+                },
+                {
+                  "id": "sha256:8e901f9b6ca3996fe198c84d5f0a305b635bbaae54757fa84932ac52479c1efa"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111"
+                },
+                {
+                  "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:4ad76aeffa1e790eaf720b659f9860c50b6e0ba4787fa0a2d0e43dfa46193035"
+                },
+                {
+                  "id": "sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe"
+                },
+                {
+                  "id": "sha256:eeb3d09845f5cde069eeade2c4339532be58b6607120be00656123cc73ea727c"
+                },
+                {
+                  "id": "sha256:ce5b1962783aa6a9374a0a1b34941a112a799baac827c733bd28c78dbb4bcf36"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
+                },
+                {
+                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
+                },
+                {
+                  "id": "sha256:b498cfb546ddbfbd5953e28137e5b39a65ba6c7220bf4fe4c3cc9bcafc73c41b"
+                },
+                {
+                  "id": "sha256:f6453ebfd8ab070567bfcd4cda99cc41c2c849237745f24228c5f040cac5d562"
+                },
+                {
+                  "id": "sha256:f7f7a2e0133dfc81f9505bac28dfb7ee3398f3dc3b32c7682c86a9be5403bfee"
+                },
+                {
+                  "id": "sha256:cf732696c9aebd80fad833157535754f246445ad0fec66e918963443bd3cfb71"
+                },
+                {
+                  "id": "sha256:fe36b1d498f9c6057ed774ba5fb0a84c8592886c3a4c7c077ce7f41326373099"
+                },
+                {
+                  "id": "sha256:cb298bd94fae6f2f713a1108a16e0632f3a1e21820a288d7ea86c8b00a4d4fef"
+                },
+                {
+                  "id": "sha256:52999df2efd2afc3fcda19e416efb2d0f9b09562aa53331eaac2cde3c88ea207"
+                },
+                {
+                  "id": "sha256:b7110cc6e76089686855ae923d8e0212a0f067b8a48f3c96e8510d50c56061a7"
+                },
+                {
+                  "id": "sha256:eddfc611c4f74bed09b2ac20b714b54f2e47d9befc7cc8af98b4c679807ba573"
+                },
+                {
+                  "id": "sha256:2442f8197039e6fb34538a4651f00be2bcbaa8d2be3a15b734fa6ddf1bd8abba"
+                },
+                {
+                  "id": "sha256:a39d3ae3da34f2b4c01193e62202d5de0db79f800a039624b0f950734782b863"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686"
+                },
+                {
+                  "id": "sha256:316d18e697dfa41e92a9fe91d8d175629db5e330348a8adc1a5b43744d01d217"
+                },
+                {
+                  "id": "sha256:68d6e3ed85174ed856b83d5d1e16c23d5279cb5dc77915ae8570a768a5a65505"
+                },
+                {
+                  "id": "sha256:4381157a0ab3568cb31f727709b2edfca21522a8645e95c411f5798b8018393d"
+                },
+                {
+                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
+                },
+                {
+                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
+                },
+                {
+                  "id": "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a"
+                },
+                {
+                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
+                },
+                {
+                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
+                },
+                {
+                  "id": "sha256:500d641b95d95deab52480573126901d76d81dfe9fe0a5caf43445df38caad7b"
+                },
+                {
+                  "id": "sha256:5bc35fd09bee19e0dc22c7f7a731d1d8f4f68b81a3fd866e32273523eda30f9e"
+                },
+                {
+                  "id": "sha256:883642e660d2ef545d3d9f0cbd12790a99aea6358fb67c46664ff22fefa8b7df"
+                },
+                {
+                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
+                },
+                {
+                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
+                },
+                {
+                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
+                },
+                {
+                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
+                },
+                {
+                  "id": "sha256:990fde98d70a0a1a75bf55978f90138e8878a7f5cc1de475e03ee25b6744ee8a"
+                },
+                {
+                  "id": "sha256:95671115820a1fb4e74d1abed36bf069ce64a8233a3a37a8909cc62dffc57293"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
+                },
+                {
+                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
+                },
+                {
+                  "id": "sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:afed7d2fb0ea7b7e9d8dbcf1c1bb62ff53840c72d380cf165294a1eccb7fdeb1"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:cb6b44243b93acef33a5ee905d92203a2a55abdc6a3b7c446c8435a41a6ad137"
+                },
+                {
+                  "id": "sha256:61bfeb2957d080cbab70b332f16b482e1991b08e77ea7a8546b68b3cde90990c"
+                },
+                {
+                  "id": "sha256:28bdff3b22fe1fe1b18313472b2060d2706b9052cbabd91aaa7bed0c88c065de"
+                },
+                {
+                  "id": "sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18"
+                },
+                {
+                  "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
+                },
+                {
+                  "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
+                },
+                {
+                  "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
+                },
+                {
+                  "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a"
+                },
+                {
+                  "id": "sha256:85830c0611a0acd7053f7b3a29f52a0511acc3695f9c5ef39a29fcfb8b80e25b"
+                },
+                {
+                  "id": "sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d"
+                },
+                {
+                  "id": "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf"
+                },
+                {
+                  "id": "sha256:0a26024d87ac934c3aeca0ec8b27e579dfb6b268ac43f3a6f945579a54c46e6e"
+                },
+                {
+                  "id": "sha256:570e342d0e4708dab94b2025f6b928845b659b405872d824b45473c4635d7b1d"
+                },
+                {
+                  "id": "sha256:ce2b8ecf9afac9f546bdbbb0902afb6088fdcb8524269ad5b4adb9b9d4959b07"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.buildstamp",
+          "options": {
+            "arch": "x86_64",
+            "product": "Red Hat Enterprise Linux",
+            "version": "10.0",
+            "final": true,
+            "variant": "",
+            "bugurl": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+              "install": {
+                "uid": 0,
+                "gid": 0,
+                "home": "/root",
+                "shell": "/usr/libexec/anaconda/run-anaconda",
+                "password": ""
+              },
+              "root": {
+                "password": ""
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.anaconda",
+          "options": {
+            "activatable-modules": [
+              "org.fedoraproject.Anaconda.Modules.Network",
+              "org.fedoraproject.Anaconda.Modules.Payloads",
+              "org.fedoraproject.Anaconda.Modules.Storage",
+              "org.fedoraproject.Anaconda.Modules.Users"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.lorax-script",
+          "options": {
+            "path": "99-generic/runtime-postinstall.tmpl",
+            "basearch": "x86_64",
+            "product": {
+              "name": "",
+              "version": ""
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.dracut",
+          "options": {
+            "kernel": [
+              "8-2.fk1.x86_64"
+            ],
+            "modules": [
+              "bash",
+              "systemd",
+              "fips",
+              "systemd-initrd",
+              "modsign",
+              "nss-softokn",
+              "i18n",
+              "convertfs",
+              "network-manager",
+              "network",
+              "url-lib",
+              "drm",
+              "plymouth",
+              "crypt",
+              "dm",
+              "dmsquash-live",
+              "kernel-modules",
+              "kernel-modules-extra",
+              "kernel-network-modules",
+              "livenet",
+              "lvm",
+              "mdraid",
+              "qemu",
+              "qemu-net",
+              "resume",
+              "rootfs-block",
+              "terminfo",
+              "udev-rules",
+              "dracut-systemd",
+              "pollcdrom",
+              "usrmount",
+              "base",
+              "fs-lib",
+              "img-lib",
+              "shutdown",
+              "uefi-lib",
+              "biosdevname",
+              "nvdimm",
+              "prefixdevname",
+              "prefixdevname-tools",
+              "net-lib",
+              "anaconda",
+              "rdma",
+              "rngd",
+              "multipath",
+              "fcoe",
+              "fcoe-uefi",
+              "iscsi",
+              "lunmask",
+              "nfs"
+            ],
+            "add_drivers": [
+              "ipmi_devintf",
+              "ipmi_msghandler"
+            ],
+            "install": [
+              "/.buildstamp"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux.config",
+          "options": {
+            "state": "permissive"
+          }
+        }
+      ]
+    },
+    {
+      "name": "efiboot-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.grub2.iso",
+          "options": {
+            "product": {
+              "name": "Red Hat Enterprise Linux",
+              "version": "10.0"
+            },
+            "kernel": {
+              "dir": "/images/pxeboot",
+              "opts": [
+                "inst.stage2=hd:LABEL=RHEL-10-0-0-BaseOS-x86_64",
+                "inst.ks=hd:LABEL=RHEL-10-0-0-BaseOS-x86_64:/osbuild.ks"
+              ]
+            },
+            "isolabel": "RHEL-10-0-0-BaseOS-x86_64",
+            "architectures": [
+              "X64"
+            ],
+            "vendor": "redhat"
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111"
+                },
+                {
+                  "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd"
+                },
+                {
+                  "id": "sha256:d87d9e526f265be973fce2ba320c5ed3ae24f6c5560d816d0b9307d0ba4d357f"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:674177213da94e10f7c2eb25574d59f64ab942abe4746b1eedf24bfd4dc17a76"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bootiso-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/images"
+              },
+              {
+                "path": "/images/pxeboot"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://tree/boot/vmlinuz-8-2.fk1.x86_64",
+                "to": "tree:///images/pxeboot/vmlinuz"
+              },
+              {
+                "from": "input://tree/boot/initramfs-8-2.fk1.x86_64.img",
+                "to": "tree:///images/pxeboot/initrd.img"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.squashfs",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "filename": "images/install.img",
+            "compression": {
+              "method": "xz",
+              "options": {
+                "bcj": "x86"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.isolinux",
+          "inputs": {
+            "data": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "product": {
+              "name": "Red Hat Enterprise Linux",
+              "version": "10.0"
+            },
+            "kernel": {
+              "dir": "/images/pxeboot",
+              "opts": [
+                "inst.stage2=hd:LABEL=RHEL-10-0-0-BaseOS-x86_64",
+                "inst.ks=hd:LABEL=RHEL-10-0-0-BaseOS-x86_64:/osbuild.ks"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "images/efiboot.img",
+            "size": "20971520"
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "75f92201"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "images/efiboot.img",
+                "size": 40960,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:efiboot-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "images/efiboot.img",
+                "size": 40960
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.fat",
+              "source": "-",
+              "target": "/"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:efiboot-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/EFI",
+                "to": "tree:///"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "/liveimg.tar.gz"
+          }
+        },
+        {
+          "type": "org.osbuild.kickstart",
+          "options": {
+            "path": "/osbuild.ks",
+            "liveimg": {
+              "url": "file:///run/install/repo/liveimg.tar.gz"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.discinfo",
+          "options": {
+            "basearch": "x86_64",
+            "release": "Red Hat Enterprise Linux 10.0"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bootiso",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.xorrisofs",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:bootiso-tree"
+              ]
+            }
+          },
+          "options": {
+            "filename": "installer.iso",
+            "volid": "RHEL-10-0-0-BaseOS-x86_64",
+            "sysid": "LINUX",
+            "boot": {
+              "image": "isolinux/isolinux.bin",
+              "catalog": "isolinux/boot.cat"
+            },
+            "efi": "images/efiboot.img",
+            "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
+            "isolevel": 3
+          }
+        },
+        {
+          "type": "org.osbuild.implantisomd5",
+          "options": {
+            "filename": "installer.iso"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64-cdboot"
+        },
+        "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a": {
+          "url": "https://example.com/repo/packages/net-tools"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112": {
+          "url": "https://example.com/repo/packages/dbus-x11"
+        },
+        "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3": {
+          "url": "https://example.com/repo/packages/bzip2"
+        },
+        "sha256:0a26024d87ac934c3aeca0ec8b27e579dfb6b268ac43f3a6f945579a54c46e6e": {
+          "url": "https://example.com/repo/packages/volume_key"
+        },
+        "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1": {
+          "url": "https://example.com/repo/packages/initscripts"
+        },
+        "sha256:0d3ffa508f3c7375c05551af609738a9d474b3eab32cb2d2194b41870b37f1a9": {
+          "url": "https://example.com/repo/packages/grub2-tools-efi"
+        },
+        "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa": {
+          "url": "https://example.com/repo/packages/iwl105-firmware"
+        },
+        "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9": {
+          "url": "https://example.com/repo/packages/bind-utils"
+        },
+        "sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe": {
+          "url": "https://example.com/repo/packages/kbd"
+        },
+        "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa": {
+          "url": "https://example.com/repo/packages/anaconda-dracut"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:1f2ce4e8c1aea4a2440b7e794e0440385f8e9c3f48b0fd65118f3dcdbca783bf": {
+          "url": "https://example.com/repo/packages/alsa-firmware"
+        },
+        "sha256:1f35e175b07fc080eb57fc9db22a3ce477d87bc5447466815f55864d3b6e6586": {
+          "url": "https://example.com/repo/packages/ftp"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:24173b7985c9c52efc25b39e51f0fd41ac7b35e7031ed17da97788f293a3ce4e": {
+          "url": "https://example.com/repo/packages/google-noto-sans-cjk-ttc-fonts"
+        },
+        "sha256:2442f8197039e6fb34538a4651f00be2bcbaa8d2be3a15b734fa6ddf1bd8abba": {
+          "url": "https://example.com/repo/packages/mt-st"
+        },
+        "sha256:263acae321870b428781a1f4cb5e88740a897a4f9b614233a1798d295f805c54": {
+          "url": "https://example.com/repo/packages/hdparm"
+        },
+        "sha256:28bdff3b22fe1fe1b18313472b2060d2706b9052cbabd91aaa7bed0c88c065de": {
+          "url": "https://example.com/repo/packages/spice-vdagent"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686": {
+          "url": "https://example.com/repo/packages/nm-connection-editor"
+        },
+        "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa": {
+          "url": "https://example.com/repo/packages/dejavu-sans-fonts"
+        },
+        "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc": {
+          "url": "https://example.com/repo/packages/dmidecode"
+        },
+        "sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f": {
+          "url": "https://example.com/repo/packages/alsa-tools-firmware"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:316d18e697dfa41e92a9fe91d8d175629db5e330348a8adc1a5b43744d01d217": {
+          "url": "https://example.com/repo/packages/nmap-ncat"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1": {
+          "url": "https://example.com/repo/packages/dnf"
+        },
+        "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0": {
+          "url": "https://example.com/repo/packages/curl"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:4381157a0ab3568cb31f727709b2edfca21522a8645e95c411f5798b8018393d": {
+          "url": "https://example.com/repo/packages/nss-tools"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce": {
+          "url": "https://example.com/repo/packages/iwl100-firmware"
+        },
+        "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674": {
+          "url": "https://example.com/repo/packages/iwl2030-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4ad76aeffa1e790eaf720b659f9860c50b6e0ba4787fa0a2d0e43dfa46193035": {
+          "url": "https://example.com/repo/packages/jomolhari-fonts"
+        },
+        "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d": {
+          "url": "https://example.com/repo/packages/less"
+        },
+        "sha256:500d641b95d95deab52480573126901d76d81dfe9fe0a5caf43445df38caad7b": {
+          "url": "https://example.com/repo/packages/pciutils"
+        },
+        "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2": {
+          "url": "https://example.com/repo/packages/anaconda-install-img-deps"
+        },
+        "sha256:52999df2efd2afc3fcda19e416efb2d0f9b09562aa53331eaac2cde3c88ea207": {
+          "url": "https://example.com/repo/packages/madan-fonts"
+        },
+        "sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781": {
+          "url": "https://example.com/repo/packages/xorriso"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:570e342d0e4708dab94b2025f6b928845b659b405872d824b45473c4635d7b1d": {
+          "url": "https://example.com/repo/packages/wget"
+        },
+        "sha256:581265de790cf918fc770318449fe4cd07a18771c975d42867760b2e2f1bd18d": {
+          "url": "https://example.com/repo/packages/fcoe-utils"
+        },
+        "sha256:5b8b6480d96480b779d6937e2d8694e03cdae14eb0664033ef24af50e1557726": {
+          "url": "https://example.com/repo/packages/default-fonts-core-sans"
+        },
+        "sha256:5bc35fd09bee19e0dc22c7f7a731d1d8f4f68b81a3fd866e32273523eda30f9e": {
+          "url": "https://example.com/repo/packages/perl-interpreter"
+        },
+        "sha256:5e4e6002bd0ef9491967c1f5f573b0c184ef5a41d165cff38c8c6c73606702cb": {
+          "url": "https://example.com/repo/packages/gsettings-desktop-schemas"
+        },
+        "sha256:5e5d7e05a668f4ec5939a246b38d17cbb6ee83c0408ecbf584f6561a9d64a383": {
+          "url": "https://example.com/repo/packages/dejavu-sans-mono-fonts"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:61bfeb2957d080cbab70b332f16b482e1991b08e77ea7a8546b68b3cde90990c": {
+          "url": "https://example.com/repo/packages/smartmontools"
+        },
+        "sha256:629e355a0345015e53cacd90ce641c7e2ef38405cd55e135f331a6303c51f509": {
+          "url": "https://example.com/repo/packages/@hardware-support"
+        },
+        "sha256:674177213da94e10f7c2eb25574d59f64ab942abe4746b1eedf24bfd4dc17a76": {
+          "url": "https://example.com/repo/packages/microcode_ctl"
+        },
+        "sha256:68d6e3ed85174ed856b83d5d1e16c23d5279cb5dc77915ae8570a768a5a65505": {
+          "url": "https://example.com/repo/packages/nss-softokn"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682": {
+          "url": "https://example.com/repo/packages/hostname"
+        },
+        "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393": {
+          "url": "https://example.com/repo/packages/grub2-tools-minimal"
+        },
+        "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8": {
+          "url": "https://example.com/repo/packages/syslinux-nonlinux"
+        },
+        "sha256:75c008414c1be65c0e6954f74e1afdf3f706369f26899ea792b4ac0f31f287bc": {
+          "url": "https://example.com/repo/packages/default-fonts-other-sans"
+        },
+        "sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18": {
+          "url": "https://example.com/repo/packages/strace"
+        },
+        "sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980": {
+          "url": "https://example.com/repo/packages/hexedit"
+        },
+        "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764": {
+          "url": "https://example.com/repo/packages/grub2-tools-extra"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5": {
+          "url": "https://example.com/repo/packages/firewalld"
+        },
+        "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a": {
+          "url": "https://example.com/repo/packages/openssh-server"
+        },
+        "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467": {
+          "url": "https://example.com/repo/packages/iwl6050-firmware"
+        },
+        "sha256:826c7f30d36dcc8cb4628bee44fc0e257a360eb06cfc31c49148a44b153e78ce": {
+          "url": "https://example.com/repo/packages/device-mapper-persistent-data"
+        },
+        "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0": {
+          "url": "https://example.com/repo/packages/ostree"
+        },
+        "sha256:85830c0611a0acd7053f7b3a29f52a0511acc3695f9c5ef39a29fcfb8b80e25b": {
+          "url": "https://example.com/repo/packages/udisks2-iscsi"
+        },
+        "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071": {
+          "url": "https://example.com/repo/packages/iwl5150-firmware"
+        },
+        "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714": {
+          "url": "https://example.com/repo/packages/iwl135-firmware"
+        },
+        "sha256:883642e660d2ef545d3d9f0cbd12790a99aea6358fb67c46664ff22fefa8b7df": {
+          "url": "https://example.com/repo/packages/pigz"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111": {
+          "url": "https://example.com/repo/packages/iwl6000g2a-firmware"
+        },
+        "sha256:8e901f9b6ca3996fe198c84d5f0a305b635bbaae54757fa84932ac52479c1efa": {
+          "url": "https://example.com/repo/packages/ipmitool"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:903be5b3913df555a8586e571d9016e1ac24eef2631a5d75b8c3f94c66f10955": {
+          "url": "https://example.com/repo/packages/anaconda-widgets"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9531c8584bbf61635c5c9b15733d9494cb6dd232a6eec85a946076c6c633e99f": {
+          "url": "https://example.com/repo/packages/grubby"
+        },
+        "sha256:95671115820a1fb4e74d1abed36bf069ce64a8233a3a37a8909cc62dffc57293": {
+          "url": "https://example.com/repo/packages/rdma-core"
+        },
+        "sha256:990fde98d70a0a1a75bf55978f90138e8878a7f5cc1de475e03ee25b6744ee8a": {
+          "url": "https://example.com/repo/packages/python3-pyatspi"
+        },
+        "sha256:9ac51bbcd5be0f507237b2d43367ad073eaf99398a65d26fa2a8fee5275f889b": {
+          "url": "https://example.com/repo/packages/glibc-all-langpacks"
+        },
+        "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd": {
+          "url": "https://example.com/repo/packages/prefixdevname"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a39d3ae3da34f2b4c01193e62202d5de0db79f800a039624b0f950734782b863": {
+          "url": "https://example.com/repo/packages/mtr"
+        },
+        "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53": {
+          "url": "https://example.com/repo/packages/plymouth"
+        },
+        "sha256:a788847c8c115aa9ae27ca92230418e77b3b36a6424f1d4f3436633864c93db9": {
+          "url": "https://example.com/repo/packages/squashfs-tools"
+        },
+        "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018": {
+          "url": "https://example.com/repo/packages/iwl3160-firmware"
+        },
+        "sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d": {
+          "url": "https://example.com/repo/packages/usbutils"
+        },
+        "sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a": {
+          "url": "https://example.com/repo/packages/udisks2"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14": {
+          "url": "https://example.com/repo/packages/sg3_utils"
+        },
+        "sha256:afed7d2fb0ea7b7e9d8dbcf1c1bb62ff53840c72d380cf165294a1eccb7fdeb1": {
+          "url": "https://example.com/repo/packages/rsyslog"
+        },
+        "sha256:b498cfb546ddbfbd5953e28137e5b39a65ba6c7220bf4fe4c3cc9bcafc73c41b": {
+          "url": "https://example.com/repo/packages/libblockdev-lvm-dbus"
+        },
+        "sha256:b7110cc6e76089686855ae923d8e0212a0f067b8a48f3c96e8510d50c56061a7": {
+          "url": "https://example.com/repo/packages/mdadm"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be": {
+          "url": "https://example.com/repo/packages/rpcbind"
+        },
+        "sha256:b81f37a043a6f767e7c94d105f4bd31282f3ecc20680bb9d09bd93461cf4c863": {
+          "url": "https://example.com/repo/packages/audit"
+        },
+        "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf": {
+          "url": "https://example.com/repo/packages/vim-minimal"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8": {
+          "url": "https://example.com/repo/packages/iwl2000-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0": {
+          "url": "https://example.com/repo/packages/iwl5000-firmware"
+        },
+        "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2": {
+          "url": "https://example.com/repo/packages/grub2-pc-modules"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c": {
+          "url": "https://example.com/repo/packages/ethtool"
+        },
+        "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0": {
+          "url": "https://example.com/repo/packages/iwl1000-firmware"
+        },
+        "sha256:cb298bd94fae6f2f713a1108a16e0632f3a1e21820a288d7ea86c8b00a4d4fef": {
+          "url": "https://example.com/repo/packages/lsof"
+        },
+        "sha256:cb6b44243b93acef33a5ee905d92203a2a55abdc6a3b7c446c8435a41a6ad137": {
+          "url": "https://example.com/repo/packages/sil-padauk-fonts"
+        },
+        "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31": {
+          "url": "https://example.com/repo/packages/gdb-gdbserver"
+        },
+        "sha256:cd2c0f63ad37d585e77b3f1c584539e26bf7928710ac8fb19fd377f61b7326e6": {
+          "url": "https://example.com/repo/packages/anaconda"
+        },
+        "sha256:ce2b8ecf9afac9f546bdbbb0902afb6088fdcb8524269ad5b4adb9b9d4959b07": {
+          "url": "https://example.com/repo/packages/xfsdump"
+        },
+        "sha256:ce5b1962783aa6a9374a0a1b34941a112a799baac827c733bd28c78dbb4bcf36": {
+          "url": "https://example.com/repo/packages/kdump-anaconda-addon"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c": {
+          "url": "https://example.com/repo/packages/cryptsetup"
+        },
+        "sha256:cf732696c9aebd80fad833157535754f246445ad0fec66e918963443bd3cfb71": {
+          "url": "https://example.com/repo/packages/linux-firmware"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9": {
+          "url": "https://example.com/repo/packages/iwl6000g2b-firmware"
+        },
+        "sha256:d87d9e526f265be973fce2ba320c5ed3ae24f6c5560d816d0b9307d0ba4d357f": {
+          "url": "https://example.com/repo/packages/lorax-templates-rhel"
+        },
+        "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd": {
+          "url": "https://example.com/repo/packages/lorax-templates-generic"
+        },
+        "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9": {
+          "url": "https://example.com/repo/packages/openssh-clients"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d": {
+          "url": "https://example.com/repo/packages/rpm-ostree"
+        },
+        "sha256:eddfc611c4f74bed09b2ac20b714b54f2e47d9befc7cc8af98b4c679807ba573": {
+          "url": "https://example.com/repo/packages/memtest86+"
+        },
+        "sha256:eeb3d09845f5cde069eeade2c4339532be58b6607120be00656123cc73ea727c": {
+          "url": "https://example.com/repo/packages/kbd-misc"
+        },
+        "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078": {
+          "url": "https://example.com/repo/packages/biosdevname"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f5f43514d2de810e4ea6d047203505e2e3c0c25f43941ec226968d17bb3aa1b5": {
+          "url": "https://example.com/repo/packages/gnome-kiosk"
+        },
+        "sha256:f6453ebfd8ab070567bfcd4cda99cc41c2c849237745f24228c5f040cac5d562": {
+          "url": "https://example.com/repo/packages/libibverbs"
+        },
+        "sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c": {
+          "url": "https://example.com/repo/packages/isomd5sum"
+        },
+        "sha256:f7f7a2e0133dfc81f9505bac28dfb7ee3398f3dc3b32c7682c86a9be5403bfee": {
+          "url": "https://example.com/repo/packages/librsvg2"
+        },
+        "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654": {
+          "url": "https://example.com/repo/packages/subscription-manager-cockpit"
+        },
+        "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23": {
+          "url": "https://example.com/repo/packages/dracut-network"
+        },
+        "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7": {
+          "url": "https://example.com/repo/packages/iwl7260-firmware"
+        },
+        "sha256:fe36b1d498f9c6057ed774ba5fb0a84c8592886c3a4c7c077ce7f41326373099": {
+          "url": "https://example.com/repo/packages/lldpad"
+        },
+        "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a": {
+          "url": "https://example.com/repo/packages/syslinux"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-image_installer-unattended_iso.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-image_installer-unattended_iso.json
@@ -31,9 +31,6 @@
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
                   "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
                 },
                 {
@@ -62,12 +59,6 @@
                 },
                 {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
@@ -151,9 +142,6 @@
                   "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
                 },
                 {
-                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
-                },
-                {
                   "id": "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2"
                 },
                 {
@@ -169,19 +157,10 @@
                   "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
                 },
                 {
-                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
-                },
-                {
-                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
-                },
-                {
                   "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
                 },
                 {
                   "id": "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c"
-                },
-                {
-                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
                 },
                 {
                   "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
@@ -208,28 +187,13 @@
                   "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
                 },
                 {
-                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
-                },
-                {
                   "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
                   "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
-                },
-                {
-                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
                 },
                 {
                   "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
@@ -259,31 +223,13 @@
                   "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
                 },
                 {
-                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
-                },
-                {
-                  "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
-                },
-                {
                   "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
                   "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
-                },
-                {
-                  "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
-                },
-                {
-                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
-                },
-                {
-                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
                 },
                 {
                   "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
@@ -293,18 +239,6 @@
                 },
                 {
                   "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
-                },
-                {
-                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
-                },
-                {
-                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
                 },
                 {
                   "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
@@ -325,9 +259,6 @@
                   "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
                 },
                 {
-                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
-                },
-                {
                   "id": "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1"
                 },
                 {
@@ -337,16 +268,7 @@
                   "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
                 },
                 {
-                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
-                },
-                {
                   "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
-                },
-                {
-                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
-                },
-                {
-                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
                 },
                 {
                   "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
@@ -355,16 +277,7 @@
                   "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
                 },
                 {
-                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
-                },
-                {
                   "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
-                },
-                {
-                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
-                },
-                {
-                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
                 },
                 {
                   "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
@@ -373,16 +286,7 @@
                   "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
                 },
                 {
-                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
-                },
-                {
                   "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
                 },
                 {
                   "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
@@ -395,12 +299,6 @@
                 },
                 {
                   "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
-                },
-                {
-                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
-                },
-                {
-                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
                 },
                 {
                   "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
@@ -419,12 +317,6 @@
                 },
                 {
                   "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
-                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
-                },
-                {
-                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
                 },
                 {
                   "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
@@ -469,9 +361,6 @@
                   "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
                 },
                 {
-                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
-                },
-                {
                   "id": "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686"
                 },
                 {
@@ -487,13 +376,7 @@
                   "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
                 },
                 {
-                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
-                },
-                {
                   "id": "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a"
-                },
-                {
-                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
                 },
                 {
                   "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
@@ -511,12 +394,6 @@
                   "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
                 },
                 {
-                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
-                },
-                {
-                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
-                },
-                {
                   "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
                 },
                 {
@@ -530,12 +407,6 @@
                 },
                 {
                   "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
                 },
                 {
                   "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
@@ -553,13 +424,7 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14"
-                },
-                {
-                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
                 },
                 {
                   "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
@@ -580,22 +445,10 @@
                   "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
                 },
                 {
-                  "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
-                },
-                {
-                  "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
-                },
-                {
                   "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
@@ -623,12 +476,6 @@
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
-                },
-                {
-                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
                 },
                 {
                   "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
@@ -842,12 +689,6 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
@@ -869,16 +710,7 @@
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
                   "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
-                },
-                {
-                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
-                },
-                {
-                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
                 },
                 {
                   "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
@@ -887,16 +719,7 @@
                   "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
                 },
                 {
-                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
-                },
-                {
                   "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
-                },
-                {
-                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
-                },
-                {
-                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
                 },
                 {
                   "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
@@ -905,22 +728,10 @@
                   "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
                 },
                 {
-                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
-                },
-                {
-                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
-                },
-                {
                   "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
                 },
                 {
                   "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
-                },
-                {
-                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
                 },
                 {
                   "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
@@ -930,9 +741,6 @@
                 },
                 {
                   "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
-                },
-                {
-                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
                 },
                 {
                   "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
@@ -953,9 +761,6 @@
                   "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
                 },
                 {
-                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
-                },
-                {
                   "id": "sha256:674177213da94e10f7c2eb25574d59f64ab942abe4746b1eedf24bfd4dc17a76"
                 },
                 {
@@ -969,9 +774,6 @@
                 },
                 {
                   "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -1004,9 +806,6 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
                 },
                 {
@@ -1014,9 +813,6 @@
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-image_installer-unattended_iso.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-image_installer-unattended_iso.json
@@ -1,0 +1,1875 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c"
+                },
+                {
+                  "id": "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:a788847c8c115aa9ae27ca92230418e77b3b36a6424f1d4f3436633864c93db9"
+                },
+                {
+                  "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
+                },
+                {
+                  "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "anaconda-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:629e355a0345015e53cacd90ce641c7e2ef38405cd55e135f331a6303c51f509"
+                },
+                {
+                  "id": "sha256:1f2ce4e8c1aea4a2440b7e794e0440385f8e9c3f48b0fd65118f3dcdbca783bf"
+                },
+                {
+                  "id": "sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f"
+                },
+                {
+                  "id": "sha256:cd2c0f63ad37d585e77b3f1c584539e26bf7928710ac8fb19fd377f61b7326e6"
+                },
+                {
+                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
+                },
+                {
+                  "id": "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa"
+                },
+                {
+                  "id": "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2"
+                },
+                {
+                  "id": "sha256:903be5b3913df555a8586e571d9016e1ac24eef2631a5d75b8c3f94c66f10955"
+                },
+                {
+                  "id": "sha256:b81f37a043a6f767e7c94d105f4bd31282f3ecc20680bb9d09bd93461cf4c863"
+                },
+                {
+                  "id": "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9"
+                },
+                {
+                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
+                },
+                {
+                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
+                },
+                {
+                  "id": "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078"
+                },
+                {
+                  "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
+                },
+                {
+                  "id": "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c"
+                },
+                {
+                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
+                },
+                {
+                  "id": "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0"
+                },
+                {
+                  "id": "sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112"
+                },
+                {
+                  "id": "sha256:5b8b6480d96480b779d6937e2d8694e03cdae14eb0664033ef24af50e1557726"
+                },
+                {
+                  "id": "sha256:75c008414c1be65c0e6954f74e1afdf3f706369f26899ea792b4ac0f31f287bc"
+                },
+                {
+                  "id": "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa"
+                },
+                {
+                  "id": "sha256:5e5d7e05a668f4ec5939a246b38d17cbb6ee83c0408ecbf584f6561a9d64a383"
+                },
+                {
+                  "id": "sha256:826c7f30d36dcc8cb4628bee44fc0e257a360eb06cfc31c49148a44b153e78ce"
+                },
+                {
+                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
+                },
+                {
+                  "id": "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
+                },
+                {
+                  "id": "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c"
+                },
+                {
+                  "id": "sha256:581265de790cf918fc770318449fe4cd07a18771c975d42867760b2e2f1bd18d"
+                },
+                {
+                  "id": "sha256:1f35e175b07fc080eb57fc9db22a3ce477d87bc5447466815f55864d3b6e6586"
+                },
+                {
+                  "id": "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31"
+                },
+                {
+                  "id": "sha256:9ac51bbcd5be0f507237b2d43367ad073eaf99398a65d26fa2a8fee5275f889b"
+                },
+                {
+                  "id": "sha256:f5f43514d2de810e4ea6d047203505e2e3c0c25f43941ec226968d17bb3aa1b5"
+                },
+                {
+                  "id": "sha256:24173b7985c9c52efc25b39e51f0fd41ac7b35e7031ed17da97788f293a3ce4e"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
+                },
+                {
+                  "id": "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
+                },
+                {
+                  "id": "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d"
+                },
+                {
+                  "id": "sha256:0d3ffa508f3c7375c05551af609738a9d474b3eab32cb2d2194b41870b37f1a9"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393"
+                },
+                {
+                  "id": "sha256:9531c8584bbf61635c5c9b15733d9494cb6dd232a6eec85a946076c6c633e99f"
+                },
+                {
+                  "id": "sha256:5e4e6002bd0ef9491967c1f5f573b0c184ef5a41d165cff38c8c6c73606702cb"
+                },
+                {
+                  "id": "sha256:263acae321870b428781a1f4cb5e88740a897a4f9b614233a1798d295f805c54"
+                },
+                {
+                  "id": "sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1"
+                },
+                {
+                  "id": "sha256:8e901f9b6ca3996fe198c84d5f0a305b635bbaae54757fa84932ac52479c1efa"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111"
+                },
+                {
+                  "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:4ad76aeffa1e790eaf720b659f9860c50b6e0ba4787fa0a2d0e43dfa46193035"
+                },
+                {
+                  "id": "sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe"
+                },
+                {
+                  "id": "sha256:eeb3d09845f5cde069eeade2c4339532be58b6607120be00656123cc73ea727c"
+                },
+                {
+                  "id": "sha256:ce5b1962783aa6a9374a0a1b34941a112a799baac827c733bd28c78dbb4bcf36"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
+                },
+                {
+                  "id": "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d"
+                },
+                {
+                  "id": "sha256:b498cfb546ddbfbd5953e28137e5b39a65ba6c7220bf4fe4c3cc9bcafc73c41b"
+                },
+                {
+                  "id": "sha256:f6453ebfd8ab070567bfcd4cda99cc41c2c849237745f24228c5f040cac5d562"
+                },
+                {
+                  "id": "sha256:f7f7a2e0133dfc81f9505bac28dfb7ee3398f3dc3b32c7682c86a9be5403bfee"
+                },
+                {
+                  "id": "sha256:cf732696c9aebd80fad833157535754f246445ad0fec66e918963443bd3cfb71"
+                },
+                {
+                  "id": "sha256:fe36b1d498f9c6057ed774ba5fb0a84c8592886c3a4c7c077ce7f41326373099"
+                },
+                {
+                  "id": "sha256:cb298bd94fae6f2f713a1108a16e0632f3a1e21820a288d7ea86c8b00a4d4fef"
+                },
+                {
+                  "id": "sha256:52999df2efd2afc3fcda19e416efb2d0f9b09562aa53331eaac2cde3c88ea207"
+                },
+                {
+                  "id": "sha256:b7110cc6e76089686855ae923d8e0212a0f067b8a48f3c96e8510d50c56061a7"
+                },
+                {
+                  "id": "sha256:eddfc611c4f74bed09b2ac20b714b54f2e47d9befc7cc8af98b4c679807ba573"
+                },
+                {
+                  "id": "sha256:2442f8197039e6fb34538a4651f00be2bcbaa8d2be3a15b734fa6ddf1bd8abba"
+                },
+                {
+                  "id": "sha256:a39d3ae3da34f2b4c01193e62202d5de0db79f800a039624b0f950734782b863"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686"
+                },
+                {
+                  "id": "sha256:316d18e697dfa41e92a9fe91d8d175629db5e330348a8adc1a5b43744d01d217"
+                },
+                {
+                  "id": "sha256:68d6e3ed85174ed856b83d5d1e16c23d5279cb5dc77915ae8570a768a5a65505"
+                },
+                {
+                  "id": "sha256:4381157a0ab3568cb31f727709b2edfca21522a8645e95c411f5798b8018393d"
+                },
+                {
+                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
+                },
+                {
+                  "id": "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9"
+                },
+                {
+                  "id": "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a"
+                },
+                {
+                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
+                },
+                {
+                  "id": "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0"
+                },
+                {
+                  "id": "sha256:500d641b95d95deab52480573126901d76d81dfe9fe0a5caf43445df38caad7b"
+                },
+                {
+                  "id": "sha256:5bc35fd09bee19e0dc22c7f7a731d1d8f4f68b81a3fd866e32273523eda30f9e"
+                },
+                {
+                  "id": "sha256:883642e660d2ef545d3d9f0cbd12790a99aea6358fb67c46664ff22fefa8b7df"
+                },
+                {
+                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
+                },
+                {
+                  "id": "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53"
+                },
+                {
+                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
+                },
+                {
+                  "id": "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd"
+                },
+                {
+                  "id": "sha256:990fde98d70a0a1a75bf55978f90138e8878a7f5cc1de475e03ee25b6744ee8a"
+                },
+                {
+                  "id": "sha256:95671115820a1fb4e74d1abed36bf069ce64a8233a3a37a8909cc62dffc57293"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
+                },
+                {
+                  "id": "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be"
+                },
+                {
+                  "id": "sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:afed7d2fb0ea7b7e9d8dbcf1c1bb62ff53840c72d380cf165294a1eccb7fdeb1"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:cb6b44243b93acef33a5ee905d92203a2a55abdc6a3b7c446c8435a41a6ad137"
+                },
+                {
+                  "id": "sha256:61bfeb2957d080cbab70b332f16b482e1991b08e77ea7a8546b68b3cde90990c"
+                },
+                {
+                  "id": "sha256:28bdff3b22fe1fe1b18313472b2060d2706b9052cbabd91aaa7bed0c88c065de"
+                },
+                {
+                  "id": "sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18"
+                },
+                {
+                  "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
+                },
+                {
+                  "id": "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a"
+                },
+                {
+                  "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
+                },
+                {
+                  "id": "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a"
+                },
+                {
+                  "id": "sha256:85830c0611a0acd7053f7b3a29f52a0511acc3695f9c5ef39a29fcfb8b80e25b"
+                },
+                {
+                  "id": "sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d"
+                },
+                {
+                  "id": "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf"
+                },
+                {
+                  "id": "sha256:0a26024d87ac934c3aeca0ec8b27e579dfb6b268ac43f3a6f945579a54c46e6e"
+                },
+                {
+                  "id": "sha256:570e342d0e4708dab94b2025f6b928845b659b405872d824b45473c4635d7b1d"
+                },
+                {
+                  "id": "sha256:ce2b8ecf9afac9f546bdbbb0902afb6088fdcb8524269ad5b4adb9b9d4959b07"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.buildstamp",
+          "options": {
+            "arch": "x86_64",
+            "product": "Red Hat Enterprise Linux",
+            "version": "10.0",
+            "final": true,
+            "variant": "",
+            "bugurl": ""
+          }
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "en_GB.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+              "install": {
+                "uid": 0,
+                "gid": 0,
+                "home": "/root",
+                "shell": "/usr/libexec/anaconda/run-anaconda",
+                "password": ""
+              },
+              "root": {
+                "password": ""
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.anaconda",
+          "options": {
+            "activatable-modules": [
+              "org.fedoraproject.Anaconda.Modules.Localization",
+              "org.fedoraproject.Anaconda.Modules.Network",
+              "org.fedoraproject.Anaconda.Modules.Payloads",
+              "org.fedoraproject.Anaconda.Modules.Services",
+              "org.fedoraproject.Anaconda.Modules.Storage",
+              "org.fedoraproject.Anaconda.Modules.Users"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.lorax-script",
+          "options": {
+            "path": "99-generic/runtime-postinstall.tmpl",
+            "basearch": "x86_64",
+            "product": {
+              "name": "",
+              "version": ""
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.dracut",
+          "options": {
+            "kernel": [
+              "8-2.fk1.x86_64"
+            ],
+            "modules": [
+              "bash",
+              "systemd",
+              "fips",
+              "systemd-initrd",
+              "modsign",
+              "nss-softokn",
+              "i18n",
+              "convertfs",
+              "network-manager",
+              "network",
+              "url-lib",
+              "drm",
+              "plymouth",
+              "crypt",
+              "dm",
+              "dmsquash-live",
+              "kernel-modules",
+              "kernel-modules-extra",
+              "kernel-network-modules",
+              "livenet",
+              "lvm",
+              "mdraid",
+              "qemu",
+              "qemu-net",
+              "resume",
+              "rootfs-block",
+              "terminfo",
+              "udev-rules",
+              "dracut-systemd",
+              "pollcdrom",
+              "usrmount",
+              "base",
+              "fs-lib",
+              "img-lib",
+              "shutdown",
+              "uefi-lib",
+              "biosdevname",
+              "nvdimm",
+              "prefixdevname",
+              "prefixdevname-tools",
+              "net-lib",
+              "anaconda",
+              "rdma",
+              "rngd",
+              "multipath",
+              "fcoe",
+              "fcoe-uefi",
+              "iscsi",
+              "lunmask",
+              "nfs"
+            ],
+            "add_drivers": [
+              "ipmi_devintf",
+              "ipmi_msghandler"
+            ],
+            "install": [
+              "/.buildstamp"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux.config",
+          "options": {
+            "state": "permissive"
+          }
+        }
+      ]
+    },
+    {
+      "name": "efiboot-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.grub2.iso",
+          "options": {
+            "product": {
+              "name": "Red Hat Enterprise Linux",
+              "version": "10.0"
+            },
+            "kernel": {
+              "dir": "/images/pxeboot",
+              "opts": [
+                "inst.stage2=hd:LABEL=RHEL-10-0-0-BaseOS-x86_64",
+                "inst.ks=hd:LABEL=RHEL-10-0-0-BaseOS-x86_64:/osbuild.ks"
+              ]
+            },
+            "isolabel": "RHEL-10-0-0-BaseOS-x86_64",
+            "architectures": [
+              "X64"
+            ],
+            "vendor": "redhat"
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071"
+                },
+                {
+                  "id": "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111"
+                },
+                {
+                  "id": "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467"
+                },
+                {
+                  "id": "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd"
+                },
+                {
+                  "id": "sha256:d87d9e526f265be973fce2ba320c5ed3ae24f6c5560d816d0b9307d0ba4d357f"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:674177213da94e10f7c2eb25574d59f64ab942abe4746b1eedf24bfd4dc17a76"
+                },
+                {
+                  "id": "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "en_GB.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "uk"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "Europe/Berlin"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bootiso-tree",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.mkdir",
+          "options": {
+            "paths": [
+              {
+                "path": "/images"
+              },
+              {
+                "path": "/images/pxeboot"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://tree/boot/vmlinuz-8-2.fk1.x86_64",
+                "to": "tree:///images/pxeboot/vmlinuz"
+              },
+              {
+                "from": "input://tree/boot/initramfs-8-2.fk1.x86_64.img",
+                "to": "tree:///images/pxeboot/initrd.img"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.squashfs",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "filename": "images/install.img",
+            "compression": {
+              "method": "xz",
+              "options": {
+                "bcj": "x86"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.isolinux",
+          "inputs": {
+            "data": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:anaconda-tree"
+              ]
+            }
+          },
+          "options": {
+            "product": {
+              "name": "Red Hat Enterprise Linux",
+              "version": "10.0"
+            },
+            "kernel": {
+              "dir": "/images/pxeboot",
+              "opts": [
+                "inst.stage2=hd:LABEL=RHEL-10-0-0-BaseOS-x86_64",
+                "inst.ks=hd:LABEL=RHEL-10-0-0-BaseOS-x86_64:/osbuild.ks"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "images/efiboot.img",
+            "size": "20971520"
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "f018ca54"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "images/efiboot.img",
+                "size": 40960,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:efiboot-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "images/efiboot.img",
+                "size": 40960
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.fat",
+              "source": "-",
+              "target": "/"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:efiboot-tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/EFI",
+                "to": "tree:///"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "/liveimg.tar.gz"
+          }
+        },
+        {
+          "type": "org.osbuild.kickstart",
+          "options": {
+            "path": "/osbuild-base.ks",
+            "liveimg": {
+              "url": "file:///run/install/repo/liveimg.tar.gz"
+            },
+            "users": {
+              "osbuild": {
+                "groups": [
+                  "wheel"
+                ],
+                "key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNebAh6SjpAn8wB53K4695cGnHGuCtl4RdaX3futZgJUultHyzeYHnzMO7d4++qnRL+Rworew62LKP560uvtncc= github.com/osbuild/images"
+              }
+            },
+            "lang": "en_GB.UTF-8",
+            "keyboard": "uk",
+            "timezone": "Europe/Berlin",
+            "display_mode": "text",
+            "reboot": {
+              "eject": true
+            },
+            "rootpw": {
+              "lock": true
+            },
+            "zerombr": true,
+            "clearpart": {
+              "all": true,
+              "initlabel": true
+            },
+            "autopart": {
+              "type": "plain",
+              "fstype": "xfs",
+              "nohome": true
+            },
+            "network": [
+              {
+                "activate": true,
+                "bootproto": "dhcp",
+                "device": "link",
+                "onboot": "on"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "file-ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434"
+                }
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://file-ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434/sha256:ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434",
+                "to": "tree:///osbuild.ks",
+                "remove_destination": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.discinfo",
+          "options": {
+            "basearch": "x86_64",
+            "release": "Red Hat Enterprise Linux 10.0"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bootiso",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.xorrisofs",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:bootiso-tree"
+              ]
+            }
+          },
+          "options": {
+            "filename": "installer.iso",
+            "volid": "RHEL-10-0-0-BaseOS-x86_64",
+            "sysid": "LINUX",
+            "boot": {
+              "image": "isolinux/isolinux.bin",
+              "catalog": "isolinux/boot.cat"
+            },
+            "efi": "images/efiboot.img",
+            "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
+            "isolevel": 3
+          }
+        },
+        {
+          "type": "org.osbuild.implantisomd5",
+          "options": {
+            "filename": "installer.iso"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:021b0fc809e1245cc6021a779e094bba7191085b7a31ce4c05490b9cc79eacc7": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64-cdboot"
+        },
+        "sha256:0272f4e79b65885cc8b0bc82cae8a4a63901e2d54ab2bbcb5227711ee432e21a": {
+          "url": "https://example.com/repo/packages/net-tools"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112": {
+          "url": "https://example.com/repo/packages/dbus-x11"
+        },
+        "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3": {
+          "url": "https://example.com/repo/packages/bzip2"
+        },
+        "sha256:0a26024d87ac934c3aeca0ec8b27e579dfb6b268ac43f3a6f945579a54c46e6e": {
+          "url": "https://example.com/repo/packages/volume_key"
+        },
+        "sha256:0b7d4f77c2cb51052db74404b259f556184bb91f64aea8e9ace8f452efb03ed1": {
+          "url": "https://example.com/repo/packages/initscripts"
+        },
+        "sha256:0d3ffa508f3c7375c05551af609738a9d474b3eab32cb2d2194b41870b37f1a9": {
+          "url": "https://example.com/repo/packages/grub2-tools-efi"
+        },
+        "sha256:10d813242917dfde64a292f0744a6c332d29f907a8ebb31188af6ea8de1d1efa": {
+          "url": "https://example.com/repo/packages/iwl105-firmware"
+        },
+        "sha256:10f98865f92b870436264dfd6dea761c85e4f9edd1688f7dacb90e7bfd725de9": {
+          "url": "https://example.com/repo/packages/bind-utils"
+        },
+        "sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe": {
+          "url": "https://example.com/repo/packages/kbd"
+        },
+        "sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa": {
+          "url": "https://example.com/repo/packages/anaconda-dracut"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:1f2ce4e8c1aea4a2440b7e794e0440385f8e9c3f48b0fd65118f3dcdbca783bf": {
+          "url": "https://example.com/repo/packages/alsa-firmware"
+        },
+        "sha256:1f35e175b07fc080eb57fc9db22a3ce477d87bc5447466815f55864d3b6e6586": {
+          "url": "https://example.com/repo/packages/ftp"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:24173b7985c9c52efc25b39e51f0fd41ac7b35e7031ed17da97788f293a3ce4e": {
+          "url": "https://example.com/repo/packages/google-noto-sans-cjk-ttc-fonts"
+        },
+        "sha256:2442f8197039e6fb34538a4651f00be2bcbaa8d2be3a15b734fa6ddf1bd8abba": {
+          "url": "https://example.com/repo/packages/mt-st"
+        },
+        "sha256:263acae321870b428781a1f4cb5e88740a897a4f9b614233a1798d295f805c54": {
+          "url": "https://example.com/repo/packages/hdparm"
+        },
+        "sha256:28bdff3b22fe1fe1b18313472b2060d2706b9052cbabd91aaa7bed0c88c065de": {
+          "url": "https://example.com/repo/packages/spice-vdagent"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2a759970ca60f649dac5cf69eb25ab6b768eddd3f6f89639140e537a688cb686": {
+          "url": "https://example.com/repo/packages/nm-connection-editor"
+        },
+        "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa": {
+          "url": "https://example.com/repo/packages/dejavu-sans-fonts"
+        },
+        "sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc": {
+          "url": "https://example.com/repo/packages/dmidecode"
+        },
+        "sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f": {
+          "url": "https://example.com/repo/packages/alsa-tools-firmware"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:316d18e697dfa41e92a9fe91d8d175629db5e330348a8adc1a5b43744d01d217": {
+          "url": "https://example.com/repo/packages/nmap-ncat"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f": {
+          "url": "https://example.com/repo/packages/e2fsprogs"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1": {
+          "url": "https://example.com/repo/packages/dnf"
+        },
+        "sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0": {
+          "url": "https://example.com/repo/packages/curl"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:4381157a0ab3568cb31f727709b2edfca21522a8645e95c411f5798b8018393d": {
+          "url": "https://example.com/repo/packages/nss-tools"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:4791c5734c81dcc16b25ab5a006d8dd8250b9555a539e557cac9bea5a60fecce": {
+          "url": "https://example.com/repo/packages/iwl100-firmware"
+        },
+        "sha256:47b7e192a116767577c34ddb8487411519a1461df1d80b482f4622dc6c1f8674": {
+          "url": "https://example.com/repo/packages/iwl2030-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4ad76aeffa1e790eaf720b659f9860c50b6e0ba4787fa0a2d0e43dfa46193035": {
+          "url": "https://example.com/repo/packages/jomolhari-fonts"
+        },
+        "sha256:4fdd3b6201a22c7814d6e67dbb7a17790224ea0fd32ef0a0ccb0a5485eae4c9d": {
+          "url": "https://example.com/repo/packages/less"
+        },
+        "sha256:500d641b95d95deab52480573126901d76d81dfe9fe0a5caf43445df38caad7b": {
+          "url": "https://example.com/repo/packages/pciutils"
+        },
+        "sha256:51385627d29f139f756b94ca84358d251c1455e6de1d625d1aa4758fe842d0e2": {
+          "url": "https://example.com/repo/packages/anaconda-install-img-deps"
+        },
+        "sha256:52999df2efd2afc3fcda19e416efb2d0f9b09562aa53331eaac2cde3c88ea207": {
+          "url": "https://example.com/repo/packages/madan-fonts"
+        },
+        "sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781": {
+          "url": "https://example.com/repo/packages/xorriso"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:570e342d0e4708dab94b2025f6b928845b659b405872d824b45473c4635d7b1d": {
+          "url": "https://example.com/repo/packages/wget"
+        },
+        "sha256:581265de790cf918fc770318449fe4cd07a18771c975d42867760b2e2f1bd18d": {
+          "url": "https://example.com/repo/packages/fcoe-utils"
+        },
+        "sha256:5b8b6480d96480b779d6937e2d8694e03cdae14eb0664033ef24af50e1557726": {
+          "url": "https://example.com/repo/packages/default-fonts-core-sans"
+        },
+        "sha256:5bc35fd09bee19e0dc22c7f7a731d1d8f4f68b81a3fd866e32273523eda30f9e": {
+          "url": "https://example.com/repo/packages/perl-interpreter"
+        },
+        "sha256:5e4e6002bd0ef9491967c1f5f573b0c184ef5a41d165cff38c8c6c73606702cb": {
+          "url": "https://example.com/repo/packages/gsettings-desktop-schemas"
+        },
+        "sha256:5e5d7e05a668f4ec5939a246b38d17cbb6ee83c0408ecbf584f6561a9d64a383": {
+          "url": "https://example.com/repo/packages/dejavu-sans-mono-fonts"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:61bfeb2957d080cbab70b332f16b482e1991b08e77ea7a8546b68b3cde90990c": {
+          "url": "https://example.com/repo/packages/smartmontools"
+        },
+        "sha256:629e355a0345015e53cacd90ce641c7e2ef38405cd55e135f331a6303c51f509": {
+          "url": "https://example.com/repo/packages/@hardware-support"
+        },
+        "sha256:674177213da94e10f7c2eb25574d59f64ab942abe4746b1eedf24bfd4dc17a76": {
+          "url": "https://example.com/repo/packages/microcode_ctl"
+        },
+        "sha256:68d6e3ed85174ed856b83d5d1e16c23d5279cb5dc77915ae8570a768a5a65505": {
+          "url": "https://example.com/repo/packages/nss-softokn"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682": {
+          "url": "https://example.com/repo/packages/hostname"
+        },
+        "sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393": {
+          "url": "https://example.com/repo/packages/grub2-tools-minimal"
+        },
+        "sha256:746ce7b983a2448f60202b7e25bc5814b8d8962d6ce867eebda2ba65c0daade8": {
+          "url": "https://example.com/repo/packages/syslinux-nonlinux"
+        },
+        "sha256:75c008414c1be65c0e6954f74e1afdf3f706369f26899ea792b4ac0f31f287bc": {
+          "url": "https://example.com/repo/packages/default-fonts-other-sans"
+        },
+        "sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18": {
+          "url": "https://example.com/repo/packages/strace"
+        },
+        "sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980": {
+          "url": "https://example.com/repo/packages/hexedit"
+        },
+        "sha256:79e849ef6eca219446118ca179bf7aa8bc5469a1c92b4696d67f6bee2dc26764": {
+          "url": "https://example.com/repo/packages/grub2-tools-extra"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5": {
+          "url": "https://example.com/repo/packages/firewalld"
+        },
+        "sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a": {
+          "url": "https://example.com/repo/packages/openssh-server"
+        },
+        "sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467": {
+          "url": "https://example.com/repo/packages/iwl6050-firmware"
+        },
+        "sha256:826c7f30d36dcc8cb4628bee44fc0e257a360eb06cfc31c49148a44b153e78ce": {
+          "url": "https://example.com/repo/packages/device-mapper-persistent-data"
+        },
+        "sha256:8373873d8c1183cc0007d0b8310c706537248401793832bd3c71b271497997c0": {
+          "url": "https://example.com/repo/packages/ostree"
+        },
+        "sha256:85830c0611a0acd7053f7b3a29f52a0511acc3695f9c5ef39a29fcfb8b80e25b": {
+          "url": "https://example.com/repo/packages/udisks2-iscsi"
+        },
+        "sha256:874acaf989b725037ce173f517404baeb8d2643275bf972edbae7c947e7c1071": {
+          "url": "https://example.com/repo/packages/iwl5150-firmware"
+        },
+        "sha256:87fdf23aeb0c0b27488ecbabd19e8fa175df1b298369845787beb99ddc849714": {
+          "url": "https://example.com/repo/packages/iwl135-firmware"
+        },
+        "sha256:883642e660d2ef545d3d9f0cbd12790a99aea6358fb67c46664ff22fefa8b7df": {
+          "url": "https://example.com/repo/packages/pigz"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8c9f207e90d45483dc9143a590f1185acd99f8cc7d9a1af4ec6eba595ecac111": {
+          "url": "https://example.com/repo/packages/iwl6000g2a-firmware"
+        },
+        "sha256:8e901f9b6ca3996fe198c84d5f0a305b635bbaae54757fa84932ac52479c1efa": {
+          "url": "https://example.com/repo/packages/ipmitool"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:903be5b3913df555a8586e571d9016e1ac24eef2631a5d75b8c3f94c66f10955": {
+          "url": "https://example.com/repo/packages/anaconda-widgets"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9531c8584bbf61635c5c9b15733d9494cb6dd232a6eec85a946076c6c633e99f": {
+          "url": "https://example.com/repo/packages/grubby"
+        },
+        "sha256:95671115820a1fb4e74d1abed36bf069ce64a8233a3a37a8909cc62dffc57293": {
+          "url": "https://example.com/repo/packages/rdma-core"
+        },
+        "sha256:990fde98d70a0a1a75bf55978f90138e8878a7f5cc1de475e03ee25b6744ee8a": {
+          "url": "https://example.com/repo/packages/python3-pyatspi"
+        },
+        "sha256:9ac51bbcd5be0f507237b2d43367ad073eaf99398a65d26fa2a8fee5275f889b": {
+          "url": "https://example.com/repo/packages/glibc-all-langpacks"
+        },
+        "sha256:9b31022b061856459fd20f63b7b37a0974bb812d47c4cac842a009b759ef19bd": {
+          "url": "https://example.com/repo/packages/prefixdevname"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a39d3ae3da34f2b4c01193e62202d5de0db79f800a039624b0f950734782b863": {
+          "url": "https://example.com/repo/packages/mtr"
+        },
+        "sha256:a744d93f2c6e8830a70b434113ecdebdaf568ba8c0557c63bd0914528760ae53": {
+          "url": "https://example.com/repo/packages/plymouth"
+        },
+        "sha256:a788847c8c115aa9ae27ca92230418e77b3b36a6424f1d4f3436633864c93db9": {
+          "url": "https://example.com/repo/packages/squashfs-tools"
+        },
+        "sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018": {
+          "url": "https://example.com/repo/packages/iwl3160-firmware"
+        },
+        "sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d": {
+          "url": "https://example.com/repo/packages/usbutils"
+        },
+        "sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a": {
+          "url": "https://example.com/repo/packages/udisks2"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:af17b5250a81ce5f2cc90c29b7d11bdc913f9abf7d61ecdc6995fe38650bfb14": {
+          "url": "https://example.com/repo/packages/sg3_utils"
+        },
+        "sha256:afed7d2fb0ea7b7e9d8dbcf1c1bb62ff53840c72d380cf165294a1eccb7fdeb1": {
+          "url": "https://example.com/repo/packages/rsyslog"
+        },
+        "sha256:b498cfb546ddbfbd5953e28137e5b39a65ba6c7220bf4fe4c3cc9bcafc73c41b": {
+          "url": "https://example.com/repo/packages/libblockdev-lvm-dbus"
+        },
+        "sha256:b7110cc6e76089686855ae923d8e0212a0f067b8a48f3c96e8510d50c56061a7": {
+          "url": "https://example.com/repo/packages/mdadm"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:b7f2141eed144d4380620b7f10620b310f168ebe9a5357d1e5cd98b79c9648be": {
+          "url": "https://example.com/repo/packages/rpcbind"
+        },
+        "sha256:b81f37a043a6f767e7c94d105f4bd31282f3ecc20680bb9d09bd93461cf4c863": {
+          "url": "https://example.com/repo/packages/audit"
+        },
+        "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf": {
+          "url": "https://example.com/repo/packages/vim-minimal"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bf079a7045b8c53dd15c009532e5f1c789260a8a2debb1eddd67ecf47712dde8": {
+          "url": "https://example.com/repo/packages/iwl2000-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0": {
+          "url": "https://example.com/repo/packages/iwl5000-firmware"
+        },
+        "sha256:c5c5b49ed7ea2ff99b6eb892df08b33bafc927a7712b7aaa942627531e0378d2": {
+          "url": "https://example.com/repo/packages/grub2-pc-modules"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c": {
+          "url": "https://example.com/repo/packages/ethtool"
+        },
+        "sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0": {
+          "url": "https://example.com/repo/packages/iwl1000-firmware"
+        },
+        "sha256:cb298bd94fae6f2f713a1108a16e0632f3a1e21820a288d7ea86c8b00a4d4fef": {
+          "url": "https://example.com/repo/packages/lsof"
+        },
+        "sha256:cb6b44243b93acef33a5ee905d92203a2a55abdc6a3b7c446c8435a41a6ad137": {
+          "url": "https://example.com/repo/packages/sil-padauk-fonts"
+        },
+        "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31": {
+          "url": "https://example.com/repo/packages/gdb-gdbserver"
+        },
+        "sha256:cd2c0f63ad37d585e77b3f1c584539e26bf7928710ac8fb19fd377f61b7326e6": {
+          "url": "https://example.com/repo/packages/anaconda"
+        },
+        "sha256:ce2b8ecf9afac9f546bdbbb0902afb6088fdcb8524269ad5b4adb9b9d4959b07": {
+          "url": "https://example.com/repo/packages/xfsdump"
+        },
+        "sha256:ce5b1962783aa6a9374a0a1b34941a112a799baac827c733bd28c78dbb4bcf36": {
+          "url": "https://example.com/repo/packages/kdump-anaconda-addon"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:cf51db7aa57c11cf84bbe5f58f73eb415d037cd000bcce129696331d9bddfc3c": {
+          "url": "https://example.com/repo/packages/cryptsetup"
+        },
+        "sha256:cf732696c9aebd80fad833157535754f246445ad0fec66e918963443bd3cfb71": {
+          "url": "https://example.com/repo/packages/linux-firmware"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d84be37f898e57d7de91b2062b2d5d8c53846fefb238d48b2bebaa3fdfeb4de9": {
+          "url": "https://example.com/repo/packages/iwl6000g2b-firmware"
+        },
+        "sha256:d87d9e526f265be973fce2ba320c5ed3ae24f6c5560d816d0b9307d0ba4d357f": {
+          "url": "https://example.com/repo/packages/lorax-templates-rhel"
+        },
+        "sha256:dad715e4ad49fa30f5a61dec5fcf18cfad20e349b90818913f99f163615266cd": {
+          "url": "https://example.com/repo/packages/lorax-templates-generic"
+        },
+        "sha256:db755438d5157104180d27e8f8e21478dc2700470e611d4fe646be7972cdcad9": {
+          "url": "https://example.com/repo/packages/openssh-clients"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d": {
+          "url": "https://example.com/repo/packages/grub2-tools"
+        },
+        "sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d": {
+          "url": "https://example.com/repo/packages/rpm-ostree"
+        },
+        "sha256:eddfc611c4f74bed09b2ac20b714b54f2e47d9befc7cc8af98b4c679807ba573": {
+          "url": "https://example.com/repo/packages/memtest86+"
+        },
+        "sha256:eeb3d09845f5cde069eeade2c4339532be58b6607120be00656123cc73ea727c": {
+          "url": "https://example.com/repo/packages/kbd-misc"
+        },
+        "sha256:f3a65c49b47eaa55e2413f4728317ab8b3a5019dc70f1f6ca66e838a77f4c078": {
+          "url": "https://example.com/repo/packages/biosdevname"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:f5f43514d2de810e4ea6d047203505e2e3c0c25f43941ec226968d17bb3aa1b5": {
+          "url": "https://example.com/repo/packages/gnome-kiosk"
+        },
+        "sha256:f6453ebfd8ab070567bfcd4cda99cc41c2c849237745f24228c5f040cac5d562": {
+          "url": "https://example.com/repo/packages/libibverbs"
+        },
+        "sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c": {
+          "url": "https://example.com/repo/packages/isomd5sum"
+        },
+        "sha256:f7f7a2e0133dfc81f9505bac28dfb7ee3398f3dc3b32c7682c86a9be5403bfee": {
+          "url": "https://example.com/repo/packages/librsvg2"
+        },
+        "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654": {
+          "url": "https://example.com/repo/packages/subscription-manager-cockpit"
+        },
+        "sha256:fbc15b96c51eaf5c099caa6a6658257c6f9a0a4c148ed907c564ad993079ac23": {
+          "url": "https://example.com/repo/packages/dracut-network"
+        },
+        "sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7": {
+          "url": "https://example.com/repo/packages/iwl7260-firmware"
+        },
+        "sha256:fe36b1d498f9c6057ed774ba5fb0a84c8592886c3a4c7c077ce7f41326373099": {
+          "url": "https://example.com/repo/packages/lldpad"
+        },
+        "sha256:ff288c563531a45d3e848ddc70320f148964ae93b088ebcafa67cd2a2f0b4d9a": {
+          "url": "https://example.com/repo/packages/syslinux"
+        }
+      }
+    },
+    "org.osbuild.inline": {
+      "items": {
+        "sha256:ca22d604790e8539428507743f646e9470b1fc9cd9b24723efcada93b4639434": {
+          "encoding": "base64",
+          "data": "JWluY2x1ZGUgL3J1bi9pbnN0YWxsL3JlcG8vb3NidWlsZC1iYXNlLmtzCgolcG9zdAplY2hvIC1lICIlc3Vkb1x0QUxMPShBTEwpXHROT1BBU1NXRDogQUxMIiA+ICIvZXRjL3N1ZG9lcnMuZC8lc3VkbyIKY2htb2QgMDQ0MCAvZXRjL3N1ZG9lcnMuZC8lc3VkbwplY2hvIC1lICIld2hlZWxcdEFMTD0oQUxMKVx0Tk9QQVNTV0Q6IEFMTCIgPiAiL2V0Yy9zdWRvZXJzLmQvJXdoZWVsIgpjaG1vZCAwNDQwIC9ldGMvc3Vkb2Vycy5kLyV3aGVlbApyZXN0b3JlY29uIC1ydkYgL2V0Yy9zdWRvZXJzLmQKJWVuZAo="
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-oci-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-oci-empty.json
@@ -19,13 +19,7 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
@@ -37,13 +31,7 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
-                },
-                {
-                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
                 },
                 {
                   "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
@@ -55,22 +43,10 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -146,12 +122,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-oci-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-oci-empty.json
@@ -1,0 +1,859 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "0aa0f845-9bc4-4be9-84f9-e53d80a0af13",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747"
+                },
+                {
+                  "id": "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280"
+                },
+                {
+                  "id": "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm",
+          "options": {
+            "dnf-plugins": {
+              "product-id": {
+                "enabled": false
+              },
+              "subscription-manager": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "0aa0f845-9bc4-4be9-84f9-e53d80a0af13",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "0aa0f845-9bc4-4be9-84f9-e53d80a0af13",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20557791,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "0aa0f845-9bc4-4be9-84f9-e53d80a0af13",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 20557791,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 20557791
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "qcow2",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.qcow2",
+            "format": {
+              "type": "qcow2",
+              "compat": "1.1"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98": {
+          "url": "https://example.com/repo/packages/exclude:fedora-repos"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b": {
+          "url": "https://example.com/repo/packages/exclude:udisks2"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747": {
+          "url": "https://example.com/repo/packages/exclude:fedora-release"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-en"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-*"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654": {
+          "url": "https://example.com/repo/packages/subscription-manager-cockpit"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ova-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ova-empty.json
@@ -1,0 +1,621 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "8c3888b5-a5f5-4419-9bf6-fcfbc562fdbb",
+            "kernel_opts": "ro"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:2ec46eb16ef55156c58b6348c9552f739a616fb6b4e22367486fe62442e3a9c4"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "8c3888b5-a5f5-4419-9bf6-fcfbc562fdbb",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "8c3888b5-a5f5-4419-9bf6-fcfbc562fdbb",
+            "kernel_opts": "ro",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "4294967296"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 7974879,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "8c3888b5-a5f5-4419-9bf6-fcfbc562fdbb",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 7974879,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 7974879
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "vmdk",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "image.vmdk",
+            "format": {
+              "type": "vmdk",
+              "subformat": "streamOptimized"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "ovf",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "vmdk-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:vmdk"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://vmdk-tree/image.vmdk",
+                "to": "tree:///"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.ovf",
+          "options": {
+            "vmdk": "image.vmdk"
+          }
+        }
+      ]
+    },
+    {
+      "name": "archive",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:ovf"
+              ]
+            }
+          },
+          "options": {
+            "filename": "image.ova",
+            "format": "ustar",
+            "paths": [
+              "image.ovf",
+              "image.mf",
+              "image.vmdk"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2ec46eb16ef55156c58b6348c9552f739a616fb6b4e22367486fe62442e3a9c4": {
+          "url": "https://example.com/repo/packages/open-vm-tools"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5": {
+          "url": "https://example.com/repo/packages/firewalld"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-ova-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-ova-empty.json
@@ -19,13 +19,7 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
@@ -37,28 +31,13 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
                 },
                 {
                   "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
                 },
                 {
-                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
-                },
-                {
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
@@ -68,9 +47,6 @@
                 },
                 {
                   "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -135,9 +111,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-qcow2-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-qcow2-empty.json
@@ -19,13 +19,7 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
@@ -37,13 +31,7 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
-                },
-                {
-                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
                 },
                 {
                   "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
@@ -55,22 +43,10 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -146,12 +122,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-qcow2-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-qcow2-empty.json
@@ -1,0 +1,859 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "c37bce61-e295-4653-b99a-0ecc69928758",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747"
+                },
+                {
+                  "id": "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280"
+                },
+                {
+                  "id": "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm",
+          "options": {
+            "dnf-plugins": {
+              "product-id": {
+                "enabled": false
+              },
+              "subscription-manager": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "c37bce61-e295-4653-b99a-0ecc69928758",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "c37bce61-e295-4653-b99a-0ecc69928758",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20557791,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "c37bce61-e295-4653-b99a-0ecc69928758",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 20557791,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 20557791
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "qcow2",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.qcow2",
+            "format": {
+              "type": "qcow2",
+              "compat": "1.1"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98": {
+          "url": "https://example.com/repo/packages/exclude:fedora-repos"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b": {
+          "url": "https://example.com/repo/packages/exclude:udisks2"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747": {
+          "url": "https://example.com/repo/packages/exclude:fedora-release"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-en"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-*"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654": {
+          "url": "https://example.com/repo/packages/subscription-manager-cockpit"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-qcow2-rhsm.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-qcow2-rhsm.json
@@ -19,13 +19,7 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
@@ -37,13 +31,7 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
-                },
-                {
-                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
                 },
                 {
                   "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
@@ -55,22 +43,10 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -146,12 +122,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-qcow2-rhsm.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-qcow2-rhsm.json
@@ -1,0 +1,867 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "8469a5fa-e64a-4582-8ba3-58db31046b3a",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc"
+                },
+                {
+                  "id": "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828"
+                },
+                {
+                  "id": "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf"
+                },
+                {
+                  "id": "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d"
+                },
+                {
+                  "id": "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901"
+                },
+                {
+                  "id": "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2"
+                },
+                {
+                  "id": "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee"
+                },
+                {
+                  "id": "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334"
+                },
+                {
+                  "id": "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747"
+                },
+                {
+                  "id": "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98"
+                },
+                {
+                  "id": "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280"
+                },
+                {
+                  "id": "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm",
+          "options": {
+            "dnf-plugins": {
+              "product-id": {
+                "enabled": true
+              },
+              "subscription-manager": {
+                "enabled": true
+              }
+            },
+            "subscription-manager": {
+              "rhsm": {
+                "manage_repos": true
+              },
+              "rhsmcertd": {
+                "auto_registration": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "8469a5fa-e64a-4582-8ba3-58db31046b3a",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "8469a5fa-e64a-4582-8ba3-58db31046b3a",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20557791,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "8469a5fa-e64a-4582-8ba3-58db31046b3a",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 20557791,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 20557791
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "qcow2",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.qcow2",
+            "format": {
+              "type": "qcow2",
+              "compat": "1.1"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98": {
+          "url": "https://example.com/repo/packages/exclude:fedora-repos"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b": {
+          "url": "https://example.com/repo/packages/exclude:udisks2"
+        },
+        "sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee": {
+          "url": "https://example.com/repo/packages/python3-jsonschema"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff": {
+          "url": "https://example.com/repo/packages/tcpdump"
+        },
+        "sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901": {
+          "url": "https://example.com/repo/packages/oddjob-mkhomedir"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d": {
+          "url": "https://example.com/repo/packages/oddjob"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334": {
+          "url": "https://example.com/repo/packages/redhat-release-eula"
+        },
+        "sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5": {
+          "url": "https://example.com/repo/packages/qemu-guest-agent"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747": {
+          "url": "https://example.com/repo/packages/exclude:fedora-release"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a37f7bf6d793ea95a78f44e78b1eb74b3d2dd302fdb092bfba1f2a3751352fb": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-en"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7": {
+          "url": "https://example.com/repo/packages/rsync"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2": {
+          "url": "https://example.com/repo/packages/psmisc"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828": {
+          "url": "https://example.com/repo/packages/cockpit-ws"
+        },
+        "sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280": {
+          "url": "https://example.com/repo/packages/exclude:langpacks-*"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6": {
+          "url": "https://example.com/repo/packages/dnf-utils"
+        },
+        "sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc": {
+          "url": "https://example.com/repo/packages/cockpit-system"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf": {
+          "url": "https://example.com/repo/packages/nfs-utils"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f6a50120d4a785cc75becb370680d24d452f1437c5064db8d22f510c75604a6d": {
+          "url": "https://example.com/repo/packages/exclude:firewalld"
+        },
+        "sha256:fad55872f0e26075082344da2db3418e620e1d82f740220c7f121e085d8fd654": {
+          "url": "https://example.com/repo/packages/subscription-manager-cockpit"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-tar-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-tar-empty.json
@@ -1,0 +1,227 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "archive",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "root.tar.xz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-tar-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-tar-empty.json
@@ -34,9 +34,6 @@
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
                 },
                 {
@@ -86,9 +83,6 @@
               "references": [
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-vhd-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-vhd-empty.json
@@ -1,0 +1,1122 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "332a358b-4a29-4f0a-866e-bf5dd2769513",
+            "kernel_opts": "ro loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221"
+                },
+                {
+                  "id": "sha256:563a278902fa76bae3ec1833f24ff89abe26329b1d32af9aaa924d6fc6fd68aa"
+                },
+                {
+                  "id": "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6"
+                },
+                {
+                  "id": "sha256:b6cae3a11438b4ec550ce10b73b35160fafbe9d436fdb4f81fea356fc5bb6fee"
+                },
+                {
+                  "id": "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:79a583014c5150aac3a44a025229af2918d16d3f6f32d005bf5786f693d6b893"
+                },
+                {
+                  "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:f48860f2daf7e7a03ab9827300ab91c865d446de1c12a279339a2fff75c00f4e"
+                },
+                {
+                  "id": "sha256:229b391b136444fc29f0a5b3a897222f8ff4ed2277427e68eeb13fccfe39905c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc"
+                },
+                {
+                  "id": "sha256:8e57cbb02cd20f0e373ae76a44d7ddd0125fe449db5dfc196b0920ef47ced56e"
+                },
+                {
+                  "id": "sha256:a4895eb44afc336fecbba6e520cd67e178dace0276655d102fceffa8e5f70570"
+                },
+                {
+                  "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:75666699b77db631f576041e8102a55b46758c01b807eacae0f170930ab59b3d"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694"
+                },
+                {
+                  "id": "sha256:01fdad2e9ee0a69f7e323ddb4258e2b0dbfaa242a21d7a8bfdfec04ebe8d3e86"
+                },
+                {
+                  "id": "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8"
+                },
+                {
+                  "id": "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6"
+                },
+                {
+                  "id": "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127"
+                },
+                {
+                  "id": "sha256:81f29ed6c790aa976572770ecf7b6f0351da3c46c9558640c7a83896b6bf8e05"
+                },
+                {
+                  "id": "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8"
+                },
+                {
+                  "id": "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a"
+                },
+                {
+                  "id": "sha256:534994290b3914604921fc2c61852b7bb4c4d8fb947f057a6fb38a3a57835d9a"
+                },
+                {
+                  "id": "sha256:0ee8cf7e33852f80cd293a8fa8c371f888dc011984ff2836f1198bcdc552dc58"
+                },
+                {
+                  "id": "sha256:5f1e4685c9b4d243264d22fa24864335aab534815fcfe6c3a88eec83ee22354f"
+                },
+                {
+                  "id": "sha256:f3e607ceb5fd279c62a109d1bbb952cc44d7467266ef679a99fd0d9c02ce8d29"
+                },
+                {
+                  "id": "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:7913d978541704fb38f5f13a949811c80ed4a52b2514d4582fe3ccb8f5a04617"
+                },
+                {
+                  "id": "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939"
+                },
+                {
+                  "id": "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2"
+                },
+                {
+                  "id": "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974"
+                },
+                {
+                  "id": "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2"
+                },
+                {
+                  "id": "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27"
+                },
+                {
+                  "id": "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71"
+                },
+                {
+                  "id": "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0"
+                },
+                {
+                  "id": "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7"
+                },
+                {
+                  "id": "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3"
+                },
+                {
+                  "id": "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269"
+                },
+                {
+                  "id": "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1"
+                },
+                {
+                  "id": "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e"
+                },
+                {
+                  "id": "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c"
+                },
+                {
+                  "id": "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79"
+                },
+                {
+                  "id": "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39"
+                },
+                {
+                  "id": "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6"
+                },
+                {
+                  "id": "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5"
+                },
+                {
+                  "id": "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8"
+                },
+                {
+                  "id": "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682"
+                },
+                {
+                  "id": "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b"
+                },
+                {
+                  "id": "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933"
+                },
+                {
+                  "id": "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d"
+                },
+                {
+                  "id": "sha256:a76985e9146fec1e9fb00cc08d5e0a76eb7f47c10a7abbc4430f8ac235a8b1cd"
+                },
+                {
+                  "id": "sha256:141b56438fdc0208877397569000e1a5857ff57807ff3bbaf2622cc87901861d"
+                },
+                {
+                  "id": "sha256:725c887b1ebcd6be8eb9a0ef6b2c476ff6d2dd8f9cf622f8d60953a1f22c94c8"
+                },
+                {
+                  "id": "sha256:53d00356d82e89cbdf0f963060c58433f73e0b339ba9f63577bd7df44f78e051"
+                },
+                {
+                  "id": "sha256:f1d96d150523777accb14a93582922ded22aa868629c58c3cd49339952293327"
+                },
+                {
+                  "id": "sha256:840109e45bc2504c9f202410bd941dc430bcef1065e1c1a98e5d08506c0c91af"
+                },
+                {
+                  "id": "sha256:b1eb4c41592e8eb6f7f2c96cdda2162fe214f52f85b01e9b174aa81bf297e01a"
+                },
+                {
+                  "id": "sha256:590ef3ccd31b243b045e9c5f9268d1013b0960060366c76028a23b070b5fb7be"
+                },
+                {
+                  "id": "sha256:9fe43931a7b645b90921b9b72d836e9d06ececc0b3cca1376fa0a297b5f522a5"
+                },
+                {
+                  "id": "sha256:49ec7b34785f32ffd1f252d5cc9a0a015ca074f75c601d2272149a72d50d42df"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ],
+            "gpgkeys.fromtree": [
+              "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.keymap",
+          "options": {
+            "keymap": "us",
+            "x11-keymap": {
+              "layouts": [
+                "us"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel-core"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "10-azure-kvp.cfg",
+            "config": {
+              "reporting": {
+                "logging": {
+                  "type": "log"
+                },
+                "telemetry": {
+                  "type": "hyperv"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.cloud-init",
+          "options": {
+            "filename": "91-azure_datasource.cfg",
+            "config": {
+              "datasource": {
+                "Azure": {
+                  "apply_network_config": false
+                }
+              },
+              "datasource_list": [
+                "Azure"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-amdgpu.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "amdgpu"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-intel-cstate.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "intel_cstate"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-floppy.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "floppy"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-nouveau.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              },
+              {
+                "command": "blacklist",
+                "modulename": "lbm-nouveau"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.modprobe",
+          "options": {
+            "filename": "blacklist-skylake-edac.conf",
+            "commands": [
+              {
+                "command": "blacklist",
+                "modulename": "skx_edac"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit",
+          "options": {
+            "unit": "nm-cloud-setup.service",
+            "dropin": "10-rh-enable-for-azure.conf",
+            "config": {
+              "Service": {
+                "Environment": [
+                  {
+                    "key": "NM_CLOUD_SETUP_AZURE",
+                    "value": "yes"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.sshd.config",
+          "options": {
+            "config": {
+              "ClientAliveInterval": 180
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.pwquality.conf",
+          "options": {
+            "config": {
+              "minlen": 6,
+              "dcredit": 0,
+              "ucredit": 0,
+              "lcredit": 0,
+              "ocredit": 0,
+              "minclass": 3
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.waagent.conf",
+          "options": {
+            "config": {
+              "ResourceDisk.Format": false,
+              "ResourceDisk.EnableSwap": false
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.udev.rules",
+          "options": {
+            "filename": "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules",
+            "rules": [
+              {
+                "comment": [
+                  "Accelerated Networking on Azure exposes a new SRIOV interface to the VM.",
+                  "This interface is transparently bonded to the synthetic interface,",
+                  "so NetworkManager should just ignore any SRIOV interfaces."
+                ]
+              },
+              [
+                {
+                  "key": "SUBSYSTEM",
+                  "op": "==",
+                  "val": "net"
+                },
+                {
+                  "key": "DRIVERS",
+                  "op": "==",
+                  "val": "hv_pci"
+                },
+                {
+                  "key": "ACTION",
+                  "op": "==",
+                  "val": "add"
+                },
+                {
+                  "key": {
+                    "name": "ENV",
+                    "arg": "NM_UNMANAGED"
+                  },
+                  "op": "=",
+                  "val": "1"
+                }
+              ]
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "332a358b-4a29-4f0a-866e-bf5dd2769513",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "332a358b-4a29-4f0a-866e-bf5dd2769513",
+            "kernel_opts": "ro loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved",
+              "disable_recovery": true,
+              "disable_submenu": true,
+              "distributor": "$(sed 's, release .*$,,g' /etc/system-release)",
+              "terminal": [
+                "serial",
+                "console"
+              ],
+              "timeout": 10,
+              "timeout_style": "countdown",
+              "serial": "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "firewalld",
+              "nm-cloud-setup.service",
+              "nm-cloud-setup.timer",
+              "sshd",
+              "waagent"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "4294967296"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 7974879,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "332a358b-4a29-4f0a-866e-bf5dd2769513",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 7974879,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 7974879
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "vpc",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.vhd",
+            "format": {
+              "type": "vpc"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:01fdad2e9ee0a69f7e323ddb4258e2b0dbfaa242a21d7a8bfdfec04ebe8d3e86": {
+          "url": "https://example.com/repo/packages/exclude:NetworkManager-config-server"
+        },
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3": {
+          "url": "https://example.com/repo/packages/exclude:iwl3160-firmware"
+        },
+        "sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3": {
+          "url": "https://example.com/repo/packages/bzip2"
+        },
+        "sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2": {
+          "url": "https://example.com/repo/packages/exclude:ivtv-firmware"
+        },
+        "sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2a-firmware"
+        },
+        "sha256:0ee8cf7e33852f80cd293a8fa8c371f888dc011984ff2836f1198bcdc552dc58": {
+          "url": "https://example.com/repo/packages/exclude:buildah"
+        },
+        "sha256:141b56438fdc0208877397569000e1a5857ff57807ff3bbaf2622cc87901861d": {
+          "url": "https://example.com/repo/packages/exclude:python3-dnf-plugin-spacewalk"
+        },
+        "sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71": {
+          "url": "https://example.com/repo/packages/exclude:iwl135-firmware"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:229b391b136444fc29f0a5b3a897222f8ff4ed2277427e68eeb13fccfe39905c": {
+          "url": "https://example.com/repo/packages/kernel-modules"
+        },
+        "sha256:28fc95b01c3d432a448ded25eb5aada86e12319fcb912666f67dd5eb97893933": {
+          "url": "https://example.com/repo/packages/exclude:libertas-usb8388-firmware"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d": {
+          "url": "https://example.com/repo/packages/exclude:plymouth"
+        },
+        "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9": {
+          "url": "https://example.com/repo/packages/rng-tools"
+        },
+        "sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8": {
+          "url": "https://example.com/repo/packages/exclude:iwl7260-firmware"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27": {
+          "url": "https://example.com/repo/packages/exclude:iwl105-firmware"
+        },
+        "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b": {
+          "url": "https://example.com/repo/packages/python3-pyyaml"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:49ec7b34785f32ffd1f252d5cc9a0a015ca074f75c601d2272149a72d50d42df": {
+          "url": "https://example.com/repo/packages/exclude:usb_modeswitch"
+        },
+        "sha256:4d0e0adebe4eb01e6db63dcdade819e617dc3c9dc412f2b08fed35ae421f8682": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8686-firmware"
+        },
+        "sha256:4e81068e88aa80ce2e9bea996a7f9e02244d06eef15c97e72ebb75b22c3ebfc5": {
+          "url": "https://example.com/repo/packages/exclude:iwl6050-firmware"
+        },
+        "sha256:4eeb0ed8c3fbd5ac0b9a9800a8cc1347f80f14bb505b0df58aefd000f978b269": {
+          "url": "https://example.com/repo/packages/exclude:iwl3945-firmware"
+        },
+        "sha256:534994290b3914604921fc2c61852b7bb4c4d8fb947f057a6fb38a3a57835d9a": {
+          "url": "https://example.com/repo/packages/exclude:bolt"
+        },
+        "sha256:53d00356d82e89cbdf0f963060c58433f73e0b339ba9f63577bd7df44f78e051": {
+          "url": "https://example.com/repo/packages/exclude:python3-rhnlib"
+        },
+        "sha256:563a278902fa76bae3ec1833f24ff89abe26329b1d32af9aaa924d6fc6fd68aa": {
+          "url": "https://example.com/repo/packages/NetworkManager"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:590ef3ccd31b243b045e9c5f9268d1013b0960060366c76028a23b070b5fb7be": {
+          "url": "https://example.com/repo/packages/exclude:rhnlib"
+        },
+        "sha256:5ac0b916a6d093edc6b702b25864007a7746a1b737c882d5a8a6d1644d731e79": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000-firmware"
+        },
+        "sha256:5b1e08d9dde2b42e638ce3f27ebfeaf4ab4c6ccded49d48ea60382d290cd90f6": {
+          "url": "https://example.com/repo/packages/exclude:alsa-firmware"
+        },
+        "sha256:5f1e4685c9b4d243264d22fa24864335aab534815fcfe6c3a88eec83ee22354f": {
+          "url": "https://example.com/repo/packages/exclude:cockpit-podman"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245": {
+          "url": "https://example.com/repo/packages/insights-client"
+        },
+        "sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221": {
+          "url": "https://example.com/repo/packages/@Server"
+        },
+        "sha256:725c887b1ebcd6be8eb9a0ef6b2c476ff6d2dd8f9cf622f8d60953a1f22c94c8": {
+          "url": "https://example.com/repo/packages/exclude:python3-hwdata"
+        },
+        "sha256:75666699b77db631f576041e8102a55b46758c01b807eacae0f170930ab59b3d": {
+          "url": "https://example.com/repo/packages/uuid"
+        },
+        "sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1": {
+          "url": "https://example.com/repo/packages/exclude:iwl4965-firmware"
+        },
+        "sha256:7913d978541704fb38f5f13a949811c80ed4a52b2514d4582fe3ccb8f5a04617": {
+          "url": "https://example.com/repo/packages/exclude:glibc-all-langpacks"
+        },
+        "sha256:79a583014c5150aac3a44a025229af2918d16d3f6f32d005bf5786f693d6b893": {
+          "url": "https://example.com/repo/packages/hyperv-daemons"
+        },
+        "sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876": {
+          "url": "https://example.com/repo/packages/exclude:dnf-plugin-spacewalk"
+        },
+        "sha256:81f29ed6c790aa976572770ecf7b6f0351da3c46c9558640c7a83896b6bf8e05": {
+          "url": "https://example.com/repo/packages/exclude:alsa-sof-firmware"
+        },
+        "sha256:840109e45bc2504c9f202410bd941dc430bcef1065e1c1a98e5d08506c0c91af": {
+          "url": "https://example.com/repo/packages/exclude:rhn-client-tools"
+        },
+        "sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0": {
+          "url": "https://example.com/repo/packages/exclude:iwl2000-firmware"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8e57cbb02cd20f0e373ae76a44d7ddd0125fe449db5dfc196b0920ef47ced56e": {
+          "url": "https://example.com/repo/packages/nvme-cli"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:99fec328617e9bc972503d5ed4c4c93218a8c44649cdc875876fdfbba0be383a": {
+          "url": "https://example.com/repo/packages/exclude:biosdevname"
+        },
+        "sha256:9a701ca1bcd3b07afca9ae5f17588a2048341e0bcdab2b5a81e10614d5ca2974": {
+          "url": "https://example.com/repo/packages/exclude:iwl100-firmware"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:9fe43931a7b645b90921b9b72d836e9d06ececc0b3cca1376fa0a297b5f522a5": {
+          "url": "https://example.com/repo/packages/exclude:rhnsd"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:a2e58f805ca848eb1fb0fb207656d11b77a96ab198244c8e7a3fa49ddc5aade6": {
+          "url": "https://example.com/repo/packages/exclude:iwl6000g2b-firmware"
+        },
+        "sha256:a2f5883db78735971fd620c3e83fb7767bda931555991194501eea3533e879e8": {
+          "url": "https://example.com/repo/packages/exclude:aic94xx-firmware"
+        },
+        "sha256:a4895eb44afc336fecbba6e520cd67e178dace0276655d102fceffa8e5f70570": {
+          "url": "https://example.com/repo/packages/patch"
+        },
+        "sha256:a76985e9146fec1e9fb00cc08d5e0a76eb7f47c10a7abbc4430f8ac235a8b1cd": {
+          "url": "https://example.com/repo/packages/exclude:podman"
+        },
+        "sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f": {
+          "url": "https://example.com/repo/packages/cloud-utils-growpart"
+        },
+        "sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7": {
+          "url": "https://example.com/repo/packages/exclude:iwl2030-firmware"
+        },
+        "sha256:b1eb4c41592e8eb6f7f2c96cdda2162fe214f52f85b01e9b174aa81bf297e01a": {
+          "url": "https://example.com/repo/packages/exclude:rhn-setup"
+        },
+        "sha256:b6cae3a11438b4ec550ce10b73b35160fafbe9d436fdb4f81fea356fc5bb6fee": {
+          "url": "https://example.com/repo/packages/WALinuxAgent"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c": {
+          "url": "https://example.com/repo/packages/exclude:iwl5150-firmware"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e": {
+          "url": "https://example.com/repo/packages/exclude:iwl5000-firmware"
+        },
+        "sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b": {
+          "url": "https://example.com/repo/packages/exclude:libertas-sd8787-firmware"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:dc326a13b89447ad3251f78a5bd784808b85c64bc4fd380d2e9533ffa00428e2": {
+          "url": "https://example.com/repo/packages/exclude:iwl1000-firmware"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:eda2b1be19a5062fa55b669761df806f9aa4675223ed3cc9cce6eceaf0677939": {
+          "url": "https://example.com/repo/packages/exclude:iprutils"
+        },
+        "sha256:f1d96d150523777accb14a93582922ded22aa868629c58c3cd49339952293327": {
+          "url": "https://example.com/repo/packages/exclude:rhn-check"
+        },
+        "sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127": {
+          "url": "https://example.com/repo/packages/exclude:alsa-lib"
+        },
+        "sha256:f3e607ceb5fd279c62a109d1bbb952cc44d7467266ef679a99fd0d9c02ce8d29": {
+          "url": "https://example.com/repo/packages/exclude:containernetworking-plugins"
+        },
+        "sha256:f48860f2daf7e7a03ab9827300ab91c865d446de1c12a279339a2fff75c00f4e": {
+          "url": "https://example.com/repo/packages/kernel-core"
+        },
+        "sha256:f4dc4ad92c4e57553b004ecd08561dd6b15d5dc7d99869c499544a890f18eddc": {
+          "url": "https://example.com/repo/packages/lvm2"
+        },
+        "sha256:fc710b8c27f067288ccb7779e98f7b04e7e0c84256260c93a69f68ad94b78fd8": {
+          "url": "https://example.com/repo/packages/exclude:alsa-tools-firmware"
+        },
+        "sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6": {
+          "url": "https://example.com/repo/packages/NetworkManager-cloud-setup"
+        },
+        "sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694": {
+          "url": "https://example.com/repo/packages/yum-utils"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-vhd-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-vhd-empty.json
@@ -19,13 +19,7 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
-                },
-                {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
@@ -37,13 +31,7 @@
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
-                },
-                {
                   "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
-                },
-                {
-                  "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
                 },
                 {
                   "id": "sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b"
@@ -55,22 +43,10 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -151,15 +127,6 @@
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
-                },
-                {
-                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
-                },
-                {
                   "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
                 },
                 {
@@ -173,9 +140,6 @@
                 },
                 {
                   "id": "sha256:69a9176ea7cf541c2ae178ff9980fffbb29857c902d27c791233d4a48545c245"
-                },
-                {
-                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
                 },
                 {
                   "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
@@ -200,9 +164,6 @@
                 },
                 {
                   "id": "sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-vmdk-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-vmdk-empty.json
@@ -1,0 +1,552 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "8c448f91-2555-48c2-8502-9bc99431f060",
+            "kernel_opts": "ro"
+          }
+        },
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a"
+                },
+                {
+                  "id": "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe"
+                },
+                {
+                  "id": "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942"
+                },
+                {
+                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
+                },
+                {
+                  "id": "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d"
+                },
+                {
+                  "id": "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5"
+                },
+                {
+                  "id": "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4"
+                },
+                {
+                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
+                },
+                {
+                  "id": "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:2ec46eb16ef55156c58b6348c9552f739a616fb6b4e22367486fe62442e3a9c4"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253"
+                },
+                {
+                  "id": "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb"
+                },
+                {
+                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
+                },
+                {
+                  "id": "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34"
+                },
+                {
+                  "id": "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "8c448f91-2555-48c2-8502-9bc99431f060",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "8c448f91-2555-48c2-8502-9bc99431f060",
+            "kernel_opts": "ro",
+            "legacy": "i386-pc",
+            "uefi": {
+              "vendor": "redhat",
+              "unified": true
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64",
+            "write_cmdline": false,
+            "config": {
+              "default": "saved"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "4294967296"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 409600,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 7974879,
+                "start": 413696,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "8c448f91-2555-48c2-8502-9bc99431f060",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 7974879,
+                "lock": true
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://-/"
+              }
+            ]
+          },
+          "devices": {
+            "-": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 413696,
+                "size": 7974879
+              }
+            },
+            "boot-efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 409600
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "-",
+              "type": "org.osbuild.xfs",
+              "source": "-",
+              "target": "/"
+            },
+            {
+              "name": "boot-efi",
+              "type": "org.osbuild.fat",
+              "source": "boot-efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "vmdk",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "disk.img"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "disk.vmdk",
+            "format": {
+              "type": "vmdk",
+              "subformat": "streamOptimized"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15": {
+          "url": "https://example.com/repo/packages/dosfstools"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49": {
+          "url": "https://example.com/repo/packages/xfsprogs"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:2ec46eb16ef55156c58b6348c9552f739a616fb6b4e22367486fe62442e3a9c4": {
+          "url": "https://example.com/repo/packages/open-vm-tools"
+        },
+        "sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c": {
+          "url": "https://example.com/repo/packages/qemu-img"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942": {
+          "url": "https://example.com/repo/packages/cloud-init"
+        },
+        "sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a": {
+          "url": "https://example.com/repo/packages/@core"
+        },
+        "sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34": {
+          "url": "https://example.com/repo/packages/exclude:dracut-config-rescue"
+        },
+        "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00": {
+          "url": "https://example.com/repo/packages/dracut-config-generic"
+        },
+        "sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe": {
+          "url": "https://example.com/repo/packages/chrony"
+        },
+        "sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c": {
+          "url": "https://example.com/repo/packages/kernel"
+        },
+        "sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5": {
+          "url": "https://example.com/repo/packages/firewalld"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253": {
+          "url": "https://example.com/repo/packages/shim-x64"
+        },
+        "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700": {
+          "url": "https://example.com/repo/packages/policycoreutils"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5": {
+          "url": "https://example.com/repo/packages/grub2-pc"
+        },
+        "sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb": {
+          "url": "https://example.com/repo/packages/tuned"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4": {
+          "url": "https://example.com/repo/packages/grub2-efi-x64"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d": {
+          "url": "https://example.com/repo/packages/efibootmgr"
+        },
+        "sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62": {
+          "url": "https://example.com/repo/packages/exclude:rng-tools"
+        }
+      }
+    }
+  }
+}

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-vmdk-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-vmdk-empty.json
@@ -19,22 +19,13 @@
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
                 },
                 {
-                  "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
                   "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
                 },
                 {
                   "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
                 },
                 {
-                  "id": "sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5"
-                },
-                {
                   "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
-                },
-                {
-                  "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
                 },
                 {
                   "id": "sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700"
@@ -49,22 +40,10 @@
                   "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
                 },
                 {
-                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
-                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
-                },
-                {
                   "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
                 },
                 {
                   "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
-                },
-                {
-                  "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
                 },
                 {
                   "id": "sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49"
@@ -128,9 +107,6 @@
                 },
                 {
                   "id": "sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15"
-                },
-                {
-                  "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"
                 },
                 {
                   "id": "sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00"

--- a/test/data/manifestdb-light/rhel_10.0-x86_64-wsl-empty.json
+++ b/test/data/manifestdb-light/rhel_10.0-x86_64-wsl-empty.json
@@ -1,0 +1,481 @@
+{
+  "version": "2",
+  "pipelines": [
+    {
+      "name": "build",
+      "runner": "org.osbuild.rhel100",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0"
+                },
+                {
+                  "id": "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d"
+                },
+                {
+                  "id": "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+            "labels": {
+              "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+              "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "os",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.rpm",
+          "inputs": {
+            "packages": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.source",
+              "references": [
+                {
+                  "id": "sha256:8a1eb106427026fd9f7daef2fbed09db45de687c264480f8d3945ff13bdd9fe6"
+                },
+                {
+                  "id": "sha256:8308da3588987ace3967a2eee85a70f8be6eca16320b1e235b636e1464bbad06"
+                },
+                {
+                  "id": "sha256:4f7872f3a4c4decf34923a48986e52563d2a58bc3225b1890b84b52e7defce09"
+                },
+                {
+                  "id": "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2"
+                },
+                {
+                  "id": "sha256:97e86df4b9e1385f56f5635f227cc75e5a59147a8d06d05d0c08241d7204a92d"
+                },
+                {
+                  "id": "sha256:839f835e4d4558140e9b92fd85c3f923b74b6220ba1ad86b9fe096b8b6305b86"
+                },
+                {
+                  "id": "sha256:1a36b318995f3383dfa35c283df090bde63776c52415a421ea201a9667f95ab3"
+                },
+                {
+                  "id": "sha256:32dcd32054ee4e9ae92eec040bc1385c94d74a0846bb0145b1bdf9958740200a"
+                },
+                {
+                  "id": "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa"
+                },
+                {
+                  "id": "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1"
+                },
+                {
+                  "id": "sha256:cbf61858f3260072d96d9b1d2e037fc35824944b9c94d0087b1a53385eccaead"
+                },
+                {
+                  "id": "sha256:5b0440b2a1ceb2db43e1832c91f96728c5fe59a1cd7b5d1f1b905bb0b2df3841"
+                },
+                {
+                  "id": "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31"
+                },
+                {
+                  "id": "sha256:f6fad119f40a1aae00b54c0de6a0fa24a1e35d4bf1284bffcfd7134bdbb837e1"
+                },
+                {
+                  "id": "sha256:cc0bbbee7c9dd4f3f30e01c7f1fcbeb839f30c47e3bcbf16db0d37789262cbb4"
+                },
+                {
+                  "id": "sha256:aa6d4532f128420f4d741f2834cd8d1d146bbbdc9554aef454b7adb8ff66f748"
+                },
+                {
+                  "id": "sha256:f8f6228d89c3de21a136641a6d66f8a393db4b9019b17e0bec92ffc88b393eb4"
+                },
+                {
+                  "id": "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682"
+                },
+                {
+                  "id": "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053"
+                },
+                {
+                  "id": "sha256:cfd4affb5ed7a688870bb3725e10cc066e63b2a94b5dd491cac681a3c2b17ca5"
+                },
+                {
+                  "id": "sha256:41ffca929b95c49690ab8815d1d1a134a5bcdd86bde407c0f46b90eabf556b05"
+                },
+                {
+                  "id": "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3"
+                },
+                {
+                  "id": "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb"
+                },
+                {
+                  "id": "sha256:5b0513b8ca5a7f03601efc10934409d271890e6ae7a3264445e7397233eac6f8"
+                },
+                {
+                  "id": "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d"
+                },
+                {
+                  "id": "sha256:87f1c82f3d3b66f168e0673e4f4227a8a3fe53000bf342780424ee8e3344d591"
+                },
+                {
+                  "id": "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca"
+                },
+                {
+                  "id": "sha256:e422e1641a99c5a045bc0b596ef5ce6429c8e7744f016444cedacd4eaf5d3e4c"
+                },
+                {
+                  "id": "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88"
+                },
+                {
+                  "id": "sha256:5f53b0a2be22e28dc4b056f663910c046a33f9b2d779eaf997ea771fe1881a13"
+                },
+                {
+                  "id": "sha256:8fb6d5f37e8055ce720bd0b1d56587f88c0071f285966ba17e72b2b12672aa73"
+                },
+                {
+                  "id": "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1"
+                },
+                {
+                  "id": "sha256:0652d77991ae054286ace9807d7b4b573b99e3be9be7ad126db8d197b5f22a68"
+                },
+                {
+                  "id": "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98"
+                },
+                {
+                  "id": "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb"
+                },
+                {
+                  "id": "sha256:ae5e2ad3b86239dbf500c630cf88d33d9775e9ce2e32d596910a07d682d97923"
+                },
+                {
+                  "id": "sha256:572d4fe95e2cfd3425b70544a829f39104cad64fb57cdc63a25f9e837fb79917"
+                },
+                {
+                  "id": "sha256:f486d76df6f0ea41b7d6acb72751d8eb4cc2a3f04e6273154fef5e76cab27e11"
+                },
+                {
+                  "id": "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf"
+                },
+                {
+                  "id": "sha256:809c2fb94fff223e96477a875bbc1b77e5b020262e8f959d4b49455100a7f9f7"
+                },
+                {
+                  "id": "sha256:6fd624e2ceb4409a98b06f7f6161a6259cc88a838b6f43454217ed5a0c18a547"
+                },
+                {
+                  "id": "sha256:2692c08277f40048982432ab907ab870ee677f69656d9a71a6f889cf03531eb4"
+                },
+                {
+                  "id": "sha256:a697ff6e769b4f3d7c9b05d77c96d575c5e001ef923a13395decbe00b7e461bb"
+                },
+                {
+                  "id": "sha256:7cb8f52fafc3465bc88412019948f599fa1217927861c07ac3f90628772efa55"
+                },
+                {
+                  "id": "sha256:10d1e54c16c491abf59ec796854ffa14563d54461ebb9092501da34f5a9184bc"
+                },
+                {
+                  "id": "sha256:c06dba625e4dfb0b49cb4013c2a82c8f314143c833c1306da12fa2d77a12e0c4"
+                },
+                {
+                  "id": "sha256:60e3d9a99e40010bb917f75d9ce99530d1f8b322d0b1aea07fe71257a369d943"
+                },
+                {
+                  "id": "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51"
+                },
+                {
+                  "id": "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d"
+                }
+              ]
+            }
+          },
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIpIp4BEAC/o5e1WzLIsS6/JOQCs4XYATYTcf6B6ALzcP05G0W3uRpUQSrL\nFRKNrU8ZCelm/B+XSh2ljJNeklp2WLxYENDOsftDXGoyLr2hEkI5OyK267IHhFNJ\ng+BN+T5Cjh4ZiiWij6o9F7x2ZpxISE9M4iI80rwSv1KOnGSw5j2zD2EwoMjTVyVE\n/t3s5XJxnDclB7ZqL+cgjv0mWUY/4+b/OoRTkhq7b8QILuZp75Y64pkrndgakm1T\n8mAGXV02mEzpNj9DyAJdUqa11PIhMJMxxHOGHJ8CcHZ2NJL2e7yJf4orTj+cMhP5\nLzJcVlaXnQYu8Zkqa0V6J1Qdj8ZXL72QsmyicRYXAtK9Jm5pvBHuYU2m6Ja7dBEB\nVkhe7lTKhAjkZC5ErPmANNS9kPdtXCOpwN1lOnmD2m04hks3kpH9OTX7RkTFUSws\neARAfRID6RLfi59B9lmAbekecnsMIFMx7qR7ZKyQb3GOuZwNYOaYFevuxusSwCHv\n4FtLDIhk+Fge+EbPdEva+VLJeMOb02gC4V/cX/oFoPkxM1A5LHjkuAM+aFLAiIRd\nNp/tAPWk1k6yc+FqkcDqOttbP4ciiXb9JPtmzTCbJD8lgH0rGp8ufyMXC9x7/dqX\nTjsiGzyvlMnrkKB4GL4DqRFl8LAR02A3846DD8CAcaxoXggL2bJCU2rgUQARAQAB\ntDVSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5IDMpIDxzZWN1cml0eUByZWRo\nYXQuY29tPokCUgQTAQgAPBYhBH5GJCWMQGU11W1vE1BU5KRaY0CzBQJiKSKeAhsD\nBQsJCAcCAyICAQYVCgkICwIEFgIDAQIeBwIXgAAKCRBQVOSkWmNAsyBfEACuTN/X\nYR+QyzeRw0pXcTvMqzNE4DKKr97hSQEwZH1/v1PEPs5O3psuVUm2iam7bqYwG+ry\nEskAgMHi8AJmY0lioQD5/LTSLTrM8UyQnU3g17DHau1NHIFTGyaW4a7xviU4C2+k\nc6X0u1CPHI1U4Q8prpNcfLsldaNYlsVZtUtYSHKPAUcswXWliW7QYjZ5tMSbu8jR\nOMOc3mZuf0fcVFNu8+XSpN7qLhRNcPv+FCNmk/wkaQfH4Pv+jVsOgHqkV3aLqJeN\nkNUnpyEKYkNqo7mNfNVWOcl+Z1KKKwSkIi3vg8maC7rODsy6IX+Y96M93sqYDQom\naaWue2gvw6thEoH4SaCrCL78mj2YFpeg1Oew4QwVcBnt68KOPfL9YyoOicNs4Vuu\nfb/vjU2ONPZAeepIKA8QxCETiryCcP43daqThvIgdbUIiWne3gae6eSj0EuUPoYe\nH5g2Lw0qdwbHIOxqp2kvN96Ii7s1DK3VyhMt/GSPCxRnDRJ8oQKJ2W/I1IT5VtiU\nzMjjq5JcYzRPzHDxfVzT9CLeU/0XQ+2OOUAiZKZ0dzSyyVn8xbpviT7iadvjlQX3\nCINaPB+d2Kxa6uFWh+ZYOLLAgZ9B8NKutUHpXN66YSfe79xFBSFWKkJ8cSIMk13/\nIfs7ApKlKCCRDpwoDqx/sjIaj1cpOfLHYjnefg==\n=UZd/\n-----END PGP PUBLIC KEY BLOCK-----",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwEIACACGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAUCSuBJPAAK\nCRAZni+R/UMdUfIkD/9m3HWv07uJG26R3KBexTo2FFu3rmZs+m2nfW8R3dBX+k0o\nAOFpgJCsNgKwU81LOPrkMN19G0+Yn/ZTCDD7cIQ7dhYuDyEX97xh4une/EhnnRuh\nASzR+1xYbj/HcYZIL9kbslgpebMn+AhxbUTQF/mziug3hLidR9Bzvygq0Q09E11c\nOZL4BU6J2HqxL+9m2F+tnLdfhL7MsAq9nbmWAOpkbGefc5SXBSq0sWfwoes3X3yD\nQ8B5Xqr9AxABU7oUB+wRqvY69ZCxi/BhuuJCUxY89ZmwXfkVxeHl1tYfROUwOnJO\nGYSbI/o41KBK4DkIiDcT7QqvqvCyudnxZdBjL2QU6OrIJvWmKs319qSF9m3mXRSt\nZzWtB89Pj5LZ6cdtuHvW9GO4qSoBLmAfB313pGkbgi1DE6tqCLHlA0yQ8zv99OWV\ncMDGmS7tVTZqfX1xQJ0N3bNORQNtikJC3G+zBCJzIeZleeDlMDQcww00yWU1oE7/\nTo2UmykMGc7o9iggFWR2g0PIcKsA/SXdRKWPqCHG2uKHBvdRTQGupdXQ1sbV+AHw\nycyA/9H/mp/NUSNM2cqnBDcZ6GhlHt59zWtEveiuU5fpTbp4GVcFXbW8jStj8j8z\n1HI3cywZO8+YNPzqyx0JWsidXGkfzkPHyS4jTG84lfu2JG8m/nqLnRSeKpl20Q==\n=79bX\n-----END PGP PUBLIC KEY BLOCK-----"
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "type": "org.osbuild.locale",
+          "options": {
+            "language": "C.UTF-8"
+          }
+        },
+        {
+          "type": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "type": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.rhsm.facts",
+          "options": {
+            "facts": {
+              "image-builder.osbuild-composer.api-type": "test-manifest"
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.wsl.conf",
+          "options": {
+            "boot": {
+              "systemd": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "archive",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.tar",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "filename": "disk.tar.gz"
+          }
+        }
+      ]
+    }
+  ],
+  "sources": {
+    "org.osbuild.curl": {
+      "items": {
+        "sha256:0652d77991ae054286ace9807d7b4b573b99e3be9be7ad126db8d197b5f22a68": {
+          "url": "https://example.com/repo/packages/subscription-manager"
+        },
+        "sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb": {
+          "url": "https://example.com/repo/packages/passwd"
+        },
+        "sha256:10d1e54c16c491abf59ec796854ffa14563d54461ebb9092501da34f5a9184bc": {
+          "url": "https://example.com/repo/packages/exclude:python-unversioned-command"
+        },
+        "sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca": {
+          "url": "https://example.com/repo/packages/redhat-release"
+        },
+        "sha256:1a36b318995f3383dfa35c283df090bde63776c52415a421ea201a9667f95ab3": {
+          "url": "https://example.com/repo/packages/crypto-policies-scripts"
+        },
+        "sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d": {
+          "url": "https://example.com/repo/packages/glibc"
+        },
+        "sha256:2692c08277f40048982432ab907ab870ee677f69656d9a71a6f889cf03531eb4": {
+          "url": "https://example.com/repo/packages/exclude:glibc-gconv-extra"
+        },
+        "sha256:2a9ba8d4e80cd1edce93e9dca00fb372fbd431ad69d0d5df71fda93f010c4efa": {
+          "url": "https://example.com/repo/packages/dejavu-sans-fonts"
+        },
+        "sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053": {
+          "url": "https://example.com/repo/packages/langpacks-en"
+        },
+        "sha256:32dcd32054ee4e9ae92eec040bc1385c94d74a0846bb0145b1bdf9958740200a": {
+          "url": "https://example.com/repo/packages/curl-minimal"
+        },
+        "sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2": {
+          "url": "https://example.com/repo/packages/bash"
+        },
+        "sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0": {
+          "url": "https://example.com/repo/packages/coreutils"
+        },
+        "sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1": {
+          "url": "https://example.com/repo/packages/dnf"
+        },
+        "sha256:41ffca929b95c49690ab8815d1d1a134a5bcdd86bde407c0f46b90eabf556b05": {
+          "url": "https://example.com/repo/packages/openssl"
+        },
+        "sha256:4f7872f3a4c4decf34923a48986e52563d2a58bc3225b1890b84b52e7defce09": {
+          "url": "https://example.com/repo/packages/basesystem"
+        },
+        "sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999": {
+          "url": "https://example.com/repo/packages/python3-iniparse"
+        },
+        "sha256:572d4fe95e2cfd3425b70544a829f39104cad64fb57cdc63a25f9e837fb79917": {
+          "url": "https://example.com/repo/packages/tzdata"
+        },
+        "sha256:5b0440b2a1ceb2db43e1832c91f96728c5fe59a1cd7b5d1f1b905bb0b2df3841": {
+          "url": "https://example.com/repo/packages/findutils"
+        },
+        "sha256:5b0513b8ca5a7f03601efc10934409d271890e6ae7a3264445e7397233eac6f8": {
+          "url": "https://example.com/repo/packages/procps-ng"
+        },
+        "sha256:5f53b0a2be22e28dc4b056f663910c046a33f9b2d779eaf997ea771fe1881a13": {
+          "url": "https://example.com/repo/packages/sed"
+        },
+        "sha256:60e3d9a99e40010bb917f75d9ce99530d1f8b322d0b1aea07fe71257a369d943": {
+          "url": "https://example.com/repo/packages/exclude:rpm-plugin-systemd-inhibit"
+        },
+        "sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1": {
+          "url": "https://example.com/repo/packages/shadow-utils"
+        },
+        "sha256:6fd624e2ceb4409a98b06f7f6161a6259cc88a838b6f43454217ed5a0c18a547": {
+          "url": "https://example.com/repo/packages/exclude:gawk-all-langpacks"
+        },
+        "sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682": {
+          "url": "https://example.com/repo/packages/hostname"
+        },
+        "sha256:7cb8f52fafc3465bc88412019948f599fa1217927861c07ac3f90628772efa55": {
+          "url": "https://example.com/repo/packages/exclude:openssl-pkcs11"
+        },
+        "sha256:809c2fb94fff223e96477a875bbc1b77e5b020262e8f959d4b49455100a7f9f7": {
+          "url": "https://example.com/repo/packages/yum"
+        },
+        "sha256:8308da3588987ace3967a2eee85a70f8be6eca16320b1e235b636e1464bbad06": {
+          "url": "https://example.com/repo/packages/audit-libs"
+        },
+        "sha256:839f835e4d4558140e9b92fd85c3f923b74b6220ba1ad86b9fe096b8b6305b86": {
+          "url": "https://example.com/repo/packages/coreutils-single"
+        },
+        "sha256:87f1c82f3d3b66f168e0673e4f4227a8a3fe53000bf342780424ee8e3344d591": {
+          "url": "https://example.com/repo/packages/python3-inotify"
+        },
+        "sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a": {
+          "url": "https://example.com/repo/packages/platform-python"
+        },
+        "sha256:8a1eb106427026fd9f7daef2fbed09db45de687c264480f8d3945ff13bdd9fe6": {
+          "url": "https://example.com/repo/packages/alternatives"
+        },
+        "sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a": {
+          "url": "https://example.com/repo/packages/xz"
+        },
+        "sha256:8fb6d5f37e8055ce720bd0b1d56587f88c0071f285966ba17e72b2b12672aa73": {
+          "url": "https://example.com/repo/packages/setup"
+        },
+        "sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb": {
+          "url": "https://example.com/repo/packages/tar"
+        },
+        "sha256:97e86df4b9e1385f56f5635f227cc75e5a59147a8d06d05d0c08241d7204a92d": {
+          "url": "https://example.com/repo/packages/ca-certificates"
+        },
+        "sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88": {
+          "url": "https://example.com/repo/packages/rpm"
+        },
+        "sha256:a697ff6e769b4f3d7c9b05d77c96d575c5e001ef923a13395decbe00b7e461bb": {
+          "url": "https://example.com/repo/packages/exclude:glibc-langpack-en"
+        },
+        "sha256:aa6d4532f128420f4d741f2834cd8d1d146bbbdc9554aef454b7adb8ff66f748": {
+          "url": "https://example.com/repo/packages/gnupg2"
+        },
+        "sha256:ae5e2ad3b86239dbf500c630cf88d33d9775e9ce2e32d596910a07d682d97923": {
+          "url": "https://example.com/repo/packages/tpm2-tss"
+        },
+        "sha256:b779e8f841cdb45f58a152168ea90a81102474bf0d4dc8b9224a433307dc7e51": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.0"
+        },
+        "sha256:ba6559ec248d211b5cfcc313380c7a871da23f845937f429f6304cc841c500cf": {
+          "url": "https://example.com/repo/packages/vim-minimal"
+        },
+        "sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528": {
+          "url": "https://example.com/repo/packages/selinux-policy-targeted"
+        },
+        "sha256:c06dba625e4dfb0b49cb4013c2a82c8f314143c833c1306da12fa2d77a12e0c4": {
+          "url": "https://example.com/repo/packages/exclude:redhat-release-eula"
+        },
+        "sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d": {
+          "url": "https://example.com/repo/packages/python3"
+        },
+        "sha256:c292fa22d3c8f05c74185be8a25495701be31db25ca27f03a6851bea3aec9d0d": {
+          "url": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.0"
+        },
+        "sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31": {
+          "url": "https://example.com/repo/packages/gdb-gdbserver"
+        },
+        "sha256:cbf61858f3260072d96d9b1d2e037fc35824944b9c94d0087b1a53385eccaead": {
+          "url": "https://example.com/repo/packages/filesystem"
+        },
+        "sha256:cc0bbbee7c9dd4f3f30e01c7f1fcbeb839f30c47e3bcbf16db0d37789262cbb4": {
+          "url": "https://example.com/repo/packages/gmp"
+        },
+        "sha256:cfd4affb5ed7a688870bb3725e10cc066e63b2a94b5dd491cac681a3c2b17ca5": {
+          "url": "https://example.com/repo/packages/libcurl-minimal"
+        },
+        "sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98": {
+          "url": "https://example.com/repo/packages/systemd"
+        },
+        "sha256:e422e1641a99c5a045bc0b596ef5ce6429c8e7744f016444cedacd4eaf5d3e4c": {
+          "url": "https://example.com/repo/packages/rootfiles"
+        },
+        "sha256:ee96e48ac867ab59efb688ad1eaef6ef54d06bc565785570164bd9bbb03d67e3": {
+          "url": "https://example.com/repo/packages/pam"
+        },
+        "sha256:f486d76df6f0ea41b7d6acb72751d8eb4cc2a3f04e6273154fef5e76cab27e11": {
+          "url": "https://example.com/repo/packages/util-linux"
+        },
+        "sha256:f6fad119f40a1aae00b54c0de6a0fa24a1e35d4bf1284bffcfd7134bdbb837e1": {
+          "url": "https://example.com/repo/packages/glibc-minimal-langpack"
+        },
+        "sha256:f8f6228d89c3de21a136641a6d66f8a393db4b9019b17e0bec92ffc88b393eb4": {
+          "url": "https://example.com/repo/packages/gobject-introspection"
+        }
+      }
+    }
+  }
+}

--- a/test/manifestdb-light/test_manifestdb_light.py
+++ b/test/manifestdb-light/test_manifestdb_light.py
@@ -1,0 +1,55 @@
+import json
+import os
+import pathlib
+import subprocess
+import textwrap
+
+import pytest
+
+def top_srcdir() -> pathlib.Path:
+    d = pathlib.Path(__file__).parent
+    while not (d / "cmd").exists():
+        d = d.parent
+        if d == "/":
+            raise RuntimeError("cannot find cmd dir")
+    return d
+
+def test_manifest_unchanged(tmp_path):
+    manifests_ref = top_srcdir() / "test/data/manifestdb-light"
+    manifests_new = tmp_path / "new"
+
+    # TODO: omit once we have a "riscv64" mirror and sources entry
+    arches = ["x86_64", "aarch64", "ppc64el", "s390x"]
+    # Only run a subset of the distros for now. All manifests are
+    # about 62Mb, (gzip) compressed 9Mb and even generating them
+    # all ~1000 just takes less than 1min so it seems feasiable
+    # to eventually do it
+    distros = ["centos-10", "rhel-10.0"]
+    
+    env = os.environ.copy()
+    env["OSBUILD_TESTING_RNG_SEED"] = "0"
+    subprocess.run([
+        "go", "run",
+        os.fspath(top_srcdir() / "cmd/gen-manifests"),
+        "-packages=false",
+        "-metadata=false",
+        "-containers=false",
+        "-arches", ",".join(arches),
+        "-distros", ",".join(distros),
+        "-output", manifests_new,
+    ], env=env, check=True)
+
+    ret = subprocess.run([
+        "diff", "-uNr", manifests_ref, manifests_new,
+    ], capture_output=True, text=True, check=False)
+    if ret.returncode != 0:
+        msg = textwrap.dedent(f"""\
+        unexpected difference between {manifests_new} and reference manifests:
+        ---
+        {ret.stdout}
+        ---
+        if this is expected, please run:
+        cp -a {manifests_new}/* {manifests_ref}
+        """)
+        pytest.fail(msg)
+        


### PR DESCRIPTION
*TODO* as a middle ground the idea of having just the list of hashes of the generated manifests was suggested and tooling to create diffs so that we can avoid carrying all the manifests in the git repo

[edit: as expected lots of resistance :) also one suggestion was to make the yaml instead of json to make them easier to diff/merge so less merge conflicts in e.g. the merge-queue (thanks @achilleas-k!)]

This PR adds new manifest reference tests to capture when we
core aspects of the generated manifests. This is inspired by the
work we did in `otk` [0].

The test is very fast, there is no depsolving or other network
activity, but because "fake" packages get generated we will
notice any changes in the packagelists.

This is very useful when working on the yamlification of the
package lists (and later the other parts) because this way
we will spot any differences right away.
See https://github.com/osbuild/images/pull/1300/ for how
this is used.

[0] https://github.com/osbuild/otk/blob/main/test/test_against_images_refs.py