### PR TITLE
gen-manifests: de-duplicate packages on the depsolve level

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -314,6 +314,8 @@ func mockDepsolve(packageSets map[string][]rpmmd.PackageSet, repos []rpmmd.RepoC
 
 	for name, pkgSetChain := range packageSets {
 		specSet := make([]rpmmd.PackageSpec, 0)
+		seenChksumsInc := make(map[string]bool)
+		seenChksumsExc := make(map[string]bool)
 		for _, pkgSet := range pkgSetChain {
 			include := pkgSet.Include
 			slices.Sort(include)
@@ -332,6 +334,11 @@ func mockDepsolve(packageSets map[string][]rpmmd.PackageSet, repos []rpmmd.RepoC
 					RemoteLocation: fmt.Sprintf("https://example.com/repo/packages/%s", pkgName),
 					Checksum:       "sha256:" + checksum,
 				}
+				if seenChksumsInc[spec.Checksum] {
+					continue
+				}
+				seenChksumsInc[spec.Checksum] = true
+
 				specSet = append(specSet, spec)
 			}
 
@@ -349,6 +356,11 @@ func mockDepsolve(packageSets map[string][]rpmmd.PackageSet, repos []rpmmd.RepoC
 					RemoteLocation: fmt.Sprintf("https://example.com/repo/packages/%s", pkgName),
 					Checksum:       "sha256:" + checksum,
 				}
+				if seenChksumsExc[spec.Checksum] {
+					continue
+				}
+				seenChksumsExc[spec.Checksum] = true
+
 				specSet = append(specSet, spec)
 			}
 		}


### PR DESCRIPTION
This is a better version of https://github.com/osbuild/images/pull/1312 that moves the de-duplication of packages into the package depsolver of gen-manifests. This is similar to how osbuild-depsolve-dnf works that also will present a de-duplicated result.

Thanks to thozza for the suggestion to do it this way.