### PR TITLE
manifest: addInlineDataAndStages() helper method for the OS and OSTreeDeployment pipelines

### DIFF
--- a/pkg/manifest/export_test.go
+++ b/pkg/manifest/export_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/dnfjson"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
@@ -58,6 +59,14 @@ func (p *OS) GetPackageSetChain(d Distro) []rpmmd.PackageSet {
 	return p.getPackageSetChain(d)
 }
 
+func (p *OS) AddInlineDataAndStages(pipeline *osbuild.Pipeline, files []*fsnode.File) {
+	p.addInlineDataAndStages(pipeline, files)
+}
+
+func (p *OS) GetInline() []string {
+	return p.getInline()
+}
+
 // NewTestOS is used in both internal and external package tests.
 // TODO: make all tests external and define this only in the manifest_test
 // package.
@@ -83,4 +92,12 @@ func (p *OSTreeDeployment) Serialize() osbuild.Pipeline {
 		Commits: []ostree.CommitSpec{{}},
 	})
 	return p.serialize()
+}
+
+func (p *OSTreeDeployment) AddInlineDataAndStages(pipeline *osbuild.Pipeline, files []*fsnode.File) {
+	p.addInlineDataAndStages(pipeline, files, "ostree/ref")
+}
+
+func (p *OSTreeDeployment) GetInline() []string {
+	return p.getInline()
 }

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -857,10 +857,10 @@ func (p *OS) serialize() osbuild.Pipeline {
 	}
 
 	if p.OSCustomizations.FIPS {
-		p.OSCustomizations.Files = append(p.OSCustomizations.Files, osbuild.GenFIPSFiles()...)
-		for _, stage := range osbuild.GenFIPSStages() {
-			pipeline.AddStage(stage)
-		}
+		fipsFiles := osbuild.GenFIPSFiles()
+		p.OSCustomizations.Files = append(p.OSCustomizations.Files, fipsFiles...) // add the files to the Files list to generate the inline data
+		pipeline.AddStages(osbuild.GenFIPSStages()...)
+		pipeline.AddStages(osbuild.GenFileNodesStages(fipsFiles)...)
 	}
 
 	// NOTE: We need to run the OpenSCAP stages as the last stage before SELinux

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -893,7 +893,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 				pipeline.AddStages(osbuild.GenFileNodesStages(files)...)
 			}
 		}
-		pipeline.AddStage(osbuild.NewCAStageStage())
+		pipeline.AddStage(osbuild.NewUpdateCATrustStage())
 	}
 
 	if p.OSCustomizations.MachineIdUninitialized {

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -87,6 +87,8 @@ type OSTreeDeployment struct {
 
 	// Use bootupd instead of grub2 as the bootloader
 	UseBootupd bool
+
+	inlineData []string
 }
 
 // NewOSTreeCommitDeployment creates a pipeline for an ostree deployment from a
@@ -440,7 +442,7 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 	}
 
 	if p.FIPS {
-		p.Files = append(p.Files, osbuild.GenFIPSFiles()...)
+		p.addInlineDataAndStages(&pipeline, osbuild.GenFIPSFiles(), ref)
 		for _, stage := range osbuild.GenFIPSStages() {
 			stage.MountOSTree(p.osName, ref, 0)
 			pipeline.AddStage(stage)
@@ -476,11 +478,7 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 	}
 
 	if len(p.Files) > 0 {
-		fileStages := osbuild.GenFileNodesStages(p.Files)
-		for _, stage := range fileStages {
-			stage.MountOSTree(p.osName, ref, 0)
-		}
-		pipeline.AddStages(fileStages...)
+		p.addInlineDataAndStages(&pipeline, p.Files, ref)
 	}
 
 	if len(p.EnabledServices) != 0 || len(p.DisabledServices) != 0 {
@@ -505,14 +503,21 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 }
 
 func (p *OSTreeDeployment) getInline() []string {
-	inlineData := []string{}
+	return p.inlineData
+}
 
-	// inline data for custom files
-	for _, file := range p.Files {
-		inlineData = append(inlineData, string(file.Data()))
+// addInlineDataAndStages generates stages for creating files and adds them to
+// the pipeline. It also adds their data to the inlineData for the pipeline so
+// that the appropriate sources are created.
+func (p *OSTreeDeployment) addInlineDataAndStages(pipeline *osbuild.Pipeline, files []*fsnode.File, ref string) {
+	for _, stage := range osbuild.GenFileNodesStages(files) {
+		stage.MountOSTree(p.osName, ref, 0)
+		pipeline.AddStage(stage)
 	}
 
-	return inlineData
+	for _, file := range files {
+		p.inlineData = append(p.inlineData, string(file.Data()))
+	}
 }
 
 // Creates systemd unit stage by ingesting the servicename and mount-points

--- a/pkg/osbuild/fips.go
+++ b/pkg/osbuild/fips.go
@@ -41,13 +41,11 @@ func GenFIPSFiles() (files []*fsnode.File) {
 }
 
 func GenFIPSStages() (stages []*Stage) {
-	stages = []*Stage{
+	return []*Stage{
 		NewUpdateCryptoPoliciesStage(
 			&UpdateCryptoPoliciesStageOptions{
 				Policy: "FIPS",
 			}),
 		NewDracutConfStage(FIPSDracutConfStageOptions),
 	}
-	stages = append(stages, GenFileNodesStages(GenFIPSFiles())...)
-	return
 }

--- a/pkg/osbuild/pki_update_ca_trust_stage.go
+++ b/pkg/osbuild/pki_update_ca_trust_stage.go
@@ -9,7 +9,7 @@ import (
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 )
 
-func NewCAStageStage() *Stage {
+func NewUpdateCATrustStage() *Stage {
 	return &Stage{
 		Type: "org.osbuild.pki.update-ca-trust",
 	}

--- a/test/data/manifest-checksums.txt
+++ b/test/data/manifest-checksums.txt
@@ -60,9 +60,9 @@
 088250bcc0440eed472f9d4ffadca185c5bacd36  fedora_40-aarch64-qcow2-minimal.json
 08a59ca47d53b7a433bdbe071479bb09b715599c  rhel_8.10-x86_64-azure_sap_rhui-empty.json
 09048038cd8dd1574dbc4b833c20b22ed433c5f6  fedora_40-x86_64-iot_qcow2_image-iot_ostree_pull_empty.json
-0921ebbaac2a2788dbd7734a828b97c03cb45bb0  rhel_9.3-aarch64-edge_ami-edge_ostree_pull_user_fips.json
 09371e318e3112b8c407aa42e50fad5cba8ba9ba  rhel_9.0-x86_64-edge_ami-edge_ostree_pull_user.json
 09786e73ffab93ba288ff99db84fe71a54b381f5  rhel_9.4-x86_64-edge_simplified_installer-edge_ostree_pull_device.json
+09911c5dafe14cd53cc89a05b0ef8d12582c3136  rhel_9.3-x86_64-edge_ami-edge_ostree_pull_user_fips.json
 09b67bff51f0357870c6f5677c036f4cc2d5d7eb  rhel_9.1-aarch64-edge_ami-edge_ostree_pull_user_minimalenv.json
 09c307f52923ffcfa4b4071910d8622367263829  rhel_8.4-aarch64-ami-empty.json
 09c7fcedd5f32aacd3dbbc2b1a1ccc6f4e2a2c16  rhel_9.7-x86_64-ami-partitioning_plain.json
@@ -84,9 +84,9 @@
 0c1ed708ebf590cdaa6f70516ad6dd7516c7632a  rhel_9.5-x86_64-qcow2-rhsm.json
 0c7f876c4599c9d4d51fc4cbfb1ab5c79b6f99ed  rhel_9.3-x86_64-wsl-empty.json
 0c884db1fd2b7f7afeb304fd6446c789fc654846  centos_10-x86_64-ami-empty.json
+0d2924ae54e95fc5d5e11f960ec2959916f6525d  rhel_9.3-aarch64-edge_simplified_installer-edge_ostree_pull_device_fips.json
 0d65af6000316b3f5a8b887480b0888ae1aa7427  rhel_8.8-x86_64-tar-empty.json
 0deb0922105abe24b4a707c812254918523be456  rhel_9.4-x86_64-ami-partitioning_plain.json
-0df4f33609593ffdaad1714101dff62dd176db24  rhel_9.3-x86_64-edge_vsphere-edge_ostree_pull_fips.json
 0e6002d8f96d71a9e45c98f465a5c157c038f22d  centos_10-s390x-qcow2-empty.json
 0e7a4fc13c91d237733310fffa177cde2f7b0ec5  rhel_9.0-x86_64-vmdk-empty.json
 0e87219ae0f4d5d1d978304b464b243dbaa92410  fedora_41-aarch64-qcow2-empty.json
@@ -147,6 +147,7 @@
 1708f78642f2e038dcefe3393443676dc045b340  fedora_41-x86_64-iot_container-empty.json
 17099438bea0b46459f0290905c55cd595f6a7e3  rhel_9.6-aarch64-ami-all_customizations.json
 1726a566e619bfed289cb90b62ec322067bc57a9  fedora_43-aarch64-qcow2-all_with_fips.json
+1728cf5fa66bf30718b0329a1eae9c703d9a5941  rhel_9.3-x86_64-edge_raw_image-edge_ostree_pull_fips.json
 173cbf7ac29704fed7c8e9ff0878110bb366257c  centos_9-x86_64-ami-partitioning_lvm.json
 17818c6b8023b3bb9ccdc9daa5ff6f09000525d1  fedora_40-x86_64-ami-empty.json
 17a59e28ac1e1c82a19a345584871e380a70e3f5  rhel_8.9-x86_64-wsl-empty.json
@@ -217,6 +218,7 @@
 21901ca3bea0729e675b71fc3652dc12a97f5923  rhel_8.9-aarch64-azure_rhui-empty.json
 21942bc76cf25b15e36e3564a02de6d22278a717  rhel_9.2-aarch64-ami-partitioning_plain.json
 219bba8e01c2465a2b7ad72b1eb9eeaeecdfd1f8  rhel_8.9-s390x-qcow2-empty.json
+21c812197de599e9d732f9834ce5f6f4e12c1550  rhel_9.4-aarch64-edge_vsphere-edge_ostree_pull_fips.json
 21e3282312d8ffde8b59952465a07f3304413e06  fedora_43-aarch64-ami-empty.json
 224e84e70a30a48608febe7cc0d244fec838d2b8  rhel_9.4-aarch64-qcow2-all_with_fips.json
 2252cfbae469e71d48e9eab36528c155e67f3c3f  rhel_8.5-x86_64-edge_container-embed_containers_2.json
@@ -292,7 +294,6 @@
 2e3dedff2440a7df663eb5145005375162faa3c1  fedora_40-ppc64le-qcow2-import_rpm_gpg_keys_from_tree_fedora.json
 2e5d9e0d76e7ca6bed1b4c15988c0acf3b5e1dd7  fedora_42-x86_64-vhd-empty.json
 2e8091a365fb9195a206c5cf3d84d39ea6f76861  rhel_8.8-x86_64-azure_rhui-empty.json
-2ea13fade6b13fbb7ba36e3ca6bf88231846362a  rhel_9.4-x86_64-edge_simplified_installer-edge_ostree_pull_device_fips.json
 2f0faa09495a3df482c4a6bc82a339ad5818b845  rhel_9.3-aarch64-ami-partitioning_plain.json
 2f2c26ff0eeb0ff36178545c140e16ec3db5b708  rhel_8.10-x86_64-azure_eap7_rhui-empty.json
 2f2e3831b04af181a4ab68874ceb85fad053dfae  rhel_8.8-x86_64-qcow2-oscap_generic.json
@@ -321,7 +322,6 @@
 34594f20ca2bb54bab4a075e3e04434a8f3011dd  rhel_9.4-aarch64-vhd-empty.json
 3496fab7d58d17cda666c2354ac81e017d2723d1  rhel_8.5-x86_64-ami-all_customizations.json
 34adccfe388e97f8d6a022259ce50afed4fb51ab  rhel_9.2-aarch64-ami-all_customizations.json
-34b399be080b01d92e1596c6513be581bef59b57  rhel_9.3-x86_64-edge_ami-edge_ostree_pull_user_fips.json
 34e6226f58ed51e70f18a387fd898cf43a0ca6ee  rhel_9.3-aarch64-edge_simplified_installer-edge_ostree_pull_device.json
 34eca769d74bb73a68b14a510adf8f987bd1bf92  rhel_9.2-aarch64-edge_container-minimal_environment.json
 34ff9b4748d16e9d59688a1701e904f178935a7b  rhel_8.9-x86_64-azure_sap_rhui-empty.json
@@ -416,6 +416,7 @@
 4496674f72db73ece4334da01b1177c2f8416b63  rhel_8.9-x86_64-ec2_ha-empty.json
 44ad36bdc1c9ec52988661d393be994d947fbb22  centos_10-aarch64-tar-empty.json
 451b3f9e73c8e1d99b55d3738b99623079bcb843  rhel_8.6-x86_64-image_installer-unattended_iso.json
+452b078ecc1acaae1fc1a5cb6a08d1fdda215081  rhel_9.4-aarch64-edge_raw_image-edge_ostree_pull_fips.json
 4540d00ff570e4f86f7adf9cdfc6f11f45b4e3bb  rhel_9.6-x86_64-edge_ami-edge_ostree_pull_user.json
 4559465da6968e4e668407cc74277cdc092d1b8e  rhel_9.6-x86_64-edge_container-ostree.json
 455e8b2c4eacbcdec95494e239515d0442045da4  rhel_8.7-aarch64-minimal_raw-firewall.json
@@ -423,6 +424,7 @@
 458ec1dacec46f30fda710f5671fb92845398d90  fedora_40-aarch64-iot_qcow2_image-iot_ostree_pull_empty.json
 45abbff8f4caaa2a71e82684206383efa8221430  rhel_8.6-x86_64-ami-partitioning_plain_r8.json
 45c24c3ae160a87cfb6b578a71ba7faa91f7378e  rhel_8.9-aarch64-ami-empty.json
+45c81f72d33056290adb0494fe99cef3441eb162  rhel_9.4-x86_64-edge_ami-edge_ostree_pull_user_fips.json
 45cf2510a2221067637adfefd5c4f47f87092c48  rhel_9.1-x86_64-edge_simplified_installer-edge_ostree_pull_device.json
 45ea5c54fb1c4d989e2f5064bf058939164b6499  rhel_9.0-s390x-tar-empty.json
 46cf840fd750c1c529d25df2ca9a6d728271c507  rhel_9.4-aarch64-edge_installer-edge_ostree_pull_fips.json
@@ -477,6 +479,7 @@
 4d97b109cc157fcece895ec4ee06ed935a60adb8  rhel_9.0-aarch64-minimal_raw-firewall.json
 4de4895418ecf4504c1f5d4872e66fb1e99564d2  rhel_8.10-aarch64-edge_container-empty.json
 4e10a49de81e18d8c2478e02e82435d28a689945  rhel_8.5-x86_64-tar-empty.json
+4e22829c6cbe91292a36a66f6982b5d430037b63  rhel_9.3-x86_64-edge_vsphere-edge_ostree_pull_fips.json
 4e3459b75ec6c48846a0bf6da6fb9602cb332a8d  fedora_41-s390x-qcow2-minimal_pkgs.json
 4e4a896826e0ba19ecbc639347dba05780692b80  fedora_43-s390x-container-empty.json
 4e4dc6573379819bdaf18792d6e3c01c913aa0a4  fedora_43-x86_64-oci-empty.json
@@ -580,6 +583,7 @@
 5c6ded4398a239de043c51551811cec2db418561  rhel_9.3-aarch64-qcow2-all_with_fips.json
 5c899281ae3df591d395bf00cfcab50b66ffb298  rhel_10.0-aarch64-wsl-empty.json
 5cd5ca87cd180aebe878012514678419fd82a0d9  centos_9-aarch64-minimal_raw-empty.json
+5cffba0b9e8251dc60b27b252862db8d5fdc0114  rhel_9.3-x86_64-edge_simplified_installer-edge_ostree_pull_device_fips.json
 5d60fdc3838d9700f21c04e05ee9b640c0b4a8e4  centos_10-s390x-qcow2-all_with_fips.json
 5d7fab5cfdb0536a13bae7f42c91fa9b33b1e8d6  rhel_8.10-aarch64-image_installer-unattended_iso.json
 5dbb197f42ea0ff9fd3348e440657febe72c9294  fedora_40-s390x-qcow2-minimal_pkgs.json
@@ -604,11 +608,11 @@
 5fb0fb8c155a2f1ca048bcc591c99ae269035056  rhel_9.1-x86_64-vmdk-empty.json
 602bbd181387f70b0ef1c65e8b6cc8dabd8068a6  rhel_10.1-s390x-tar-empty.json
 60340ad4ccd2bc911529febeafc19cda3eb786af  fedora_41-aarch64-minimal_raw-firewall.json
+605c743048c0cdd075476770e71c1d3ee0a2e7c1  rhel_9.4-x86_64-edge_raw_image-edge_ostree_pull_fips.json
 607117b5d8567ee882c965bcfcae4a4fd1fa197c  rhel_8.8-x86_64-azure_sap_rhui-empty.json
 6086e9cef142a12da0cebc24b0389bd588f5840f  rhel_9.7-x86_64-gce-empty.json
 6096a9bb0e2605b48675260ed8c2357a72b27345  rhel_8.7-x86_64-minimal_raw-empty.json
 60a4ab5e1be8af8b07519ed5a8d792ede3d8a98b  rhel_9.4-aarch64-ami-oscap_rhel9.json
-60a54ac07c327d02e7461f92ebe18e575459194a  rhel_9.3-x86_64-edge_simplified_installer-edge_ostree_pull_device_fips.json
 61418670b181c3b33bc46301ef4490a6c2032596  fedora_40-aarch64-ami-partitioning_plain.json
 614e4934bbcb8c4c3b75fe95d42bd7bb40f7ae23  rhel_9.3-aarch64-ami-empty.json
 61a733a6c4daaf60bb57ea427121736623e5c2ad  rhel_8.8-aarch64-edge_commit-ostree.json
@@ -637,7 +641,6 @@
 64be2c3a8cdc7cd0a8ec1a59607558ce62d558cc  rhel_8.9-x86_64-edge_container-ostree.json
 64d4bb8a0315c0ed611cbef58b728856b104f654  rhel_9.1-s390x-qcow2-empty.json
 6501b01bc7b98dfb840783d0caf0e1699b494d5c  rhel_9.6-x86_64-vmdk-empty.json
-6509f844a04fedc85b4a24c58f579b1181b78ab4  rhel_9.3-x86_64-edge_raw_image-edge_ostree_pull_fips.json
 65a3e40c9e3774664ae70c2f708baca23d16c1e9  rhel_9.7-x86_64-openstack-empty.json
 65a712361221c19d20dfb71ac62c5a290fc8387d  rhel_9.5-ppc64le-qcow2-import_rpm_gpg_keys_from_tree_rhel.json
 65b83370a0344a92570cd0b0f23a9146584e8b50  rhel_8.7-x86_64-ec2_ha-empty.json
@@ -693,6 +696,7 @@
 6d96b8b2b9c5e75cd7f3a4733c07122a5dd49585  rhel_8.10-x86_64-tar-empty.json
 6dd834313ab01e21cacae867e4fa91079a513055  rhel_8.10-s390x-qcow2-import_rpm_gpg_keys_from_tree_rhel.json
 6e4966747ed19323ccac844294c3401942552804  rhel_8.4-aarch64-edge_commit-ostree.json
+6e60109920dce7d404df22944256bf3301f5b594  rhel_9.4-aarch64-edge_ami-edge_ostree_pull_user_fips.json
 6e6051765bd83045a20c1b89e3c8731f5a4f4fe9  rhel_8.4-x86_64-ami-empty.json
 6e8029ba83813222ca549c488416dc3fda40ccef  rhel_8.10-x86_64-edge_commit-ostree.json
 6e9e463bac1d7ec479413805de2f5ec3f4f6ed0b  rhel_8.8-x86_64-image_installer-unattended_iso.json
@@ -722,6 +726,7 @@
 72b6203681ef3f7540abbcd6672ebb3c4737de50  rhel_9.6-aarch64-edge_commit-ostree.json
 72b812078ceed48660602c280dc3290e0c929d37  rhel_9.6-aarch64-image_installer-empty.json
 72eb1bd57ad2021f3e3aeedebb0704db9ebb637e  rhel_9.3-aarch64-edge_installer-unattended_iso_edge.json
+731ec1b1867f528a992f8c9fb09cf7a869fe9c5e  rhel_9.3-aarch64-edge_vsphere-edge_ostree_pull_fips.json
 732eefa973f7d2ecd1937b4fe2138fd0c4f60fad  rhel_9.4-x86_64-edge_container-empty.json
 73d03373f7f103ec5bc9787cf84e4ec3ad272fe2  rhel_9.3-x86_64-edge_ami-edge_ostree_pull_user_minimalenv.json
 7403c507c4ced4972d1f6b3848ad39c16dc4dd45  rhel_9.7-aarch64-ami-all_customizations.json
@@ -756,6 +761,7 @@
 797c709d32ef1c2c00dfe6273fdcfeceef1a3e57  fedora_42-ppc64le-qcow2-empty.json
 7989b997b2aff346184fe0c510b0fc2a6519f7b0  fedora_42-aarch64-container-empty.json
 799ba16cb8a70533e9a5eb5c814a331def299a99  fedora_42-x86_64-iot_container-iot_customizations_full.json
+79b74f812e6fa354cc9335fd7cb5ebda12d98dc7  rhel_9.3-aarch64-edge_raw_image-edge_ostree_pull_fips.json
 79bc31a8182c17c20fe184c706edaef592033adb  rhel_8.10-x86_64-gce-empty.json
 79e05361e7d16bd79adea0e339c279ee0d5c6789  rhel_8.9-aarch64-qcow2-empty.json
 79f182fc7c6f23dd5deb23b8613d22f891fd5920  rhel_9.3-aarch64-edge_container-embed_containers_2.json
@@ -795,6 +801,7 @@
 7ef3768b0662866068f79a39e7b7052726684925  centos_10-aarch64-ami-partitioning_plain.json
 7f2ba329ff5974a567c0522a743d45d7882919dd  rhel_9.1-aarch64-edge_raw_image-edge_ostree_pull_empty.json
 7f46cc751846342d38ab6aac2fe06f1f4d528e1e  rhel_8.8-x86_64-edge_container-embed_containers_2.json
+7f905425bf6d0d84bd629ca76e3d892c53ac0551  rhel_9.4-x86_64-edge_simplified_installer-edge_ostree_pull_device_fips.json
 7fa8a484dc5739ff4b7c80e57c1f87b0f7841295  rhel_8.5-x86_64-vhd-empty.json
 7fbf7e20fb2fecaf37e6e15c1a50701aa125c774  rhel_9.5-x86_64-minimal_raw-empty.json
 7fcbf9aebd3d7bc8f22721624541baf868fae18c  rhel_8.5-x86_64-ec2-empty.json
@@ -848,7 +855,6 @@
 8819116ae5c298de8a4cfc0c7765cc37217a6c62  rhel_9.7-x86_64-edge_container-ostree.json
 881d28de2f021e82c891116e4254495c6e5a9508  centos_9-x86_64-minimal_raw-firewall.json
 88223c3910e2efbad54d8668dddd05d321e06b85  rhel_9.2-aarch64-edge_commit-ostree.json
-882df984bdf8d8d2c091d0ea07458bff5a1be95c  rhel_9.4-aarch64-edge_ami-edge_ostree_pull_user_fips.json
 886a4aae64ee597c73c7b9baf11d34d9baabc12d  rhel_8.4-ppc64le-qcow2-empty.json
 8885c6d308787b0dcd26ef04d7bd955b82a0d22e  rhel_10.0-aarch64-ami-empty.json
 88a25996cfb9e0f5465d41d9111bef01e7edcc0c  rhel_9.0-x86_64-openstack-empty.json
@@ -870,7 +876,6 @@
 8a1c8a6a4d637de293564c7a5ae6a2e0ed337532  fedora_43-aarch64-iot_raw_image-iot_ostree_pull_empty.json
 8a37444cbfb085abfa103c8926287a28025d1e6f  rhel_8.6-x86_64-azure_eap7_rhui-empty.json
 8a46688f9e0df631538c3215764aec281a760cdf  centos_9-x86_64-ami-modularity_in_packages.json
-8a554380c65e662846009235149a462a4423633c  rhel_9.4-aarch64-edge_simplified_installer-edge_ostree_pull_device_fips.json
 8a877bf2c162960ceb3cc10774e2a8ba477199e1  rhel_9.0-aarch64-edge_container-empty.json
 8b4748218779fb9ced7260f274c230ad03c354d3  rhel_9.6-x86_64-edge_installer-edge_ostree_pull_empty.json
 8b62b549f256fc47518d804d5989ce723f057427  fedora_43-x86_64-iot_qcow2_image-iot_ostree_pull_empty.json
@@ -905,7 +910,6 @@
 90011edd36b2f3726e1153e0a938e87686596870  rhel_8.8-aarch64-ami-all_customizations.json
 9045d98fecf8576affdba47e060c41bedb97be25  centos_9-x86_64-tar-empty.json
 905901895695eddfd5e4498d8853fabdc16eb0d6  fedora_42-x86_64-qcow2-minimal.json
-908a195d0dd97f6d0454cb0afe5bfa51e9aef2b4  rhel_9.4-aarch64-edge_raw_image-edge_ostree_pull_fips.json
 90994d84eaf74bc4499700f340e65f0808eb4167  rhel_10.0-x86_64-wsl-empty.json
 913a89eb00b09158ed1d8aaa107aec5fdf6cbb0e  rhel_9.0-aarch64-edge_vsphere-edge_ostree_pull_empty.json
 916ccc398cb0735078055f359375c4c86d86a8ae  rhel_8.5-x86_64-gce_rhui-empty.json
@@ -922,7 +926,6 @@
 935397cb2c784fc4e918146570e4abda8054df7b  rhel_9.4-aarch64-edge_vsphere-ostree_filesystem_customizations.json
 935dadb79e07a1541f1139d5f07f6a8419382dfb  rhel_9.5-x86_64-edge_ami-edge_ostree_pull_user.json
 93c7823ca22e8658d8a095207b91382c73c5bc3e  rhel_9.5-aarch64-openstack-empty.json
-93e2e3abb2c6c2bbc6c8466dd83be9cc6917f6bc  rhel_9.3-aarch64-edge_simplified_installer-edge_ostree_pull_device_fips.json
 9422135b267aebbdf7248313c0d8079ef70022c7  rhel_8.7-x86_64-gce-empty.json
 9490c8d7a8c286d2da5b822d891a4867870a9b18  rhel_8.7-x86_64-azure_eap7_rhui-empty.json
 94c4deaaf478242df82f9d048e88c246905881f3  rhel_8.7-x86_64-edge_simplified_installer-edge_ostree_pull_device.json
@@ -988,9 +991,9 @@
 9d192f5a8c0d7870c7037c2e9bca9b5a76fc8bd3  rhel_8.8-x86_64-qcow2-empty.json
 9d1b0e204002741600b7a9c811c4415c8c68dbc7  rhel_9.1-aarch64-minimal_raw-empty.json
 9d6f67da8098b6b523586ef0ff82aba09c3ff151  rhel_8.7-aarch64-image_installer-empty.json
+9d890d407bcbc2415173cc0f3e5b8ab25127b733  rhel_9.4-aarch64-edge_simplified_installer-edge_ostree_pull_device_fips.json
 9dbaf52e6cc0b7d5aaeb4570cae41fdcfaef20b1  fedora_42-aarch64-openstack-empty.json
 9dbe18820998b310d6b009a5e4e09713efab3576  fedora_41-s390x-container-empty.json
-9e1f45103e1ba5a7d346d0ed4a8e3d34ec4f0a4f  rhel_9.3-aarch64-edge_vsphere-edge_ostree_pull_fips.json
 9e25b51aca80f66bbd6af24e4d3b37505d449f06  rhel_9.0-aarch64-edge_simplified_installer-edge_ostree_pull_device.json
 9e499249d2a912f50b58c455df690aa8485286ed  rhel_9.7-x86_64-minimal_raw-firewall.json
 9e7f220a9e472de871f3746a6974fad692b82d99  rhel_9.3-x86_64-azure_rhui-empty.json
@@ -1198,7 +1201,6 @@ bd6389e79061118b11f34bedb59c26ea86f88d41  rhel_8.9-x86_64-vmdk-empty.json
 bd6bcd286d3c21b654af9fb4ae548b2f5b633332  rhel_8.7-x86_64-ami-partitioning_plain_r8.json
 bd7f763b2c44b62797bbc38108b0582d42aaff82  rhel_9.7-aarch64-edge_commit-edge_ostree_pull_user.json
 bdbf89aa73b5d5ec7c6093b441b6bb7bbb3a7b23  fedora_42-x86_64-iot_installer-unattended_iso_iot.json
-bdd1a5aa114cbed3e7b143188d5193ee88ab1e49  rhel_9.4-aarch64-edge_vsphere-edge_ostree_pull_fips.json
 be08b26c445134461a0432fff4c0b5a5e3022db9  rhel_9.2-aarch64-tar-empty.json
 be2181dfcb77b48f7860aaf3e99eaa84c1893de6  rhel_9.0-x86_64-ami-partitioning_lvm.json
 be403e3275ec818d2393d4da30ac8c62900c6c15  rhel_9.2-aarch64-image_installer-unattended_iso.json
@@ -1356,8 +1358,8 @@ d5dd536889926b18b4ede2ea0da5a663903403a6  rhel_8.4-x86_64-oci-empty.json
 d5fd3178fd4eeaa042504de0cca6ef5caab3f518  rhel_8.8-aarch64-edge_simplified_installer-edge_ostree_pull_device.json
 d6213320e8e45c4b97aba51209de6e596e9fd530  rhel_9.7-x86_64-ova-empty.json
 d651fdc6665ea28e600445bcb47e826a1c32b814  rhel_8.7-aarch64-edge_commit-embed_containers.json
+d675b541b55c801761c5b1421b375b3e51cc525c  rhel_9.3-aarch64-edge_ami-edge_ostree_pull_user_fips.json
 d6765f88316d3266053bf09c4a97f71879a1782e  fedora_40-x86_64-iot_qcow2_image-iot_ostree_pull_user.json
-d6e1dae0e2725229c59af98e8abb5272f8b4c84b  rhel_9.3-aarch64-edge_raw_image-edge_ostree_pull_fips.json
 d6e8d49c7fa350cd90efd4cfec8c65244a816ef4  rhel_9.7-x86_64-edge_installer-unattended_iso_edge.json
 d738251e1481fd6155a08e310926c85d109137d2  fedora_40-s390x-qcow2-minimal.json
 d766b87f9f8c915d430eed203ac890423bfed39d  rhel_9.5-x86_64-ami-all_customizations.json
@@ -1389,6 +1391,7 @@ db4bf8c72d10c3390beb168c0c92aeb249344f0c  rhel_10.0-aarch64-ami-partitioning_pla
 dbd167256d853985c10f83f79ad82a32e071db21  fedora_42-s390x-qcow2-import_rpm_gpg_keys_from_tree_fedora.json
 dc258a9dce9ed8589b2af869bc69f0258cffe13f  rhel_9.4-x86_64-edge_simplified_installer-ostree_filesystem_customizations_installer.json
 dcf3648fa02ceed142727d18c8aef6bf7785b99e  fedora_40-x86_64-minimal_raw-empty.json
+dd0c02795d4baa3a0ce563c134df03bfeb9c8aea  rhel_9.4-x86_64-edge_vsphere-edge_ostree_pull_fips.json
 dd33ea927dcec69cfe1a4e618e45017bcf6bf629  rhel_8.5-x86_64-edge_container-empty.json
 dd3d8b62e780b0bbfc0cfec886dd9f57652abf56  rhel_9.6-x86_64-openstack-empty.json
 dd444c9591a16b763761892e8ccea4d4c27e5537  rhel_8.8-x86_64-edge_commit-embed_containers.json
@@ -1448,7 +1451,6 @@ e5b6c1ceaaceb30ffbfaabb3883aaf562451dfc0  rhel_8.6-aarch64-edge_commit-embed_con
 e5b921f8a9be6b2f91b74ee248c8134d483f192a  rhel_10.1-ppc64le-qcow2-empty.json
 e5e84362372955bd43d51595891f623fcd2e792e  fedora_40-x86_64-ami-partitioning_btrfs.json
 e60d816878411311d9dcf42a39cb966b6eca5923  rhel_8.6-x86_64-ec2_ha-empty.json
-e66026fc579a3f9c11fbb522f07bb7917f06c4bd  rhel_9.4-x86_64-edge_raw_image-edge_ostree_pull_fips.json
 e6d27038c2f258d5a4572a8a51ec26df1503e4b3  rhel_9.0-aarch64-edge_ami-edge_ostree_pull_user.json
 e7bf05829ca34d2124a0ce310bf7040cc3048971  centos_9-x86_64-image_installer-unattended_iso.json
 e7e54caff9e94371a435141b750132a3b32a9250  rhel_9.7-s390x-tar-empty.json
@@ -1529,7 +1531,6 @@ f67c68df72759310310041a41e6159017fc05a91  rhel_8.8-x86_64-oci-empty.json
 f69c2da66f53f3b40464b01b7e8d8dd8e5737833  rhel_9.3-x86_64-edge_installer-edge_ostree_pull_empty.json
 f6a9868c5f93f9ba8b401e5ef9c34986bd12034a  rhel_9.1-aarch64-edge_container-empty.json
 f6ae0d300e7ad89510e45249579c626f7ef2e61e  rhel_8.4-ppc64le-tar-empty.json
-f746be99cbc38f09f194ae23e7ca1278f30c6f49  rhel_9.4-x86_64-edge_vsphere-edge_ostree_pull_fips.json
 f7a53d0c99ce039b6332d69200c90db3920e2f62  rhel_9.5-aarch64-edge_commit-edge_ostree_pull_user.json
 f7a656964b2eaaed7fa2f8c50f6bec147e305bef  rhel_8.10-x86_64-vmdk-empty.json
 f7afc4d5a48ba7dd1c27c48597d0818e6eb655c3  fedora_42-x86_64-ami-empty.json
@@ -1562,7 +1563,6 @@ fb905a01704df4c9ca5e8ca5b34b7165010368b5  rhel_9.0-aarch64-edge_commit-edge_ostr
 fb91822954489ac65fc2bdb78d33f5386e2ad7da  rhel_9.1-aarch64-qcow2-empty.json
 fb92c656fcbec7acb06c855b0b6edba1663b8c6f  fedora_40-x86_64-qcow2-oscap_generic.json
 fbb0b9fe63a0fd9c19d8da9586af184eeccf4bd1  rhel_9.6-x86_64-image_installer-unattended_iso.json
-fbc8a9442af05ed5ec5894e69514bac76b35df44  rhel_9.4-x86_64-edge_ami-edge_ostree_pull_user_fips.json
 fbf8a15ea866bce0cca90d34cd98071868b98a0c  rhel_9.2-x86_64-ami-partitioning_lvm.json
 fc2edc480c58c4513aa3b8330ef5001b407f6049  rhel_9.2-aarch64-qcow2-oscap_generic.json
 fc3e357a3b4989935a94b03140867f2b06b242be  rhel_9.2-x86_64-tar-empty.json

--- a/test/data/manifest-checksums.txt
+++ b/test/data/manifest-checksums.txt
@@ -43,6 +43,7 @@
 061f6ddafa37c9916e393fc98c2f89bdaafeab75  rhel_8.6-x86_64-openstack-empty.json
 06206ca2d0be333ab7800c32754cbf3d9f565ba1  rhel_8.7-x86_64-oci-empty.json
 062170f19abb4a276d333fc4de15fb53e57d44b5  rhel_8.4-x86_64-ec2_sap-disable_lm_sensors.json
+063ae379162ade54988b2ea4fa32ab60040be4e4  rhel_9.4-aarch64-edge_ami-edge_ostree_pull_user_fips.json
 06516b05b6518414e3abba3fc93b4889f780d615  rhel_10.0-aarch64-qcow2-empty.json
 0662e3131ab360d21f6635eef4ce8ffabcee6408  rhel_9.0-aarch64-ami-partitioning_lvm.json
 0669a2576d6a0a025b57b61c53f3563da1097441  rhel_9.4-x86_64-edge_vsphere-ostree_filesystem_customizations.json
@@ -54,6 +55,7 @@
 07e71b6b0985441ca35bb5c6f99c03251d1079de  rhel_8.9-aarch64-vhd-empty.json
 07f3ffbaf84f56a56120ca7f360e14567fe0a8b9  rhel_8.9-aarch64-edge_commit-ostree.json
 07f4dc71932a4f8a3652b1810a85d2dacfda9e74  centos_10-x86_64-image_installer-empty.json
+07f9d714604427ee36baba690c9a5681bdccc75b  rhel_9.3-aarch64-edge_ami-edge_ostree_pull_user_fips.json
 084488c722e0324b70de0cb381f6c0d7dfeb219e  centos_10-x86_64-ami-partitioning_lvm.json
 085c96a83f4464c0ded9a1be5b42cd5bd9756660  rhel_8.7-aarch64-qcow2-oscap_generic.json
 08624dc56b83b52142bca3d4416ce1979f4c1ca8  centos_10-aarch64-ami-all_customizations.json
@@ -62,7 +64,6 @@
 09048038cd8dd1574dbc4b833c20b22ed433c5f6  fedora_40-x86_64-iot_qcow2_image-iot_ostree_pull_empty.json
 09371e318e3112b8c407aa42e50fad5cba8ba9ba  rhel_9.0-x86_64-edge_ami-edge_ostree_pull_user.json
 09786e73ffab93ba288ff99db84fe71a54b381f5  rhel_9.4-x86_64-edge_simplified_installer-edge_ostree_pull_device.json
-09911c5dafe14cd53cc89a05b0ef8d12582c3136  rhel_9.3-x86_64-edge_ami-edge_ostree_pull_user_fips.json
 09b67bff51f0357870c6f5677c036f4cc2d5d7eb  rhel_9.1-aarch64-edge_ami-edge_ostree_pull_user_minimalenv.json
 09c307f52923ffcfa4b4071910d8622367263829  rhel_8.4-aarch64-ami-empty.json
 09c7fcedd5f32aacd3dbbc2b1a1ccc6f4e2a2c16  rhel_9.7-x86_64-ami-partitioning_plain.json
@@ -84,7 +85,6 @@
 0c1ed708ebf590cdaa6f70516ad6dd7516c7632a  rhel_9.5-x86_64-qcow2-rhsm.json
 0c7f876c4599c9d4d51fc4cbfb1ab5c79b6f99ed  rhel_9.3-x86_64-wsl-empty.json
 0c884db1fd2b7f7afeb304fd6446c789fc654846  centos_10-x86_64-ami-empty.json
-0d2924ae54e95fc5d5e11f960ec2959916f6525d  rhel_9.3-aarch64-edge_simplified_installer-edge_ostree_pull_device_fips.json
 0d65af6000316b3f5a8b887480b0888ae1aa7427  rhel_8.8-x86_64-tar-empty.json
 0deb0922105abe24b4a707c812254918523be456  rhel_9.4-x86_64-ami-partitioning_plain.json
 0e6002d8f96d71a9e45c98f465a5c157c038f22d  centos_10-s390x-qcow2-empty.json
@@ -101,6 +101,7 @@
 1019e623ac28d179eec74f40c4f1ed16e6ee5498  rhel_9.1-x86_64-edge_ami-edge_ostree_pull_user.json
 10777d1035655f5426b3f3e7a80f0ae727f377bd  fedora_42-aarch64-iot_simplified_installer-iot_ostree_pull_device.json
 107b0a0bb1fd4bdc5299e47970ad551d9c7b7fee  rhel_9.6-ppc64le-tar-empty.json
+108d9acfae417c9278480cbf0079bc84c41acafd  rhel_9.3-x86_64-edge_ami-edge_ostree_pull_user_fips.json
 111698f3ef0420241d04d1b7d9f063bf118a2381  fedora_42-aarch64-iot_installer-iot_ostree_pull_empty.json
 112db38cce32a0586f8ce0d151d66ba75bdfcf09  fedora_41-aarch64-qcow2-import_rpm_gpg_keys_from_tree_fedora.json
 11819ed09974919361a06fbcf61320be416e1af8  rhel_9.7-aarch64-qcow2-empty.json
@@ -147,7 +148,6 @@
 1708f78642f2e038dcefe3393443676dc045b340  fedora_41-x86_64-iot_container-empty.json
 17099438bea0b46459f0290905c55cd595f6a7e3  rhel_9.6-aarch64-ami-all_customizations.json
 1726a566e619bfed289cb90b62ec322067bc57a9  fedora_43-aarch64-qcow2-all_with_fips.json
-1728cf5fa66bf30718b0329a1eae9c703d9a5941  rhel_9.3-x86_64-edge_raw_image-edge_ostree_pull_fips.json
 173cbf7ac29704fed7c8e9ff0878110bb366257c  centos_9-x86_64-ami-partitioning_lvm.json
 17818c6b8023b3bb9ccdc9daa5ff6f09000525d1  fedora_40-x86_64-ami-empty.json
 17a59e28ac1e1c82a19a345584871e380a70e3f5  rhel_8.9-x86_64-wsl-empty.json
@@ -218,7 +218,6 @@
 21901ca3bea0729e675b71fc3652dc12a97f5923  rhel_8.9-aarch64-azure_rhui-empty.json
 21942bc76cf25b15e36e3564a02de6d22278a717  rhel_9.2-aarch64-ami-partitioning_plain.json
 219bba8e01c2465a2b7ad72b1eb9eeaeecdfd1f8  rhel_8.9-s390x-qcow2-empty.json
-21c812197de599e9d732f9834ce5f6f4e12c1550  rhel_9.4-aarch64-edge_vsphere-edge_ostree_pull_fips.json
 21e3282312d8ffde8b59952465a07f3304413e06  fedora_43-aarch64-ami-empty.json
 224e84e70a30a48608febe7cc0d244fec838d2b8  rhel_9.4-aarch64-qcow2-all_with_fips.json
 2252cfbae469e71d48e9eab36528c155e67f3c3f  rhel_8.5-x86_64-edge_container-embed_containers_2.json
@@ -234,10 +233,12 @@
 23b3bcdd0c5564a33060a106547246110da82c3b  rhel_9.2-x86_64-edge_ami-edge_ostree_pull_user_minimalenv.json
 23c07dd51704267ae5de6c01775178b30804b3a4  rhel_8.9-aarch64-minimal_raw-empty.json
 244708d143bf1b9078a34854fafd2ada36abcdad  rhel_8.9-aarch64-edge_container-embed_containers_2.json
+247a8e5b711eaedcae9ebc02651c13aa7dc5676d  rhel_9.4-aarch64-edge_simplified_installer-edge_ostree_pull_device_fips.json
 2486770f81d2c296e5404ca48b9f41073e1dc8fe  rhel_9.0-x86_64-minimal_raw-empty.json
 249d5e5d9f8f04558273f9c2648d52e875276ce7  rhel_9.0-x86_64-edge_ami-edge_ostree_pull_user_minimalenv.json
 24becaadad8f09a784780da4c47047ed22a26946  fedora_41-x86_64-wsl-empty.json
 24c1b68f0a79e968b5e2d192a8f5493ea7453410  rhel_8.6-x86_64-edge_simplified_installer-edge_ostree_pull_device.json
+254b3311ee5f6d5e0bec52b25841cf0ee993efa2  rhel_9.3-x86_64-edge_simplified_installer-edge_ostree_pull_device_fips.json
 256d0f81171de921cb1bfc211d61e7824f125b02  rhel_9.1-aarch64-azure_rhui-empty.json
 26077320d2a0d6313212d856c40c481280c226d8  rhel_8.5-x86_64-ami-empty.json
 2616069f91ed8e2b25dd90c45d0f7dc1c30cae9c  rhel_9.1-ppc64le-qcow2-oscap_generic.json
@@ -348,6 +349,7 @@
 38e1f3e109774c552e57e5821dc9d720d1554166  fedora_40-aarch64-container-empty.json
 38eedd12150bd54764ddfa04d4922d35ccb750d6  rhel_9.7-aarch64-ami-empty.json
 392879d497ea4c75d63f8f189ba3e21a84e37c8c  centos_9-x86_64-qcow2-all_with_fips.json
+392c13611b0be3ab88178de43cbf2bf1badafa98  rhel_9.3-aarch64-edge_vsphere-edge_ostree_pull_fips.json
 398d3819416e3a9ac67f3ffc2e96ca8fe09c29b6  fedora_41-aarch64-qcow2-oscap_generic.json
 39d0b63fe1123e6189276a17b23b016bcb7b474c  rhel_8.5-x86_64-edge_installer-unattended_iso_edge.json
 39fa412f5c411f88219add78520738f0390b191a  fedora_41-s390x-qcow2-oscap_generic.json
@@ -416,7 +418,6 @@
 4496674f72db73ece4334da01b1177c2f8416b63  rhel_8.9-x86_64-ec2_ha-empty.json
 44ad36bdc1c9ec52988661d393be994d947fbb22  centos_10-aarch64-tar-empty.json
 451b3f9e73c8e1d99b55d3738b99623079bcb843  rhel_8.6-x86_64-image_installer-unattended_iso.json
-452b078ecc1acaae1fc1a5cb6a08d1fdda215081  rhel_9.4-aarch64-edge_raw_image-edge_ostree_pull_fips.json
 4540d00ff570e4f86f7adf9cdfc6f11f45b4e3bb  rhel_9.6-x86_64-edge_ami-edge_ostree_pull_user.json
 4559465da6968e4e668407cc74277cdc092d1b8e  rhel_9.6-x86_64-edge_container-ostree.json
 455e8b2c4eacbcdec95494e239515d0442045da4  rhel_8.7-aarch64-minimal_raw-firewall.json
@@ -424,7 +425,6 @@
 458ec1dacec46f30fda710f5671fb92845398d90  fedora_40-aarch64-iot_qcow2_image-iot_ostree_pull_empty.json
 45abbff8f4caaa2a71e82684206383efa8221430  rhel_8.6-x86_64-ami-partitioning_plain_r8.json
 45c24c3ae160a87cfb6b578a71ba7faa91f7378e  rhel_8.9-aarch64-ami-empty.json
-45c81f72d33056290adb0494fe99cef3441eb162  rhel_9.4-x86_64-edge_ami-edge_ostree_pull_user_fips.json
 45cf2510a2221067637adfefd5c4f47f87092c48  rhel_9.1-x86_64-edge_simplified_installer-edge_ostree_pull_device.json
 45ea5c54fb1c4d989e2f5064bf058939164b6499  rhel_9.0-s390x-tar-empty.json
 46cf840fd750c1c529d25df2ca9a6d728271c507  rhel_9.4-aarch64-edge_installer-edge_ostree_pull_fips.json
@@ -435,6 +435,7 @@
 47a2a2a7149af691ba2eb793f44f8adeba1bca02  rhel_8.5-aarch64-minimal_raw-firewall.json
 47a9e2600b6e008f127198b3b2c36e9b63a04df9  rhel_8.9-x86_64-edge_container-empty.json
 47d81413599576f0af28d88e4783b4c753a047eb  rhel_8.6-aarch64-qcow2-empty.json
+487d85d3f1d0cfad1ca7922e2c106f548362b127  rhel_9.4-x86_64-edge_ami-edge_ostree_pull_user_fips.json
 487e2a40ddc0ad16710dffb7a369871ea3881bc1  rhel_8.9-x86_64-ami-partitioning_lvm_noswap.json
 48a75b25f31fe4009a1ff5056470e0c74e37e472  rhel_9.2-x86_64-edge_simplified_installer-ostree_filesystem_customizations_installer.json
 48c80cb15d2e0813837e1fe7df0d79ede3313b64  rhel_8.10-ppc64le-qcow2-all_with_fips.json
@@ -479,7 +480,6 @@
 4d97b109cc157fcece895ec4ee06ed935a60adb8  rhel_9.0-aarch64-minimal_raw-firewall.json
 4de4895418ecf4504c1f5d4872e66fb1e99564d2  rhel_8.10-aarch64-edge_container-empty.json
 4e10a49de81e18d8c2478e02e82435d28a689945  rhel_8.5-x86_64-tar-empty.json
-4e22829c6cbe91292a36a66f6982b5d430037b63  rhel_9.3-x86_64-edge_vsphere-edge_ostree_pull_fips.json
 4e3459b75ec6c48846a0bf6da6fb9602cb332a8d  fedora_41-s390x-qcow2-minimal_pkgs.json
 4e4a896826e0ba19ecbc639347dba05780692b80  fedora_43-s390x-container-empty.json
 4e4dc6573379819bdaf18792d6e3c01c913aa0a4  fedora_43-x86_64-oci-empty.json
@@ -583,7 +583,6 @@
 5c6ded4398a239de043c51551811cec2db418561  rhel_9.3-aarch64-qcow2-all_with_fips.json
 5c899281ae3df591d395bf00cfcab50b66ffb298  rhel_10.0-aarch64-wsl-empty.json
 5cd5ca87cd180aebe878012514678419fd82a0d9  centos_9-aarch64-minimal_raw-empty.json
-5cffba0b9e8251dc60b27b252862db8d5fdc0114  rhel_9.3-x86_64-edge_simplified_installer-edge_ostree_pull_device_fips.json
 5d60fdc3838d9700f21c04e05ee9b640c0b4a8e4  centos_10-s390x-qcow2-all_with_fips.json
 5d7fab5cfdb0536a13bae7f42c91fa9b33b1e8d6  rhel_8.10-aarch64-image_installer-unattended_iso.json
 5dbb197f42ea0ff9fd3348e440657febe72c9294  fedora_40-s390x-qcow2-minimal_pkgs.json
@@ -608,7 +607,6 @@
 5fb0fb8c155a2f1ca048bcc591c99ae269035056  rhel_9.1-x86_64-vmdk-empty.json
 602bbd181387f70b0ef1c65e8b6cc8dabd8068a6  rhel_10.1-s390x-tar-empty.json
 60340ad4ccd2bc911529febeafc19cda3eb786af  fedora_41-aarch64-minimal_raw-firewall.json
-605c743048c0cdd075476770e71c1d3ee0a2e7c1  rhel_9.4-x86_64-edge_raw_image-edge_ostree_pull_fips.json
 607117b5d8567ee882c965bcfcae4a4fd1fa197c  rhel_8.8-x86_64-azure_sap_rhui-empty.json
 6086e9cef142a12da0cebc24b0389bd588f5840f  rhel_9.7-x86_64-gce-empty.json
 6096a9bb0e2605b48675260ed8c2357a72b27345  rhel_8.7-x86_64-minimal_raw-empty.json
@@ -651,6 +649,7 @@
 66b3cdbb3d8a63eb879553858fae53bd9fdafe42  rhel_9.4-x86_64-edge_raw_image-edge_ostree_pull_empty.json
 66d31c84304733b6afacad0ba7476ae48aa65029  fedora_42-aarch64-iot_bootable_container-empty.json
 6708f115605cf6405d70fa92eda01647b35b8925  rhel_9.3-x86_64-ova-empty.json
+67358a27dca4af5d4c412235818de45b774891cd  rhel_9.3-aarch64-edge_simplified_installer-edge_ostree_pull_device_fips.json
 6742f7f27373dfa611370ecaa588b72cfb9d8cfc  rhel_8.6-x86_64-vmdk-empty.json
 678d19a54786a6aaa8c70a2f9376c9ac5f2a7051  fedora_40-x86_64-iot_simplified_installer-iot_ostree_pull_device.json
 6821bc7b49098107d7b5a8b233694991410f5775  centos_9-x86_64-ova-empty.json
@@ -696,7 +695,6 @@
 6d96b8b2b9c5e75cd7f3a4733c07122a5dd49585  rhel_8.10-x86_64-tar-empty.json
 6dd834313ab01e21cacae867e4fa91079a513055  rhel_8.10-s390x-qcow2-import_rpm_gpg_keys_from_tree_rhel.json
 6e4966747ed19323ccac844294c3401942552804  rhel_8.4-aarch64-edge_commit-ostree.json
-6e60109920dce7d404df22944256bf3301f5b594  rhel_9.4-aarch64-edge_ami-edge_ostree_pull_user_fips.json
 6e6051765bd83045a20c1b89e3c8731f5a4f4fe9  rhel_8.4-x86_64-ami-empty.json
 6e8029ba83813222ca549c488416dc3fda40ccef  rhel_8.10-x86_64-edge_commit-ostree.json
 6e9e463bac1d7ec479413805de2f5ec3f4f6ed0b  rhel_8.8-x86_64-image_installer-unattended_iso.json
@@ -718,6 +716,7 @@
 715163c88d43ae64304c03784b63c46ed3acc129  rhel_9.4-x86_64-ec2_sap-ec2_sap_empty.json
 71735571836d75cd2bdfc1d546888cdd6635d22c  rhel_9.7-x86_64-edge_installer-edge_ostree_pull_empty.json
 717abe313c7802221da344c3af4447909c3c9460  fedora_40-x86_64-iot_commit-kernel_debug.json
+7185a5da15ba9cf83540badfa1dbafe70e00eb7a  rhel_9.4-x86_64-edge_vsphere-edge_ostree_pull_fips.json
 7190a2f896d2ac937493fb8870ea7262297707a5  rhel_8.8-x86_64-minimal_raw-empty.json
 71ab6b7f2e8966e5f535c207683007d72122c957  rhel_9.1-x86_64-edge_commit-edge_ostree_pull_user.json
 71cd11c0b74ada99c68ab9f11b57263169b4ecc4  fedora_41-ppc64le-container-empty.json
@@ -726,7 +725,6 @@
 72b6203681ef3f7540abbcd6672ebb3c4737de50  rhel_9.6-aarch64-edge_commit-ostree.json
 72b812078ceed48660602c280dc3290e0c929d37  rhel_9.6-aarch64-image_installer-empty.json
 72eb1bd57ad2021f3e3aeedebb0704db9ebb637e  rhel_9.3-aarch64-edge_installer-unattended_iso_edge.json
-731ec1b1867f528a992f8c9fb09cf7a869fe9c5e  rhel_9.3-aarch64-edge_vsphere-edge_ostree_pull_fips.json
 732eefa973f7d2ecd1937b4fe2138fd0c4f60fad  rhel_9.4-x86_64-edge_container-empty.json
 73d03373f7f103ec5bc9787cf84e4ec3ad272fe2  rhel_9.3-x86_64-edge_ami-edge_ostree_pull_user_minimalenv.json
 7403c507c4ced4972d1f6b3848ad39c16dc4dd45  rhel_9.7-aarch64-ami-all_customizations.json
@@ -761,12 +759,12 @@
 797c709d32ef1c2c00dfe6273fdcfeceef1a3e57  fedora_42-ppc64le-qcow2-empty.json
 7989b997b2aff346184fe0c510b0fc2a6519f7b0  fedora_42-aarch64-container-empty.json
 799ba16cb8a70533e9a5eb5c814a331def299a99  fedora_42-x86_64-iot_container-iot_customizations_full.json
-79b74f812e6fa354cc9335fd7cb5ebda12d98dc7  rhel_9.3-aarch64-edge_raw_image-edge_ostree_pull_fips.json
 79bc31a8182c17c20fe184c706edaef592033adb  rhel_8.10-x86_64-gce-empty.json
 79e05361e7d16bd79adea0e339c279ee0d5c6789  rhel_8.9-aarch64-qcow2-empty.json
 79f182fc7c6f23dd5deb23b8613d22f891fd5920  rhel_9.3-aarch64-edge_container-embed_containers_2.json
 7a17c26840c0666ca365a6efe694fd3e52d3b101  fedora_41-aarch64-qcow2-minimal.json
 7a1ccb2f95c9b9468a78e35cc534fa346f4525f9  rhel_9.4-x86_64-vhd-empty.json
+7a4372ade9e986c9f4a4237532c0ae41d54984d4  rhel_9.3-x86_64-edge_raw_image-edge_ostree_pull_fips.json
 7a5131135fc33d4b52ca1c1cfec18de68ad39e04  rhel_8.10-aarch64-ec2-empty.json
 7a87f8e1cd2c059b35f28c4ce712376655d8d234  rhel_8.4-aarch64-edge_installer-unattended_iso_edge.json
 7ab563c7fab6e7faf8de88552ca4e3077d077a02  rhel_9.1-x86_64-ec2_sap-ec2_sap_empty.json
@@ -801,7 +799,7 @@
 7ef3768b0662866068f79a39e7b7052726684925  centos_10-aarch64-ami-partitioning_plain.json
 7f2ba329ff5974a567c0522a743d45d7882919dd  rhel_9.1-aarch64-edge_raw_image-edge_ostree_pull_empty.json
 7f46cc751846342d38ab6aac2fe06f1f4d528e1e  rhel_8.8-x86_64-edge_container-embed_containers_2.json
-7f905425bf6d0d84bd629ca76e3d892c53ac0551  rhel_9.4-x86_64-edge_simplified_installer-edge_ostree_pull_device_fips.json
+7f757cb0dc278b4e7b9f61f6a516ac96e2255d2e  rhel_9.3-aarch64-edge_raw_image-edge_ostree_pull_fips.json
 7fa8a484dc5739ff4b7c80e57c1f87b0f7841295  rhel_8.5-x86_64-vhd-empty.json
 7fbf7e20fb2fecaf37e6e15c1a50701aa125c774  rhel_9.5-x86_64-minimal_raw-empty.json
 7fcbf9aebd3d7bc8f22721624541baf868fae18c  rhel_8.5-x86_64-ec2-empty.json
@@ -991,11 +989,11 @@
 9d192f5a8c0d7870c7037c2e9bca9b5a76fc8bd3  rhel_8.8-x86_64-qcow2-empty.json
 9d1b0e204002741600b7a9c811c4415c8c68dbc7  rhel_9.1-aarch64-minimal_raw-empty.json
 9d6f67da8098b6b523586ef0ff82aba09c3ff151  rhel_8.7-aarch64-image_installer-empty.json
-9d890d407bcbc2415173cc0f3e5b8ab25127b733  rhel_9.4-aarch64-edge_simplified_installer-edge_ostree_pull_device_fips.json
 9dbaf52e6cc0b7d5aaeb4570cae41fdcfaef20b1  fedora_42-aarch64-openstack-empty.json
 9dbe18820998b310d6b009a5e4e09713efab3576  fedora_41-s390x-container-empty.json
 9e25b51aca80f66bbd6af24e4d3b37505d449f06  rhel_9.0-aarch64-edge_simplified_installer-edge_ostree_pull_device.json
 9e499249d2a912f50b58c455df690aa8485286ed  rhel_9.7-x86_64-minimal_raw-firewall.json
+9e504c16e8ded88bbc7ca7e9104a2c844e0eb35b  rhel_9.4-aarch64-edge_raw_image-edge_ostree_pull_fips.json
 9e7f220a9e472de871f3746a6974fad692b82d99  rhel_9.3-x86_64-azure_rhui-empty.json
 9e946cc9d6f3a422f079be932028f6525db5e44a  rhel_8.7-aarch64-ec2-empty.json
 9eaec1f2681cbde6bbc0aa85326dbf2bbad1761e  rhel_9.6-aarch64-edge_vsphere-edge_ostree_pull_empty.json
@@ -1008,6 +1006,7 @@
 9fa4454321ff0b1108afed1d421172d5d898434f  fedora_43-aarch64-iot_container-empty.json
 9fbaadcd1bd7a86bf8bc5c35ed9fcf7d3f4652f5  rhel_8.7-x86_64-image_installer-unattended_iso.json
 9ff3fdac4aaf9abeeb240e26eedaf17b26177b14  fedora_42-aarch64-oci-empty.json
+a01af414ea1c045daeb55bbf8aead54663386bce  rhel_9.4-aarch64-edge_vsphere-edge_ostree_pull_fips.json
 a01bc9b93e8bab0e8fdbd54f1657df7de51a42bd  rhel_9.2-aarch64-edge_simplified_installer-edge_ostree_pull_device.json
 a088daa2250c74e3fc070d78ff7281fdcc621590  rhel_9.4-x86_64-edge_ami-edge_ostree_pull_user.json
 a0bdc4a226b0b0e5a5dbe5a05eb8ab57f1fdbcda  rhel_8.7-aarch64-azure_rhui-empty.json
@@ -1335,6 +1334,7 @@ d2825d7854bfcce592af40fac2696c76986f5b21  fedora_43-x86_64-qcow2-import_rpm_gpg_
 d2bd9a7f6275823f09555e4aec4152debf30511d  centos_9-aarch64-edge_container-embed_containers_2.json
 d2c37f5590449204156e638e44346177034b0f27  rhel_8.6-x86_64-ami-all_customizations.json
 d312a5a720d6ff6610513edb887e63cabd9abf49  rhel_9.4-x86_64-edge_commit-ostree.json
+d34407ad54eeecab5c6eefe5a0b673535ef42e66  rhel_9.4-x86_64-edge_raw_image-edge_ostree_pull_fips.json
 d36a2200e967c86cba12870810431a73430c99b1  rhel_9.2-aarch64-edge_ami-edge_ostree_pull_user_minimalenv.json
 d36a2a0fc92cbd848a1c96a7b24794ab333a950c  rhel_10.1-x86_64-qcow2-empty.json
 d39091e8cca96f9415652dd75d43c8007fbb02d3  rhel_10.1-aarch64-image_installer-unattended_iso.json
@@ -1358,7 +1358,6 @@ d5dd536889926b18b4ede2ea0da5a663903403a6  rhel_8.4-x86_64-oci-empty.json
 d5fd3178fd4eeaa042504de0cca6ef5caab3f518  rhel_8.8-aarch64-edge_simplified_installer-edge_ostree_pull_device.json
 d6213320e8e45c4b97aba51209de6e596e9fd530  rhel_9.7-x86_64-ova-empty.json
 d651fdc6665ea28e600445bcb47e826a1c32b814  rhel_8.7-aarch64-edge_commit-embed_containers.json
-d675b541b55c801761c5b1421b375b3e51cc525c  rhel_9.3-aarch64-edge_ami-edge_ostree_pull_user_fips.json
 d6765f88316d3266053bf09c4a97f71879a1782e  fedora_40-x86_64-iot_qcow2_image-iot_ostree_pull_user.json
 d6e8d49c7fa350cd90efd4cfec8c65244a816ef4  rhel_9.7-x86_64-edge_installer-unattended_iso_edge.json
 d738251e1481fd6155a08e310926c85d109137d2  fedora_40-s390x-qcow2-minimal.json
@@ -1381,6 +1380,7 @@ d9b6a48c70a80ce5e4e9df9e633fb2f500967895  fedora_40-x86_64-qcow2-import_rpm_gpg_
 d9edc72f4556e806b63c1967e353182e920bc9b2  rhel_9.5-x86_64-ec2_sap-ec2_sap_empty.json
 d9fdc08f1d5c16c6618c5fde5fa022f416ec2882  rhel_10.1-aarch64-ec2-empty.json
 da136c5154aa6b4a426998138aa2a39bfa3b1418  rhel_8.8-x86_64-vmdk-empty.json
+da28bb40b2d14c4075e6af22e33c354bdea31de2  rhel_9.4-x86_64-edge_simplified_installer-edge_ostree_pull_device_fips.json
 daad274fbc6602552db74080180356e34f7a32c7  rhel_9.4-aarch64-azure_rhui-empty.json
 dae1639150d6f3ba29346d099f72be8fcae0417e  fedora_42-aarch64-qcow2-all_with_fips.json
 db06de7655b4ab43c6085af3fef2c51b95870acc  rhel_8.7-x86_64-edge_container-ostree.json
@@ -1391,7 +1391,6 @@ db4bf8c72d10c3390beb168c0c92aeb249344f0c  rhel_10.0-aarch64-ami-partitioning_pla
 dbd167256d853985c10f83f79ad82a32e071db21  fedora_42-s390x-qcow2-import_rpm_gpg_keys_from_tree_fedora.json
 dc258a9dce9ed8589b2af869bc69f0258cffe13f  rhel_9.4-x86_64-edge_simplified_installer-ostree_filesystem_customizations_installer.json
 dcf3648fa02ceed142727d18c8aef6bf7785b99e  fedora_40-x86_64-minimal_raw-empty.json
-dd0c02795d4baa3a0ce563c134df03bfeb9c8aea  rhel_9.4-x86_64-edge_vsphere-edge_ostree_pull_fips.json
 dd33ea927dcec69cfe1a4e618e45017bcf6bf629  rhel_8.5-x86_64-edge_container-empty.json
 dd3d8b62e780b0bbfc0cfec886dd9f57652abf56  rhel_9.6-x86_64-openstack-empty.json
 dd444c9591a16b763761892e8ccea4d4c27e5537  rhel_8.8-x86_64-edge_commit-embed_containers.json
@@ -1440,6 +1439,7 @@ e3f044a30b824f2ffaf8072a2348db3bdd87a8ff  rhel_9.0-aarch64-edge_container-ostree
 e43c1d1bb48d773f6017929730767d3b11857913  rhel_9.4-aarch64-openstack-empty.json
 e44a823494d4220bc13aff44f8a50760baf54126  rhel_9.5-x86_64-gce-empty.json
 e4537cfa85522e6f28188cb9b5ecb085a6d8af1d  rhel_9.1-aarch64-ami-partitioning_plain.json
+e48d0bb04146fc3f45e005ddab378637d4d59358  rhel_9.3-x86_64-edge_vsphere-edge_ostree_pull_fips.json
 e4a3630ef2c89a0132f0706d24148693f2cfa57d  rhel_9.4-x86_64-minimal_raw-firewall.json
 e4b0ac7af3c648910c090e8b224277d6f245c22f  rhel_8.9-ppc64le-tar-empty.json
 e4da3371d11f13a2d2c716480423bc23152b312c  rhel_9.3-x86_64-edge_container-embed_containers_2.json


### PR DESCRIPTION
The new addInlineDataAndStages() method of the OS and OSTreeDeployment pipeline generators appends file creation, chmod, and chown stages to the pipeline and also adds the inline data to the inlineData property.  The inlineData list is used to return inline data that was collected during manifest generation.

Previously, we used the OSCustomizations.Files list in two ways:
- To define files to be created externally, during the initialisation of OSCustomizations (e.g. from a blueprint).
- To collect files that needed to be created under certain conditions or for certain stages while generating the pipeline.

This lead to inconsistencies.  The handling of the Files list was meant to always be near the end of the pipeline, before the selinux stage.  However, files were being added to the list after the Files list was handled, which meant that appending to the Files was done to generate the inline data, but not to generate stages.  This meant that appending to the stages was necessary in some cases and not others (depending on whether the files were added to the list before or after the stage generation from the OSCustomization.Files list), which could (and very likely did) lead to confusion.

This change also makes the usage of OSCustomizations more consistent.
During pipeline generation, it's better to treat OSCustomizations as read-only properties, initialised before serialization starts.  We might consider enforcing this in code.
