### PR TITLE
Add ro to FSTabOptions for IoT raw disk

### DIFF
--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -396,7 +396,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 					Type:         "ext4",
 					Label:        "root",
 					Mountpoint:   "/",
-					FSTabOptions: "defaults",
+					FSTabOptions: "defaults,ro",
 					FSTabFreq:    1,
 					FSTabPassNo:  1,
 				},


### PR DESCRIPTION
Adds `ro` to FSTabOptions for Fedora IoT raw disk images.

Fixes https://github.com/fedora-iot/iot-distro/issues/81