### PR TITLE
rhel8: extract package sets into a single YAML file

### DIFF
--- a/pkg/distro/packagesets/rhel-8/package_sets.yaml
+++ b/pkg/distro/packagesets/rhel-8/package_sets.yaml
@@ -1,0 +1,1047 @@
+---
+.common:
+  ec2_common_pkgset: &ec2_common_pkgset
+    include:
+      - "@core"
+      - "authselect-compat"
+      - "chrony"
+      - "cloud-init"
+      - "cloud-utils-growpart"
+      - "dhcp-client"
+      - "dracut-config-generic"
+      - "dracut-norescue"
+      - "gdisk"
+      - "grub2"
+      - "langpacks-en"
+      - "NetworkManager"
+      - "NetworkManager-cloud-setup"
+      - "redhat-release"
+      - "redhat-release-eula"
+      - "rsync"
+      - "tar"
+      - "yum-utils"
+    exclude:
+      - "aic94xx-firmware"
+      - "alsa-firmware"
+      - "alsa-tools-firmware"
+      - "biosdevname"
+      - "firewalld"
+      - "iprutils"
+      - "ivtv-firmware"
+      - "iwl1000-firmware"
+      - "iwl100-firmware"
+      - "iwl105-firmware"
+      - "iwl135-firmware"
+      - "iwl2000-firmware"
+      - "iwl2030-firmware"
+      - "iwl3160-firmware"
+      - "iwl3945-firmware"
+      - "iwl4965-firmware"
+      - "iwl5000-firmware"
+      - "iwl5150-firmware"
+      - "iwl6000-firmware"
+      - "iwl6000g2a-firmware"
+      - "iwl6000g2b-firmware"
+      - "iwl6050-firmware"
+      - "iwl7260-firmware"
+      - "libertas-sd8686-firmware"
+      - "libertas-sd8787-firmware"
+      - "libertas-usb8388-firmware"
+      - "plymouth"
+      # RHBZ#2075815
+      - "qemu-guest-agent"
+    condition:
+      distro_name:
+        rhel:
+          include:
+            - "insights-client"
+
+  azure_common_pkgset: &azure_common_pkgset
+    include:
+      - "@Server"
+      - "NetworkManager"
+      - "NetworkManager-cloud-setup"
+      - "WALinuxAgent"
+      - "bzip2"
+      - "cloud-init"
+      - "cloud-utils-growpart"
+      - "cryptsetup-reencrypt"
+      - "dracut-config-generic"
+      - "dracut-norescue"
+      - "efibootmgr"
+      - "gdisk"
+      - "hyperv-daemons"
+      - "kernel"
+      - "kernel-core"
+      - "kernel-modules"
+      - "langpacks-en"
+      - "lvm2"
+      - "nvme-cli"
+      - "patch"
+      - "rng-tools"
+      - "selinux-policy-targeted"
+      - "uuid"
+      - "yum-utils"
+    exclude:
+      - "NetworkManager-config-server"
+      - "aic94xx-firmware"
+      - "alsa-firmware"
+      - "alsa-sof-firmware"
+      - "alsa-tools-firmware"
+      - "biosdevname"
+      - "bolt"
+      - "buildah"
+      - "cockpit-podman"
+      - "containernetworking-plugins"
+      - "dnf-plugin-spacewalk"
+      - "dracut-config-rescue"
+      - "glibc-all-langpacks"
+      - "iprutils"
+      - "ivtv-firmware"
+      - "iwl100-firmware"
+      - "iwl1000-firmware"
+      - "iwl105-firmware"
+      - "iwl135-firmware"
+      - "iwl2000-firmware"
+      - "iwl2030-firmware"
+      - "iwl3160-firmware"
+      - "iwl3945-firmware"
+      - "iwl4965-firmware"
+      - "iwl5000-firmware"
+      - "iwl5150-firmware"
+      - "iwl6000-firmware"
+      - "iwl6000g2a-firmware"
+      - "iwl6000g2b-firmware"
+      - "iwl6050-firmware"
+      - "iwl7260-firmware"
+      - "libertas-sd8686-firmware"
+      - "libertas-sd8787-firmware"
+      - "libertas-usb8388-firmware"
+      - "plymouth"
+      - "podman"
+      - "python3-dnf-plugin-spacewalk"
+      - "python3-hwdata"
+      - "python3-rhnlib"
+      - "rhn-check"
+      - "rhn-client-tools"
+      - "rhn-setup"
+      - "rhnlib"
+      - "rhnsd"
+      - "usb_modeswitch"
+    condition:
+      distro_name:
+        "rhel":
+          include:
+            - "insights-client"
+            # XXX: this is defined in azure.go:commonPackageSets but
+            # there is a bug in the original code so this never gets
+            # actually added so we don't add it here either
+            # - "rhc"
+
+  sap_pkgset: &sap_pkgset
+    include:
+      # RHBZ#2074107
+      - "@Server"
+      # SAP System Roles
+      # https://access.redhat.com/sites/default/files/attachments/rhel_system_roles_for_sap_1.pdf
+      - "rhel-system-roles-sap"
+      # RHBZ#1959813
+      - "bind-utils"
+      - "compat-sap-c++-9"
+      # RHBZ#2074114
+      - "compat-sap-c++-10"
+      - "nfs-utils"
+      - "tcsh"
+      # RHBZ#1959955
+      - "uuidd"
+      # RHBZ#1959923
+      - "cairo"
+      - "expect"
+      - "graphviz"
+      - "gtk2"
+      - "iptraf-ng"
+      - "krb5-workstation"
+      - "libaio"
+      - "libatomic"
+      - "libcanberra-gtk2"
+      - "libicu"
+      - "libpng12"
+      - "libtool-ltdl"
+      - "lm_sensors"
+      - "net-tools"
+      - "numactl"
+      - "PackageKit-gtk3-module"
+      - "xorg-x11-xauth"
+      # RHBZ#1960617
+      - "tuned-profiles-sap-hana"
+      # RHBZ#1961168
+      - "libnsl"
+    condition:
+      version_less_than:
+        "8.6":
+          include:
+            - "ansible"
+      version_greater_or_equal:
+        "8.6":
+          include:
+            - "ansible-core"
+
+  installer_pkgset: &installer_pkgset
+    include:
+      - "anaconda-dracut"
+      - "curl"
+      - "dracut-config-generic"
+      - "dracut-network"
+      - "hostname"
+      - "iwl100-firmware"
+      - "iwl1000-firmware"
+      - "iwl105-firmware"
+      - "iwl135-firmware"
+      - "iwl2000-firmware"
+      - "iwl2030-firmware"
+      - "iwl3160-firmware"
+      - "iwl5000-firmware"
+      - "iwl5150-firmware"
+      - "iwl6000-firmware"
+      - "iwl6050-firmware"
+      - "iwl7260-firmware"
+      - "kernel"
+      - "less"
+      - "nfs-utils"
+      - "openssh-clients"
+      - "ostree"
+      - "plymouth"
+      - "prefixdevname"
+      - "rng-tools"
+      - "rpcbind"
+      - "selinux-policy-targeted"
+      - "systemd"
+      - "tar"
+      - "xfsprogs"
+      - "xz"
+    condition:
+      architecture:
+        x86_64:
+          include:
+            - "biosdevname"
+
+  anaconda_boot_pkgset: &anaconda_boot_pkgset
+    condition:
+      architecture:
+        x86_64:
+          include:
+            # eficommon
+            - "efibootmgr"
+            # XXX: de-dup?
+            # grub-common
+            - "grub2-tools"
+            - "grub2-tools-extra"
+            - "grub2-tools-minimal"
+            # arch specific
+            - "grub2-efi-ia32-cdboot"
+            - "grub2-efi-x64"
+            - "grub2-efi-x64-cdboot"
+            - "grub2-pc"
+            - "grub2-pc-modules"
+            - "shim-ia32"
+            - "shim-x64"
+            - "syslinux"
+            - "syslinux-nonlinux"
+        aarch64:
+          include:
+            # eficommon
+            - "efibootmgr"
+            # XXX: de-dup?
+            # grub-common
+            - "grub2-tools"
+            - "grub2-tools-extra"
+            - "grub2-tools-minimal"
+            # arch specific
+            - "grub2-efi-aa64-cdboot"
+            - "grub2-efi-aa64"
+            - "shim-aa64"
+
+  anaconda_pkgset: &anaconda_pkgset
+    include:
+       - "aajohan-comfortaa-fonts"
+       - "abattis-cantarell-fonts"
+       - "alsa-firmware"
+       - "alsa-tools-firmware"
+       - "anaconda"
+       - "anaconda-install-env-deps"
+       - "anaconda-widgets"
+       - "audit"
+       - "bind-utils"
+       - "bitmap-fangsongti-fonts"
+       - "bzip2"
+       - "cryptsetup"
+       - "dbus-x11"
+       - "dejavu-sans-fonts"
+       - "dejavu-sans-mono-fonts"
+       - "device-mapper-persistent-data"
+       - "dnf"
+       - "dump"
+       - "ethtool"
+       - "fcoe-utils"
+       - "ftp"
+       - "gdb-gdbserver"
+       - "gdisk"
+       - "gfs2-utils"
+       - "glibc-all-langpacks"
+       - "google-noto-sans-cjk-ttc-fonts"
+       - "gsettings-desktop-schemas"
+       - "hdparm"
+       - "hexedit"
+       - "initscripts"
+       - "ipmitool"
+       - "iwl3945-firmware"
+       - "iwl4965-firmware"
+       - "iwl6000g2a-firmware"
+       - "iwl6000g2b-firmware"
+       - "jomolhari-fonts"
+       - "kacst-farsi-fonts"
+       - "kacst-qurn-fonts"
+       - "kbd"
+       - "kbd-misc"
+       - "kdump-anaconda-addon"
+       - "khmeros-base-fonts"
+       - "libblockdev-lvm-dbus"
+       - "libertas-sd8686-firmware"
+       - "libertas-sd8787-firmware"
+       - "libertas-usb8388-firmware"
+       - "libertas-usb8388-olpc-firmware"
+       - "libibverbs"
+       - "libreport-plugin-bugzilla"
+       - "libreport-plugin-reportuploader"
+       - "libreport-rhel-anaconda-bugzilla"
+       - "librsvg2"
+       - "linux-firmware"
+       - "lklug-fonts"
+       - "lldpad"
+       - "lohit-assamese-fonts"
+       - "lohit-bengali-fonts"
+       - "lohit-devanagari-fonts"
+       - "lohit-gujarati-fonts"
+       - "lohit-gurmukhi-fonts"
+       - "lohit-kannada-fonts"
+       - "lohit-odia-fonts"
+       - "lohit-tamil-fonts"
+       - "lohit-telugu-fonts"
+       - "lsof"
+       - "madan-fonts"
+       - "metacity"
+       - "mtr"
+       - "mt-st"
+       - "net-tools"
+       - "nmap-ncat"
+       - "nm-connection-editor"
+       - "nss-tools"
+       - "openssh-server"
+       - "oscap-anaconda-addon"
+       - "pciutils"
+       - "perl-interpreter"
+       - "pigz"
+       - "python3-pyatspi"
+       - "rdma-core"
+       - "redhat-release-eula"
+       - "rpm-ostree"
+       - "rsync"
+       - "rsyslog"
+       - "sg3_utils"
+       - "sil-abyssinica-fonts"
+       - "sil-padauk-fonts"
+       - "sil-scheherazade-fonts"
+       - "smartmontools"
+       - "smc-meera-fonts"
+       - "spice-vdagent"
+       - "strace"
+       - "system-storage-manager"
+       - "thai-scalable-waree-fonts"
+       - "tigervnc-server-minimal"
+       - "tigervnc-server-module"
+       - "udisks2"
+       - "udisks2-iscsi"
+       - "usbutils"
+       - "vim-minimal"
+       - "volume_key"
+       - "wget"
+       - "xfsdump"
+       - "xorg-x11-drivers"
+       - "xorg-x11-fonts-misc"
+       - "xorg-x11-server-utils"
+       - "xorg-x11-server-Xorg"
+       - "xorg-x11-xauth"
+    condition:
+      architecture:
+        x86_64:
+          include:
+            - "biosdevname"
+            - "dmidecode"
+            - "memtest86+"
+        aarch64:
+          include:
+            - "dmidecode"
+
+  gce_common_pkgset: &gce_common_pkgset
+    include:
+      - "@core"
+      - "langpacks-en" # not in Google's KS
+      - "acpid"
+      - "dhcp-client"
+      - "dnf-automatic"
+      - "net-tools"
+      #- "openssh-server" included in core
+      - "python3"
+      - "rng-tools"
+      - "tar"
+      - "vim"
+      # GCE guest tools
+      - "google-compute-engine"
+      - "google-osconfig-agent"
+      - "gce-disk-expand"
+      # Not explicitly included in GCP kickstart, but present on the image
+      # for time synchronization
+      - "chrony"
+      - "timedatex"
+      # EFI
+      - "grub2-tools-efi"
+    exclude:
+      - "alsa-utils"
+      - "b43-fwcutter"
+      - "dmraid"
+      - "eject"
+      - "gpm"
+      - "irqbalance"
+      - "microcode_ctl"
+      - "smartmontools"
+      - "aic94xx-firmware"
+      - "atmel-firmware"
+      - "b43-openfwwf"
+      - "bfa-firmware"
+      - "ipw2100-firmware"
+      - "ipw2200-firmware"
+      - "ivtv-firmware"
+      - "iwl100-firmware"
+      - "iwl1000-firmware"
+      - "iwl3945-firmware"
+      - "iwl4965-firmware"
+      - "iwl5000-firmware"
+      - "iwl5150-firmware"
+      - "iwl6000-firmware"
+      - "iwl6000g2a-firmware"
+      - "iwl6050-firmware"
+      - "kernel-firmware"
+      - "libertas-usb8388-firmware"
+      - "ql2100-firmware"
+      - "ql2200-firmware"
+      - "ql23xx-firmware"
+      - "ql2400-firmware"
+      - "ql2500-firmware"
+      - "rt61pci-firmware"
+      - "rt73usb-firmware"
+      - "xorg-x11-drv-ati-firmware"
+      - "zd1211-firmware"
+      # RHBZ#2075815
+      - "qemu-guest-agent"
+    condition:
+      distro_name:
+        rhel:
+          include:
+            - "insights-client"
+
+  qcow2_common_pkgset: &qcow2_common_pkgset
+    include:
+      - "@core"
+      - "authselect-compat"
+      - "chrony"
+      - "cloud-init"
+      - "cloud-utils-growpart"
+      - "cockpit-system"
+      - "cockpit-ws"
+      - "dhcp-client"
+      - "dnf"
+      - "dnf-utils"
+      - "dosfstools"
+      - "dracut-norescue"
+      - "net-tools"
+      - "NetworkManager"
+      - "nfs-utils"
+      - "oddjob"
+      - "oddjob-mkhomedir"
+      - "psmisc"
+      - "python3-jsonschema"
+      - "qemu-guest-agent"
+      - "redhat-release"
+      - "redhat-release-eula"
+      - "rsync"
+      - "tar"
+      - "tcpdump"
+      - "yum"
+    exclude:
+      - "aic94xx-firmware"
+      - "alsa-firmware"
+      - "alsa-lib"
+      - "alsa-tools-firmware"
+      - "biosdevname"
+      - "dnf-plugin-spacewalk"
+      - "dracut-config-rescue"
+      - "fedora-release"
+      - "fedora-repos"
+      - "firewalld"
+      - "fwupd"
+      - "iprutils"
+      - "ivtv-firmware"
+      - "iwl1000-firmware"
+      - "iwl100-firmware"
+      - "iwl105-firmware"
+      - "iwl135-firmware"
+      - "iwl2000-firmware"
+      - "iwl2030-firmware"
+      - "iwl3160-firmware"
+      - "iwl3945-firmware"
+      - "iwl4965-firmware"
+      - "iwl5000-firmware"
+      - "iwl5150-firmware"
+      - "iwl6000-firmware"
+      - "iwl6000g2a-firmware"
+      - "iwl6000g2b-firmware"
+      - "iwl6050-firmware"
+      - "iwl7260-firmware"
+      - "langpacks-*"
+      - "langpacks-en"
+      - "langpacks-en"
+      - "libertas-sd8686-firmware"
+      - "libertas-sd8787-firmware"
+      - "libertas-usb8388-firmware"
+      - "nss"
+      - "plymouth"
+      - "rng-tools"
+      - "udisks2"
+    condition:
+      distro_name:
+        rhel:
+          include:
+            - "insights-client"
+            - "subscription-manager-cockpit"
+    
+
+image_types:
+  # XXX: not a real pkgset but the "os" pipeline pkgset for image-installer
+  # find a nicer way to represent this
+  bare_metal:
+    package_sets:
+      - include:
+          - "@core"
+          - "authselect-compat"
+          - "chrony"
+          - "cockpit-system"
+          - "cockpit-ws"
+          - "dhcp-client"
+          - "dnf"
+          - "dnf-utils"
+          - "dosfstools"
+          - "dracut-norescue"
+          - "iwl1000-firmware"
+          - "iwl100-firmware"
+          - "iwl105-firmware"
+          - "iwl135-firmware"
+          - "iwl2000-firmware"
+          - "iwl2030-firmware"
+          - "iwl3160-firmware"
+          - "iwl3945-firmware"
+          - "iwl4965-firmware"
+          - "iwl5000-firmware"
+          - "iwl5150-firmware"
+          - "iwl6000-firmware"
+          - "iwl6000g2a-firmware"
+          - "iwl6000g2b-firmware"
+          - "iwl6050-firmware"
+          - "iwl7260-firmware"
+          - "lvm2"
+          - "net-tools"
+          - "NetworkManager"
+          - "nfs-utils"
+          - "oddjob"
+          - "oddjob-mkhomedir"
+          - "policycoreutils"
+          - "psmisc"
+          - "python3-jsonschema"
+          - "qemu-guest-agent"
+          - "redhat-release"
+          - "redhat-release-eula"
+          - "rsync"
+          - "selinux-policy-targeted"
+          - "tar"
+          - "tcpdump"
+          - "yum"
+        condition:
+          distro_name:
+            rhel:
+              include:
+                - "insights-client"
+                - "subscription-manager-cockpit"
+
+  ec2: &ec2
+    package_sets:
+      - *ec2_common_pkgset
+      - include:
+          - "rh-amazon-rhui-client"
+        exclude:
+          - "alsa-lib"
+        condition:
+          version_greater_or_equal:
+            "8.7":
+              include:
+                - "redhat-cloud-client-configuration"
+
+  ec2_ha:
+    package_sets:
+      - *ec2_common_pkgset
+      - include:
+          - "fence-agents-all"
+          - "pacemaker"
+          - "pcs"
+          - "rh-amazon-rhui-client-ha"
+        exclude:
+          - "alsa-lib"
+        condition:
+          version_greater_or_equal:
+            "8.7":
+              include:
+                - "redhat-cloud-client-configuration"
+
+  ami:
+    package_sets:
+      - *ec2_common_pkgset
+
+  ec2_sap:
+    package_sets:
+      - *ec2_common_pkgset
+      - *sap_pkgset
+      - condition:
+          version_less_than:
+            "8.10":
+              include:
+                - "rh-amazon-rhui-client-sap-bundle-e4s"
+          version_greater_or_equal:
+            "8.10":
+              include:
+                - "rh-amazon-rhui-client-sap-bundle"
+            "8.7":
+              include:
+                - "redhat-cloud-client-configuration"
+
+  azure_rhui:
+    package_sets:
+      - *azure_common_pkgset
+      - include:
+          - "firewalld"
+          - "rhui-azure-rhel8"
+        exclude:
+          - "alsa-lib"
+
+  azure_sap_rhui:
+    package_sets:
+      - *azure_common_pkgset
+      - *sap_pkgset
+      - include:
+          - "firewalld"
+        condition:
+          version_greater_or_equal:
+            "8.10":
+              include:
+                - "rhui-azure-rhel8-base-sap-ha"
+          version_less_than:
+            "8.10":
+              include:
+                - "rhui-azure-rhel8-sap-ha"
+
+  azure_eap7_rhui:
+    package_sets:
+      - *azure_common_pkgset
+      - include:
+          - "rhui-azure-rhel8"
+        exclude:
+          - "firewalld"
+
+  vhd:
+    package_sets:
+      - *azure_common_pkgset
+      - &azure_pkgset
+        include:
+          - "firewalld"
+        exclude:
+          - "alsa-lib"
+
+  image_installer:
+    package_sets:
+      - *installer_pkgset
+      - *anaconda_pkgset
+      - *anaconda_boot_pkgset
+
+  tar:
+    package_sets:
+      - include:
+          - "policycoreutils"
+          - "selinux-policy-targeted"
+        exclude:
+          - "rng-tools"
+
+
+  edge_commit:
+    package_sets:
+      - &edge_commit_pkgset
+        include:
+          - "attr"
+          - "audit"
+          - "basesystem"
+          - "bash"
+          - "bash-completion"
+          - "chrony"
+          - "clevis"
+          - "clevis-dracut"
+          - "clevis-luks"
+          - "container-selinux"
+          - "coreutils"
+          - "criu"
+          - "cryptsetup"
+          - "curl"
+          - "dnsmasq"
+          - "dosfstools"
+          - "dracut-config-generic"
+          - "dracut-network"
+          - "e2fsprogs"
+          - "firewalld"
+          - "fuse-overlayfs"
+          - "fwupd"
+          - "glibc"
+          - "glibc-minimal-langpack"
+          - "gnupg2"
+          - "greenboot"
+          - "gzip"
+          - "hostname"
+          - "ima-evm-utils"
+          - "iproute"
+          - "iptables"
+          - "iputils"
+          - "keyutils"
+          - "less"
+          - "lvm2"
+          - "NetworkManager"
+          - "NetworkManager-wifi"
+          - "NetworkManager-wwan"
+          - "nss-altfiles"
+          - "openssh-clients"
+          - "openssh-server"
+          - "passwd"
+          - "pinentry"
+          - "platform-python"
+          - "podman"
+          - "policycoreutils"
+          - "policycoreutils-python-utils"
+          - "polkit"
+          - "procps-ng"
+          - "redhat-release"
+          - "rootfiles"
+          - "rpm"
+          - "rpm-ostree"
+          - "rsync"
+          - "selinux-policy-targeted"
+          - "setools-console"
+          - "setup"
+          - "shadow-utils"
+          - "shadow-utils"
+          - "skopeo"
+          - "slirp4netns"
+          - "sudo"
+          - "systemd"
+          - "tar"
+          - "tmux"
+          - "traceroute"
+          - "usbguard"
+          - "util-linux"
+          - "vim-minimal"
+          - "wpa_supplicant"
+          - "xz"
+        exclude:
+          - "rng-tools"
+        condition:
+          architecture:
+            x86_64: &edge_commit_x86_64_pkgset
+              include:
+                - "efibootmgr"
+                - "grub2"
+                - "grub2-efi-x64"
+                - "iwl1000-firmware"
+                - "iwl100-firmware"
+                - "iwl105-firmware"
+                - "iwl135-firmware"
+                - "iwl2000-firmware"
+                - "iwl2030-firmware"
+                - "iwl3160-firmware"
+                - "iwl5000-firmware"
+                - "iwl5150-firmware"
+                - "iwl6000-firmware"
+                - "iwl6050-firmware"
+                - "iwl7260-firmware"
+                - "microcode_ctl"
+                - "shim-x64"
+            aarch64: &edge_commit_aarch64_pkgset
+              include:
+                - "grub2-efi-aa64"
+                - "efibootmgr"
+                - "shim-aa64"
+                - "iwl7260-firmware"
+          version_less_than:
+            "8.6":
+              include:
+                - "greenboot-grub2"
+                - "greenboot-reboot"
+                - "greenboot-rpm-ostree-grub2"
+                - "greenboot-status"
+          version_greater_or_equal:
+            "8.6": &edge_commit_new_rhel
+              include:
+                - "fdo-client"
+                - "fdo-owner-cli"
+                - "greenboot-default-health-checks"
+                - "sos"
+          distro_name:
+            centos:
+              *edge_commit_new_rhel
+
+  edge_installer:
+    package_sets:
+      # TODO: non-arch-specific package set handling for installers
+      # This image type requires build packages for installers and
+      # ostree/edge.  For now we only have x86-64 installer build
+      # package sets defined.  When we add installer build package sets
+      # for other architectures, this will need to be moved to the
+      # architecture and the merging will happen in the PackageSets()
+      # method like the other sets.
+      - *installer_pkgset
+      - *anaconda_pkgset
+      - *anaconda_boot_pkgset
+
+  edge_simplified_installer:
+    package_sets:
+      # TODO: non-arch-specific package set handling for installers
+      # This image type requires build packages for installers and
+      # ostree/edge.  For now we only have x86-64 installer build
+      # package sets defined.  When we add installer build package sets
+      # for other architectures, this will need to be moved to the
+      # architecture and the merging will happen in the PackageSets()
+      # method like the other sets.
+      - *installer_pkgset
+      - include:
+          - "attr"
+          - "basesystem"
+          - "binutils"
+          - "bsdtar"
+          - "clevis-dracut"
+          - "clevis-luks"
+          - "cloud-utils-growpart"
+          - "coreos-installer"
+          - "coreos-installer-dracut"
+          - "coreutils"
+          - "device-mapper-multipath"
+          - "dnsmasq"
+          - "dosfstools"
+          - "dracut-live"
+          - "e2fsprogs"
+          - "fcoe-utils"
+          - "fdo-init"
+          - "gzip"
+          - "ima-evm-utils"
+          - "iproute"
+          - "iptables"
+          - "iputils"
+          - "iscsi-initiator-utils"
+          - "keyutils"
+          - "lldpad"
+          - "lvm2"
+          - "passwd"
+          - "policycoreutils"
+          - "policycoreutils-python-utils"
+          - "procps-ng"
+          - "redhat-logos"
+          - "rootfiles"
+          - "setools-console"
+          - "sudo"
+          - "traceroute"
+          - "util-linux"
+        condition:
+          architecture:
+            x86_64:
+              *edge_commit_x86_64_pkgset
+            aarch64:
+              *edge_commit_aarch64_pkgset
+
+  edge_container:
+    package_sets:
+      - *edge_commit_pkgset
+
+  # XXX: not a real pkgset but the "containerPkgsKey"
+  edge_container_pipeline_pkgset:
+    package_sets:
+      - include:
+          - "nginx"
+
+  vmdk:
+    package_sets: &vmdk_pkgsets
+      - include:
+          - "@core"
+          - "chrony"
+          - "cloud-init"
+          - "firewalld"
+          - "langpacks-en"
+          - "open-vm-tools"
+          - "selinux-policy-targeted"
+        exclude:
+          - "dracut-config-rescue"
+          - "rng-tools"
+
+  ova:
+    package_sets: *vmdk_pkgsets
+
+  gce:
+    package_sets:
+      - *gce_common_pkgset
+
+  gce_rhui:
+    package_sets:
+      - *gce_common_pkgset
+      - include:
+          - "google-rhui-client-rhel8"
+
+  qcow2:
+    package_sets: &qcow2_pkgset
+      - *qcow2_common_pkgset
+
+  oci:
+    package_sets: *qcow2_pkgset
+
+  openstack:
+    package_sets:
+      - include:
+          - "@Core"
+          - "langpacks-en"
+          # From the lorax kickstart
+          - "selinux-policy-targeted"
+          - "cloud-init"
+          - "qemu-guest-agent"
+          - "spice-vdagent"
+        exclude:
+          - "dracut-config-rescue"
+          - "rng-tools"
+
+  wsl:
+    package_sets:
+      - include:
+          - "alternatives"
+          - "audit-libs"
+          - "basesystem"
+          - "bash"
+          - "brotli"
+          - "ca-certificates"
+          - "cloud-init"
+          - "coreutils-single"
+          - "crypto-policies-scripts"
+          - "curl"
+          - "libcurl"
+          - "dnf"
+          - "filesystem"
+          - "findutils"
+          - "gdb-gdbserver"
+          # Differs from official UBI, as we don't include CRB repos
+          # - "gdbm"
+          - "glibc-minimal-langpack"
+          - "gmp"
+          - "gnupg2"
+          - "gobject-introspection"
+          - "hostname"
+          - "langpacks-en"
+          - "pam"
+          - "passwd"
+          - "python3"
+          - "python3-inotify"
+          - "python3-systemd"
+          - "redhat-release"
+          - "rootfiles"
+          - "rpm"
+          - "sed"
+          - "setup"
+          - "shadow-utils"
+          - "subscription-manager"
+          - "systemd"
+          - "tar"
+          - "tpm2-tss"
+          - "tzdata"
+          - "util-linux"
+          - "vim-minimal"
+          - "yum"
+        exclude:
+          - "aic94xx-firmware"
+          - "alsa-firmware"
+          - "alsa-lib"
+          - "alsa-tools-firmware"
+          - "biosdevname"
+          - "cpio"
+          - "dnf-plugin-spacewalk"
+          - "dracut"
+          - "elfutils-debuginfod-client"
+          - "fedora-release"
+          - "fedora-repos"
+          - "fontpackages-filesystem"
+          - "gawk-all-langpacks"
+          - "gettext"
+          - "glibc-gconv-extra"
+          - "glibc-langpack-en"
+          - "gnupg2-smime"
+          - "grub2-common"
+          - "hardlink"
+          - "iprutils"
+          - "ivtv-firmware"
+          - "kbd"
+          - "kmod"
+          - "kpartx"
+          - "libcroco"
+          - "libcrypt-compat"
+          - "libevent"
+          - "libkcapi"
+          - "libkcapi-hmaccalc"
+          - "libsecret"
+          - "libxkbcommon"
+          - "libertas-sd8787-firmware"
+          - "memstrack"
+          - "nss"
+          - "openssl-pkcs11"
+          - "os-prober"
+          - "pigz"
+          - "pinentry"
+          - "plymouth"
+          - "python3-unbound"
+          - "redhat-release-eula"
+          - "rng-tools"
+          - "rpm-plugin-selinux"
+          - "rpm-plugin-systemd-inhibit"
+          - "selinux-policy"
+          - "selinux"
+          - "selinux-policy-targeted"
+          - "shared-mime-info"
+          - "systemd-udev"
+          - "trousers"
+          - "udisks2"
+          - "unbound-libs"
+          - "xkeyboard-config"
+          - "xz"
+
+  minimal_raw:
+    package_sets:
+      - include:
+          - "@core"
+          - "initial-setup"
+          - "libxkbcommon"
+          - "NetworkManager-wifi"
+          - "iwl7260-firmware"
+          - "iwl3160-firmware"

--- a/pkg/distro/rhel/rhel8/bare_metal.go
+++ b/pkg/distro/rhel/rhel8/bare_metal.go
@@ -1,10 +1,9 @@
 package rhel8
 
 import (
-	"fmt"
-
-	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distro/packagesets"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -15,8 +14,10 @@ func mkImageInstaller() *rhel.ImageType {
 		"installer.iso",
 		"application/x-iso9660-image",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey:        bareMetalPackageSet,
-			rhel.InstallerPkgsKey: anacondaPackageSet,
+			rhel.OSPkgsKey: func(t *rhel.ImageType) rpmmd.PackageSet {
+				return common.Must(packagesets.Load(t, "bare-metal", nil))
+			},
+			rhel.InstallerPkgsKey: packageSetLoader,
 		},
 		rhel.ImageInstallerImage,
 		[]string{"build"},
@@ -45,12 +46,7 @@ func mkTarImgType() *rhel.ImageType {
 		"root.tar.xz",
 		"application/x-tar",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: func(t *rhel.ImageType) rpmmd.PackageSet {
-				return rpmmd.PackageSet{
-					Include: []string{"policycoreutils", "selinux-policy-targeted"},
-					Exclude: []string{"rng-tools"},
-				}
-			},
+			rhel.OSPkgsKey: packageSetLoader,
 		},
 		rhel.TarImage,
 		[]string{"build"},
@@ -59,259 +55,4 @@ func mkTarImgType() *rhel.ImageType {
 	)
 
 	return it
-}
-
-func bareMetalPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	ps := rpmmd.PackageSet{
-		Include: []string{
-			"@core",
-			"authselect-compat",
-			"chrony",
-			"cockpit-system",
-			"cockpit-ws",
-			"dhcp-client",
-			"dnf",
-			"dnf-utils",
-			"dosfstools",
-			"dracut-norescue",
-			"iwl1000-firmware",
-			"iwl100-firmware",
-			"iwl105-firmware",
-			"iwl135-firmware",
-			"iwl2000-firmware",
-			"iwl2030-firmware",
-			"iwl3160-firmware",
-			"iwl3945-firmware",
-			"iwl4965-firmware",
-			"iwl5000-firmware",
-			"iwl5150-firmware",
-			"iwl6000-firmware",
-			"iwl6000g2a-firmware",
-			"iwl6000g2b-firmware",
-			"iwl6050-firmware",
-			"iwl7260-firmware",
-			"lvm2",
-			"net-tools",
-			"NetworkManager",
-			"nfs-utils",
-			"oddjob",
-			"oddjob-mkhomedir",
-			"policycoreutils",
-			"psmisc",
-			"python3-jsonschema",
-			"qemu-guest-agent",
-			"redhat-release",
-			"redhat-release-eula",
-			"rsync",
-			"selinux-policy-targeted",
-			"tar",
-			"tcpdump",
-			"yum",
-		},
-		Exclude: nil,
-	}.Append(distroSpecificPackageSet(t))
-
-	// Ensure to not pull in subscription-manager on non-RHEL distro
-	if t.IsRHEL() {
-		ps = ps.Append(rpmmd.PackageSet{
-			Include: []string{
-				"subscription-manager-cockpit",
-			},
-		})
-	}
-
-	return ps
-}
-
-func installerPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	ps := rpmmd.PackageSet{
-		Include: []string{
-			"anaconda-dracut",
-			"curl",
-			"dracut-config-generic",
-			"dracut-network",
-			"hostname",
-			"iwl100-firmware",
-			"iwl1000-firmware",
-			"iwl105-firmware",
-			"iwl135-firmware",
-			"iwl2000-firmware",
-			"iwl2030-firmware",
-			"iwl3160-firmware",
-			"iwl5000-firmware",
-			"iwl5150-firmware",
-			"iwl6000-firmware",
-			"iwl6050-firmware",
-			"iwl7260-firmware",
-			"kernel",
-			"less",
-			"nfs-utils",
-			"openssh-clients",
-			"ostree",
-			"plymouth",
-			"prefixdevname",
-			"rng-tools",
-			"rpcbind",
-			"selinux-policy-targeted",
-			"systemd",
-			"tar",
-			"xfsprogs",
-			"xz",
-		},
-	}
-
-	switch t.Arch().Name() {
-	case arch.ARCH_X86_64.String():
-		ps = ps.Append(rpmmd.PackageSet{
-			Include: []string{
-				"biosdevname",
-			},
-		})
-	}
-
-	return ps
-}
-
-func anacondaPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-
-	// common installer packages
-	ps := installerPackageSet(t)
-
-	ps = ps.Append(rpmmd.PackageSet{
-		Include: []string{
-			"aajohan-comfortaa-fonts",
-			"abattis-cantarell-fonts",
-			"alsa-firmware",
-			"alsa-tools-firmware",
-			"anaconda",
-			"anaconda-install-env-deps",
-			"anaconda-widgets",
-			"audit",
-			"bind-utils",
-			"bitmap-fangsongti-fonts",
-			"bzip2",
-			"cryptsetup",
-			"dbus-x11",
-			"dejavu-sans-fonts",
-			"dejavu-sans-mono-fonts",
-			"device-mapper-persistent-data",
-			"dnf",
-			"dump",
-			"ethtool",
-			"fcoe-utils",
-			"ftp",
-			"gdb-gdbserver",
-			"gdisk",
-			"gfs2-utils",
-			"glibc-all-langpacks",
-			"google-noto-sans-cjk-ttc-fonts",
-			"gsettings-desktop-schemas",
-			"hdparm",
-			"hexedit",
-			"initscripts",
-			"ipmitool",
-			"iwl3945-firmware",
-			"iwl4965-firmware",
-			"iwl6000g2a-firmware",
-			"iwl6000g2b-firmware",
-			"jomolhari-fonts",
-			"kacst-farsi-fonts",
-			"kacst-qurn-fonts",
-			"kbd",
-			"kbd-misc",
-			"kdump-anaconda-addon",
-			"khmeros-base-fonts",
-			"libblockdev-lvm-dbus",
-			"libertas-sd8686-firmware",
-			"libertas-sd8787-firmware",
-			"libertas-usb8388-firmware",
-			"libertas-usb8388-olpc-firmware",
-			"libibverbs",
-			"libreport-plugin-bugzilla",
-			"libreport-plugin-reportuploader",
-			"libreport-rhel-anaconda-bugzilla",
-			"librsvg2",
-			"linux-firmware",
-			"lklug-fonts",
-			"lldpad",
-			"lohit-assamese-fonts",
-			"lohit-bengali-fonts",
-			"lohit-devanagari-fonts",
-			"lohit-gujarati-fonts",
-			"lohit-gurmukhi-fonts",
-			"lohit-kannada-fonts",
-			"lohit-odia-fonts",
-			"lohit-tamil-fonts",
-			"lohit-telugu-fonts",
-			"lsof",
-			"madan-fonts",
-			"metacity",
-			"mtr",
-			"mt-st",
-			"net-tools",
-			"nmap-ncat",
-			"nm-connection-editor",
-			"nss-tools",
-			"openssh-server",
-			"oscap-anaconda-addon",
-			"pciutils",
-			"perl-interpreter",
-			"pigz",
-			"python3-pyatspi",
-			"rdma-core",
-			"redhat-release-eula",
-			"rpm-ostree",
-			"rsync",
-			"rsyslog",
-			"sg3_utils",
-			"sil-abyssinica-fonts",
-			"sil-padauk-fonts",
-			"sil-scheherazade-fonts",
-			"smartmontools",
-			"smc-meera-fonts",
-			"spice-vdagent",
-			"strace",
-			"system-storage-manager",
-			"thai-scalable-waree-fonts",
-			"tigervnc-server-minimal",
-			"tigervnc-server-module",
-			"udisks2",
-			"udisks2-iscsi",
-			"usbutils",
-			"vim-minimal",
-			"volume_key",
-			"wget",
-			"xfsdump",
-			"xorg-x11-drivers",
-			"xorg-x11-fonts-misc",
-			"xorg-x11-server-utils",
-			"xorg-x11-server-Xorg",
-			"xorg-x11-xauth",
-		},
-	})
-
-	ps = ps.Append(anacondaBootPackageSet(t))
-
-	switch t.Arch().Name() {
-	case arch.ARCH_X86_64.String():
-		ps = ps.Append(rpmmd.PackageSet{
-			Include: []string{
-				"biosdevname",
-				"dmidecode",
-				"memtest86+",
-			},
-		})
-
-	case arch.ARCH_AARCH64.String():
-		ps = ps.Append(rpmmd.PackageSet{
-			Include: []string{
-				"dmidecode",
-			},
-		})
-
-	default:
-		panic(fmt.Sprintf("unsupported arch: %s", t.Arch().Name()))
-	}
-
-	return ps
 }

--- a/pkg/distro/rhel/rhel8/edge.go
+++ b/pkg/distro/rhel/rhel8/edge.go
@@ -1,14 +1,12 @@
 package rhel8
 
 import (
-	"fmt"
-
 	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distro/packagesets"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -20,7 +18,7 @@ func mkEdgeCommitImgType(rd *rhel.Distribution) *rhel.ImageType {
 		"commit.tar",
 		"application/x-tar",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: edgeCommitPackageSet,
+			rhel.OSPkgsKey: packageSetLoader,
 		},
 		rhel.EdgeCommitImage,
 		[]string{"build"},
@@ -44,11 +42,9 @@ func mkEdgeOCIImgType(rd *rhel.Distribution) *rhel.ImageType {
 		"container.tar",
 		"application/x-tar",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: edgeCommitPackageSet,
+			rhel.OSPkgsKey: packageSetLoader,
 			rhel.ContainerPkgsKey: func(t *rhel.ImageType) rpmmd.PackageSet {
-				return rpmmd.PackageSet{
-					Include: []string{"nginx"},
-				}
+				return common.Must(packagesets.Load(t, "edge_container_pipeline_pkgset", nil))
 			},
 		},
 		rhel.EdgeContainerImage,
@@ -107,14 +103,7 @@ func mkEdgeInstallerImgType(rd *rhel.Distribution) *rhel.ImageType {
 		"installer.iso",
 		"application/x-iso9660-image",
 		map[string]rhel.PackageSetFunc{
-			// TODO: non-arch-specific package set handling for installers
-			// This image type requires build packages for installers and
-			// ostree/edge.  For now we only have x86-64 installer build
-			// package sets defined.  When we add installer build package sets
-			// for other architectures, this will need to be moved to the
-			// architecture and the merging will happen in the PackageSets()
-			// method like the other sets.
-			rhel.InstallerPkgsKey: edgeInstallerPackageSet,
+			rhel.InstallerPkgsKey: packageSetLoader,
 		},
 		rhel.EdgeInstallerImage,
 		[]string{"build"},
@@ -146,14 +135,7 @@ func mkEdgeSimplifiedInstallerImgType(rd *rhel.Distribution) *rhel.ImageType {
 		"simplified-installer.iso",
 		"application/x-iso9660-image",
 		map[string]rhel.PackageSetFunc{
-			// TODO: non-arch-specific package set handling for installers
-			// This image type requires build packages for installers and
-			// ostree/edge.  For now we only have x86-64 installer build
-			// package sets defined.  When we add installer build package sets
-			// for other architectures, this will need to be moved to the
-			// architecture and the merging will happen in the PackageSets()
-			// method like the other sets.
-			rhel.InstallerPkgsKey: edgeSimplifiedInstallerPackageSet,
+			rhel.InstallerPkgsKey: packageSetLoader,
 		},
 		rhel.EdgeSimplifiedInstallerImage,
 		[]string{"build"},
@@ -197,7 +179,7 @@ func mkMinimalRawImgType() *rhel.ImageType {
 		"disk.raw.xz",
 		"application/xz",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: minimalrpmPackageSet,
+			rhel.OSPkgsKey: packageSetLoader,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -218,219 +200,6 @@ func mkMinimalRawImgType() *rhel.ImageType {
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
-}
-
-// edge commit OS package set
-func edgeCommitPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	ps := rpmmd.PackageSet{
-		Include: []string{
-			"attr",
-			"audit",
-			"basesystem",
-			"bash",
-			"bash-completion",
-			"chrony",
-			"clevis",
-			"clevis-dracut",
-			"clevis-luks",
-			"container-selinux",
-			"coreutils",
-			"criu",
-			"cryptsetup",
-			"curl",
-			"dnsmasq",
-			"dosfstools",
-			"dracut-config-generic",
-			"dracut-network",
-			"e2fsprogs",
-			"firewalld",
-			"fuse-overlayfs",
-			"fwupd",
-			"glibc",
-			"glibc-minimal-langpack",
-			"gnupg2",
-			"greenboot",
-			"gzip",
-			"hostname",
-			"ima-evm-utils",
-			"iproute",
-			"iptables",
-			"iputils",
-			"keyutils",
-			"less",
-			"lvm2",
-			"NetworkManager",
-			"NetworkManager-wifi",
-			"NetworkManager-wwan",
-			"nss-altfiles",
-			"openssh-clients",
-			"openssh-server",
-			"passwd",
-			"pinentry",
-			"platform-python",
-			"podman",
-			"policycoreutils",
-			"policycoreutils-python-utils",
-			"polkit",
-			"procps-ng",
-			"redhat-release",
-			"rootfiles",
-			"rpm",
-			"rpm-ostree",
-			"rsync",
-			"selinux-policy-targeted",
-			"setools-console",
-			"setup",
-			"shadow-utils",
-			"shadow-utils",
-			"skopeo",
-			"slirp4netns",
-			"sudo",
-			"systemd",
-			"tar",
-			"tmux",
-			"traceroute",
-			"usbguard",
-			"util-linux",
-			"vim-minimal",
-			"wpa_supplicant",
-			"xz",
-		},
-		Exclude: []string{"rng-tools"},
-	}
-
-	switch t.Arch().Name() {
-	case arch.ARCH_X86_64.String():
-		ps = ps.Append(x8664EdgeCommitPackageSet(t))
-
-	case arch.ARCH_AARCH64.String():
-		ps = ps.Append(aarch64EdgeCommitPackageSet(t))
-	}
-
-	if t.IsRHEL() && common.VersionLessThan(t.Arch().Distro().OsVersion(), "8.6") {
-		ps = ps.Append(rpmmd.PackageSet{
-			Include: []string{
-				"greenboot-grub2",
-				"greenboot-reboot",
-				"greenboot-rpm-ostree-grub2",
-				"greenboot-status",
-			},
-		})
-	} else {
-		// 8.6+ and CS8
-		ps = ps.Append(rpmmd.PackageSet{
-			Include: []string{
-				"fdo-client",
-				"fdo-owner-cli",
-				"greenboot-default-health-checks",
-				"sos",
-			},
-		})
-	}
-
-	return ps
-
-}
-
-func x8664EdgeCommitPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			"efibootmgr",
-			"grub2",
-			"grub2-efi-x64",
-			"iwl1000-firmware",
-			"iwl100-firmware",
-			"iwl105-firmware",
-			"iwl135-firmware",
-			"iwl2000-firmware",
-			"iwl2030-firmware",
-			"iwl3160-firmware",
-			"iwl5000-firmware",
-			"iwl5150-firmware",
-			"iwl6000-firmware",
-			"iwl6050-firmware",
-			"iwl7260-firmware",
-			"microcode_ctl",
-			"shim-x64",
-		},
-		Exclude: nil,
-	}
-}
-
-func aarch64EdgeCommitPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			"efibootmgr",
-			"grub2-efi-aa64",
-			"iwl7260-firmware",
-			"shim-aa64",
-		},
-		Exclude: nil,
-	}
-}
-
-func edgeInstallerPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	return anacondaPackageSet(t)
-}
-
-func edgeSimplifiedInstallerPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	// common installer packages
-	ps := installerPackageSet(t)
-
-	ps = ps.Append(rpmmd.PackageSet{
-		Include: []string{
-			"attr",
-			"basesystem",
-			"binutils",
-			"bsdtar",
-			"clevis-dracut",
-			"clevis-luks",
-			"cloud-utils-growpart",
-			"coreos-installer",
-			"coreos-installer-dracut",
-			"coreutils",
-			"device-mapper-multipath",
-			"dnsmasq",
-			"dosfstools",
-			"dracut-live",
-			"e2fsprogs",
-			"fcoe-utils",
-			"fdo-init",
-			"gzip",
-			"ima-evm-utils",
-			"iproute",
-			"iptables",
-			"iputils",
-			"iscsi-initiator-utils",
-			"keyutils",
-			"lldpad",
-			"lvm2",
-			"passwd",
-			"policycoreutils",
-			"policycoreutils-python-utils",
-			"procps-ng",
-			"redhat-logos",
-			"rootfiles",
-			"setools-console",
-			"sudo",
-			"traceroute",
-			"util-linux",
-		},
-		Exclude: nil,
-	})
-
-	switch t.Arch().Name() {
-
-	case arch.ARCH_X86_64.String():
-		ps = ps.Append(x8664EdgeCommitPackageSet(t))
-	case arch.ARCH_AARCH64.String():
-		ps = ps.Append(aarch64EdgeCommitPackageSet(t))
-
-	default:
-		panic(fmt.Sprintf("unsupported arch: %s", t.Arch().Name()))
-	}
-
-	return ps
 }
 
 func edgeServices(rd *rhel.Distribution) []string {

--- a/pkg/distro/rhel/rhel8/gce.go
+++ b/pkg/distro/rhel/rhel8/gce.go
@@ -7,7 +7,6 @@ import (
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 func gceKernelOptions() []string {
@@ -20,7 +19,7 @@ func mkGceImgType(rd distro.Distro) *rhel.ImageType {
 		"image.tar.gz",
 		"application/gzip",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: gcePackageSet,
+			rhel.OSPkgsKey: packageSetLoader,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -44,7 +43,7 @@ func mkGceRhuiImgType(rd distro.Distro) *rhel.ImageType {
 		"image.tar.gz",
 		"application/gzip",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: gceRhuiPackageSet,
+			rhel.OSPkgsKey: packageSetLoader,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -197,88 +196,4 @@ func defaultGceRhuiImageConfig(rd distro.Distro) *distro.ImageConfig {
 	}
 	ic = ic.InheritFrom(defaultGceByosImageConfig(rd))
 	return ic
-}
-
-// common GCE image
-func gceCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			"@core",
-			"langpacks-en", // not in Google's KS
-			"acpid",
-			"dhcp-client",
-			"dnf-automatic",
-			"net-tools",
-			//"openssh-server", included in core
-			"python3",
-			"rng-tools",
-			"tar",
-			"vim",
-
-			// GCE guest tools
-			"google-compute-engine",
-			"google-osconfig-agent",
-			"gce-disk-expand",
-
-			// Not explicitly included in GCP kickstart, but present on the image
-			// for time synchronization
-			"chrony",
-			"timedatex",
-			// EFI
-			"grub2-tools-efi",
-		},
-		Exclude: []string{
-			"alsa-utils",
-			"b43-fwcutter",
-			"dmraid",
-			"eject",
-			"gpm",
-			"irqbalance",
-			"microcode_ctl",
-			"smartmontools",
-			"aic94xx-firmware",
-			"atmel-firmware",
-			"b43-openfwwf",
-			"bfa-firmware",
-			"ipw2100-firmware",
-			"ipw2200-firmware",
-			"ivtv-firmware",
-			"iwl100-firmware",
-			"iwl1000-firmware",
-			"iwl3945-firmware",
-			"iwl4965-firmware",
-			"iwl5000-firmware",
-			"iwl5150-firmware",
-			"iwl6000-firmware",
-			"iwl6000g2a-firmware",
-			"iwl6050-firmware",
-			"kernel-firmware",
-			"libertas-usb8388-firmware",
-			"ql2100-firmware",
-			"ql2200-firmware",
-			"ql23xx-firmware",
-			"ql2400-firmware",
-			"ql2500-firmware",
-			"rt61pci-firmware",
-			"rt73usb-firmware",
-			"xorg-x11-drv-ati-firmware",
-			"zd1211-firmware",
-			// RHBZ#2075815
-			"qemu-guest-agent",
-		},
-	}.Append(distroSpecificPackageSet(t))
-}
-
-// GCE BYOS image
-func gcePackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	return gceCommonPackageSet(t)
-}
-
-// GCE RHUI image
-func gceRhuiPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			"google-rhui-client-rhel8",
-		},
-	}.Append(gceCommonPackageSet(t))
 }

--- a/pkg/distro/rhel/rhel8/package_sets.go
+++ b/pkg/distro/rhel/rhel8/package_sets.go
@@ -3,87 +3,12 @@ package rhel8
 // This file defines package sets that are used by more than one image type.
 
 import (
-	"fmt"
-
-	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/distro/packagesets"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-// installer boot package sets, needed for booting and
-// also in the build host
-
-func anacondaBootPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	ps := rpmmd.PackageSet{}
-
-	grubCommon := rpmmd.PackageSet{
-		Include: []string{
-			"grub2-tools",
-			"grub2-tools-extra",
-			"grub2-tools-minimal",
-		},
-	}
-
-	efiCommon := rpmmd.PackageSet{
-		Include: []string{
-			"efibootmgr",
-		},
-	}
-
-	switch t.Arch().Name() {
-	case arch.ARCH_X86_64.String():
-		ps = ps.Append(grubCommon)
-		ps = ps.Append(efiCommon)
-		ps = ps.Append(rpmmd.PackageSet{
-			Include: []string{
-				"grub2-efi-ia32-cdboot",
-				"grub2-efi-x64",
-				"grub2-efi-x64-cdboot",
-				"grub2-pc",
-				"grub2-pc-modules",
-				"shim-ia32",
-				"shim-x64",
-				"syslinux",
-				"syslinux-nonlinux",
-			},
-		})
-	case arch.ARCH_AARCH64.String():
-		ps = ps.Append(grubCommon)
-		ps = ps.Append(efiCommon)
-		ps = ps.Append(rpmmd.PackageSet{
-			Include: []string{
-				"grub2-efi-aa64-cdboot",
-				"grub2-efi-aa64",
-				"shim-aa64",
-			},
-		})
-
-	default:
-		panic(fmt.Sprintf("unsupported arch: %s", t.Arch().Name()))
-	}
-
-	return ps
-}
-
-// packages that are only in some (sub)-distributions
-func distroSpecificPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	if t.IsRHEL() {
-		return rpmmd.PackageSet{
-			Include: []string{"insights-client"},
-		}
-	}
-	return rpmmd.PackageSet{}
-}
-
-func minimalrpmPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			"@core",
-			"initial-setup",
-			"libxkbcommon",
-			"NetworkManager-wifi",
-			"iwl7260-firmware",
-			"iwl3160-firmware",
-		},
-	}
+func packageSetLoader(t *rhel.ImageType) rpmmd.PackageSet {
+	return common.Must(packagesets.Load(t, "", nil))
 }

--- a/pkg/distro/rhel/rhel8/qcow2.go
+++ b/pkg/distro/rhel/rhel8/qcow2.go
@@ -6,7 +6,6 @@ import (
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
-	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 func mkQcow2ImgType(rd *rhel.Distribution) *rhel.ImageType {
@@ -15,7 +14,7 @@ func mkQcow2ImgType(rd *rhel.Distribution) *rhel.ImageType {
 		"disk.qcow2",
 		"application/x-qemu-disk",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: qcow2CommonPackageSet,
+			rhel.OSPkgsKey: packageSetLoader,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -38,7 +37,7 @@ func mkOCIImgType(rd *rhel.Distribution) *rhel.ImageType {
 		"disk.qcow2",
 		"application/x-qemu-disk",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: qcow2CommonPackageSet,
+			rhel.OSPkgsKey: packageSetLoader,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -61,7 +60,7 @@ func mkOpenstackImgType() *rhel.ImageType {
 		"disk.qcow2",
 		"application/x-qemu-disk",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: openstackCommonPackageSet,
+			rhel.OSPkgsKey: packageSetLoader,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -75,111 +74,6 @@ func mkOpenstackImgType() *rhel.ImageType {
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
-}
-
-func qcow2CommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	ps := rpmmd.PackageSet{
-		Include: []string{
-			"@core",
-			"authselect-compat",
-			"chrony",
-			"cloud-init",
-			"cloud-utils-growpart",
-			"cockpit-system",
-			"cockpit-ws",
-			"dhcp-client",
-			"dnf",
-			"dnf-utils",
-			"dosfstools",
-			"dracut-norescue",
-			"net-tools",
-			"NetworkManager",
-			"nfs-utils",
-			"oddjob",
-			"oddjob-mkhomedir",
-			"psmisc",
-			"python3-jsonschema",
-			"qemu-guest-agent",
-			"redhat-release",
-			"redhat-release-eula",
-			"rsync",
-			"tar",
-			"tcpdump",
-			"yum",
-		},
-		Exclude: []string{
-			"aic94xx-firmware",
-			"alsa-firmware",
-			"alsa-lib",
-			"alsa-tools-firmware",
-			"biosdevname",
-			"dnf-plugin-spacewalk",
-			"dracut-config-rescue",
-			"fedora-release",
-			"fedora-repos",
-			"firewalld",
-			"fwupd",
-			"iprutils",
-			"ivtv-firmware",
-			"iwl1000-firmware",
-			"iwl100-firmware",
-			"iwl105-firmware",
-			"iwl135-firmware",
-			"iwl2000-firmware",
-			"iwl2030-firmware",
-			"iwl3160-firmware",
-			"iwl3945-firmware",
-			"iwl4965-firmware",
-			"iwl5000-firmware",
-			"iwl5150-firmware",
-			"iwl6000-firmware",
-			"iwl6000g2a-firmware",
-			"iwl6000g2b-firmware",
-			"iwl6050-firmware",
-			"iwl7260-firmware",
-			"langpacks-*",
-			"langpacks-en",
-			"langpacks-en",
-			"libertas-sd8686-firmware",
-			"libertas-sd8787-firmware",
-			"libertas-usb8388-firmware",
-			"nss",
-			"plymouth",
-			"rng-tools",
-			"udisks2",
-		},
-	}.Append(distroSpecificPackageSet(t))
-
-	// Ensure to not pull in subscription-manager on non-RHEL distro
-	if t.IsRHEL() {
-		ps = ps.Append(rpmmd.PackageSet{
-			Include: []string{
-				"subscription-manager-cockpit",
-			},
-		})
-	}
-
-	return ps
-}
-
-func openstackCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			// Defaults
-			"@Core",
-			"langpacks-en",
-
-			// From the lorax kickstart
-			"selinux-policy-targeted",
-			"cloud-init",
-			"qemu-guest-agent",
-			"spice-vdagent",
-		},
-		Exclude: []string{
-			"dracut-config-rescue",
-			"rng-tools",
-		},
-	}
 }
 
 func qcowImageConfig(d *rhel.Distribution) *distro.ImageConfig {

--- a/pkg/distro/rhel/rhel8/sap.go
+++ b/pkg/distro/rhel/rhel8/sap.go
@@ -3,9 +3,7 @@ package rhel8
 import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/distro"
-	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 // sapImageConfig returns the SAP specific ImageConfig data
@@ -123,58 +121,4 @@ func sapImageConfig(rd distro.Distro) *distro.ImageConfig {
 	}
 
 	return ic
-}
-
-func SapPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	packageSet := rpmmd.PackageSet{
-		Include: []string{
-			// RHBZ#2074107
-			"@Server",
-			// SAP System Roles
-			// https://access.redhat.com/sites/default/files/attachments/rhel_system_roles_for_sap_1.pdf
-			"rhel-system-roles-sap",
-			// RHBZ#1959813
-			"bind-utils",
-			"compat-sap-c++-9",
-			"compat-sap-c++-10", // RHBZ#2074114
-			"nfs-utils",
-			"tcsh",
-			// RHBZ#1959955
-			"uuidd",
-			// RHBZ#1959923
-			"cairo",
-			"expect",
-			"graphviz",
-			"gtk2",
-			"iptraf-ng",
-			"krb5-workstation",
-			"libaio",
-			"libatomic",
-			"libcanberra-gtk2",
-			"libicu",
-			"libpng12",
-			"libtool-ltdl",
-			"lm_sensors",
-			"net-tools",
-			"numactl",
-			"PackageKit-gtk3-module",
-			"xorg-x11-xauth",
-			// RHBZ#1960617
-			"tuned-profiles-sap-hana",
-			// RHBZ#1961168
-			"libnsl",
-		},
-	}
-
-	if common.VersionLessThan(t.Arch().Distro().OsVersion(), "8.6") {
-		packageSet = packageSet.Append(rpmmd.PackageSet{
-			Include: []string{"ansible"},
-		})
-	} else {
-		// 8.6+ and CS8 (image type does not exist on 8.5)
-		packageSet = packageSet.Append(rpmmd.PackageSet{
-			Include: []string{"ansible-core"}, // RHBZ#2077356
-		})
-	}
-	return packageSet
 }

--- a/pkg/distro/rhel/rhel8/ubi.go
+++ b/pkg/distro/rhel/rhel8/ubi.go
@@ -5,7 +5,6 @@ import (
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 func mkWslImgType() *rhel.ImageType {
@@ -14,7 +13,7 @@ func mkWslImgType() *rhel.ImageType {
 		"disk.tar.gz",
 		"application/x-tar",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: wslPackageSet,
+			rhel.OSPkgsKey: packageSetLoader,
 		},
 		rhel.TarImage,
 		[]string{"build"},
@@ -47,111 +46,4 @@ func mkWslImgType() *rhel.ImageType {
 	}
 
 	return it
-}
-
-func wslPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	ps := rpmmd.PackageSet{
-		Include: []string{
-			"alternatives",
-			"audit-libs",
-			"basesystem",
-			"bash",
-			"brotli",
-			"ca-certificates",
-			"cloud-init",
-			"coreutils-single",
-			"crypto-policies-scripts",
-			"curl",
-			"libcurl",
-			"dnf",
-			"filesystem",
-			"findutils",
-			"gdb-gdbserver",
-			// Differs from official UBI, as we don't include CRB repos
-			// "gdbm",
-			"glibc-minimal-langpack",
-			"gmp",
-			"gnupg2",
-			"gobject-introspection",
-			"hostname",
-			"langpacks-en",
-			"pam",
-			"passwd",
-			"python3",
-			"python3-inotify",
-			"python3-systemd",
-			"redhat-release",
-			"rootfiles",
-			"rpm",
-			"sed",
-			"setup",
-			"shadow-utils",
-			"subscription-manager",
-			"systemd",
-			"tar",
-			"tpm2-tss",
-			"tzdata",
-			"util-linux",
-			"vim-minimal",
-			"yum",
-		},
-		Exclude: []string{
-			"aic94xx-firmware",
-			"alsa-firmware",
-			"alsa-lib",
-			"alsa-tools-firmware",
-			"biosdevname",
-			"cpio",
-			"dnf-plugin-spacewalk",
-			"dracut",
-			"elfutils-debuginfod-client",
-			"fedora-release",
-			"fedora-repos",
-			"fontpackages-filesystem",
-			"gawk-all-langpacks",
-			"gettext",
-			"glibc-gconv-extra",
-			"glibc-langpack-en",
-			"gnupg2-smime",
-			"grub2-common",
-			"hardlink",
-			"iprutils",
-			"ivtv-firmware",
-			"kbd",
-			"kmod",
-			"kpartx",
-			"libcroco",
-			"libcrypt-compat",
-			"libevent",
-			"libkcapi",
-			"libkcapi-hmaccalc",
-			"libsecret",
-			"libxkbcommon",
-			"libertas-sd8787-firmware",
-			"memstrack",
-			"nss",
-			"openssl-pkcs11",
-			"os-prober",
-			"pigz",
-			"pinentry",
-			"plymouth",
-			"python3-unbound",
-			"redhat-release-eula",
-			"rng-tools",
-			"rpm-plugin-selinux",
-			"rpm-plugin-systemd-inhibit",
-			"selinux-policy",
-			"selinux",
-			"selinux-policy-targeted",
-			"shared-mime-info",
-			"systemd-udev",
-			"trousers",
-			"udisks2",
-			"unbound-libs",
-			"xkeyboard-config",
-			"xz",
-		},
-	}
-
-	return ps
 }

--- a/pkg/distro/rhel/rhel8/vmdk.go
+++ b/pkg/distro/rhel/rhel8/vmdk.go
@@ -3,7 +3,6 @@ package rhel8
 import (
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro/rhel"
-	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 func vmdkKernelOptions() []string {
@@ -16,7 +15,7 @@ func mkVmdkImgType() *rhel.ImageType {
 		"disk.vmdk",
 		"application/x-vmdk",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: vmdkCommonPackageSet,
+			rhel.OSPkgsKey: packageSetLoader,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -38,7 +37,7 @@ func mkOvaImgType() *rhel.ImageType {
 		"image.ova",
 		"application/ovf",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: vmdkCommonPackageSet,
+			rhel.OSPkgsKey: packageSetLoader,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -52,22 +51,4 @@ func mkOvaImgType() *rhel.ImageType {
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
-}
-
-func vmdkCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			"@core",
-			"chrony",
-			"cloud-init",
-			"firewalld",
-			"langpacks-en",
-			"open-vm-tools",
-			"selinux-policy-targeted",
-		},
-		Exclude: []string{
-			"dracut-config-rescue",
-			"rng-tools",
-		},
-	}
 }


### PR DESCRIPTION
Move the rhel8 packages into yaml. Similar to e.g. PR#1300. The existing structure in code was tried to be preserved.

Tested via:
```console
$ ./tools/gen-manifests-diff
no diff found to main
```

Build on top of https://github.com/osbuild/images/pull/1300