### PR TITLE
rhel{7,10}: move partition table into yaml

### DIFF
--- a/pkg/distro/defs/rhel-10/distro.yaml
+++ b/pkg/distro/defs/rhel-10/distro.yaml
@@ -152,6 +152,89 @@
             - "grub2-efi-aa64"
             - "shim-aa64"
 
+  partitioning:
+    ids:
+      - &prep_partition_dosid "41"
+      - &filesystem_linux_dosid "83"
+      - &fat16_bdosid "06"
+    guids:
+      - &bios_boot_partition_guid "21686148-6449-6E6F-744E-656564454649"
+      - &efi_system_partition_guid "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+      - &filesystem_data_guid "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
+      - &xboot_ldr_partition_guid "BC13C2FF-59E6-4262-A352-B275FD6F7172"
+    # static UUIDs for partitions and filesystems
+    # NOTE(akoutsou): These are unnecessary and have stuck around since the
+    # beginning where (I believe) the goal was to have predictable,
+    # reproducible partition tables. They might be removed soon in favour of
+    # proper, random UUIDs, with reproducibility being controlled by fixing
+    # rng seeds.
+    uuids:
+      - &bios_boot_partition_uuid "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+      - &root_partition_uuid "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+      - &data_partition_uuid "CB07C243-BC44-4717-853E-28852021225B"
+      - &efi_system_partition_uuid "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+      - &efi_filesystem_uuid "7B77-95E7"
+
+    default_partition_tables: &default_partition_tables
+      x86_64:
+        uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
+        type: "gpt"
+        partitions:
+          - size: 1_048_576  # 1 MiB
+            bootable: true
+            type: *bios_boot_partition_guid
+            uuid: *bios_boot_partition_uuid
+          - &default_partition_table_part_efi
+            size: 209_715_200  # 200 MiB
+            type: *efi_system_partition_guid
+            uuid: *efi_system_partition_uuid
+            payload_type: "filesystem"
+            payload:
+              type: vfat
+              uuid: *efi_filesystem_uuid
+              mountpoint: "/boot/efi"
+              label: "EFI-SYSTEM"
+              fstab_options: "defaults,uid=0,gid=0,umask=077,shortname=winnt"
+              fstab_freq: 0
+              fstab_passno: 2
+          - &default_partition_table_part_root
+            size: 2_147_483_648  # 2 * datasizes.GibiByte,
+            type: *filesystem_data_guid
+            uuid: *root_partition_uuid
+            payload_type: "filesystem"
+            payload: &default_partition_table_part_root_payload
+              type: "xfs"
+              label: "root"
+              mountpoint: "/"
+              fstab_options: "defaults"
+              fstab_freq: 0
+              fstab_passno: 0
+      aarch64: &default_partition_table_aarch64
+        uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
+        type: "gpt"
+        partitions:
+          - *default_partition_table_part_efi
+          - *default_partition_table_part_root
+      ppc64le:
+        uuid: "0x14fc63d2"
+        type: "dos"
+        partitions:
+          - size: 4_194_304  # 4 MiB
+            bootable: true
+            type: *prep_partition_dosid
+          - &default_partition_table_part_root_ppc64le
+            size: 2_147_483_648  # 2 * datasizes.GibiByte,
+            payload_type: "filesystem"
+            payload:
+              <<: *default_partition_table_part_root_payload
+              label: ""
+      s390x:
+        uuid: "0x14fc63d2"
+        type: "dos"
+        partitions:
+          - <<: *default_partition_table_part_root_ppc64le
+            bootable: true
+
 image_config:
   default:
     default_kernel: "kernel"
@@ -220,6 +303,8 @@ image_types:
                 - "subscription-manager-cockpit"
 
   qcow2: &qcow2
+    partition_table:
+      <<: *default_partition_tables
     package_sets:
       - include:
           - "@core"
@@ -287,6 +372,8 @@ image_types:
   oci: *qcow2
 
   vhd: &vhd
+    partition_table:
+      <<: *default_partition_tables
     package_sets:
       - &vhd_pkgset
         include:
@@ -380,6 +467,8 @@ image_types:
           - "rng-tools"
 
   vmdk: &vmdk
+    partition_table:
+      <<: *default_partition_tables
     package_sets:
       - include:
           - "@core"
@@ -396,6 +485,8 @@ image_types:
   ova: *vmdk
 
   ami: &ami
+    partition_table:
+      <<: *default_partition_tables
     package_sets:
       - &ami_pkgset
         include:
@@ -455,6 +546,7 @@ image_types:
   ec2: *ami
 
   ec2_ha:
+    <<: *ami
     package_sets:
       - *ami_pkgset
       - include:
@@ -463,6 +555,7 @@ image_types:
           - "pcs"
 
   ec2_sap:
+    <<: *ami
     package_sets:
       - *ami_pkgset
       - *sap_pkgset
@@ -648,6 +741,8 @@ image_types:
                 - "dmidecode"
 
   gce:
+    partition_table:
+      <<: *default_partition_tables
     package_sets:
       - include:
           - "@core"

--- a/pkg/distro/defs/rhel-7/distro.yaml
+++ b/pkg/distro/defs/rhel-7/distro.yaml
@@ -44,6 +44,77 @@
           include:
             - "insights-client"
 
+  partitioning:
+    ids:
+      - &prep_partition_dosid "41"
+      - &filesystem_linux_dosid "83"
+      - &fat16_bdosid "06"
+    guids:
+      - &bios_boot_partition_guid "21686148-6449-6E6F-744E-656564454649"
+      - &efi_system_partition_guid "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+      - &filesystem_data_guid "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
+      - &xboot_ldr_partition_guid "BC13C2FF-59E6-4262-A352-B275FD6F7172"
+    # static UUIDs for partitions and filesystems
+    # NOTE(akoutsou): These are unnecessary and have stuck around since the
+    # beginning where (I believe) the goal was to have predictable,
+    # reproducible partition tables. They might be removed soon in favour of
+    # proper, random UUIDs, with reproducibility being controlled by fixing
+    # rng seeds.
+    uuids:
+      - &bios_boot_partition_uuid "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+      - &root_partition_uuid "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+      - &data_partition_uuid "CB07C243-BC44-4717-853E-28852021225B"
+      - &efi_system_partition_uuid "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+      - &efi_filesystem_uuid "7B77-95E7"
+
+    default_partition_tables: &default_partition_tables
+      x86_64:
+        uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
+        type: "gpt"
+        partitions:
+          - size: 1_048_576  # 1 MiB
+            bootable: true
+            type: *bios_boot_partition_guid
+            uuid: *bios_boot_partition_uuid
+          - &default_partition_table_part_efi
+            size: 209_715_200  # 200 MiB
+            type: *efi_system_partition_guid
+            uuid: *efi_system_partition_uuid
+            payload_type: "filesystem"
+            payload:
+              type: vfat
+              uuid: *efi_filesystem_uuid
+              mountpoint: "/boot/efi"
+              label: "EFI-SYSTEM"
+              fstab_options: "defaults,uid=0,gid=0,umask=077,shortname=winnt"
+              fstab_freq: 0
+              fstab_passno: 2
+          - &default_partition_table_part_boot
+            size: 524_288_000  # 500 * MiB
+            type: *filesystem_data_guid
+            uuid: *data_partition_uuid
+            payload_type: "filesystem"
+            payload:
+              type: "xfs"
+              mountpoint: "/boot"
+              label: "boot"
+              fstab_options: "defaults"
+              fstab_freq: 0
+              fstab_passno: 0
+          - &default_partition_table_part_root
+            size: 2_147_483_648  # 2 * datasizes.GibiByte,
+            type: *filesystem_data_guid
+            uuid: *root_partition_uuid
+            payload_type: "filesystem"
+            payload: &default_partition_table_part_root_payload
+              type: "xfs"
+              label: "root"
+              mountpoint: "/"
+              fstab_options: "defaults"
+              fstab_freq: 0
+              fstab_passno: 0
+
+
 image_config:
   default:
     timezone: "America/New_York"
@@ -63,10 +134,14 @@ image_config:
 
 image_types:
   azure_rhui:
+    partition_table:
+      <<: *default_partition_tables
     package_sets:
       - *azure_rhui_common_pkgset
 
   ec2:
+    partition_table:
+      <<: *default_partition_tables
     package_sets:
       - include:
           - "@core"
@@ -120,6 +195,8 @@ image_types:
           - "firewalld"
           
   qcow2:
+    partition_table:
+      <<: *default_partition_tables
     package_sets:
       - include:
           - "@core"

--- a/pkg/distro/rhel/rhel10/partition_tables.go
+++ b/pkg/distro/rhel/rhel10/partition_tables.go
@@ -1,131 +1,25 @@
 package rhel10
 
 import (
-	"github.com/osbuild/images/pkg/arch"
-	"github.com/osbuild/images/pkg/datasizes"
+	"errors"
+
 	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/distro/rhel"
 )
 
 func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
-	switch t.Arch().Name() {
-	case arch.ARCH_X86_64.String():
-		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: disk.PT_GPT,
-			Partitions: []disk.Partition{
-				{
-					Size:     1 * datasizes.MebiByte,
-					Bootable: true,
-					Type:     disk.BIOSBootPartitionGUID,
-					UUID:     disk.BIOSBootPartitionUUID,
-				},
-				{
-					Size: 200 * datasizes.MebiByte,
-					Type: disk.EFISystemPartitionGUID,
-					UUID: disk.EFISystemPartitionUUID,
-					Payload: &disk.Filesystem{
-						Type:         "vfat",
-						UUID:         disk.EFIFilesystemUUID,
-						Mountpoint:   "/boot/efi",
-						Label:        "EFI-SYSTEM",
-						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-						FSTabFreq:    0,
-						FSTabPassNo:  2,
-					},
-				},
-				{
-					Size: 2 * datasizes.GibiByte,
-					Type: disk.FilesystemDataGUID,
-					UUID: disk.RootPartitionUUID,
-					Payload: &disk.Filesystem{
-						Type:         "xfs",
-						Label:        "root",
-						Mountpoint:   "/",
-						FSTabOptions: "defaults",
-						FSTabFreq:    0,
-						FSTabPassNo:  0,
-					},
-				},
-			},
-		}, true
-	case arch.ARCH_AARCH64.String():
-		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: disk.PT_GPT,
-			Partitions: []disk.Partition{
-				{
-					Size: 200 * datasizes.MebiByte,
-					Type: disk.EFISystemPartitionGUID,
-					UUID: disk.EFISystemPartitionUUID,
-					Payload: &disk.Filesystem{
-						Type:         "vfat",
-						UUID:         disk.EFIFilesystemUUID,
-						Mountpoint:   "/boot/efi",
-						Label:        "EFI-SYSTEM",
-						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-						FSTabFreq:    0,
-						FSTabPassNo:  2,
-					},
-				},
-				{
-					Size: 2 * datasizes.GibiByte,
-					Type: disk.FilesystemDataGUID,
-					UUID: disk.RootPartitionUUID,
-					Payload: &disk.Filesystem{
-						Type:         "xfs",
-						Label:        "root",
-						Mountpoint:   "/",
-						FSTabOptions: "defaults",
-						FSTabFreq:    0,
-						FSTabPassNo:  0,
-					},
-				},
-			},
-		}, true
-	case arch.ARCH_PPC64LE.String():
-		return disk.PartitionTable{
-			UUID: "0x14fc63d2",
-			Type: disk.PT_DOS,
-			Partitions: []disk.Partition{
-				{
-					Size:     4 * datasizes.MebiByte,
-					Type:     disk.PRepPartitionDOSID,
-					Bootable: true,
-				},
-				{
-					Size: 2 * datasizes.GibiByte,
-					Payload: &disk.Filesystem{
-						Type:         "xfs",
-						Mountpoint:   "/",
-						FSTabOptions: "defaults",
-						FSTabFreq:    0,
-						FSTabPassNo:  0,
-					},
-				},
-			},
-		}, true
-
-	case arch.ARCH_S390X.String():
-		return disk.PartitionTable{
-			UUID: "0x14fc63d2",
-			Type: disk.PT_DOS,
-			Partitions: []disk.Partition{
-				{
-					Size:     2 * datasizes.GibiByte,
-					Bootable: true,
-					Payload: &disk.Filesystem{
-						Type:         "xfs",
-						Mountpoint:   "/",
-						FSTabOptions: "defaults",
-						FSTabFreq:    0,
-						FSTabPassNo:  0,
-					},
-				},
-			},
-		}, true
-
-	default:
+	partitionTable, err := defs.PartitionTable(t, nil)
+	if errors.Is(err, defs.ErrNoPartitionTableForImgType) {
 		return disk.PartitionTable{}, false
 	}
+	if err != nil {
+		panic(err)
+	}
+
+	if partitionTable == nil {
+		return disk.PartitionTable{}, false
+	}
+
+	return *partitionTable, true
 }

--- a/pkg/distro/rhel/rhel7/partition_tables.go
+++ b/pkg/distro/rhel/rhel7/partition_tables.go
@@ -1,69 +1,25 @@
 package rhel7
 
 import (
-	"github.com/osbuild/images/pkg/arch"
-	"github.com/osbuild/images/pkg/datasizes"
+	"errors"
+
 	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/distro/rhel"
 )
 
 func defaultBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
-	switch t.Arch().Name() {
-	case arch.ARCH_X86_64.String():
-		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: disk.PT_GPT,
-			Partitions: []disk.Partition{
-				{
-					Size:     1 * datasizes.MebiByte,
-					Bootable: true,
-					Type:     disk.BIOSBootPartitionGUID,
-					UUID:     disk.BIOSBootPartitionUUID,
-				},
-				{
-					Size: 200 * datasizes.MebiByte,
-					Type: disk.EFISystemPartitionGUID,
-					UUID: disk.EFISystemPartitionUUID,
-					Payload: &disk.Filesystem{
-						Type:         "vfat",
-						UUID:         disk.EFIFilesystemUUID,
-						Mountpoint:   "/boot/efi",
-						Label:        "EFI-SYSTEM",
-						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-						FSTabFreq:    0,
-						FSTabPassNo:  2,
-					},
-				},
-				{
-					Size: 500 * datasizes.MebiByte,
-					Type: disk.FilesystemDataGUID,
-					UUID: disk.DataPartitionUUID,
-					Payload: &disk.Filesystem{
-						Type:         "xfs",
-						Mountpoint:   "/boot",
-						Label:        "boot",
-						FSTabOptions: "defaults",
-						FSTabFreq:    0,
-						FSTabPassNo:  0,
-					},
-				},
-				{
-					Size: 2 * datasizes.GibiByte,
-					Type: disk.FilesystemDataGUID,
-					UUID: disk.RootPartitionUUID,
-					Payload: &disk.Filesystem{
-						Type:         "xfs",
-						Label:        "root",
-						Mountpoint:   "/",
-						FSTabOptions: "defaults",
-						FSTabFreq:    0,
-						FSTabPassNo:  0,
-					},
-				},
-			},
-		}, true
-
-	default:
+	partitionTable, err := defs.PartitionTable(t, nil)
+	if errors.Is(err, defs.ErrNoPartitionTableForImgType) {
 		return disk.PartitionTable{}, false
 	}
+	if err != nil {
+		panic(err)
+	}
+
+	if partitionTable == nil {
+		return disk.PartitionTable{}, false
+	}
+
+	return *partitionTable, true
 }


### PR DESCRIPTION
This commit moves the partition tables for RHEL-10,7 (and by implication
Centos-10) into YAML.
