### PR TITLE
distro: refactor packageSetFunc() to return an error

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -75,7 +75,7 @@ func mkImageInstallerImgType(d distribution) imageType {
 		filename:    "installer.iso",
 		mimeType:    "application/x-iso9660-image",
 		packageSets: map[string]packageSetFunc{
-			osPkgsKey: func(t *imageType) rpmmd.PackageSet {
+			osPkgsKey: func(t *imageType) (rpmmd.PackageSet, error) {
 				// use the minimal raw image type for the OS package set
 				return packagesets.Load(t, "minimal-raw", VersionReplacements())
 			},
@@ -172,8 +172,8 @@ func mkIotOCIImgType(d distribution) imageType {
 		mimeType:    "application/x-tar",
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: packageSetLoader,
-			containerPkgsKey: func(t *imageType) rpmmd.PackageSet {
-				return rpmmd.PackageSet{}
+			containerPkgsKey: func(t *imageType) (rpmmd.PackageSet, error) {
+				return rpmmd.PackageSet{}, nil
 			},
 		},
 		defaultImageConfig: &distro.ImageConfig{

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -26,7 +26,7 @@ import (
 
 type imageFunc func(workload workload.Workload, t *imageType, bp *blueprint.Blueprint, options distro.ImageOptions, packageSets map[string]rpmmd.PackageSet, containers []container.SourceSpec, rng *rand.Rand) (image.ImageKind, error)
 
-type packageSetFunc func(t *imageType) rpmmd.PackageSet
+type packageSetFunc func(t *imageType) (rpmmd.PackageSet, error)
 
 type isoLabelFunc func(t *imageType) string
 
@@ -233,7 +233,11 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 	// don't add any static packages if Minimal was selected
 	if !bp.Minimal {
 		for name, getter := range t.packageSets {
-			staticPackageSets[name] = getter(t)
+			pkgSet, err := getter(t)
+			if err != nil {
+				return nil, nil, err
+			}
+			staticPackageSets[name] = pkgSet
 		}
 	}
 

--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -5,6 +5,6 @@ import (
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-func packageSetLoader(t *imageType) rpmmd.PackageSet {
+func packageSetLoader(t *imageType) (rpmmd.PackageSet, error) {
 	return packagesets.Load(t, "", VersionReplacements())
 }

--- a/pkg/distro/packagesets/loader_test.go
+++ b/pkg/distro/packagesets/loader_test.go
@@ -54,8 +54,8 @@ test_type:
 	restore := packagesets.MockDataFS(baseDir)
 	defer restore()
 
-	pkgSet := packagesets.Load(it, "", nil)
-	assert.NotNil(t, pkgSet)
+	pkgSet, err := packagesets.Load(it, "", nil)
+	assert.NoError(t, err)
 	assert.Equal(t, rpmmd.PackageSet{
 		Include: []string{"inc1", "from-condition-inc2"},
 		Exclude: []string{"exc1", "from-condition-exc2"},
@@ -77,8 +77,8 @@ test_type:
 	restore := packagesets.MockDataFS(baseDir)
 	defer restore()
 
-	pkgSet := packagesets.Load(it, "override-name", nil)
-	assert.NotNil(t, pkgSet)
+	pkgSet, err := packagesets.Load(it, "override-name", nil)
+	assert.NoError(t, err)
 	assert.Equal(t, rpmmd.PackageSet{
 		Include: []string{"from-override-inc1"},
 		Exclude: []string{"from-override-exc1"},


### PR DESCRIPTION
This commit tweaks the packageSetFunc() to return an error. With that we can avoid `panics()` and instead just pass the error up.

Thanks to Brian for suggesting to clean this up.

(standalone version of https://github.com/osbuild/images/pull/1287 for easier/quicker review, as the other one is slightly controversial)