### PR TITLE
workflow: do not run unit test with -v

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
       # We need to run the test as root, since we use the root
       # containers-storage for the local resolvers
       - name: Run unit tests
-        run: sudo go test -v ./pkg/container/... --force-local-resolver
+        run: sudo go test ./pkg/container/... --force-local-resolver
 
   unit-tests-cs:
     strategy:
@@ -129,7 +129,7 @@ jobs:
         run: git config --global --add safe.directory "$(pwd)"
 
       - name: Run unit tests
-        run: go test -v -race  ./...
+        run: go test -race  ./...
 
       - name: Install openssl for cgo test below
         run: dnf -y install openssl
@@ -139,7 +139,7 @@ jobs:
         run: CGO_ENABLED=0 go test -tags "containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_overlay" ./...
 
       - name: Run depsolver tests with force-dnf to make sure it's not skipped for any reason
-        run: go test -v -race ./pkg/dnfjson/... -force-dnf
+        run: go test -race ./pkg/dnfjson/... -force-dnf
 
   lint:
     name: "⌨ Lint"


### PR DESCRIPTION
Do not run our unit tests with `-v` as the signal to noise ratio on failure is really bad. In my case [0] it produced 22607(!) lines and the failure is in line 192.

If there is a deeper reason to run with with `-v` please let me know and I will change this to add a comment why we need it :)

[0] https://github.com/osbuild/images/actions/runs/14057755420/job/39360970265?pr=1355