### PR TITLE
Updates ro inclusion with conditionals for IoT version

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -12,6 +12,7 @@ import (
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/oscap"
 	"github.com/osbuild/images/pkg/datasizes"
+	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -249,6 +250,10 @@ func mkIotSimplifiedInstallerImgType(d distribution) imageType {
 }
 
 func mkIotRawImgType(d distribution) imageType {
+	if common.VersionGreaterThanOrEqual(d.osVersion, "42") {
+		rootPartition := &iotBasePartitionTables[arch.ARCH_X86_64.String()].Partitions[2]
+		rootPartition.Payload.(*disk.Filesystem).FSTabOptions += ",ro"
+	}
 	return imageType{
 		name:        "iot-raw-image",
 		nameAliases: []string{"fedora-iot-raw-image"},

--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -396,7 +396,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 					Type:         "ext4",
 					Label:        "root",
 					Mountpoint:   "/",
-					FSTabOptions: "defaults,ro",
+					FSTabOptions: "defaults",
 					FSTabFreq:    1,
 					FSTabPassNo:  1,
 				},


### PR DESCRIPTION
Updates IoT fstab to only include `ro` in versions 42 and above. 

Follow up to this PR: https://github.com/osbuild/images/pull/1346

Fix for this issue: https://github.com/fedora-iot/iot-distro/issues/81

Going to start this out as a draft to confirm that this is the only location `ro` is needed.