### PR TITLE
Imageconfig no osbuild

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -438,10 +438,8 @@ func mkWslImgType(d distribution) imageType {
 			ExcludeDocs: common.ToPtr(true),
 			Locale:      common.ToPtr("C.UTF-8"),
 			Timezone:    common.ToPtr("Etc/UTC"),
-			WSLConfig: &osbuild.WSLConfStageOptions{
-				Boot: osbuild.WSLConfBootOptions{
-					Systemd: true,
-				},
+			WSLConfig: &distro.WSLConfig{
+				BootSystemd: true,
 			},
 		},
 		image:                  containerImage,

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -210,7 +210,7 @@ func osCustomizations(
 	osc.ShellInit = imageConfig.ShellInit
 
 	osc.Grub2Config = imageConfig.Grub2Config
-	osc.Sysconfig = imageConfig.Sysconfig
+	osc.Sysconfig = imageConfig.SysconfigStageOptions()
 	osc.SystemdLogind = imageConfig.SystemdLogind
 	osc.CloudInit = imageConfig.CloudInit
 	osc.Modprobe = imageConfig.Modprobe

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -226,7 +226,7 @@ func osCustomizations(
 	osc.SshdConfig = imageConfig.SshdConfig
 	osc.AuthConfig = imageConfig.Authconfig
 	osc.PwQuality = imageConfig.PwQuality
-	osc.WSLConfig = imageConfig.WSLConfig
+	osc.WSLConfig = imageConfig.WSLConfStageOptions()
 
 	osc.Files = append(osc.Files, imageConfig.Files...)
 	osc.Directories = append(osc.Directories, imageConfig.Directories...)

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -64,7 +64,8 @@ type ImageConfig struct {
 	Firewall            *osbuild.FirewallStageOptions
 	UdevRules           *osbuild.UdevRulesStageOptions
 	GCPGuestAgentConfig *osbuild.GcpGuestAgentConfigOptions
-	WSLConfig           *osbuild.WSLConfStageOptions
+
+	WSLConfig *WSLConfig
 
 	Files       []*fsnode.File
 	Directories []*fsnode.Directory
@@ -110,6 +111,10 @@ type ImageConfig struct {
 	MountUnits *bool
 }
 
+type WSLConfig struct {
+	BootSystemd bool
+}
+
 // InheritFrom inherits unset values from the provided parent configuration and
 // returns a new structure instance, which is a result of the inheritance.
 func (c *ImageConfig) InheritFrom(parentConfig *ImageConfig) *ImageConfig {
@@ -133,4 +138,15 @@ func (c *ImageConfig) InheritFrom(parentConfig *ImageConfig) *ImageConfig {
 		}
 	}
 	return &finalConfig
+}
+
+func (c *ImageConfig) WSLConfStageOptions() *osbuild.WSLConfStageOptions {
+	if c.WSLConfig == nil {
+		return nil
+	}
+	return &osbuild.WSLConfStageOptions{
+		Boot: osbuild.WSLConfBootOptions{
+			Systemd: c.WSLConfig.BootSystemd,
+		},
+	}
 }

--- a/pkg/distro/image_config_test.go
+++ b/pkg/distro/image_config_test.go
@@ -30,31 +30,6 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				EnabledServices:  []string{"sshd"},
 				DisabledServices: []string{"named"},
 				DefaultTarget:    common.ToPtr("multi-user.target"),
-				Sysconfig: []*osbuild.SysconfigStageOptions{
-					{
-						Kernel: &osbuild.SysconfigKernelOptions{
-							UpdateDefault: true,
-							DefaultKernel: "kernel",
-						},
-						Network: &osbuild.SysconfigNetworkOptions{
-							Networking: true,
-							NoZeroConf: true,
-						},
-						NetworkScripts: &osbuild.NetworkScriptsOptions{
-							IfcfgFiles: map[string]osbuild.IfcfgFile{
-								"eth0": {
-									Device:    "eth0",
-									Bootproto: osbuild.IfcfgBootprotoDHCP,
-									OnBoot:    common.ToPtr(true),
-									Type:      osbuild.IfcfgTypeEthernet,
-									UserCtl:   common.ToPtr(true),
-									PeerDNS:   common.ToPtr(true),
-									IPv6Init:  common.ToPtr(false),
-								},
-							},
-						},
-					},
-				},
 			},
 			imageConfig: &ImageConfig{
 				Timezone: common.ToPtr("UTC"),
@@ -92,31 +67,6 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				EnabledServices:  []string{"sshd"},
 				DisabledServices: []string{"named"},
 				DefaultTarget:    common.ToPtr("multi-user.target"),
-				Sysconfig: []*osbuild.SysconfigStageOptions{
-					{
-						Kernel: &osbuild.SysconfigKernelOptions{
-							UpdateDefault: true,
-							DefaultKernel: "kernel",
-						},
-						Network: &osbuild.SysconfigNetworkOptions{
-							Networking: true,
-							NoZeroConf: true,
-						},
-						NetworkScripts: &osbuild.NetworkScriptsOptions{
-							IfcfgFiles: map[string]osbuild.IfcfgFile{
-								"eth0": {
-									Device:    "eth0",
-									Bootproto: osbuild.IfcfgBootprotoDHCP,
-									OnBoot:    common.ToPtr(true),
-									Type:      osbuild.IfcfgTypeEthernet,
-									UserCtl:   common.ToPtr(true),
-									PeerDNS:   common.ToPtr(true),
-									IPv6Init:  common.ToPtr(false),
-								},
-							},
-						},
-					},
-				},
 			},
 		},
 		{

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -241,7 +241,7 @@ func osCustomizations(
 
 	osc.ShellInit = imageConfig.ShellInit
 	osc.Grub2Config = imageConfig.Grub2Config
-	osc.Sysconfig = imageConfig.Sysconfig
+	osc.Sysconfig = imageConfig.SysconfigStageOptions()
 	osc.SystemdLogind = imageConfig.SystemdLogind
 	osc.CloudInit = imageConfig.CloudInit
 	osc.Modprobe = imageConfig.Modprobe

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -263,7 +263,7 @@ func osCustomizations(
 	osc.WAAgentConfig = imageConfig.WAAgentConfig
 	osc.UdevRules = imageConfig.UdevRules
 	osc.GCPGuestAgentConfig = imageConfig.GCPGuestAgentConfig
-	osc.WSLConfig = imageConfig.WSLConfig
+	osc.WSLConfig = imageConfig.WSLConfStageOptions()
 
 	osc.Files = append(osc.Files, imageConfig.Files...)
 	osc.Directories = append(osc.Directories, imageConfig.Directories...)

--- a/pkg/distro/rhel/rhel10/ami.go
+++ b/pkg/distro/rhel/rhel10/ami.go
@@ -203,18 +203,12 @@ func defaultEc2ImageConfig() *distro.ImageConfig {
 			"reboot.target",
 			"tuned",
 		},
-		DefaultTarget: common.ToPtr("multi-user.target"),
-		Sysconfig: []*osbuild.SysconfigStageOptions{
-			{
-				Kernel: &osbuild.SysconfigKernelOptions{
-					UpdateDefault: true,
-					DefaultKernel: "kernel",
-				},
-				Network: &osbuild.SysconfigNetworkOptions{
-					Networking: true,
-					NoZeroConf: true,
-				},
-			},
+		DefaultTarget:       common.ToPtr("multi-user.target"),
+		UpdateDefaultKernel: common.ToPtr(true),
+		DefaultKernel:       common.ToPtr("kernel"),
+		Sysconfig: &distro.Sysconfig{
+			Networking: true,
+			NoZeroConf: true,
 		},
 		SystemdLogind: []*osbuild.SystemdLogindStageOptions{
 			{

--- a/pkg/distro/rhel/rhel10/azure.go
+++ b/pkg/distro/rhel/rhel10/azure.go
@@ -321,17 +321,11 @@ func defaultAzureImageConfig(rd *rhel.Distribution) *distro.ImageConfig {
 				Layouts: []string{"us"},
 			},
 		},
-		Sysconfig: []*osbuild.SysconfigStageOptions{
-			{
-				Kernel: &osbuild.SysconfigKernelOptions{
-					UpdateDefault: true,
-					DefaultKernel: "kernel-core",
-				},
-				Network: &osbuild.SysconfigNetworkOptions{
-					Networking: true,
-					NoZeroConf: true,
-				},
-			},
+		UpdateDefaultKernel: common.ToPtr(true),
+		DefaultKernel:       common.ToPtr("kernel-core"),
+		Sysconfig: &distro.Sysconfig{
+			Networking: true,
+			NoZeroConf: true,
 		},
 		EnabledServices: []string{
 			"firewalld",

--- a/pkg/distro/rhel/rhel10/distro.go
+++ b/pkg/distro/rhel/rhel10/distro.go
@@ -9,7 +9,6 @@ import (
 	"github.com/osbuild/images/pkg/customizations/oscap"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
-	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
 )
 
@@ -51,19 +50,13 @@ func distroISOLabelFunc(t *rhel.ImageType) string {
 
 func defaultDistroImageConfig(d *rhel.Distribution) *distro.ImageConfig {
 	return &distro.ImageConfig{
-		Timezone: common.ToPtr("UTC"),
-		Locale:   common.ToPtr("C.UTF-8"),
-		Sysconfig: []*osbuild.SysconfigStageOptions{
-			{
-				Kernel: &osbuild.SysconfigKernelOptions{
-					UpdateDefault: true,
-					DefaultKernel: "kernel",
-				},
-				Network: &osbuild.SysconfigNetworkOptions{
-					Networking: true,
-					NoZeroConf: true,
-				},
-			},
+		Timezone:            common.ToPtr("UTC"),
+		Locale:              common.ToPtr("C.UTF-8"),
+		UpdateDefaultKernel: common.ToPtr(true),
+		DefaultKernel:       common.ToPtr("kernel"),
+		Sysconfig: &distro.Sysconfig{
+			Networking: true,
+			NoZeroConf: true,
 		},
 		DefaultOSCAPDatastream: common.ToPtr(oscap.DefaultRHEL10Datastream(d.IsRHEL())),
 		InstallWeakDeps:        common.ToPtr(true),

--- a/pkg/distro/rhel/rhel10/gce.go
+++ b/pkg/distro/rhel/rhel10/gce.go
@@ -108,14 +108,14 @@ func baseGCEImageConfig() *distro.ImageConfig {
 				PermitRootLogin:        osbuild.PermitRootLoginValueNo,
 			},
 		},
-		Sysconfig: []*osbuild.SysconfigStageOptions{
-			{
-				Kernel: &osbuild.SysconfigKernelOptions{
-					DefaultKernel: "kernel-core",
-					UpdateDefault: true,
-				},
-			},
-		},
+		UpdateDefaultKernel: common.ToPtr(true),
+		DefaultKernel:       common.ToPtr("kernel-core"),
+		// XXX: ensure the "old" behavior is preserved (that is
+		// likely a bug) where for GCE the sysconfig network
+		// options are not set because the merge of imageConfig
+		// is shallow and the previous setup was changing the
+		// kernel without also changing the network options.
+		Sysconfig: &distro.Sysconfig{},
 		Modprobe: []*osbuild.ModprobeStageOptions{
 			{
 				Filename: "blacklist-floppy.conf",

--- a/pkg/distro/rhel/rhel10/ubi.go
+++ b/pkg/distro/rhel/rhel10/ubi.go
@@ -37,10 +37,8 @@ func mkWSLImgType() *rhel.ImageType {
 			},
 		},
 		NoSElinux: common.ToPtr(true),
-		WSLConfig: &osbuild.WSLConfStageOptions{
-			Boot: osbuild.WSLConfBootOptions{
-				Systemd: true,
-			},
+		WSLConfig: &distro.WSLConfig{
+			BootSystemd: true,
 		},
 	}
 

--- a/pkg/distro/rhel/rhel7/ami.go
+++ b/pkg/distro/rhel/rhel7/ami.go
@@ -108,31 +108,13 @@ func ec2ImageConfig() *distro.ImageConfig {
 			"sshd",
 			"rsyslog",
 		},
-		DefaultTarget: common.ToPtr("multi-user.target"),
-		Sysconfig: []*osbuild.SysconfigStageOptions{
-			{
-				Kernel: &osbuild.SysconfigKernelOptions{
-					UpdateDefault: true,
-					DefaultKernel: "kernel",
-				},
-				Network: &osbuild.SysconfigNetworkOptions{
-					Networking: true,
-					NoZeroConf: true,
-				},
-				NetworkScripts: &osbuild.NetworkScriptsOptions{
-					IfcfgFiles: map[string]osbuild.IfcfgFile{
-						"eth0": {
-							Device:    "eth0",
-							Bootproto: osbuild.IfcfgBootprotoDHCP,
-							OnBoot:    common.ToPtr(true),
-							Type:      osbuild.IfcfgTypeEthernet,
-							UserCtl:   common.ToPtr(true),
-							PeerDNS:   common.ToPtr(true),
-							IPv6Init:  common.ToPtr(false),
-						},
-					},
-				},
-			},
+		DefaultTarget:       common.ToPtr("multi-user.target"),
+		UpdateDefaultKernel: common.ToPtr(true),
+		DefaultKernel:       common.ToPtr("kernel"),
+		Sysconfig: &distro.Sysconfig{
+			Networking:                  true,
+			NoZeroConf:                  true,
+			CreateDefaultNetworkScripts: true,
 		},
 		SystemdLogind: []*osbuild.SystemdLogindStageOptions{
 			{

--- a/pkg/distro/rhel/rhel7/azure.go
+++ b/pkg/distro/rhel/rhel7/azure.go
@@ -49,17 +49,12 @@ var azureDefaultImgConfig = &distro.ImageConfig{
 	},
 	SELinuxForceRelabel: common.ToPtr(true),
 	Authconfig:          &osbuild.AuthconfigStageOptions{},
-	Sysconfig: []*osbuild.SysconfigStageOptions{
-		{
-			Kernel: &osbuild.SysconfigKernelOptions{
-				UpdateDefault: true,
-				DefaultKernel: "kernel-core",
-			},
-			Network: &osbuild.SysconfigNetworkOptions{
-				Networking: true,
-				NoZeroConf: true,
-			},
-		},
+	UpdateDefaultKernel: common.ToPtr(true),
+	DefaultKernel:       common.ToPtr("kernel-core"),
+
+	Sysconfig: &distro.Sysconfig{
+		Networking: true,
+		NoZeroConf: true,
 	},
 	EnabledServices: []string{
 		"cloud-config",

--- a/pkg/distro/rhel/rhel7/distro.go
+++ b/pkg/distro/rhel/rhel7/distro.go
@@ -7,7 +7,6 @@ import (
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
-	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
 )
 
@@ -19,17 +18,11 @@ func defaultDistroImageConfig(d *rhel.Distribution) *distro.ImageConfig {
 		GPGKeyFiles: []string{
 			"/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
 		},
-		Sysconfig: []*osbuild.SysconfigStageOptions{
-			{
-				Kernel: &osbuild.SysconfigKernelOptions{
-					UpdateDefault: true,
-					DefaultKernel: "kernel",
-				},
-				Network: &osbuild.SysconfigNetworkOptions{
-					Networking: true,
-					NoZeroConf: true,
-				},
-			},
+		UpdateDefaultKernel: common.ToPtr(true),
+		DefaultKernel:       common.ToPtr("kernel"),
+		Sysconfig: &distro.Sysconfig{
+			Networking: true,
+			NoZeroConf: true,
 		},
 		KernelOptionsBootloader: common.ToPtr(true),
 		NoBLS:                   common.ToPtr(true), // RHEL 7 grub does not support BLS

--- a/pkg/distro/rhel/rhel7/qcow2.go
+++ b/pkg/distro/rhel/rhel7/qcow2.go
@@ -38,30 +38,12 @@ func mkQcow2ImgType() *rhel.ImageType {
 var qcow2DefaultImgConfig = &distro.ImageConfig{
 	DefaultTarget:       common.ToPtr("multi-user.target"),
 	SELinuxForceRelabel: common.ToPtr(true),
-	Sysconfig: []*osbuild.SysconfigStageOptions{
-		{
-			Kernel: &osbuild.SysconfigKernelOptions{
-				UpdateDefault: true,
-				DefaultKernel: "kernel",
-			},
-			Network: &osbuild.SysconfigNetworkOptions{
-				Networking: true,
-				NoZeroConf: true,
-			},
-			NetworkScripts: &osbuild.NetworkScriptsOptions{
-				IfcfgFiles: map[string]osbuild.IfcfgFile{
-					"eth0": {
-						Device:    "eth0",
-						Bootproto: osbuild.IfcfgBootprotoDHCP,
-						OnBoot:    common.ToPtr(true),
-						Type:      osbuild.IfcfgTypeEthernet,
-						UserCtl:   common.ToPtr(true),
-						PeerDNS:   common.ToPtr(true),
-						IPv6Init:  common.ToPtr(false),
-					},
-				},
-			},
-		},
+	UpdateDefaultKernel: common.ToPtr(true),
+	DefaultKernel:       common.ToPtr("kernel"),
+	Sysconfig: &distro.Sysconfig{
+		Networking:                  true,
+		NoZeroConf:                  true,
+		CreateDefaultNetworkScripts: true,
 	},
 	RHSMConfig: map[subscription.RHSMStatus]*subscription.RHSMConfig{
 		subscription.RHSMConfigNoSubscription: {

--- a/pkg/distro/rhel/rhel8/ami.go
+++ b/pkg/distro/rhel/rhel8/ami.go
@@ -197,31 +197,13 @@ func baseEc2ImageConfig() *distro.ImageConfig {
 			"cloud-final",
 			"reboot.target",
 		},
-		DefaultTarget: common.ToPtr("multi-user.target"),
-		Sysconfig: []*osbuild.SysconfigStageOptions{
-			{
-				Kernel: &osbuild.SysconfigKernelOptions{
-					UpdateDefault: true,
-					DefaultKernel: "kernel",
-				},
-				Network: &osbuild.SysconfigNetworkOptions{
-					Networking: true,
-					NoZeroConf: true,
-				},
-				NetworkScripts: &osbuild.NetworkScriptsOptions{
-					IfcfgFiles: map[string]osbuild.IfcfgFile{
-						"eth0": {
-							Device:    "eth0",
-							Bootproto: osbuild.IfcfgBootprotoDHCP,
-							OnBoot:    common.ToPtr(true),
-							Type:      osbuild.IfcfgTypeEthernet,
-							UserCtl:   common.ToPtr(true),
-							PeerDNS:   common.ToPtr(true),
-							IPv6Init:  common.ToPtr(false),
-						},
-					},
-				},
-			},
+		DefaultTarget:       common.ToPtr("multi-user.target"),
+		UpdateDefaultKernel: common.ToPtr(true),
+		DefaultKernel:       common.ToPtr("kernel"),
+		Sysconfig: &distro.Sysconfig{
+			Networking:                  true,
+			NoZeroConf:                  true,
+			CreateDefaultNetworkScripts: true,
 		},
 		SystemdLogind: []*osbuild.SystemdLogindStageOptions{
 			{

--- a/pkg/distro/rhel/rhel8/azure.go
+++ b/pkg/distro/rhel/rhel8/azure.go
@@ -370,17 +370,11 @@ var defaultAzureImageConfig = &distro.ImageConfig{
 			Layouts: []string{"us"},
 		},
 	},
-	Sysconfig: []*osbuild.SysconfigStageOptions{
-		{
-			Kernel: &osbuild.SysconfigKernelOptions{
-				UpdateDefault: true,
-				DefaultKernel: "kernel-core",
-			},
-			Network: &osbuild.SysconfigNetworkOptions{
-				Networking: true,
-				NoZeroConf: true,
-			},
-		},
+	DefaultKernel:       common.ToPtr("kernel-core"),
+	UpdateDefaultKernel: common.ToPtr(true),
+	Sysconfig: &distro.Sysconfig{
+		Networking: true,
+		NoZeroConf: true,
 	},
 	EnabledServices: []string{
 		"nm-cloud-setup.service",

--- a/pkg/distro/rhel/rhel8/distro.go
+++ b/pkg/distro/rhel/rhel8/distro.go
@@ -9,7 +9,6 @@ import (
 	"github.com/osbuild/images/pkg/customizations/oscap"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
-	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
 )
 
@@ -38,19 +37,13 @@ var (
 // RHEL-based OS image configuration defaults
 func defaultDistroImageConfig(d *rhel.Distribution) *distro.ImageConfig {
 	return &distro.ImageConfig{
-		Timezone: common.ToPtr("America/New_York"),
-		Locale:   common.ToPtr("en_US.UTF-8"),
-		Sysconfig: []*osbuild.SysconfigStageOptions{
-			{
-				Kernel: &osbuild.SysconfigKernelOptions{
-					UpdateDefault: true,
-					DefaultKernel: "kernel",
-				},
-				Network: &osbuild.SysconfigNetworkOptions{
-					Networking: true,
-					NoZeroConf: true,
-				},
-			},
+		Timezone:            common.ToPtr("America/New_York"),
+		Locale:              common.ToPtr("en_US.UTF-8"),
+		UpdateDefaultKernel: common.ToPtr(true),
+		DefaultKernel:       common.ToPtr("kernel"),
+		Sysconfig: &distro.Sysconfig{
+			Networking: true,
+			NoZeroConf: true,
 		},
 		KernelOptionsBootloader: common.ToPtr(true),
 		DefaultOSCAPDatastream:  common.ToPtr(oscap.DefaultRHEL8Datastream(d.IsRHEL())),

--- a/pkg/distro/rhel/rhel8/gce.go
+++ b/pkg/distro/rhel/rhel8/gce.go
@@ -129,14 +129,14 @@ func defaultGceByosImageConfig(rd distro.Distro) *distro.ImageConfig {
 				PermitRootLogin:        osbuild.PermitRootLoginValueNo,
 			},
 		},
-		Sysconfig: []*osbuild.SysconfigStageOptions{
-			{
-				Kernel: &osbuild.SysconfigKernelOptions{
-					DefaultKernel: "kernel-core",
-					UpdateDefault: true,
-				},
-			},
-		},
+		DefaultKernel:       common.ToPtr("kernel-core"),
+		UpdateDefaultKernel: common.ToPtr(true),
+		// XXX: ensure the "old" behavior is preserved (that is
+		// likely a bug) where for GCE the sysconfig network
+		// options are not set because the merge of imageConfig
+		// is shallow and the previous setup was changing the
+		// kernel without also changing the network options.
+		Sysconfig: &distro.Sysconfig{},
 		Modprobe: []*osbuild.ModprobeStageOptions{
 			{
 				Filename: "blacklist-floppy.conf",

--- a/pkg/distro/rhel/rhel8/ubi.go
+++ b/pkg/distro/rhel/rhel8/ubi.go
@@ -4,7 +4,6 @@ import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
-	"github.com/osbuild/images/pkg/osbuild"
 )
 
 func mkWslImgType() *rhel.ImageType {
@@ -24,10 +23,8 @@ func mkWslImgType() *rhel.ImageType {
 	it.DefaultImageConfig = &distro.ImageConfig{
 		Locale:    common.ToPtr("en_US.UTF-8"),
 		NoSElinux: common.ToPtr(true),
-		WSLConfig: &osbuild.WSLConfStageOptions{
-			Boot: osbuild.WSLConfBootOptions{
-				Systemd: true,
-			},
+		WSLConfig: &distro.WSLConfig{
+			BootSystemd: true,
 		},
 	}
 

--- a/pkg/distro/rhel/rhel9/ami.go
+++ b/pkg/distro/rhel/rhel9/ami.go
@@ -50,31 +50,14 @@ func defaultEc2ImageConfig() *distro.ImageConfig {
 			"reboot.target",
 			"tuned",
 		},
-		DefaultTarget: common.ToPtr("multi-user.target"),
-		Sysconfig: []*osbuild.SysconfigStageOptions{
-			{
-				Kernel: &osbuild.SysconfigKernelOptions{
-					UpdateDefault: true,
-					DefaultKernel: "kernel",
-				},
-				Network: &osbuild.SysconfigNetworkOptions{
-					Networking: true,
-					NoZeroConf: true,
-				},
-				NetworkScripts: &osbuild.NetworkScriptsOptions{
-					IfcfgFiles: map[string]osbuild.IfcfgFile{
-						"eth0": {
-							Device:    "eth0",
-							Bootproto: osbuild.IfcfgBootprotoDHCP,
-							OnBoot:    common.ToPtr(true),
-							Type:      osbuild.IfcfgTypeEthernet,
-							UserCtl:   common.ToPtr(true),
-							PeerDNS:   common.ToPtr(true),
-							IPv6Init:  common.ToPtr(false),
-						},
-					},
-				},
-			},
+		DefaultTarget:       common.ToPtr("multi-user.target"),
+		UpdateDefaultKernel: common.ToPtr(true),
+		DefaultKernel:       common.ToPtr("kernel"),
+
+		Sysconfig: &distro.Sysconfig{
+			Networking:                  true,
+			NoZeroConf:                  true,
+			CreateDefaultNetworkScripts: true,
 		},
 		SystemdLogind: []*osbuild.SystemdLogindStageOptions{
 			{

--- a/pkg/distro/rhel/rhel9/azure.go
+++ b/pkg/distro/rhel/rhel9/azure.go
@@ -334,17 +334,11 @@ func defaultAzureImageConfig(rd *rhel.Distribution) *distro.ImageConfig {
 				Layouts: []string{"us"},
 			},
 		},
-		Sysconfig: []*osbuild.SysconfigStageOptions{
-			{
-				Kernel: &osbuild.SysconfigKernelOptions{
-					UpdateDefault: true,
-					DefaultKernel: "kernel-core",
-				},
-				Network: &osbuild.SysconfigNetworkOptions{
-					Networking: true,
-					NoZeroConf: true,
-				},
-			},
+		UpdateDefaultKernel: common.ToPtr(true),
+		DefaultKernel:       common.ToPtr("kernel-core"),
+		Sysconfig: &distro.Sysconfig{
+			Networking: true,
+			NoZeroConf: true,
 		},
 		EnabledServices: []string{
 			"firewalld",

--- a/pkg/distro/rhel/rhel9/distro.go
+++ b/pkg/distro/rhel/rhel9/distro.go
@@ -9,7 +9,6 @@ import (
 	"github.com/osbuild/images/pkg/customizations/oscap"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
-	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
 )
 
@@ -54,19 +53,14 @@ func distroISOLabelFunc(t *rhel.ImageType) string {
 
 func defaultDistroImageConfig(d *rhel.Distribution) *distro.ImageConfig {
 	return &distro.ImageConfig{
-		Timezone: common.ToPtr("America/New_York"),
-		Locale:   common.ToPtr("C.UTF-8"),
-		Sysconfig: []*osbuild.SysconfigStageOptions{
-			{
-				Kernel: &osbuild.SysconfigKernelOptions{
-					UpdateDefault: true,
-					DefaultKernel: "kernel",
-				},
-				Network: &osbuild.SysconfigNetworkOptions{
-					Networking: true,
-					NoZeroConf: true,
-				},
-			},
+		Timezone:            common.ToPtr("America/New_York"),
+		Locale:              common.ToPtr("C.UTF-8"),
+		UpdateDefaultKernel: common.ToPtr(true),
+		DefaultKernel:       common.ToPtr("kernel"),
+
+		Sysconfig: &distro.Sysconfig{
+			Networking: true,
+			NoZeroConf: true,
 		},
 		DefaultOSCAPDatastream: common.ToPtr(oscap.DefaultRHEL9Datastream(d.IsRHEL())),
 		InstallWeakDeps:        common.ToPtr(true),

--- a/pkg/distro/rhel/rhel9/gce.go
+++ b/pkg/distro/rhel/rhel9/gce.go
@@ -105,14 +105,14 @@ func baseGCEImageConfig() *distro.ImageConfig {
 				PermitRootLogin:        osbuild.PermitRootLoginValueNo,
 			},
 		},
-		Sysconfig: []*osbuild.SysconfigStageOptions{
-			{
-				Kernel: &osbuild.SysconfigKernelOptions{
-					DefaultKernel: "kernel-core",
-					UpdateDefault: true,
-				},
-			},
-		},
+		UpdateDefaultKernel: common.ToPtr(true),
+		DefaultKernel:       common.ToPtr("kernel-core"),
+		// XXX: ensure the "old" behavior is preserved (that is
+		// likely a bug) where for GCE the sysconfig network
+		// options are not set because the merge of imageConfig
+		// is shallow and the previous setup was changing the
+		// kernel without also changing the network options.
+		Sysconfig: &distro.Sysconfig{},
 		Modprobe: []*osbuild.ModprobeStageOptions{
 			{
 				Filename: "blacklist-floppy.conf",

--- a/pkg/distro/rhel/rhel9/ubi.go
+++ b/pkg/distro/rhel/rhel9/ubi.go
@@ -38,10 +38,8 @@ func mkWSLImgType() *rhel.ImageType {
 		},
 		Locale:    common.ToPtr("en_US.UTF-8"),
 		NoSElinux: common.ToPtr(true),
-		WSLConfig: &osbuild.WSLConfStageOptions{
-			Boot: osbuild.WSLConfBootOptions{
-				Systemd: true,
-			},
+		WSLConfig: &distro.WSLConfig{
+			BootSystemd: true,
 		},
 	}
 


### PR DESCRIPTION
In PR#1337 the desire was expressed to move all direct `osbuild` reference out of `distro.ImageConfig` to make it a more high level abstraction. This commit is the first step to show how this could be done with the simple `osbuild.WSLConfStageOptions`.

However doing this with the more complex ones will be quite a bit of busywork and reviewing. I am not sure we should do this before we do the yamlification as I'm worried converting the other ~26 structs that needs similar converstion will take some time.

The other concern with this is that we currently have json schema information for all osbuild options. So validating the yaml against the json-schema of osbuild seems feasible. If add this conversion stage we will need to also duplicate the json schema.

---

distro: move `osbuild.SysconfOptions` out of ImageConfig

This commit shows what needs to happen for a more complex option
in image config. With that we can/could continue with PR#1337.

Note that moving Kernel/UpdateDefaultKernel is based on an initial brainstorm with @achilleas-k but we could of course move it back into sysconfig (that would also fix the XXX that we have in gce.go). The downside of doing that is that we may conflate unrelated concerns and introduce bugs/confusion. Because we only do shallow merging it seems risky (c.f. the XXX in gce.go).
