### PR TITLE
Depsolve customization packages separately

### DIFF
--- a/cmd/osbuild-playground/my-container.go
+++ b/cmd/osbuild-playground/my-container.go
@@ -51,7 +51,7 @@ func (img *MyContainer) InstantiateManifest(m *manifest.Manifest,
 
 	// create a minimal non-bootable OS tree
 	os := manifest.NewOS(build, &platform.X86{}, repos)
-	os.ExtraBasePackages = []string{"@core"}
+	os.BasePackages = []string{"@core"}
 	os.OSCustomizations.Language = "en_US.UTF-8"
 	os.OSCustomizations.Hostname = "my-host"
 	os.OSCustomizations.Timezone = "UTC"

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -270,7 +270,7 @@ func TestPipelineRepositories(t *testing.T) {
 			},
 			result: map[string][]stringSet{
 				"*":  {newStringSet([]string{"global-21", "global-22"})},
-				"os": {newStringSet([]string{"os-1", "os-2"}), newStringSet([]string{"os-1", "os-2"})},
+				"os": {newStringSet([]string{"os-1", "os-2"}), newStringSet([]string{"os-1", "os-2"}), newStringSet([]string{"os-1", "os-2"})},
 			},
 		},
 		"global+os+payload": { // global repos with os-specific repos and (user-defined) payload repositories
@@ -304,9 +304,11 @@ func TestPipelineRepositories(t *testing.T) {
 			result: map[string][]stringSet{
 				"*": {newStringSet([]string{"global-21", "global-22"})},
 				"os": {
-					// chain with payload repo only in the second set for the blueprint package depsolve
+					// chain with payload repo only in the third set for the blueprint package depsolve
 					newStringSet([]string{"os-1", "os-2"}),
-					newStringSet([]string{"os-1", "os-2", "payload"})},
+					newStringSet([]string{"os-1", "os-2"}),
+					newStringSet([]string{"os-1", "os-2", "payload"}),
+				},
 			},
 		},
 		"noglobal": { // no global repositories; only pipeline restricted ones (unrealistic but technically valid)
@@ -350,7 +352,7 @@ func TestPipelineRepositories(t *testing.T) {
 			result: map[string][]stringSet{
 				"*":              nil,
 				"build":          {newStringSet([]string{"build-1", "build-2"})},
-				"os":             {newStringSet([]string{"os-1", "os-2"}), newStringSet([]string{"os-1", "os-2"})},
+				"os":             {newStringSet([]string{"os-1", "os-2"}), newStringSet([]string{"os-1", "os-2"}), newStringSet([]string{"os-1", "os-2"})},
 				"anaconda-tree":  {newStringSet([]string{"anaconda-1"})},
 				"container-tree": {newStringSet([]string{"container-1"})},
 				"coi-tree":       {newStringSet([]string{"coi-1"})},

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -52,7 +52,7 @@ func osCustomizations(
 
 	osc.FIPS = c.GetFIPS()
 
-	osc.ExtraBasePackages = osPackageSet.Include
+	osc.BasePackages = osPackageSet.Include
 	osc.ExcludeBasePackages = osPackageSet.Exclude
 	osc.ExtraBaseRepos = osPackageSet.Repositories
 

--- a/pkg/distro/imagetype_test.go
+++ b/pkg/distro/imagetype_test.go
@@ -41,7 +41,7 @@ func TestManifestRepositoryCustomization(t *testing.T) {
 				osChains := chains["os"]
 				baseChain := osChains[0]
 				assert.Contains(t, baseChain.Include, "kernel")
-				payloadChain := osChains[1]
+				payloadChain := osChains[2]
 				assert.Equal(t, []string{"hello"}, payloadChain.Include)
 				if installFrom {
 					// the bp repo got added for this payload resolv

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -54,7 +54,7 @@ func osCustomizations(
 
 	osc.FIPS = c.GetFIPS()
 
-	osc.ExtraBasePackages = osPackageSet.Include
+	osc.BasePackages = osPackageSet.Include
 	osc.ExcludeBasePackages = osPackageSet.Exclude
 	osc.ExtraBaseRepos = osPackageSet.Repositories
 

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -226,11 +226,8 @@ func (p *OS) getPackageSetChain(Distro) []rpmmd.PackageSet {
 		environmentPackages = p.Environment.GetPackages()
 	}
 
-	// If we have a logical volume we need to include the lvm2 package.
-	// OSTree-based images (commit and container) aren't bootable images and
-	// don't have partition tables.
 	var partitionTablePackages []string
-	if p.PartitionTable != nil && p.OSTreeRef == "" {
+	if p.PartitionTable != nil {
 		partitionTablePackages = p.PartitionTable.GetBuildPackages()
 	}
 

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -35,9 +35,9 @@ import (
 //	can always be applied.
 type OSCustomizations struct {
 
-	// Packages to install in addition to the ones required by the
-	// pipeline.
-	ExtraBasePackages []string
+	// Packages to install in addition to the ones required by the pipeline.
+	// These are the statically defined packages for the image type.
+	BasePackages []string
 
 	// Packages to exclude from the base package set. This is useful in
 	// case of weak dependencies, comps groups, or where multiple packages
@@ -274,7 +274,7 @@ func (p *OS) getPackageSetChain(Distro) []rpmmd.PackageSet {
 
 	chain := []rpmmd.PackageSet{
 		{
-			Include:         append(packages, p.ExtraBasePackages...),
+			Include:         append(packages, p.BasePackages...),
 			Exclude:         p.ExcludeBasePackages,
 			Repositories:    osRepos,
 			InstallWeakDeps: p.InstallWeakDeps,


### PR DESCRIPTION
The OS package set chain now consists of three transactions (up from two).

The transactions contain the following packages:
1. Platform, Environment, Partition Table, and Base (static Image Type) packages, *with* Excludes from the Base package set.
    - Weak dependency installation is controlled by the Image Type's ImageConfig.
2. Customization packages: These are packages that are selected based on ImageConfig and Blueprint customizations (e.g. 'chrony' for NTP, 'firewalld' for firewall configuration).
    - Weak dependency installation is *disabled*.
3. Blueprint (Workload) packages: This is the same as the previous second transaction in the chain.

This change solves the problem where a package selected by a customization could conflict with a base package set exclude.

See linked issue for a full description of the problem.

This PR has no effect on generated manifests.

Fixes #1323