### PR TITLE
Add check-spec-deps-action action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+---
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - check-spec-deps-action
+
+jobs:
+  python-lint:
+    name: "🐍 Lint"
+    runs-on: ubuntu-24.04
+    container: registry.fedoraproject.org/fedora:latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Install job dependencies
+        run: dnf -y install pylint ruff python3-packaging
+
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Run pylint
+        run: |
+            pylint --version
+            pylint *.py
+
+      - name: Run ruff
+        run: |
+          ruff --version
+          ruff check *.py

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,8 @@
+[FORMAT]
+max-line-length=120
+
+[MESSAGES CONTROL]
+disable=missing-module-docstring,
+    missing-class-docstring,
+    missing-function-docstring,
+    invalid-name,

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# images@check-spec-deps-action
+
+Action for projects depending on `osbuild/images` module, to ensure that they depend at least on the component version specified by the module. The action checks the project's spec file and compares the dependencies version with the minimum version specified by the `osbuild/images` module.
+
+## Requirements
+
+The action assumes to be run in a Fedora container, as it uses `dnf` to install its dependencies and SPEC build dependencies (to ensure that all RPM macros are defined).
+
+## Usage
+
+```yaml
+name: Check osbuild/images dependencies in spec file
+
+on: [pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Check dependencies in spec file
+      uses: osbuild/images@check-spec-deps-action
+      with:
+        specfile: "osbuild-composer.spec"
+        images_path: "./vendor/github.com/osbuild/images"
+```
+
+## Inputs
+
+### `specfile`
+
+**Optional** The path to the spec file. By default, the action will look for `*.spec` files in the repository, including the ones in the subdirectories. If there are multiple spec files, the action will fail.
+
+### `images_path`
+
+**Optional** The path to the `osbuild/images` module in the repository. By default, the action will look for the module in `./vendor/github.com/osbuild/images` directory.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,55 @@
+name: "check-spec-deps-action"
+description: "Check osbuild/images dependencies in SPEC file. The action is meant to be run in a Fedora environment."
+
+inputs:
+  specfile:
+    description: "The specfile to check. If not provided, the action will look for a single spec file in the repository"
+    required: false
+  images_path:
+    description: "The path to the vendored osbuild/images module. Default is './vendor/github.com/osbuild/images'."
+    default: "./vendor/github.com/osbuild/images"
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install action dependencies
+      shell: bash
+      run: sudo dnf install -y python3 python3-packaging /usr/bin/rpmspec
+
+    - name: Determine the SPEC file to check
+      shell: bash
+      env:
+        SPECFILE: ${{ inputs.specfile }}
+      run: |
+        if [[ -n "$SPECFILE" ]]; then
+          if [[ ! -f "$SPECFILE" ]]; then
+            echo "::error file=$SPECFILE,title=⛔ error hint::file not found"
+            exit 1
+          fi
+          echo "SPECFILE=$SPECFILE" >> $GITHUB_ENV
+        else
+          specfiles=$(find . -name '*.spec')
+          if [[ -z "$specfiles" ]]; then
+            echo "::error title=⛔ error hint::no SPEC file found in the repository"
+            exit 1
+          fi
+          if [[ $(echo "$specfiles" | wc -l) -ne 1 ]]; then
+            echo "::error title=⛔ error hint::multiple SPEC files found, please specify the 'specfile' input"
+            exit 1
+          fi
+          echo "SPECFILE=$specfiles" >> $GITHUB_ENV
+        fi
+
+    - name: Install SPEC build dependencies (for RPM macros)
+      shell: bash
+      env:
+        SPECFILE: ${{ env.SPECFILE }}
+      run: sudo dnf builddep -y $SPECFILE
+
+    - name: Check SPEC file against dependencies specified by osbuild/images
+      shell: bash
+      env:
+        SPECFILE: ${{ env.SPECFILE }}
+        IMAGES_PATH: ${{ inputs.images_path }}
+      run: $GITHUB_ACTION_PATH/check-spec-deps.py $SPECFILE $IMAGES_PATH

--- a/check-spec-deps.py
+++ b/check-spec-deps.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import subprocess
+import sys
+from collections import namedtuple
+from typing import List, Tuple
+
+from packaging.version import Version
+
+SpecDep = namedtuple('SpecDep', ['name', 'op', 'version'])
+SpecDep.__str__ = lambda self: f'{self.name} {self.op} {self.version}'
+
+
+def get_spec_deps(spec: str) -> List[Tuple[str, str, str]]:
+    """
+    Get the RPM dependencies from a SPEC file using 'rpmspec'
+    """
+    deps = []
+    cmd = ['rpmspec', '-q', spec, '--requires']
+    try:
+        output = subprocess.check_output(cmd, text=True)
+    except subprocess.CalledProcessError as e:
+        print(f"::error file={spec},title=⛔ error hint::Failed to extract dependencies using 'rpmspec': {e}")
+        sys.exit(1)
+
+    for line in set(output.splitlines()):
+        line = line.strip()
+        if line:
+            parts = iter(line.split(maxsplit=2))
+            dep_name, dep_op, dep_version = [next(parts, None) for _ in range(3)]
+            deps.append(SpecDep(dep_name, dep_op, dep_version))
+    return deps
+
+
+ImagesDep = namedtuple('ImagesDep', ['name', 'min_version'])
+
+
+def get_images_deps(images_dir: str) -> List[Tuple[str, str]]:
+    """
+    Get the osbuild/images dependencies from the images directory
+
+    Each non-go file in the 'data/dependencies' directory is considered a dependency.
+    The filename is the name of the dependency and the content is the minimum version.
+    """
+    deps = []
+    deps_dir = os.path.abspath(os.path.join(images_dir, 'data', 'dependencies'))
+    # prevent directory traversal
+    if not deps_dir.startswith(os.getcwd()):
+        print(f"::error file={images_dir},title=⛔ error hint::Normalization of the path failed. "
+              f"{deps_dir} is not within {os.getcwd()}")
+        sys.exit(1)
+    if not os.path.exists(deps_dir):
+        print(f"::error file={images_dir},title=⛔ error hint::Dependencies directory not found")
+        sys.exit(1)
+
+    for dep_file in os.listdir(deps_dir):
+        # Skip go and markdown files
+        if dep_file.endswith('.go') or dep_file.endswith('.md'):
+            continue
+
+        dep_name = dep_file
+        with open(os.path.join(deps_dir, dep_file), 'r', encoding='utf-8') as f:
+            dep_version = f.read().strip()
+        deps.append(ImagesDep(dep_name, dep_version))
+
+    return deps
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check SPEC file dependencies")
+    parser.add_argument(
+        'SPEC',
+        help="Path to the SPEC file to check"
+    )
+    parser.add_argument(
+        'IMAGES_DIR',
+        help="Path to the directory containing the images",
+        nargs='?',
+        default='./vendor/github.com/osbuild/images'
+    )
+
+    args = parser.parse_args()
+    spec = args.SPEC
+    images_dir = args.IMAGES_DIR
+
+    if not os.path.exists(spec):
+        print(f"::error file={spec},title=⛔ error hint::File not found")
+        sys.exit(1)
+
+    if not os.path.isdir(images_dir):
+        print(f"::error file={images_dir},title=⛔ error hint::osbuild/images directory not found")
+        sys.exit(1)
+
+    spec_deps = get_spec_deps(spec)
+    print(f"::debug::spec_deps={spec_deps}")
+
+    images_deps = get_images_deps(images_dir)
+    print(f"::debug::images_deps={images_deps}")
+
+    error = False
+    # SPEC file must depend at least on the minimum version defined in the dependency file
+    #
+    # The dependency operators must be either `=` or `>` or `>=`, but not `<` or `<=`,
+    # because the library defines the minimum required version.
+    for dep in images_deps:
+        spec_dep = next((spec_dep for spec_dep in spec_deps if spec_dep.name == dep.name), None)
+        if not spec_dep:
+            print(f"::error file={spec},title=⛔ error hint::Missing dependency in the SPEC file: {dep.name}")
+            error = True
+            continue
+
+        if not spec_dep.op or not spec_dep.version:
+            print(f"::error file={spec},title=⛔ error hint::Missing operator or version in the SPEC file dependency: "
+                  f"{spec_dep.name}")
+            error = True
+            continue
+
+        if spec_dep.op in ['<', '<=']:
+            print(f"::error file={spec},title=⛔ error hint::Unsupported operator in the SPEC file: '{spec_dep}'. "
+                  "he osbuild/images defines the minimum version, so only '=', '>=', '>' operators are allowed")
+            error = True
+            continue
+
+        # If the operator is `>`, the version must be at maximum one version less than the minimum version.
+        # However, we don't know which version it was and what versioning scheme is used by the dependency.
+        # Therefore we only assume that the version in SPEC must be at least the minimum version.
+        # Effectively, this is the same as the `>=` and '=' operator.
+        if spec_dep.op in ['=', '>=', '>'] and Version(spec_dep.version) < Version(dep.min_version):
+            print(f"::error file={spec},title=⛔ error hint::Incorrect required dependency version in the SPEC file: "
+                  f"'{spec_dep}'. Expected: {dep.name} {spec_dep.op} {dep.min_version} (at least)")
+            error = True
+            continue
+
+        print(f"✅ SPEC file dependency for '{spec_dep}' is correct")
+
+    if error:
+        print(f"::error file={spec},title=⛔ error hint::Incorrect dependencies in the SPEC file")
+        sys.exit(1)
+    else:
+        print("✅ All SPEC file dependencies are correct")
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+packaging


### PR DESCRIPTION
Add a composite action, which can be used by projects that depend on `osbuild/images` and are packaged as RPM, to check that the dependencies in their SPEC file specify the minimum versions as required by `osbuild/images`.

For now, only `osbuild` dependency is checked.

The goal is to use this action in `osbuild-composer` and `image-builder-cli` repositories to check the SPEC files.