### PR TITLE
distro/fedora: move defaultImageConfig into YAML

### DIFF
--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -263,12 +263,13 @@
         <<: *iot_simplified_installer_partition_tables_x86
 
 image_config:
-  default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml"
-  hostname: "localhost.localdomain"
-  install_weak_deps: true
-  locale: "C.UTF-8"
-  machine_id_uninitialized: true
-  timezone: "UTC"
+  default:
+    default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml"
+    hostname: "localhost.localdomain"
+    install_weak_deps: true
+    locale: "C.UTF-8"
+    machine_id_uninitialized: true
+    timezone: "UTC"
 
 image_types:
   qcow2: &qcow2

--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -262,6 +262,14 @@
       aarch64:
         <<: *iot_simplified_installer_partition_tables_x86
 
+image_config:
+  default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml"
+  hostname: "localhost.localdomain"
+  install_weak_deps: true
+  locale: "C.UTF-8"
+  machine_id_uninitialized: true
+  timezone: "UTC"
+
 image_types:
   qcow2: &qcow2
     partition_table:

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -27,8 +27,9 @@ var data embed.FS
 var DataFS fs.FS = data
 
 type toplevelYAML struct {
-	ImageTypes map[string]imageType `yaml:"image_types"`
-	Common     map[string]any       `yaml:".common,omitempty"`
+	ImageConfig *distro.ImageConfig  `yaml:"image_config,omitempty"`
+	ImageTypes  map[string]imageType `yaml:"image_types"`
+	Common      map[string]any       `yaml:".common,omitempty"`
 }
 
 type imageType struct {
@@ -107,6 +108,17 @@ func (op *partitionTablesOverrideOp) Apply(pt *disk.PartitionTable) error {
 	}
 
 	return nil
+}
+
+// DistroImageConfig returns the distro wide ImageConfig.
+//
+// Each ImageType gets this as their default ImageConfig.
+func DistroImageConfig(distroNameVer string) (*distro.ImageConfig, error) {
+	toplevel, err := load(distroNameVer)
+	if err != nil {
+		return nil, err
+	}
+	return toplevel.ImageConfig, nil
 }
 
 // PackageSet loads the PackageSet from the yaml source file discovered via the

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -344,7 +344,13 @@ image_types:
 func TestDefsImageConfig(t *testing.T) {
 	fakeDistroYaml := `
 image_config:
-  locale: "C.UTF-8"
+  default:
+    locale: "C.UTF-8"
+    timezone: "DefaultTZ"
+  condition:
+    distro_name:
+      "test-distro":
+        timezone: "OverrideTZ"
 `
 	fakeDistroName := "test-distro"
 	fakeDistroVer := "42"
@@ -356,6 +362,7 @@ image_config:
 	imgConfig, err := defs.DistroImageConfig(distroNameVer)
 	assert.NoError(t, err)
 	assert.Equal(t, &distro.ImageConfig{
-		Locale: common.ToPtr("C.UTF-8"),
+		Locale:   common.ToPtr("C.UTF-8"),
+		Timezone: common.ToPtr("OverrideTZ"),
 	}, imgConfig)
 }

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/defs"
@@ -338,4 +339,23 @@ image_types:
 			},
 		},
 	}, partTable)
+}
+
+func TestDefsImageConfig(t *testing.T) {
+	fakeDistroYaml := `
+image_config:
+  locale: "C.UTF-8"
+`
+	fakeDistroName := "test-distro"
+	fakeDistroVer := "42"
+	baseDir := makeFakePkgsSet(t, fakeDistroName, fakeDistroYaml)
+	restore := defs.MockDataFS(baseDir)
+	defer restore()
+
+	distroNameVer := fakeDistroName + "-" + fakeDistroVer
+	imgConfig, err := defs.DistroImageConfig(distroNameVer)
+	assert.NoError(t, err)
+	assert.Equal(t, &distro.ImageConfig{
+		Locale: common.ToPtr("C.UTF-8"),
+	}, imgConfig)
 }

--- a/pkg/distro/defs/rhel-10/distro.yaml
+++ b/pkg/distro/defs/rhel-10/distro.yaml
@@ -153,16 +153,21 @@
             - "shim-aa64"
 
 image_config:
-  default_kernel: "kernel"
-  # XXX: this needs to be conditional for centos and rhel  
-  default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-rhel10-ds.xml"
-  install_weak_deps: true
-  locale: "C.UTF-8"
-  sysconfig:
-    networking: true
-    no_zero_conf: true
-  timezone: "UTC"
-  update_default_kernel: true
+  default:
+    default_kernel: "kernel"
+    # XXX: this needs to be conditional for centos and rhel  
+    default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-rhel10-ds.xml"
+    install_weak_deps: true
+    locale: "C.UTF-8"
+    sysconfig:
+      networking: true
+      no_zero_conf: true
+    timezone: "UTC"
+    update_default_kernel: true
+  condition:
+    distro_name:
+      centos:
+        default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-cs10-ds.xml"
 
 image_types:
   # XXX: not a real pkgset but the "os" pipeline pkgset for image-installer

--- a/pkg/distro/defs/rhel-10/distro.yaml
+++ b/pkg/distro/defs/rhel-10/distro.yaml
@@ -152,6 +152,18 @@
             - "grub2-efi-aa64"
             - "shim-aa64"
 
+image_config:
+  default_kernel: "kernel"
+  # XXX: this needs to be conditional for centos and rhel  
+  default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-rhel10-ds.xml"
+  install_weak_deps: true
+  locale: "C.UTF-8"
+  sysconfig:
+    networking: true
+    no_zero_conf: true
+  timezone: "UTC"
+  update_default_kernel: true
+
 image_types:
   # XXX: not a real pkgset but the "os" pipeline pkgset for image-installer
   # find a nicer way to represent this

--- a/pkg/distro/defs/rhel-7/distro.yaml
+++ b/pkg/distro/defs/rhel-7/distro.yaml
@@ -45,20 +45,21 @@
             - "insights-client"
 
 image_config:
-  timezone: "America/New_York"
-  locale:   "en_US.UTF-8"
-  gpgkey_files:
-    - "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
-  sysconfig:
-    networking: true
-    no_zero_conf: true
-    create_default_network_scripts: true
-  default_kernel: "kernel"
-  update_default_kernel: true
-  kernel_options_bootloader: true
-  # RHEL 7 grub does not support BLS
-  no_bls: true
-  install_weak_deps: true
+  default:
+    timezone: "America/New_York"
+    locale:   "en_US.UTF-8"
+    gpgkey_files:
+      - "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+    sysconfig:
+      networking: true
+      no_zero_conf: true
+      create_default_network_scripts: true
+    default_kernel: "kernel"
+    update_default_kernel: true
+    kernel_options_bootloader: true
+    # RHEL 7 grub does not support BLS
+    no_bls: true
+    install_weak_deps: true
 
 image_types:
   azure_rhui:

--- a/pkg/distro/defs/rhel-7/distro.yaml
+++ b/pkg/distro/defs/rhel-7/distro.yaml
@@ -44,6 +44,22 @@
           include:
             - "insights-client"
 
+image_config:
+  timezone: "America/New_York"
+  locale:   "en_US.UTF-8"
+  gpgkey_files:
+    - "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+  sysconfig:
+    networking: true
+    no_zero_conf: true
+    create_default_network_scripts: true
+  default_kernel: "kernel"
+  update_default_kernel: true
+  kernel_options_bootloader: true
+  # RHEL 7 grub does not support BLS
+  no_bls: true
+  install_weak_deps: true
+
 image_types:
   azure_rhui:
     package_sets:

--- a/pkg/distro/defs/rhel-8/distro.yaml
+++ b/pkg/distro/defs/rhel-8/distro.yaml
@@ -524,6 +524,18 @@
             - "insights-client"
             - "subscription-manager-cockpit"
     
+image_config:
+  default_kernel: "kernel"
+  # XXX: this needs to be conditional for centos and rhel
+  default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml"
+  install_weak_deps: true
+  kernel_options_bootloader: true
+  locale:   "en_US.UTF-8"
+  sysconfig:
+    networking: true
+    no_zero_conf: true
+  timezone: "America/New_York"
+  update_default_kernel: true
 
 image_types:
   # XXX: not a real pkgset but the "os" pipeline pkgset for image-installer

--- a/pkg/distro/defs/rhel-8/distro.yaml
+++ b/pkg/distro/defs/rhel-8/distro.yaml
@@ -525,17 +525,22 @@
             - "subscription-manager-cockpit"
     
 image_config:
-  default_kernel: "kernel"
-  # XXX: this needs to be conditional for centos and rhel
-  default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml"
-  install_weak_deps: true
-  kernel_options_bootloader: true
-  locale:   "en_US.UTF-8"
-  sysconfig:
-    networking: true
-    no_zero_conf: true
-  timezone: "America/New_York"
-  update_default_kernel: true
+  default:
+    default_kernel: "kernel"
+    # XXX: this needs to be conditional for centos and rhel
+    default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml"
+    install_weak_deps: true
+    kernel_options_bootloader: true
+    locale:   "en_US.UTF-8"
+    sysconfig:
+      networking: true
+      no_zero_conf: true
+    timezone: "America/New_York"
+    update_default_kernel: true
+  condition:
+    distro_name:
+      centos:
+        default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-centos8-ds.xml"
 
 image_types:
   # XXX: not a real pkgset but the "os" pipeline pkgset for image-installer

--- a/pkg/distro/defs/rhel-9/distro.yaml
+++ b/pkg/distro/defs/rhel-9/distro.yaml
@@ -362,6 +362,18 @@
           include:
             - "dmidecode"
 
+image_config:
+  default_kernel: "kernel"
+  # XXX: this needs to be conditional for centos and rhel
+  default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml"
+  install_weak_deps: true
+  locale: "C.UTF-8"
+  sysconfig:
+    networking: true
+    no_zero_conf: true
+  timezone: "America/New_York"
+  update_default_kernel: true
+
 image_types:
   # XXX: not a real pkgset but the "os" pipeline pkgset for image-installer
   # find a nicer way to represent this

--- a/pkg/distro/defs/rhel-9/distro.yaml
+++ b/pkg/distro/defs/rhel-9/distro.yaml
@@ -363,16 +363,20 @@
             - "dmidecode"
 
 image_config:
-  default_kernel: "kernel"
-  # XXX: this needs to be conditional for centos and rhel
-  default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml"
-  install_weak_deps: true
-  locale: "C.UTF-8"
-  sysconfig:
-    networking: true
-    no_zero_conf: true
-  timezone: "America/New_York"
-  update_default_kernel: true
+  default:
+    default_kernel: "kernel"
+    default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml"
+    install_weak_deps: true
+    locale: "C.UTF-8"
+    sysconfig:
+      networking: true
+      no_zero_conf: true
+    timezone: "America/New_York"
+    update_default_kernel: true
+  condition:
+    distro_name:
+      centos:
+        default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-cs9-ds.xml"
 
 image_types:
   # XXX: not a real pkgset but the "os" pipeline pkgset for image-installer

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -506,16 +506,6 @@ type distribution struct {
 	defaultImageConfig *distro.ImageConfig
 }
 
-// Fedora based OS image configuration defaults
-var defaultDistroImageConfig = &distro.ImageConfig{
-	Hostname:               common.ToPtr("localhost.localdomain"),
-	Timezone:               common.ToPtr("UTC"),
-	Locale:                 common.ToPtr("C.UTF-8"),
-	DefaultOSCAPDatastream: common.ToPtr(oscap.DefaultFedoraDatastream()),
-	InstallWeakDeps:        common.ToPtr(true),
-	MachineIdUninitialized: common.ToPtr(true),
-}
-
 func defaultDistroInstallerConfig(d *distribution) *distro.InstallerConfig {
 	config := distro.InstallerConfig{}
 	// In Fedora 42 the ifcfg module was replaced by net-lib.
@@ -541,15 +531,16 @@ func getDistro(version int) distribution {
 	if version < 0 {
 		panic("Invalid Fedora version (must be positive)")
 	}
+	nameVer := fmt.Sprintf("fedora-%d", version)
 	return distribution{
-		name:               fmt.Sprintf("fedora-%d", version),
+		name:               nameVer,
 		product:            "Fedora",
 		osVersion:          strconv.Itoa(version),
 		releaseVersion:     strconv.Itoa(version),
 		modulePlatformID:   fmt.Sprintf("platform:f%d", version),
 		ostreeRefTmpl:      fmt.Sprintf("fedora/%d/%%s/iot", version),
 		runner:             &runner.Fedora{Version: uint64(version)},
-		defaultImageConfig: defaultDistroImageConfig,
+		defaultImageConfig: common.Must(defs.DistroImageConfig(nameVer)),
 	}
 }
 

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -23,12 +23,12 @@ type ImageConfig struct {
 	MaskedServices      []string
 	DefaultTarget       *string
 
-	Sysconfig           *Sysconfig
-	DefaultKernel       *string
-	UpdateDefaultKernel *bool
+	Sysconfig           *Sysconfig `yaml:"sysconfig,omitempty"`
+	DefaultKernel       *string    `yaml:"default_kernel,omitempty"`
+	UpdateDefaultKernel *bool      `yaml:"update_default_kernel,omitempty"`
 
 	// List of files from which to import GPG keys into the RPM database
-	GPGKeyFiles []string
+	GPGKeyFiles []string `yaml:"gpgkey_files,omitempty"`
 
 	// Disable SELinux labelling
 	NoSElinux *bool
@@ -80,7 +80,7 @@ type ImageConfig struct {
 	//
 	// This should only be used for old distros that use grub and it is
 	// applied on all architectures, except for s390x.
-	KernelOptionsBootloader *bool
+	KernelOptionsBootloader *bool `yaml:"kernel_options_bootloader,omitempty"`
 
 	// The default OSCAP datastream to use for the image as a fallback,
 	// if no datastream value is provided by the user.
@@ -88,7 +88,7 @@ type ImageConfig struct {
 
 	// NoBLS configures the image bootloader with traditional menu entries
 	// instead of BLS. Required for legacy systems like RHEL 7.
-	NoBLS *bool
+	NoBLS *bool `yaml:"no_bls,omitempty"`
 
 	// OSTree specific configuration
 
@@ -156,10 +156,10 @@ func (c *ImageConfig) WSLConfStageOptions() *osbuild.WSLConfStageOptions {
 }
 
 type Sysconfig struct {
-	Networking bool
-	NoZeroConf bool
+	Networking bool `yaml:"networking,omitempty"`
+	NoZeroConf bool `yaml:"no_zero_conf,omitempty"`
 
-	CreateDefaultNetworkScripts bool
+	CreateDefaultNetworkScripts bool `yaml:"create_default_network_scripts,omitempty"`
 }
 
 func (c *ImageConfig) SysconfigStageOptions() []*osbuild.SysconfigStageOptions {

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -13,10 +13,10 @@ import (
 
 // ImageConfig represents a (default) configuration applied to the image payload.
 type ImageConfig struct {
-	Hostname            *string
-	Timezone            *string
+	Hostname            *string `yaml:"hostname,omitempty"`
+	Timezone            *string `yaml:"timezone,omitempty"`
 	TimeSynchronization *osbuild.ChronyStageOptions
-	Locale              *string
+	Locale              *string `yaml:"locale,omitempty"`
 	Keyboard            *osbuild.KeymapStageOptions
 	EnabledServices     []string
 	DisabledServices    []string
@@ -84,7 +84,7 @@ type ImageConfig struct {
 
 	// The default OSCAP datastream to use for the image as a fallback,
 	// if no datastream value is provided by the user.
-	DefaultOSCAPDatastream *string
+	DefaultOSCAPDatastream *string `yaml:"default_oscap_datastream,omitempty"`
 
 	// NoBLS configures the image bootloader with traditional menu entries
 	// instead of BLS. Required for legacy systems like RHEL 7.
@@ -103,12 +103,12 @@ type ImageConfig struct {
 
 	// InstallWeakDeps enables installation of weak dependencies for packages
 	// that are statically defined for the pipeline.
-	InstallWeakDeps *bool
+	InstallWeakDeps *bool `yaml:"install_weak_deps,omitempty"`
 
 	// How to handle the /etc/machine-id file, when set to true it causes the
 	// machine id to be set to 'uninitialized' which causes ConditionFirstboot
 	// to be triggered in systemd
-	MachineIdUninitialized *bool
+	MachineIdUninitialized *bool `yaml:"machine_id_uninitialized,omitempty"`
 
 	// MountUnits creates systemd .mount units to describe the filesystem
 	// instead of writing to /etc/fstab

--- a/pkg/distro/rhel/rhel10/distro.go
+++ b/pkg/distro/rhel/rhel10/distro.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/oscap"
 	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/platform"
 )
@@ -49,18 +50,7 @@ func distroISOLabelFunc(t *rhel.ImageType) string {
 }
 
 func defaultDistroImageConfig(d *rhel.Distribution) *distro.ImageConfig {
-	return &distro.ImageConfig{
-		Timezone:            common.ToPtr("UTC"),
-		Locale:              common.ToPtr("C.UTF-8"),
-		UpdateDefaultKernel: common.ToPtr(true),
-		DefaultKernel:       common.ToPtr("kernel"),
-		Sysconfig: &distro.Sysconfig{
-			Networking: true,
-			NoZeroConf: true,
-		},
-		DefaultOSCAPDatastream: common.ToPtr(oscap.DefaultRHEL10Datastream(d.IsRHEL())),
-		InstallWeakDeps:        common.ToPtr(true),
-	}
+	return common.Must(defs.DistroImageConfig(d.Name()))
 }
 
 func newDistro(name string, major, minor int) *rhel.Distribution {

--- a/pkg/distro/rhel/rhel7/distro.go
+++ b/pkg/distro/rhel/rhel7/distro.go
@@ -6,28 +6,14 @@ import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/platform"
 )
 
 // RHEL-based OS image configuration defaults
 func defaultDistroImageConfig(d *rhel.Distribution) *distro.ImageConfig {
-	return &distro.ImageConfig{
-		Timezone: common.ToPtr("America/New_York"),
-		Locale:   common.ToPtr("en_US.UTF-8"),
-		GPGKeyFiles: []string{
-			"/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
-		},
-		UpdateDefaultKernel: common.ToPtr(true),
-		DefaultKernel:       common.ToPtr("kernel"),
-		Sysconfig: &distro.Sysconfig{
-			Networking: true,
-			NoZeroConf: true,
-		},
-		KernelOptionsBootloader: common.ToPtr(true),
-		NoBLS:                   common.ToPtr(true), // RHEL 7 grub does not support BLS
-		InstallWeakDeps:         common.ToPtr(true),
-	}
+	return common.Must(defs.DistroImageConfig(d.Name()))
 }
 
 func newDistro(name string, minor int) *rhel.Distribution {

--- a/pkg/distro/rhel/rhel8/distro.go
+++ b/pkg/distro/rhel/rhel8/distro.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/oscap"
 	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/platform"
 )
@@ -36,19 +37,7 @@ var (
 
 // RHEL-based OS image configuration defaults
 func defaultDistroImageConfig(d *rhel.Distribution) *distro.ImageConfig {
-	return &distro.ImageConfig{
-		Timezone:            common.ToPtr("America/New_York"),
-		Locale:              common.ToPtr("en_US.UTF-8"),
-		UpdateDefaultKernel: common.ToPtr(true),
-		DefaultKernel:       common.ToPtr("kernel"),
-		Sysconfig: &distro.Sysconfig{
-			Networking: true,
-			NoZeroConf: true,
-		},
-		KernelOptionsBootloader: common.ToPtr(true),
-		DefaultOSCAPDatastream:  common.ToPtr(oscap.DefaultRHEL8Datastream(d.IsRHEL())),
-		InstallWeakDeps:         common.ToPtr(true),
-	}
+	return common.Must(defs.DistroImageConfig(d.Name()))
 }
 
 func distroISOLabelFunc(t *rhel.ImageType) string {

--- a/pkg/distro/rhel/rhel9/distro.go
+++ b/pkg/distro/rhel/rhel9/distro.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/oscap"
 	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/platform"
 )
@@ -52,19 +53,7 @@ func distroISOLabelFunc(t *rhel.ImageType) string {
 }
 
 func defaultDistroImageConfig(d *rhel.Distribution) *distro.ImageConfig {
-	return &distro.ImageConfig{
-		Timezone:            common.ToPtr("America/New_York"),
-		Locale:              common.ToPtr("C.UTF-8"),
-		UpdateDefaultKernel: common.ToPtr(true),
-		DefaultKernel:       common.ToPtr("kernel"),
-
-		Sysconfig: &distro.Sysconfig{
-			Networking: true,
-			NoZeroConf: true,
-		},
-		DefaultOSCAPDatastream: common.ToPtr(oscap.DefaultRHEL9Datastream(d.IsRHEL())),
-		InstallWeakDeps:        common.ToPtr(true),
-	}
+	return common.Must(defs.DistroImageConfig(d.Name()))
 }
 
 func newDistro(name string, major, minor int) *rhel.Distribution {

--- a/pkg/osbuild/sysconfig_stage.go
+++ b/pkg/osbuild/sysconfig_stage.go
@@ -1,11 +1,11 @@
 package osbuild
 
 type SysconfigStageOptions struct {
-	Kernel         *SysconfigKernelOptions  `json:"kernel,omitempty"`
-	Network        *SysconfigNetworkOptions `json:"network,omitempty"`
-	NetworkScripts *NetworkScriptsOptions   `json:"network-scripts,omitempty"`
-	Desktop        *SysconfigDesktopOptions `json:"desktop,omitempty"`
-	LiveSys        *SysconfigLivesysOptions `json:"livesys,omitempty"`
+	Kernel         *SysconfigKernelOptions  `json:"kernel,omitempty" yaml:"kernel,omitempty"`
+	Network        *SysconfigNetworkOptions `json:"network,omitempty" yaml:"network,omitempty"`
+	NetworkScripts *NetworkScriptsOptions   `json:"network-scripts,omitempty" yaml:"network-scripts,omitempty"`
+	Desktop        *SysconfigDesktopOptions `json:"desktop,omitempty" yaml:"desktop,omitempty"`
+	LiveSys        *SysconfigLivesysOptions `json:"livesys,omitempty" yaml:"libesys,omitempty"`
 }
 
 func (SysconfigStageOptions) isStageOptions() {}
@@ -19,12 +19,14 @@ func NewSysconfigStage(options *SysconfigStageOptions) *Stage {
 
 type SysconfigNetworkOptions struct {
 	Networking bool `json:"networking,omitempty"`
-	NoZeroConf bool `json:"no_zero_conf,omitempty"`
+	// XXX: ideally this would be no_zeroconf" (because zeroconf
+	// is the program name) but we need to keep for compatibility
+	NoZeroConf bool `json:"no_zero_conf,omitempty" yaml:"no_zero_conf,omitempty"`
 }
 
 type SysconfigKernelOptions struct {
-	UpdateDefault bool   `json:"update_default,omitempty"`
-	DefaultKernel string `json:"default_kernel,omitempty"`
+	UpdateDefault bool   `json:"update_default,omitempty" yaml:"update_default,omitempty"`
+	DefaultKernel string `json:"default_kernel,omitempty" yaml:"default_kernel,omitempty"`
 }
 
 type SysconfigDesktopOptions struct {


### PR DESCRIPTION
Now that all the package sets are part of the YAML this moves
the default distro.ImageConfiguration into YAML.

Note that the individual imageType ImageConfiguration are not moved yet and that will (probably) still take a while.
