### PR TITLE
disk: add luks/lvm payload loading support via json/yaml

### DIFF
--- a/cmd/otk/osbuild-gen-partition-table/main_test.go
+++ b/cmd/otk/osbuild-gen-partition-table/main_test.go
@@ -224,8 +224,7 @@ var expectedSimplePartOutput = `{
               "size": 1048576,
               "type": "21686148-6449-6E6F-744E-656564454649",
               "bootable": true,
-              "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549",
-              "payload_type": "no-payload"
+              "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
             },
             {
               "start": 10097152,

--- a/pkg/disk/partition_test.go
+++ b/pkg/disk/partition_test.go
@@ -28,8 +28,14 @@ func TestMarshalUnmarshalSimple(t *testing.T) {
 
 func TestMarshalUnmarshalSad(t *testing.T) {
 	var part disk.Partition
-	err := json.Unmarshal([]byte(`{"randon": "json"}`), &part)
-	assert.ErrorContains(t, err, `cannot build partition from "{`)
+	err := json.Unmarshal([]byte(`{"random": "json"}`), &part)
+	assert.ErrorContains(t, err, `json: unknown field "random"`)
+}
+
+func TestMarshalUnmarshalPayloadButNoPayloadTypeSad(t *testing.T) {
+	var part disk.Partition
+	err := json.Unmarshal([]byte(`{"payload": "some-payload-but-no-payload-type-field"}`), &part)
+	assert.ErrorContains(t, err, `cannot build payload: empty payload type but payload is`)
 }
 
 func TestMarshalUnmarshalPartitionHappy(t *testing.T) {

--- a/pkg/disk/unmarshal.go
+++ b/pkg/disk/unmarshal.go
@@ -1,8 +1,10 @@
 package disk
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
 )
 
 // unmarshalYAMLviaJSON unmarshals via the JSON interface, this avoids code
@@ -21,4 +23,36 @@ func unmarshalYAMLviaJSON(u json.Unmarshaler, unmarshal func(any) error) error {
 		return fmt.Errorf("unmarshal yaml via json for %s failed: %w", dataJSON, err)
 	}
 	return nil
+}
+
+func unmarshalJSONPayload(data []byte) (PayloadEntity, error) {
+	var payload struct {
+		Payload     json.RawMessage `json:"payload"`
+		PayloadType string          `json:"payload_type,omitempty"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("cannot peek payload: %w", err)
+	}
+	if payload.PayloadType == "" {
+		if len(payload.Payload) > 0 {
+			return nil, fmt.Errorf("cannot build payload: empty payload type but payload is: %q", payload.Payload)
+		}
+		return nil, nil
+	}
+	entType := payloadEntityMap[payload.PayloadType]
+	if entType == nil {
+		return nil, fmt.Errorf("cannot build payload from %q: unknown payload type %q", data, payload.PayloadType)
+	}
+	entValP := reflect.New(entType).Elem().Addr()
+	ent := entValP.Interface()
+	if err := jsonUnmarshalStrict(payload.Payload, &ent); err != nil {
+		return nil, fmt.Errorf("cannot decode payload for %q: %w", data, err)
+	}
+	return ent.(PayloadEntity), nil
+}
+
+func jsonUnmarshalStrict(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewBuffer(data))
+	dec.DisallowUnknownFields()
+	return dec.Decode(&v)
 }


### PR DESCRIPTION
[split out of https://github.com/osbuild/images/pull/1339]

This commit adds support to load payloads for LUKS/LVM via
json/yaml. This is needed for PR#1339 where we extract the
partition tables into YAML. We have nested LUKS/LVM partitions
in e.g. the iot simplified installer.

This sadly involves some duplicated code in the Partition,
LUKSContainer, LVMLogicalVolume `UnmarshalJSON()` code.

Ideally we would write somethign like:
```go
func payloadUnmarshaller[T any](data []byte) (*T, error) {
        type alias T
        var withoutPayload struct {
                alias
                Payload     json.RawMessage `json:"payload"`
                PayloadType string          `json:"payload_type"`
        }
        if err := jsonUnmarshalStrict(data, &withoutPayload); err != nil {
                return nil, fmt.Errorf("cannot unmarshal %q: %w", data, err)
        }
        t := T(withoutPayload.alias)

        payload, err := unmarshalJSONPayload(data)
        t.Payload = payload
        return payload, err
}

func (lv *LVMLogicalVolume) UnmarshalJSON(data []byte) (err error) {
        *lv, err = payloadUnmarshaller[*LVMLogicalVolume](data)
        return err
}
```
but GO does not let us and sadly its pretty fundamental:
```
./lvm.go:248:13: cannot use a type parameter as RHS in type declaration
```
and without type aliases in the custom unmarshaler we run into
an infinite recursion. So unless go supports this we will have to
live with the duplication.
