### PR TITLE
tools: add new "gen-manifests-diff" tool

### DIFF
--- a/tools/gen-manifests-diff
+++ b/tools/gen-manifests-diff
@@ -1,0 +1,72 @@
+#!/usr/bin/python3
+#
+# gen-manifests-diff is a helper to diff the generated manifests
+# against what the current "main" of the images library would do.
+#
+# Alternatively a revision can be given as the first argument
+# and with that the diff is calculated against that. All images
+# types and architectures are used by default. It is still
+# very fast (typically 3s).
+
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+# TODO: omit once we have a "riscv64" mirror and sources entry
+arches = ["x86_64", "aarch64", "ppc64el", "s390x"]
+
+
+def top_srcdir() -> pathlib.Path:
+    d = pathlib.Path(__file__).parent
+    while not (d / "cmd" / "gen-manifests").exists():
+        d = d.parent
+        if d == "/":
+            raise RuntimeError("cannot find gen-manifests dir")
+    return d
+
+
+def run_gen_manifests(cmd, output_dir):
+    env = os.environ.copy()
+    env["OSBUILD_TESTING_RNG_SEED"] = "0"
+    subprocess.run(cmd + [
+        "-packages=false",
+        "-metadata=false",
+        "-containers=false",
+        "-arches", ",".join(arches),
+        "-output", output_dir,
+    ], env=env, text=True, capture_output=True, check=True)
+
+
+def manifests_diff(tmp_path, rev):
+    manifests_old = tmp_path / "ref"
+    manifests_new = tmp_path / "new"
+
+    print(f"calculating diff against {rev}")
+    cmd_new = ["go", "run", f"github.com/osbuild/images/cmd/gen-manifests@{rev}"]
+    run_gen_manifests(cmd_new, manifests_old)
+
+    cmd_new = ["go", "run", os.fspath(top_srcdir() / "cmd/gen-manifests")]
+    run_gen_manifests(cmd_new, manifests_new)
+
+    ret = subprocess.run([
+        "diff", "-uNr", manifests_old, manifests_new,
+    ], capture_output=True, text=True, check=False)
+    if ret.returncode == 0:
+        print(f"no diff found to '{rev}'")
+    else:
+        print(f"found difference between {manifests_new} and reference manifests:")
+        print(ret.stdout)
+
+
+def main():
+    rev = "main"
+    if len(sys.argv) > 1:
+        rev = sys.argv[1]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        manifests_diff(pathlib.Path(tmpdir), rev)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
gen-manifests-diff is a helper to diff the generated manifests against what the current "main" of the images library would do.

Alternatively a revision can be given as the first argument and with that the diff is calculated against that. All images types and architectures are used by default. It is still very fast (typically 3s).

Example output:
```diff
calculating diff against d285ec65bac83fad1b36e88b50cecd5f5a5612f9
found differences between /tmp/tmpbjhime7p/new and reference manifests:
diff -uNr /tmp/tmpbjhime7p/ref/centos_9-aarch64-edge_ami-edge_ostree_pull_user.json /tmp/tmpbjhime7p/new/centos_9-aarch64-edge_ami-edge_ostree_pull_user.json
--- /tmp/tmpbjhime7p/ref/centos_9-aarch64-edge_ami-edge_ostree_pull_user.json   2025-03-10 20:55:20.736477268 +0100
+++ /tmp/tmpbjhime7p/new/centos_9-aarch64-edge_ami-edge_ostree_pull_user.json   2025-03-10 20:55:22.294453956 +0100
@@ -161,7 +161,13 @@
             },
             "kernel_opts": [
               "luks.uuid=e3eb0343-83b0-441c-a8aa-6a715afc1d39",
-              "console=tty0 console=ttyS0,115200n8 net.ifnames=0 nvme_core.io_timeout=4294967295 modprobe.blacklist=vc4 rw coreos.no_persist_ip",
+              "console=tty0",
+              "console=ttyS0,115200n8",
+              "net.ifnames=0",
+              "nvme_core.io_timeout=4294967295",
+              "modprobe.blacklist=vc4",
+              "rw",
+              "coreos.no_persist_ip",
               "ignition.platform.id=metal",
               "$ignition_firstboot"
             ]
...
```

This is (hopefully) the uncontroversial part of
https://github.com/osbuild/images/pull/1307
and already useful when checking that a yamlification (or other change) is not resulting in any regressions. Also useful to see if a change results in the expected change(s).

I still think it would be nice to have this as part of our tests (like in #1307) but that is a bigger discussion of course :)