### PR TITLE
fedora: add ro to FSTabOptions for IoT raw disk (aarch64)

### DIFF
--- a/pkg/distro/fedora/partition_tables.go
+++ b/pkg/distro/fedora/partition_tables.go
@@ -441,7 +441,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 					Type:         "ext4",
 					Label:        "root",
 					Mountpoint:   "/",
-					FSTabOptions: "defaults",
+					FSTabOptions: "defaults,ro",
 					FSTabFreq:    1,
 					FSTabPassNo:  1,
 				},


### PR DESCRIPTION
Followup for https://github.com/osbuild/images/pull/1346 where we only added `ro` to the x86_64 partition table.

This commit also adds the same change to the `aarch64` partition table.