### PR TITLE
osbuild: do not write duplicated package IDs

### DIFF
--- a/pkg/osbuild/rpm_stage.go
+++ b/pkg/osbuild/rpm_stage.go
@@ -126,15 +126,23 @@ func NewRpmStageSourceFilesInputs(specs []rpmmd.PackageSpec) *RPMStageInputs {
 }
 
 func pkgRefs(specs []rpmmd.PackageSpec) FilesInputRef {
-	refs := make([]FilesInputSourceArrayRefEntry, len(specs))
-	for idx, pkg := range specs {
+	refs := make([]FilesInputSourceArrayRefEntry, 0, len(specs))
+
+	// skip duplicated pkgs
+	seenChksums := make(map[string]bool, len(specs))
+	for _, pkg := range specs {
+		if seenChksums[pkg.Checksum] {
+			continue
+		}
+		seenChksums[pkg.Checksum] = true
+
 		var pkgMetadata FilesInputRefMetadata
 		if pkg.CheckGPG {
 			pkgMetadata = &RPMStageReferenceMetadata{
 				CheckGPG: pkg.CheckGPG,
 			}
 		}
-		refs[idx] = NewFilesInputSourceArrayRefEntry(pkg.Checksum, pkgMetadata)
+		refs = append(refs, NewFilesInputSourceArrayRefEntry(pkg.Checksum, pkgMetadata))
 	}
 	return NewFilesInputSourceArrayRef(refs)
 }

--- a/pkg/osbuild/rpm_stage_test.go
+++ b/pkg/osbuild/rpm_stage_test.go
@@ -154,6 +154,20 @@ func TestNewRpmStageSourceFilesInputs(t *testing.T) {
 			CheckGPG:       true,
 			IgnoreSSL:      true,
 		},
+		// duplicated on purpose to ensure we only add the same
+		// ID only once to make the manifests more stable.
+		{
+			Name:           "package-with-md5-checksum",
+			Epoch:          1,
+			Version:        "3.4.2.",
+			Release:        "5.el9",
+			Arch:           "x86_64",
+			RemoteLocation: "https://example.com/repo/Packages/package-with-md5-checksum-4.3.2-5.el9.x86_64.rpm",
+			Checksum:       "md5:8133f479f38118c5f9facfe2a2d9a071",
+			Secrets:        "",
+			CheckGPG:       true,
+			IgnoreSSL:      true,
+		},
 	}
 	inputs := NewRpmStageSourceFilesInputs(pkgSpecs)
 
@@ -179,4 +193,6 @@ func TestNewRpmStageSourceFilesInputs(t *testing.T) {
 			assert.Equal(md.CheckGPG, pkg.CheckGPG)
 		}
 	}
+	// the duplicated entry is not part of the resulting refs array
+	assert.Equal(len(pkgSpecs)-1, len(refsArray))
 }

--- a/pkg/osbuild/rpm_stage_test.go
+++ b/pkg/osbuild/rpm_stage_test.go
@@ -91,7 +91,6 @@ func Test_OSBuildMetadataToRPMs(t *testing.T) {
 func TestNewRpmStageSourceFilesInputs(t *testing.T) {
 
 	assert := assert.New(t)
-	require := require.New(t)
 
 	pkgSpecs := []rpmmd.PackageSpec{
 		{
@@ -171,28 +170,45 @@ func TestNewRpmStageSourceFilesInputs(t *testing.T) {
 	}
 	inputs := NewRpmStageSourceFilesInputs(pkgSpecs)
 
-	refsArrayPtr, convOk := inputs.Packages.References.(*FilesInputSourceArrayRef)
-	require.True(convOk)
-	require.NotNil(refsArrayPtr)
-
-	refsArray := *refsArrayPtr
-
-	for idx := range refsArray {
-		refItem := refsArray[idx]
-		pkg := pkgSpecs[idx]
-		assert.Equal(pkg.Checksum, refItem.ID)
-
-		if pkg.CheckGPG {
-			// GPG check enabled: metadata expected
-			require.NotNil(refItem.Options)
-			require.NotNil(refItem.Options.Metadata)
-
-			md, convOk := refItem.Options.Metadata.(*RPMStageReferenceMetadata)
-			require.True(convOk)
-			require.NotNil(md)
-			assert.Equal(md.CheckGPG, pkg.CheckGPG)
-		}
+	expected := &RPMStageInputs{
+		Packages: &FilesInput{
+			inputCommon: inputCommon{
+				Type:   "org.osbuild.files",
+				Origin: "org.osbuild.source",
+			},
+			References: &FilesInputSourceArrayRef{
+				{
+					ID:      "sha256:fcf2515ec9115551c99d552da721803ecbca23b7ae5a974309975000e8bef666",
+					Options: (*FilesInputSourceOptions)(nil),
+				},
+				{
+					ID:      "sha256:4be41142a5fb2b4cd6d812e126838cffa57b7c84e5a79d65f66bb9cf1d2830a3",
+					Options: (*FilesInputSourceOptions)(nil),
+				},
+				{
+					ID:      "sha256:da167e41efd19cf25fd1c708b6f123d0203824324b14dd32401d49f2aa0ef0a6",
+					Options: (*FilesInputSourceOptions)(nil),
+				},
+				{
+					ID: "sha1:6e01b8076a2ab729d564048bf2e3a97c7ac83c13",
+					Options: &FilesInputSourceOptions{
+						Metadata: &RPMStageReferenceMetadata{
+							CheckGPG: true,
+						},
+					},
+				},
+				{
+					// note that the duplicated package above is added
+					// only once
+					ID: "md5:8133f479f38118c5f9facfe2a2d9a071",
+					Options: &FilesInputSourceOptions{
+						Metadata: &RPMStageReferenceMetadata{
+							CheckGPG: true,
+						},
+					},
+				},
+			},
+		},
 	}
-	// the duplicated entry is not part of the resulting refs array
-	assert.Equal(len(pkgSpecs)-1, len(refsArray))
+	assert.Equal(expected, inputs)
 }


### PR DESCRIPTION
This commit is a very naive fix to avoid writing duplicated packages
into the osbuild manifest. Writing multiple identical package ids
into the manifest is no real problem but with the new manifest
compare tooling it creates unneeded diffs (if there is reason
to do/allow duplicated IDs and I'm missing that my apologies,
I will close this of course).

This shows up in e.g. https://github.com/osbuild/images/pull/1300

Note that this is incredible naive - the right thing to do here would
be to make the []rpmmd.PackageSpec a type that abstracts that
it is a list and has an "Add()" that will automatically de-dup. But
that would distract (a lot) from the yaml-ifaction so this naive
version first.

The PR also contains a test change in the second commit. This
is totally optional but I found it nicer to look at the expected data
structure to see what is going on and it feels nice to know exactly
what is going on and what is converted in the result. I.e. I was
surprised that we set "IgnoreSSL" to true in the test but the resulting
FilesInputSourceArrayRef does not contain this. In the old style of
the test less visible if it is not checked or not there. I don't see a
real downside, the previous test was also casting into the right types
already (so not using interfaces) but I will not fight over it and can
drop the commit.