### PR TITLE
disk: add new unmarshalYAMLviaJSON helper

### DIFF
--- a/cmd/otk/osbuild-gen-partition-table/main_test.go
+++ b/cmd/otk/osbuild-gen-partition-table/main_test.go
@@ -145,31 +145,20 @@ func TestUnmarshalOutput(t *testing.T) {
     },
     "internal": {
       "partition-table": {
-        "Size": 911,
-        "UUID": "",
-        "Type": "",
-        "Partitions": [
+        "size": 911,
+        "type": "",
+        "partitions": [
           {
-            "Start": 0,
-            "Size": 0,
-            "Type": "119119",
-            "Bootable": false,
-            "UUID": "911911",
-            "Payload": {
-              "Type": "ext4",
-              "UUID": "",
-              "Label": "",
-              "Mountpoint": "",
-              "FSTabOptions": "",
-              "FSTabFreq": 0,
-              "FSTabPassNo": 0
+            "start": 0,
+            "size": 0,
+            "type": "119119",
+            "uuid": "911911",
+            "payload": {
+              "type": "ext4"
             },
-            "PayloadType": "filesystem"
+            "payload_type": "filesystem"
           }
-        ],
-        "SectorSize": 0,
-        "ExtraPadding": 0,
-        "StartOffset": 0
+        ]
       }
     },
     "filename": "disk.img"
@@ -226,74 +215,59 @@ var expectedSimplePartOutput = `{
       },
       "internal": {
         "partition-table": {
-          "Size": 11821645824,
-          "UUID": "dbd21911-1c4e-4107-8a9f-14fe6e751358",
-          "Type": "gpt",
-          "Partitions": [
+          "size": 11821645824,
+          "uuid": "dbd21911-1c4e-4107-8a9f-14fe6e751358",
+          "type": "gpt",
+          "partitions": [
             {
-              "Start": 9048576,
-              "Size": 1048576,
-              "Type": "21686148-6449-6E6F-744E-656564454649",
-              "Bootable": true,
-              "UUID": "FAC7F1FB-3E8D-4137-A512-961DE09A5549",
-              "Payload": null,
-              "PayloadType": "no-payload"
+              "start": 9048576,
+              "size": 1048576,
+              "type": "21686148-6449-6E6F-744E-656564454649",
+              "bootable": true,
+              "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549",
+              "payload_type": "no-payload"
             },
             {
-              "Start": 10097152,
-              "Size": 2147483648,
-              "Type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-              "Bootable": false,
-              "UUID": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33",
-              "Payload": {
-                "Type": "vfat",
-                "UUID": "7B77-95E7",
-                "Label": "EFI-SYSTEM",
-                "Mountpoint": "/boot/efi",
-                "FSTabOptions": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                "FSTabFreq": 0,
-                "FSTabPassNo": 2
+              "start": 10097152,
+              "size": 2147483648,
+              "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+              "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33",
+              "payload": {
+                "type": "vfat",
+                "uuid": "7B77-95E7",
+                "label": "EFI-SYSTEM",
+                "mountpoint": "/boot/efi",
+                "fstab_options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "fstab_passno": 2
               },
-              "PayloadType": "filesystem"
+              "payload_type": "filesystem"
             },
             {
-              "Start": 4305064448,
-              "Size": 7516564480,
-              "Type": "",
-              "Bootable": false,
-              "UUID": "ed130be6-c822-49af-83bb-4ea648bb2264",
-              "Payload": {
-                "Type": "ext4",
-                "UUID": "9851898e-0b30-437d-8fad-51ec16c3697f",
-                "Label": "root",
-                "Mountpoint": "/",
-                "FSTabOptions": "",
-                "FSTabFreq": 0,
-                "FSTabPassNo": 0
+              "start": 4305064448,
+              "size": 7516564480,
+              "uuid": "ed130be6-c822-49af-83bb-4ea648bb2264",
+              "payload": {
+                "type": "ext4",
+                "uuid": "9851898e-0b30-437d-8fad-51ec16c3697f",
+                "label": "root",
+                "mountpoint": "/"
               },
-              "PayloadType": "filesystem"
+              "payload_type": "filesystem"
             },
             {
-              "Start": 2157580800,
-              "Size": 2147483648,
-              "Type": "",
-              "Bootable": false,
-              "UUID": "9f6173fd-edc9-4dbe-9313-632af556c607",
-              "Payload": {
-                "Type": "ext4",
-                "UUID": "d8bb61b8-81cf-4c85-937b-69439a23dc5e",
-                "Label": "home",
-                "Mountpoint": "/home",
-                "FSTabOptions": "",
-                "FSTabFreq": 0,
-                "FSTabPassNo": 0
+              "start": 2157580800,
+              "size": 2147483648,
+              "uuid": "9f6173fd-edc9-4dbe-9313-632af556c607",
+              "payload": {
+                "type": "ext4",
+                "uuid": "d8bb61b8-81cf-4c85-937b-69439a23dc5e",
+                "label": "home",
+                "mountpoint": "/home"
               },
-              "PayloadType": "filesystem"
+              "payload_type": "filesystem"
             }
           ],
-          "SectorSize": 0,
-          "ExtraPadding": 0,
-          "StartOffset": 8000000
+          "start_offset": 8000000
         }
       },
       "filename": "disk.img"

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -262,6 +262,10 @@ func (t *PartitionTableType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (t *PartitionTableType) UnmarshalYAML(unmarshal func(any) error) error {
+	return unmarshalYAMLviaJSON(t, unmarshal)
+}
+
 func NewPartitionTableType(s string) (PartitionTableType, error) {
 	switch s {
 	case "":

--- a/pkg/disk/filesystem.go
+++ b/pkg/disk/filesystem.go
@@ -9,18 +9,19 @@ import (
 
 // Filesystem related functions
 type Filesystem struct {
-	Type string
+	Type string `json:"type"`
+
 	// ID of the filesystem, vfat doesn't use traditional UUIDs, therefore this
 	// is just a string.
-	UUID       string
-	Label      string
-	Mountpoint string
+	UUID       string `json:"uuid,omitempty"`
+	Label      string `json:"label,omitempty"`
+	Mountpoint string `json:"mountpoint,omitempty"`
 	// The fourth field of fstab(5); fs_mntops
-	FSTabOptions string
+	FSTabOptions string `json:"fstab_options,omitempty"`
 	// The fifth field of fstab(5); fs_freq
-	FSTabFreq uint64
+	FSTabFreq uint64 `json:"fstab_freq,omitempty"`
 	// The sixth field of fstab(5); fs_passno
-	FSTabPassNo uint64
+	FSTabPassNo uint64 `json:"fstab_passno,omitempty"`
 }
 
 func init() {

--- a/pkg/disk/partition.go
+++ b/pkg/disk/partition.go
@@ -8,17 +8,21 @@ import (
 )
 
 type Partition struct {
-	Start    uint64 // Start of the partition in bytes
-	Size     uint64 // Size of the partition in bytes
-	Type     string // Partition type, e.g. 0x83 for MBR or a UUID for gpt
-	Bootable bool   // `Legacy BIOS bootable` (GPT) or `active` (DOS) flag
+	// Start of the partition in bytes
+	Start uint64 `json:"start"`
+	// Size of the partition in bytes
+	Size uint64 `json:"size"`
+	// Partition type, e.g. 0x83 for MBR or a UUID for gpt
+	Type string `json:"type,omitempty"`
+	// `Legacy BIOS bootable` (GPT) or `active` (DOS) flag
+	Bootable bool `json:"bootable,omitempty"`
 
 	// ID of the partition, dos doesn't use traditional UUIDs, therefore this
 	// is just a string.
-	UUID string
+	UUID string `json:"uuid,omitempty"`
 
 	// If nil, the partition is raw; It doesn't contain a payload.
-	Payload PayloadEntity
+	Payload PayloadEntity `json:"payload,omitempty"`
 }
 
 func (p *Partition) Clone() Entity {
@@ -108,7 +112,7 @@ func (p *Partition) MarshalJSON() ([]byte, error) {
 
 	partWithPayloadType := struct {
 		partAlias
-		PayloadType string
+		PayloadType string `json:"payload_type,omitempty"`
 	}{
 		partAlias(*p),
 		entityName,
@@ -121,8 +125,8 @@ func (p *Partition) UnmarshalJSON(data []byte) error {
 	type partAlias Partition
 	var partWithoutPayload struct {
 		partAlias
-		Payload     json.RawMessage
-		PayloadType string
+		Payload     json.RawMessage `json:"payload"`
+		PayloadType string          `json:"payload_type,omitempty"`
 	}
 
 	dec := json.NewDecoder(bytes.NewBuffer(data))

--- a/pkg/disk/partition.go
+++ b/pkg/disk/partition.go
@@ -137,7 +137,7 @@ func (p *Partition) UnmarshalJSON(data []byte) error {
 
 	entType := payloadEntityMap[partWithoutPayload.PayloadType]
 	if entType == nil {
-		return fmt.Errorf("cannot build partition from %q", data)
+		return fmt.Errorf("cannot build partition from %q: unknown payload %q", data, partWithoutPayload.PayloadType)
 	}
 	entValP := reflect.New(entType).Elem().Addr()
 	ent := entValP.Interface()
@@ -146,4 +146,7 @@ func (p *Partition) UnmarshalJSON(data []byte) error {
 	}
 	p.Payload = ent.(PayloadEntity)
 	return nil
+}
+func (t *Partition) UnmarshalYAML(unmarshal func(any) error) error {
+	return unmarshalYAMLviaJSON(t, unmarshal)
 }

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -14,14 +14,20 @@ import (
 )
 
 type PartitionTable struct {
-	Size       uint64             // Size of the disk (in bytes).
-	UUID       string             // Unique identifier of the partition table (GPT only).
-	Type       PartitionTableType // Partition table type, e.g. dos, gpt.
-	Partitions []Partition
+	// Size of the disk (in bytes).
+	Size uint64 `json:"size"`
+	// Unique identifier of the partition table (GPT only).
+	UUID string `json:"uuid,omitempty"`
+	// Partition table type, e.g. dos, gpt.
+	Type       PartitionTableType `json:"type"`
+	Partitions []Partition        `json:"partitions"`
 
-	SectorSize   uint64 // Sector size in bytes
-	ExtraPadding uint64 // Extra space at the end of the partition table (sectors)
-	StartOffset  uint64 // Starting offset of the first partition in the table (Mb)
+	// Sector size in bytes
+	SectorSize uint64 `json:"sector_size,omitempty"`
+	// Extra space at the end of the partition table (sectors)
+	ExtraPadding uint64 `json:"extra_padding,omitempty"`
+	// Starting offset of the first partition in the table (Mb)
+	StartOffset uint64 `json:"start_offset,omitempty"`
 }
 
 type PartitioningMode string

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/osbuild/images/internal/testdisk"
 	"github.com/osbuild/images/pkg/arch"
@@ -2792,4 +2793,39 @@ func TestPartitionTableFeatures(t *testing.T) {
 		require.True(ok, "expected test result not defined for test partition table %q: please update the %s test", name, t.Name())
 		require.Equal(exp, disk.GetPartitionTableFeatures(pt))
 	}
+}
+
+func TestPartitionTableUnmarshalYAML(t *testing.T) {
+	inputYAML := `dos`
+	var partType disk.PartitionTableType
+
+	err := yaml.Unmarshal([]byte(inputYAML), &partType)
+	assert.NoError(t, err)
+	assert.Equal(t, disk.PT_DOS, partType)
+}
+
+func TestPartitionUnmarshalYAML(t *testing.T) {
+	inputYAML := `
+Start: 123
+Size: 456
+Type: "0x83"
+Bootable: true
+PayloadType: "filesystem"
+Payload:
+  type: vfat
+`
+	var part disk.Partition
+
+	err := yaml.Unmarshal([]byte(inputYAML), &part)
+	assert.NoError(t, err)
+	expected := disk.Partition{
+		Start:    123,
+		Size:     456,
+		Type:     "0x83",
+		Bootable: true,
+		Payload: &disk.Filesystem{
+			Type: "vfat",
+		},
+	}
+	assert.Equal(t, expected, part)
 }

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 
 	"github.com/osbuild/images/internal/testdisk"
 	"github.com/osbuild/images/pkg/arch"
@@ -2793,39 +2792,4 @@ func TestPartitionTableFeatures(t *testing.T) {
 		require.True(ok, "expected test result not defined for test partition table %q: please update the %s test", name, t.Name())
 		require.Equal(exp, disk.GetPartitionTableFeatures(pt))
 	}
-}
-
-func TestPartitionTableUnmarshalYAML(t *testing.T) {
-	inputYAML := `dos`
-	var partType disk.PartitionTableType
-
-	err := yaml.Unmarshal([]byte(inputYAML), &partType)
-	assert.NoError(t, err)
-	assert.Equal(t, disk.PT_DOS, partType)
-}
-
-func TestPartitionUnmarshalYAML(t *testing.T) {
-	inputYAML := `
-Start: 123
-Size: 456
-Type: "0x83"
-Bootable: true
-PayloadType: "filesystem"
-Payload:
-  type: vfat
-`
-	var part disk.Partition
-
-	err := yaml.Unmarshal([]byte(inputYAML), &part)
-	assert.NoError(t, err)
-	expected := disk.Partition{
-		Start:    123,
-		Size:     456,
-		Type:     "0x83",
-		Bootable: true,
-		Payload: &disk.Filesystem{
-			Type: "vfat",
-		},
-	}
-	assert.Equal(t, expected, part)
 }

--- a/pkg/disk/partition_table_yaml_test.go
+++ b/pkg/disk/partition_table_yaml_test.go
@@ -1,0 +1,120 @@
+package disk_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/osbuild/images/pkg/disk"
+)
+
+func TestPartitionTableTypeUnmarshalYAML(t *testing.T) {
+	inputYAML := `dos`
+	var partType disk.PartitionTableType
+
+	err := yaml.Unmarshal([]byte(inputYAML), &partType)
+	require.NoError(t, err)
+	assert.Equal(t, disk.PT_DOS, partType)
+}
+
+func TestPartitionTableUnmarshalYAMLSimple(t *testing.T) {
+	inputYAML := `
+guids:
+  - &bios_boot_partition_guid "21686148-6449-6E6F-744E-656564454649"
+  - &efi_system_partition_guid "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+  - &filesystem_data_guid "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
+uuids:
+  - &bios_boot_partition_uuid "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+  - &root_partition_uuid "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+  - &data_partition_uuid "CB07C243-BC44-4717-853E-28852021225B"
+  - &efi_system_partition_uuid "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+  - &efi_filesystem_uuid "7B77-95E7"
+partition_table:
+  uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
+  type: "gpt"
+  partitions:
+    - size: 1_048_576  # 1 MiB
+      bootable: true
+      type: *bios_boot_partition_guid
+      uuid: *bios_boot_partition_uuid
+      payload_type: "no-payload"
+    - &default_partition_table_part_efi
+      size: 209_715_200  # 200 MiB
+      type: *efi_system_partition_guid
+      uuid: *efi_system_partition_uuid
+      payload_type: "filesystem"
+      payload:
+        type: vfat
+        uuid: *efi_filesystem_uuid
+        mountpoint: "/boot/efi"
+        label: "EFI-SYSTEM"
+        fstab_options: "defaults,uid=0,gid=0,umask=077,shortname=winnt"
+        fstab_freq: 0
+        fstab_passno: 2
+    - &default_partition_table_part_root
+      size: 2_147_483_648  # 2 * datasizes.GibiByte,
+      type: *filesystem_data_guid
+      uuid: *root_partition_uuid
+      payload_type: "filesystem"
+      payload:
+        type: "ext4"
+        label: "root"
+        mountpoint: "/"
+        fstab_options: "defaults"
+        fstab_freq: 0
+        fstab_passno: 0
+`
+	var ptWrapper struct {
+		PartitionTable disk.PartitionTable `yaml:"partition_table"`
+	}
+
+	err := yaml.Unmarshal([]byte(inputYAML), &ptWrapper)
+	require.NoError(t, err)
+	expected := disk.PartitionTable{
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: disk.PT_GPT,
+		Partitions: []disk.Partition{
+			{
+				Start:    0,
+				Size:     1048576,
+				Type:     "21686148-6449-6E6F-744E-656564454649",
+				Bootable: true,
+				UUID:     "FAC7F1FB-3E8D-4137-A512-961DE09A5549",
+			},
+			{
+				Start:    0,
+				Size:     209715200,
+				Type:     "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+				Bootable: false,
+				UUID:     "68B2905B-DF3E-4FB3-80FA-49D1E773AA33",
+				Payload: &disk.Filesystem{
+					Type:         "vfat",
+					UUID:         "7B77-95E7",
+					Label:        "EFI-SYSTEM",
+					Mountpoint:   "/boot/efi",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			}, {
+				Start:    0,
+				Size:     2147483648,
+				Type:     "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+				Bootable: false,
+				UUID:     "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
+				Payload: &disk.Filesystem{
+					Type:         "ext4",
+					UUID:         "",
+					Label:        "root",
+					Mountpoint:   "/",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+		},
+	}
+	assert.Equal(t, expected, ptWrapper.PartitionTable)
+}

--- a/pkg/disk/unmarshal.go
+++ b/pkg/disk/unmarshal.go
@@ -1,0 +1,24 @@
+package disk
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// unmarshalYAMLviaJSON unmarshals via the JSON interface, this avoids code
+// duplication on the expense of slightly uglier errors
+func unmarshalYAMLviaJSON(u json.Unmarshaler, unmarshal func(any) error) error {
+	var data any
+	if err := unmarshal(&data); err != nil {
+		return fmt.Errorf("cannot unmarshal to any: %w", err)
+	}
+
+	dataJSON, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("unmarshal yaml via json failed: %w", err)
+	}
+	if err := u.UnmarshalJSON(dataJSON); err != nil {
+		return fmt.Errorf("unmarshal yaml via json for %s failed: %w", dataJSON, err)
+	}
+	return nil
+}


### PR DESCRIPTION
Split out of https://github.com/osbuild/images/pull/1339 to make this PR more reviewable.

With partition tables moving into the distro YAML we need a way to write them in a "nice"
way. Yaml offers some helper with anchors and aliases here (shown as part of the tests)
but we still need to add json tags to all our (internal) disk structs. This of course means that
when we change our disk data structure we need to update the yaml. As long as we maintain
the distro YAML in our repo this should be fine. The alternative would be to use the advanced
partitioning but it is currently not able to express what we need and my worry is that tweaking
it to deal with what we need inside #1339 is going to slow us down significantly (but I'm open
to discuss this of course).

---

This commit adds a new 'unmarshalYAMLviaJSON` helper and uses
it (initially) for the `disk.PartitionTableType` and
`disk.Partition`.

This allows us to cheaply reuse all our custom json unmarshal
code when we define partition tables in yaml.

---

disk: give struct fields "nice" json names

This commit prepares for moving partition tables into the YAML
distro definitions by making the names "nice". This commit only
changes the common things so far which is partition-table,
partition and some payloads.
