### PR TITLE
tools: make `gen-manifests-diff` run against the merge base

### DIFF
--- a/tools/gen-manifests-diff
+++ b/tools/gen-manifests-diff
@@ -61,9 +61,21 @@ def manifests_diff(tmp_path, rev):
 
 
 def main():
-    rev = "main"
-    if len(sys.argv) > 1:
-        rev = sys.argv[1]
+    match len(sys.argv):
+        case 1:
+            print("no revision given as argument, running against merge base")
+            # merge base is calculated against upstream
+            # "github.com/osbuild/images" not against the users fork
+            rev = subprocess.run(
+                ["git", "merge-base", "upstream/main", "HEAD"],
+                capture_output=True, text=True, check=True,
+            ).stdout.strip()
+        case 2:
+            rev = sys.argv[1]
+        case _:
+            print("only a single revision argument can be passed")
+            sys.exit(1)
+
     print("Note that this diff does *not* include depsolved rpms,")
     print("so upstream dependency changes will not be caught\n")
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
This commit tweak `gen-manifests-diff` to run against the merge base of the upstream branch instead of whatever is upstream@main. This avoids potentially confusing output when upstream/main has moved forward since the branching and the diff would include unrelated upstream changes.

Thanks to Achilleas for suggesting this.

Closes: https://github.com/osbuild/images/issues/1322