### PR TITLE
Add cloud init options to WSL images

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -420,6 +420,20 @@ func mkWslImgType(d distribution) imageType {
 			osPkgsKey: packageSetLoader,
 		},
 		defaultImageConfig: &distro.ImageConfig{
+			CloudInit: []*osbuild.CloudInitStageOptions{
+				{
+					Filename: "99_wsl.cfg",
+					Config: osbuild.CloudInitConfigFile{
+						DatasourceList: []string{
+							"WSL",
+							"None",
+						},
+						Network: &osbuild.CloudInitConfigNetwork{
+							Config: "disabled",
+						},
+					},
+				},
+			},
 			NoSElinux:   common.ToPtr(true),
 			ExcludeDocs: common.ToPtr(true),
 			Locale:      common.ToPtr("C.UTF-8"),

--- a/pkg/distro/packagesets/fedora/package_sets.yaml
+++ b/pkg/distro/packagesets/fedora/package_sets.yaml
@@ -523,7 +523,54 @@ image_types:
           - "trousers"
           - "whois-nls"
           - "xkeyboard-config"
-  wsl: *container
+
+  wsl:
+    package_sets:
+      - include:
+          - "bash"
+          - "coreutils"
+          - "cloud-init"
+          - "yum"
+          - "dnf"
+          - "fedora-release-container"
+          - "glibc-minimal-langpack"
+          - "rootfiles"
+          - "rpm"
+          - "sudo"
+          - "tar"
+          - "util-linux-core"
+          - "vim-minimal"
+        exclude:
+          - "crypto-policies-scripts"
+          - "deltarpm"
+          - "dosfstools"
+          - "elfutils-debuginfod-client"
+          - "gawk-all-langpacks"
+          - "glibc-gconv-extra"
+          - "glibc-langpack-en"
+          - "gnupg2-smime"
+          - "grubby"
+          - "kernel-core"
+          - "kernel-debug-core"
+          - "kernel"
+          - "langpacks-en_GB"
+          - "langpacks-en"
+          - "libxcrypt-compat"
+          - "nano"
+          - "openssl-pkcs11"
+          - "pinentry"
+          - "python3-unbound"
+          - "shared-mime-info"
+          - "sssd-client"
+          - "sudo-python-plugin"
+          - "trousers"
+          - "whois-nls"
+          - "xkeyboard-config"
+        condition:
+          version_greater_or_equal:
+            "41":
+              exclude:
+                - "fuse-libs"
 
   minimal_raw: &minimal_raw
     package_sets:

--- a/pkg/distro/packagesets/rhel-10/package_sets.yaml
+++ b/pkg/distro/packagesets/rhel-10/package_sets.yaml
@@ -450,7 +450,7 @@ image_types:
       - *ami_pkgset
       - *sap_pkgset
 
-  ubi: &ubi
+  wsl:
     package_sets:
       - include:
           - "alternatives"
@@ -458,6 +458,7 @@ image_types:
           - "basesystem"
           - "bash"
           - "ca-certificates"
+          - "cloud-init"
           - "coreutils-single"
           - "crypto-policies-scripts"
           - "curl-minimal"
@@ -503,8 +504,6 @@ image_types:
           - "python-unversioned-command"
           - "redhat-release-eula"
           - "rpm-plugin-systemd-inhibit"
-
-  wsl: *ubi
 
   image_installer:
     package_sets:

--- a/pkg/distro/rhel/rhel10/ubi.go
+++ b/pkg/distro/rhel/rhel10/ubi.go
@@ -22,6 +22,20 @@ func mkWSLImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = &distro.ImageConfig{
+		CloudInit: []*osbuild.CloudInitStageOptions{
+			{
+				Filename: "99_wsl.cfg",
+				Config: osbuild.CloudInitConfigFile{
+					DatasourceList: []string{
+						"WSL",
+						"None",
+					},
+					Network: &osbuild.CloudInitConfigNetwork{
+						Config: "disabled",
+					},
+				},
+			},
+		},
 		NoSElinux: common.ToPtr(true),
 		WSLConfig: &osbuild.WSLConfStageOptions{
 			Boot: osbuild.WSLConfBootOptions{

--- a/pkg/distro/rhel/rhel8/ubi.go
+++ b/pkg/distro/rhel/rhel8/ubi.go
@@ -14,7 +14,7 @@ func mkWslImgType() *rhel.ImageType {
 		"disk.tar.gz",
 		"application/x-tar",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: ubiCommonPackageSet,
+			rhel.OSPkgsKey: wslPackageSet,
 		},
 		rhel.TarImage,
 		[]string{"build"},
@@ -23,6 +23,20 @@ func mkWslImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = &distro.ImageConfig{
+		CloudInit: []*osbuild.CloudInitStageOptions{
+			{
+				Filename: "99_wsl.cfg",
+				Config: osbuild.CloudInitConfigFile{
+					DatasourceList: []string{
+						"WSL",
+						"None",
+					},
+					Network: &osbuild.CloudInitConfigNetwork{
+						Config: "disabled",
+					},
+				},
+			},
+		},
 		Locale:    common.ToPtr("en_US.UTF-8"),
 		NoSElinux: common.ToPtr(true),
 		WSLConfig: &osbuild.WSLConfStageOptions{
@@ -35,7 +49,7 @@ func mkWslImgType() *rhel.ImageType {
 	return it
 }
 
-func ubiCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
+func wslPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	ps := rpmmd.PackageSet{
 		Include: []string{
 			"alternatives",
@@ -44,6 +58,7 @@ func ubiCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 			"bash",
 			"brotli",
 			"ca-certificates",
+			"cloud-init",
 			"coreutils-single",
 			"crypto-policies-scripts",
 			"curl",
@@ -87,7 +102,6 @@ func ubiCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 			"alsa-tools-firmware",
 			"biosdevname",
 			"cpio",
-			"diffutils",
 			"dnf-plugin-spacewalk",
 			"dracut",
 			"elfutils-debuginfod-client",
@@ -112,18 +126,15 @@ func ubiCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 			"libkcapi",
 			"libkcapi-hmaccalc",
 			"libsecret",
-			"libselinux-utils",
 			"libxkbcommon",
 			"libertas-sd8787-firmware",
 			"memstrack",
 			"nss",
-			"openssl",
 			"openssl-pkcs11",
 			"os-prober",
 			"pigz",
 			"pinentry",
 			"plymouth",
-			"policycoreutils",
 			"python3-unbound",
 			"redhat-release-eula",
 			"rng-tools",

--- a/pkg/distro/rhel/rhel9/ubi.go
+++ b/pkg/distro/rhel/rhel9/ubi.go
@@ -14,7 +14,7 @@ func mkWSLImgType() *rhel.ImageType {
 		"disk.tar.gz",
 		"application/x-tar",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: ubiCommonPackageSet,
+			rhel.OSPkgsKey: wslPackageSet,
 		},
 		rhel.TarImage,
 		[]string{"build"},
@@ -23,6 +23,20 @@ func mkWSLImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = &distro.ImageConfig{
+		CloudInit: []*osbuild.CloudInitStageOptions{
+			{
+				Filename: "99_wsl.cfg",
+				Config: osbuild.CloudInitConfigFile{
+					DatasourceList: []string{
+						"WSL",
+						"None",
+					},
+					Network: &osbuild.CloudInitConfigNetwork{
+						Config: "disabled",
+					},
+				},
+			},
+		},
 		Locale:    common.ToPtr("en_US.UTF-8"),
 		NoSElinux: common.ToPtr(true),
 		WSLConfig: &osbuild.WSLConfStageOptions{
@@ -35,7 +49,7 @@ func mkWSLImgType() *rhel.ImageType {
 	return it
 }
 
-func ubiCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
+func wslPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	ps := rpmmd.PackageSet{
 		Include: []string{
 			"alternatives",
@@ -43,6 +57,7 @@ func ubiCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 			"basesystem",
 			"bash",
 			"ca-certificates",
+			"cloud-init",
 			"coreutils-single",
 			"crypto-policies-scripts",
 			"curl-minimal",

--- a/pkg/osbuild/cloud_init_stage_test.go
+++ b/pkg/osbuild/cloud_init_stage_test.go
@@ -73,6 +73,15 @@ func TestCloudInitStage_NewStage_Invalid(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "empty-network-section",
+			options: CloudInitStageOptions{
+				Filename: "00-default_user.cfg",
+				Config: CloudInitConfigFile{
+					Network: &CloudInitConfigNetwork{},
+				},
+			},
+		},
 	}
 	for idx := range tests {
 		tt := tests[idx]


### PR DESCRIPTION


This mirrors the Ubuntu images in the MS store. The WSL datasource looks for userdata on the Windows host.


---


also see https://cloudinit.readthedocs.io/en/latest/reference/datasources/wsl.html
