### PR TITLE
distro: tweaks to the pacakgeset loader

### DIFF
--- a/pkg/distro/packagesets/rhel-9/package_sets.yaml
+++ b/pkg/distro/packagesets/rhel-9/package_sets.yaml
@@ -915,6 +915,12 @@ image_types:
     package_sets:
       - *edge_commit_pkgset
 
+  # XXX: not a real pkgset but the "containerPkgsKey"
+  edge_container_pipeline_pkgset:
+    package_sets:
+      - include:
+          - "nginx"
+
   edge_installer:
     package_sets:
       - *installer_pkgset

--- a/pkg/distro/rhel/imagetype.go
+++ b/pkg/distro/rhel/imagetype.go
@@ -49,7 +49,7 @@ var requiredDirectorySizes = map[string]uint64{
 
 type ImageFunc func(workload workload.Workload, t *ImageType, customizations *blueprint.Customizations, options distro.ImageOptions, packageSets map[string]rpmmd.PackageSet, containers []container.SourceSpec, rng *rand.Rand) (image.ImageKind, error)
 
-type PackageSetFunc func(t *ImageType) rpmmd.PackageSet
+type PackageSetFunc func(t *ImageType) (rpmmd.PackageSet, error)
 
 type BasePartitionTableFunc func(t *ImageType) (disk.PartitionTable, bool)
 
@@ -285,7 +285,11 @@ func (t *ImageType) Manifest(bp *blueprint.Blueprint,
 	staticPackageSets := make(map[string]rpmmd.PackageSet)
 
 	for name, getter := range t.packageSets {
-		staticPackageSets[name] = getter(t)
+		pkgSets, err := getter(t)
+		if err != nil {
+			return nil, nil, err
+		}
+		staticPackageSets[name] = pkgSets
 	}
 
 	// amend with repository information and collect payload repos

--- a/pkg/distro/rhel/rhel10/bare_metal.go
+++ b/pkg/distro/rhel/rhel10/bare_metal.go
@@ -1,7 +1,6 @@
 package rhel10
 
 import (
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/packagesets"
 	"github.com/osbuild/images/pkg/distro/rhel"
@@ -29,8 +28,8 @@ func mkImageInstallerImgType() *rhel.ImageType {
 		"installer.iso",
 		"application/x-iso9660-image",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: func(t *rhel.ImageType) rpmmd.PackageSet {
-				return common.Must(packagesets.Load(t, "bare-metal", nil))
+			rhel.OSPkgsKey: func(t *rhel.ImageType) (rpmmd.PackageSet, error) {
+				return packagesets.Load(t, "bare-metal", nil)
 			},
 			rhel.InstallerPkgsKey: packageSetLoader,
 		},

--- a/pkg/distro/rhel/rhel10/package_sets.go
+++ b/pkg/distro/rhel/rhel10/package_sets.go
@@ -3,12 +3,11 @@ package rhel10
 // This file defines package sets that are used by more than one image type.
 
 import (
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/distro/packagesets"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-func packageSetLoader(t *rhel.ImageType) rpmmd.PackageSet {
-	return common.Must(packagesets.Load(t, "", nil))
+func packageSetLoader(t *rhel.ImageType) (rpmmd.PackageSet, error) {
+	return packagesets.Load(t, "", nil)
 }

--- a/pkg/distro/rhel/rhel7/package_sets.go
+++ b/pkg/distro/rhel/rhel7/package_sets.go
@@ -1,12 +1,11 @@
 package rhel7
 
 import (
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/distro/packagesets"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-func packageSetLoader(t *rhel.ImageType) rpmmd.PackageSet {
-	return common.Must(packagesets.Load(t, "", nil))
+func packageSetLoader(t *rhel.ImageType) (rpmmd.PackageSet, error) {
+	return packagesets.Load(t, "", nil)
 }

--- a/pkg/distro/rhel/rhel8/bare_metal.go
+++ b/pkg/distro/rhel/rhel8/bare_metal.go
@@ -1,7 +1,6 @@
 package rhel8
 
 import (
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/packagesets"
 	"github.com/osbuild/images/pkg/distro/rhel"
@@ -14,8 +13,8 @@ func mkImageInstaller() *rhel.ImageType {
 		"installer.iso",
 		"application/x-iso9660-image",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: func(t *rhel.ImageType) rpmmd.PackageSet {
-				return common.Must(packagesets.Load(t, "bare-metal", nil))
+			rhel.OSPkgsKey: func(t *rhel.ImageType) (rpmmd.PackageSet, error) {
+				return packagesets.Load(t, "bare-metal", nil)
 			},
 			rhel.InstallerPkgsKey: packageSetLoader,
 		},

--- a/pkg/distro/rhel/rhel8/edge.go
+++ b/pkg/distro/rhel/rhel8/edge.go
@@ -43,8 +43,8 @@ func mkEdgeOCIImgType(rd *rhel.Distribution) *rhel.ImageType {
 		"application/x-tar",
 		map[string]rhel.PackageSetFunc{
 			rhel.OSPkgsKey: packageSetLoader,
-			rhel.ContainerPkgsKey: func(t *rhel.ImageType) rpmmd.PackageSet {
-				return common.Must(packagesets.Load(t, "edge_container_pipeline_pkgset", nil))
+			rhel.ContainerPkgsKey: func(t *rhel.ImageType) (rpmmd.PackageSet, error) {
+				return packagesets.Load(t, "edge_container_pipeline_pkgset", nil)
 			},
 		},
 		rhel.EdgeContainerImage,

--- a/pkg/distro/rhel/rhel8/package_sets.go
+++ b/pkg/distro/rhel/rhel8/package_sets.go
@@ -3,12 +3,11 @@ package rhel8
 // This file defines package sets that are used by more than one image type.
 
 import (
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/distro/packagesets"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-func packageSetLoader(t *rhel.ImageType) rpmmd.PackageSet {
-	return common.Must(packagesets.Load(t, "", nil))
+func packageSetLoader(t *rhel.ImageType) (rpmmd.PackageSet, error) {
+	return packagesets.Load(t, "", nil)
 }

--- a/pkg/distro/rhel/rhel9/bare_metal.go
+++ b/pkg/distro/rhel/rhel9/bare_metal.go
@@ -14,12 +14,7 @@ func mkTarImgType() *rhel.ImageType {
 		"root.tar.xz",
 		"application/x-tar",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: func(t *rhel.ImageType) rpmmd.PackageSet {
-				return rpmmd.PackageSet{
-					Include: []string{"policycoreutils", "selinux-policy-targeted"},
-					Exclude: []string{"rng-tools"},
-				}
-			},
+			rhel.OSPkgsKey: packageSetLoader,
 		},
 		rhel.TarImage,
 		[]string{"build"},

--- a/pkg/distro/rhel/rhel9/bare_metal.go
+++ b/pkg/distro/rhel/rhel9/bare_metal.go
@@ -29,8 +29,8 @@ func mkImageInstallerImgType() *rhel.ImageType {
 		"installer.iso",
 		"application/x-iso9660-image",
 		map[string]rhel.PackageSetFunc{
-			rhel.OSPkgsKey: func(t *rhel.ImageType) rpmmd.PackageSet {
-				return common.Must(packagesets.Load(t, "bare-metal", nil))
+			rhel.OSPkgsKey: func(t *rhel.ImageType) (rpmmd.PackageSet, error) {
+				return packagesets.Load(t, "bare-metal", nil)
 			},
 			rhel.InstallerPkgsKey: packageSetLoader,
 		},

--- a/pkg/distro/rhel/rhel9/edge.go
+++ b/pkg/distro/rhel/rhel9/edge.go
@@ -53,8 +53,8 @@ func mkEdgeOCIImgType(d *rhel.Distribution) *rhel.ImageType {
 		"application/x-tar",
 		map[string]rhel.PackageSetFunc{
 			rhel.OSPkgsKey: packageSetLoader,
-			rhel.ContainerPkgsKey: func(t *rhel.ImageType) rpmmd.PackageSet {
-				return common.Must(packagesets.Load(t, "edge_container_pipeline_pkgset", nil))
+			rhel.ContainerPkgsKey: func(t *rhel.ImageType) (rpmmd.PackageSet, error) {
+				return packagesets.Load(t, "edge_container_pipeline_pkgset", nil)
 			},
 		},
 		rhel.EdgeContainerImage,

--- a/pkg/distro/rhel/rhel9/edge.go
+++ b/pkg/distro/rhel/rhel9/edge.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distro/packagesets"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -53,9 +54,7 @@ func mkEdgeOCIImgType(d *rhel.Distribution) *rhel.ImageType {
 		map[string]rhel.PackageSetFunc{
 			rhel.OSPkgsKey: packageSetLoader,
 			rhel.ContainerPkgsKey: func(t *rhel.ImageType) rpmmd.PackageSet {
-				return rpmmd.PackageSet{
-					Include: []string{"nginx"}, // FIXME: this has no effect
-				}
+				return common.Must(packagesets.Load(t, "edge_container_pipeline_pkgset", nil))
 			},
 		},
 		rhel.EdgeContainerImage,

--- a/pkg/distro/rhel/rhel9/package_sets.go
+++ b/pkg/distro/rhel/rhel9/package_sets.go
@@ -1,12 +1,11 @@
 package rhel9
 
 import (
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/distro/packagesets"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-func packageSetLoader(t *rhel.ImageType) rpmmd.PackageSet {
-	return common.Must(packagesets.Load(t, "", nil))
+func packageSetLoader(t *rhel.ImageType) (rpmmd.PackageSet, error) {
+	return packagesets.Load(t, "", nil)
 }


### PR DESCRIPTION
Some small tweak now that the bulk of the package set yaml is merged (thanks for the reviews!)

----

rhel: add error return in PackageSetFunc

This is a small cleanup/tweak to return an error if the rhel
PackageSetFunc fails. This avoid us having to panic and we
can just bubble the error up.

---

rhel9: fix two leftover hardcoded packagesets

This commit fixes two leftover package sets that were hardcoded
and are now defined in YAML. Sorry for overlooking them in my
previous commit.
