### PR TITLE
rhel7: extract package sets into a single YAML file

### DIFF
--- a/pkg/distro/packagesets/rhel-7/package_sets.yaml
+++ b/pkg/distro/packagesets/rhel-7/package_sets.yaml
@@ -1,0 +1,157 @@
+---
+.common:
+  azure_rhui_common_pkgset: &azure_rhui_common_pkgset
+    include:
+       - "@base"
+       - "@core"
+       - "authconfig"
+       - "bpftool"
+       - "bzip2"
+       - "chrony"
+       - "cloud-init"
+       - "cloud-utils-growpart"
+       - "dracut-config-generic"
+       - "dracut-norescue"
+       - "efibootmgr"
+       - "firewalld"
+       - "gdisk"
+       - "grub2-efi-x64"
+       - "grub2-pc"
+       - "grub2"
+       - "hyperv-daemons"
+       - "kernel"
+       - "lvm2"
+       - "redhat-release-eula"
+       - "redhat-support-tool"
+       - "rh-dotnetcore11"
+       - "rhn-setup"
+       - "rhui-azure-rhel7"
+       - "rsync"
+       - "shim-x64"
+       - "tar"
+       - "tcpdump"
+       - "WALinuxAgent"
+       - "yum-rhn-plugin"
+       - "yum-utils"
+    exclude:
+       - "dracut-config-rescue"
+       - "mariadb-libs"
+       - "NetworkManager-config-server"
+       - "postfix"
+    condition:
+      distro_name:
+        "rhel":
+          include:
+            - "insights-client"
+
+image_types:
+  azure_rhui:
+    package_sets:
+      - *azure_rhui_common_pkgset
+
+  ec2:
+    package_sets:
+      - include:
+          - "@core"
+          - "authconfig"
+          - "kernel"
+          - "yum-utils"
+          - "cloud-init"
+          - "dracut-config-generic"
+          - "dracut-norescue"
+          - "grub2"
+          - "tar"
+          - "rsync"
+          - "rh-amazon-rhui-client"
+          - "redhat-cloud-client-configuration"
+          - "chrony"
+          - "cloud-utils-growpart"
+          - "gdisk"
+        exclude:
+          - "aic94xx-firmware"
+          - "alsa-firmware"
+          - "alsa-lib"
+          - "alsa-tools-firmware"
+          - "ivtv-firmware"
+          - "iwl1000-firmware"
+          - "iwl100-firmware"
+          - "iwl105-firmware"
+          - "iwl135-firmware"
+          - "iwl2000-firmware"
+          - "iwl2030-firmware"
+          - "iwl3160-firmware"
+          - "iwl3945-firmware"
+          - "iwl4965-firmware"
+          - "iwl5000-firmware"
+          - "iwl5150-firmware"
+          - "iwl6000-firmware"
+          - "iwl6000g2a-firmware"
+          - "iwl6000g2b-firmware"
+          - "iwl6050-firmware"
+          - "iwl7260-firmware"
+          - "libertas-sd8686-firmware"
+          - "libertas-sd8787-firmware"
+          - "libertas-usb8388-firmware"
+          - "biosdevname"
+          - "plymouth"
+          # NM is excluded by the original KS, but it is in the image built from it.
+          # - "NetworkManager"
+          - "iprutils"
+          # linux-firmware is uninstalled by the original KS, but it is a direct dependency of kernel,
+          # so we can't exclude it.
+          # - "linux-firmware"
+          - "firewalld"
+          
+  qcow2:
+    package_sets:
+      - include:
+          - "@core"
+          - "kernel"
+          - "nfs-utils"
+          - "yum-utils"
+          - "cloud-init"
+          # - "ovirt-guest-agent-common"
+          - "rhn-setup"
+          - "yum-rhn-plugin"
+          - "cloud-utils-growpart"
+          - "dracut-config-generic"
+          - "tar"
+          - "tcpdump"
+          - "rsync"
+        exclude:
+          - "biosdevname"
+          - "dracut-config-rescue"
+          - "iprutils"
+          - "NetworkManager-team"
+          - "NetworkManager-tui"
+          - "NetworkManager"
+          - "plymouth"
+          - "aic94xx-firmware"
+          - "alsa-firmware"
+          - "alsa-lib"
+          - "alsa-tools-firmware"
+          - "ivtv-firmware"
+          - "iwl1000-firmware"
+          - "iwl100-firmware"
+          - "iwl105-firmware"
+          - "iwl135-firmware"
+          - "iwl2000-firmware"
+          - "iwl2030-firmware"
+          - "iwl3160-firmware"
+          - "iwl3945-firmware"
+          - "iwl4965-firmware"
+          - "iwl5000-firmware"
+          - "iwl5150-firmware"
+          - "iwl6000-firmware"
+          - "iwl6000g2a-firmware"
+          - "iwl6000g2b-firmware"
+          - "iwl6050-firmware"
+          - "iwl7260-firmware"
+          - "libertas-sd8686-firmware"
+          - "libertas-sd8787-firmware"
+          - "libertas-usb8388-firmware"
+        condition:
+          distro_name:
+            "rhel":
+              include:
+                - "insights-client"

--- a/pkg/distro/rhel/rhel7/ami.go
+++ b/pkg/distro/rhel/rhel7/ami.go
@@ -11,7 +11,6 @@ import (
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 func ec2KernelOptions() []string {
@@ -24,7 +23,7 @@ func mkEc2ImgTypeX86_64() *rhel.ImageType {
 		"image.raw.xz",
 		"application/xz",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: ec2PackageSet,
+			rhel.OSPkgsKey: packageSetLoader,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -194,63 +193,6 @@ func ec2ImageConfig() *distro.ImageConfig {
 			hostnameFile,
 		},
 		SELinuxForceRelabel: common.ToPtr(true),
-	}
-}
-
-func ec2PackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			"@core",
-			"authconfig",
-			"kernel",
-			"yum-utils",
-			"cloud-init",
-			"dracut-config-generic",
-			"dracut-norescue",
-			"grub2",
-			"tar",
-			"rsync",
-			"rh-amazon-rhui-client",
-			"redhat-cloud-client-configuration",
-			"chrony",
-			"cloud-utils-growpart",
-			"gdisk",
-		},
-		Exclude: []string{
-			"aic94xx-firmware",
-			"alsa-firmware",
-			"alsa-lib",
-			"alsa-tools-firmware",
-			"ivtv-firmware",
-			"iwl1000-firmware",
-			"iwl100-firmware",
-			"iwl105-firmware",
-			"iwl135-firmware",
-			"iwl2000-firmware",
-			"iwl2030-firmware",
-			"iwl3160-firmware",
-			"iwl3945-firmware",
-			"iwl4965-firmware",
-			"iwl5000-firmware",
-			"iwl5150-firmware",
-			"iwl6000-firmware",
-			"iwl6000g2a-firmware",
-			"iwl6000g2b-firmware",
-			"iwl6050-firmware",
-			"iwl7260-firmware",
-			"libertas-sd8686-firmware",
-			"libertas-sd8787-firmware",
-			"libertas-usb8388-firmware",
-			"biosdevname",
-			"plymouth",
-			// NM is excluded by the original KS, but it is in the image built from it.
-			// "NetworkManager",
-			"iprutils",
-			// linux-firmware is uninstalled by the original KS, but it is a direct dependency of kernel,
-			// so we can't exclude it.
-			// "linux-firmware",
-			"firewalld",
-		},
 	}
 }
 

--- a/pkg/distro/rhel/rhel7/azure.go
+++ b/pkg/distro/rhel/rhel7/azure.go
@@ -9,7 +9,6 @@ import (
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 func mkAzureRhuiImgType() *rhel.ImageType {
@@ -18,7 +17,7 @@ func mkAzureRhuiImgType() *rhel.ImageType {
 		"disk.vhd.xz",
 		"application/xz",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: azureRhuiCommonPackageSet,
+			rhel.OSPkgsKey: packageSetLoader,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -225,60 +224,6 @@ var azureDefaultImgConfig = &distro.ImageConfig{
 		},
 	},
 	DefaultTarget: common.ToPtr("multi-user.target"),
-}
-
-func azureRhuiCommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	ps := rpmmd.PackageSet{
-		Include: []string{
-			"@base",
-			"@core",
-			"authconfig",
-			"bpftool",
-			"bzip2",
-			"chrony",
-			"cloud-init",
-			"cloud-utils-growpart",
-			"dracut-config-generic",
-			"dracut-norescue",
-			"efibootmgr",
-			"firewalld",
-			"gdisk",
-			"grub2-efi-x64",
-			"grub2-pc",
-			"grub2",
-			"hyperv-daemons",
-			"kernel",
-			"lvm2",
-			"redhat-release-eula",
-			"redhat-support-tool",
-			"rh-dotnetcore11",
-			"rhn-setup",
-			"rhui-azure-rhel7",
-			"rsync",
-			"shim-x64",
-			"tar",
-			"tcpdump",
-			"WALinuxAgent",
-			"yum-rhn-plugin",
-			"yum-utils",
-		},
-		Exclude: []string{
-			"dracut-config-rescue",
-			"mariadb-libs",
-			"NetworkManager-config-server",
-			"postfix",
-		},
-	}
-
-	if t.IsRHEL() {
-		ps = ps.Append(rpmmd.PackageSet{
-			Include: []string{
-				"insights-client",
-			},
-		})
-	}
-
-	return ps
 }
 
 func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {

--- a/pkg/distro/rhel/rhel7/package_sets.go
+++ b/pkg/distro/rhel/rhel7/package_sets.go
@@ -1,16 +1,12 @@
 package rhel7
 
 import (
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/distro/packagesets"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-// packages that are only in some (sub)-distributions
-func distroSpecificPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	if t.IsRHEL() {
-		return rpmmd.PackageSet{
-			Include: []string{"insights-client"},
-		}
-	}
-	return rpmmd.PackageSet{}
+func packageSetLoader(t *rhel.ImageType) rpmmd.PackageSet {
+	return common.Must(packagesets.Load(t, "", nil))
 }

--- a/pkg/distro/rhel/rhel7/qcow2.go
+++ b/pkg/distro/rhel/rhel7/qcow2.go
@@ -7,7 +7,6 @@ import (
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 func mkQcow2ImgType() *rhel.ImageType {
@@ -16,7 +15,7 @@ func mkQcow2ImgType() *rhel.ImageType {
 		"disk.qcow2",
 		"application/x-qemu-disk",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: qcow2CommonPackageSet,
+			rhel.OSPkgsKey: packageSetLoader,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
@@ -76,61 +75,4 @@ var qcow2DefaultImgConfig = &distro.ImageConfig{
 			},
 		},
 	},
-}
-
-func qcow2CommonPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
-	ps := rpmmd.PackageSet{
-		Include: []string{
-			"@core",
-			"kernel",
-			"nfs-utils",
-			"yum-utils",
-
-			"cloud-init",
-			//"ovirt-guest-agent-common",
-			"rhn-setup",
-			"yum-rhn-plugin",
-			"cloud-utils-growpart",
-			"dracut-config-generic",
-			"tar",
-			"tcpdump",
-			"rsync",
-		},
-		Exclude: []string{
-			"biosdevname",
-			"dracut-config-rescue",
-			"iprutils",
-			"NetworkManager-team",
-			"NetworkManager-tui",
-			"NetworkManager",
-			"plymouth",
-
-			"aic94xx-firmware",
-			"alsa-firmware",
-			"alsa-lib",
-			"alsa-tools-firmware",
-			"ivtv-firmware",
-			"iwl1000-firmware",
-			"iwl100-firmware",
-			"iwl105-firmware",
-			"iwl135-firmware",
-			"iwl2000-firmware",
-			"iwl2030-firmware",
-			"iwl3160-firmware",
-			"iwl3945-firmware",
-			"iwl4965-firmware",
-			"iwl5000-firmware",
-			"iwl5150-firmware",
-			"iwl6000-firmware",
-			"iwl6000g2a-firmware",
-			"iwl6000g2b-firmware",
-			"iwl6050-firmware",
-			"iwl7260-firmware",
-			"libertas-sd8686-firmware",
-			"libertas-sd8787-firmware",
-			"libertas-usb8388-firmware",
-		},
-	}.Append(distroSpecificPackageSet(t))
-
-	return ps
 }


### PR DESCRIPTION
rhel7: extract package sets into a single YAML file

Move hte rhel7 packages into yaml.

This was validate by running `./tools/gen-manifest-diff`.
