### PR TITLE
disk: add missing json/yaml keys for disk structs

### DIFF
--- a/cmd/otk/osbuild-gen-partition-table/main_test.go
+++ b/cmd/otk/osbuild-gen-partition-table/main_test.go
@@ -149,7 +149,6 @@ func TestUnmarshalOutput(t *testing.T) {
         "type": "",
         "partitions": [
           {
-            "start": 0,
             "size": 0,
             "type": "119119",
             "uuid": "911911",

--- a/pkg/disk/btrfs.go
+++ b/pkg/disk/btrfs.go
@@ -11,10 +11,10 @@ import (
 const DefaultBtrfsCompression = "zstd:1"
 
 type Btrfs struct {
-	UUID       string
-	Label      string
-	Mountpoint string
-	Subvolumes []BtrfsSubvolume
+	UUID       string           `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Label      string           `json:"label,omitempty" yaml:"label,omitempty"`
+	Mountpoint string           `json:"mountpoint,omitempty" yaml:"mountpoint,omitempty"`
+	Subvolumes []BtrfsSubvolume `json:"subvolumes,omitempty" yaml:"subvolumes,omitempty"`
 }
 
 func init() {
@@ -107,15 +107,15 @@ func (b *Btrfs) minSize(size uint64) uint64 {
 }
 
 type BtrfsSubvolume struct {
-	Name       string
-	Size       uint64
-	Mountpoint string
-	GroupID    uint64
-	Compress   string
-	ReadOnly   bool
+	Name       string `json:"name" yaml:"name"`
+	Size       uint64 `json:"size" yaml:"size"`
+	Mountpoint string `json:"mountpoint,omitempty" yaml:"mountpoint,omitempty"`
+	GroupID    uint64 `json:"group_id,omitempty" yaml:"group_id,omitempty"`
+	Compress   string `json:"compress,omitempty" yaml:"compress,omitempty"`
+	ReadOnly   bool   `json:"read_only,omitempty" yaml:"read_only,omitempty"`
 
 	// UUID of the parent volume
-	UUID string
+	UUID string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 }
 
 func (bs *BtrfsSubvolume) Clone() Entity {

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -24,11 +24,11 @@ import (
 	"io"
 	"math/rand"
 	"reflect"
+	"slices"
 	"strings"
 
-	"slices"
-
 	"github.com/google/uuid"
+
 	"github.com/osbuild/images/pkg/arch"
 )
 
@@ -246,6 +246,10 @@ func (t PartitionTableType) String() string {
 
 func (t PartitionTableType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.String())
+}
+
+func (t PartitionTableType) MarshalYAML() (interface{}, error) {
+	return t.String(), nil
 }
 
 func (t *PartitionTableType) UnmarshalJSON(data []byte) error {

--- a/pkg/disk/enums_test.go
+++ b/pkg/disk/enums_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 
 	"github.com/osbuild/images/pkg/disk"
 )
@@ -53,6 +54,28 @@ func TestEnumPartitionTableTypeJSON(t *testing.T) {
 	var unmarshaledNum disk.PartitionTableType
 	err := json.Unmarshal([]byte(`"bad"`), &unmarshaledNum)
 	assert.EqualError(t, err, `unknown or unsupported partition table type name: bad`)
+}
+
+func TestEnumPartitionTableTypeYAML(t *testing.T) {
+	for name, num := range partitionTypeEnumMap {
+		yamlData, err := yaml.Marshal(num)
+		assert.NoError(t, err)
+		if name == "" {
+			assert.Equal(t, `""`+"\n", string(yamlData))
+		} else {
+			assert.Equal(t, fmt.Sprintf("%s\n", name), string(yamlData))
+		}
+
+		var unmarshaledNum disk.PartitionTableType
+		err = yaml.Unmarshal(yamlData, &unmarshaledNum)
+		assert.NoError(t, err)
+		assert.Equal(t, unmarshaledNum, num)
+	}
+
+	// bad unmarshal
+	var unmarshaledNum disk.PartitionTableType
+	err := yaml.Unmarshal([]byte(`"bad"`), &unmarshaledNum)
+	assert.EqualError(t, err, `unmarshal yaml via json for "bad" failed: unknown or unsupported partition table type name: bad`)
 }
 
 func TestEnumFSType(t *testing.T) {

--- a/pkg/disk/filesystem.go
+++ b/pkg/disk/filesystem.go
@@ -9,19 +9,19 @@ import (
 
 // Filesystem related functions
 type Filesystem struct {
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 
 	// ID of the filesystem, vfat doesn't use traditional UUIDs, therefore this
 	// is just a string.
-	UUID       string `json:"uuid,omitempty"`
-	Label      string `json:"label,omitempty"`
-	Mountpoint string `json:"mountpoint,omitempty"`
+	UUID       string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Label      string `json:"label,omitempty" yaml:"label,omitempty"`
+	Mountpoint string `json:"mountpoint,omitempty" yaml:"mountpoint,omitempty"`
 	// The fourth field of fstab(5); fs_mntops
-	FSTabOptions string `json:"fstab_options,omitempty"`
+	FSTabOptions string `json:"fstab_options,omitempty" yaml:"fstab_options,omitempty"`
 	// The fifth field of fstab(5); fs_freq
-	FSTabFreq uint64 `json:"fstab_freq,omitempty"`
+	FSTabFreq uint64 `json:"fstab_freq,omitempty" yaml:"fstab_freq,omitempty"`
 	// The sixth field of fstab(5); fs_passno
-	FSTabPassNo uint64 `json:"fstab_passno,omitempty"`
+	FSTabPassNo uint64 `json:"fstab_passno,omitempty" yaml:"fstab_passno,omitempty"`
 }
 
 func init() {

--- a/pkg/disk/luks.go
+++ b/pkg/disk/luks.go
@@ -14,39 +14,39 @@ import (
 // Argon2id defines parameters for the key derivation function for LUKS.
 type Argon2id struct {
 	// Number of iterations to perform.
-	Iterations uint
+	Iterations uint `json:"iterations,omitempty" yaml:"iterations,omitempty"`
 
 	// Amount of memory to use (in KiB).
-	Memory uint
+	Memory uint `json:"memory,omitempty" yaml:"memory,omitempty"`
 
 	// Degree of parallelism (i.e. number of threads).
-	Parallelism uint
+	Parallelism uint `json:"parallelism,omitempty" yaml:"parallelism,omitempty"`
 }
 
 // ClevisBind defines parameters for binding a LUKS device with a given policy.
 type ClevisBind struct {
-	Pin    string
-	Policy string
+	Pin    string `json:"pin,omitempty" yaml:"pin,omitempty"`
+	Policy string `json:"policy,omitempty" yaml:"policy,omitempty"`
 
 	// If enabled, the passphrase will be removed from the LUKS device at the
 	// end of the build (using the org.osbuild.luks2.remove-key stage).
-	RemovePassphrase bool `json:"remove_passphrase" yaml:"remove_passphrase"`
+	RemovePassphrase bool `json:"remove_passphrase,omitempty" yaml:"remove_passphrase,omitempty"`
 }
 
 // LUKSContainer represents a LUKS encrypted volume.
 type LUKSContainer struct {
-	Passphrase string
-	UUID       string
-	Cipher     string
-	Label      string
-	Subsystem  string
-	SectorSize uint64
+	Passphrase string `json:"passphrase,omitempty" yaml:"passphrase,omitempty"`
+	UUID       string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Cipher     string `json:"cipher,omitempty" yaml:"cipher,omitempty"`
+	Label      string `json:"label,omitempty" yaml:"label,omitempty"`
+	Subsystem  string `json:"subsystem,omitempty" yaml:"subsystem,omitempty"`
+	SectorSize uint64 `json:"sector_size,omitempty" yaml:"sector_size,omitempty"`
 
 	// The password-based key derivation function's parameters.
-	PBKDF Argon2id
+	PBKDF Argon2id `json:"pbkdf,omitempty" yaml:"pbkdf,omitempty"`
 
 	// Parameters for binding the LUKS device.
-	Clevis *ClevisBind
+	Clevis *ClevisBind `json:"clevis,omitempty" yaml:"clevis,omitempty"`
 
 	Payload Entity `json:"payload,omitempty" yaml:"payload,omitempty"`
 }

--- a/pkg/disk/luks.go
+++ b/pkg/disk/luks.go
@@ -30,7 +30,7 @@ type ClevisBind struct {
 
 	// If enabled, the passphrase will be removed from the LUKS device at the
 	// end of the build (using the org.osbuild.luks2.remove-key stage).
-	RemovePassphrase bool `json:"remove_passphrase"`
+	RemovePassphrase bool `json:"remove_passphrase" yaml:"remove_passphrase"`
 }
 
 // LUKSContainer represents a LUKS encrypted volume.
@@ -48,7 +48,7 @@ type LUKSContainer struct {
 	// Parameters for binding the LUKS device.
 	Clevis *ClevisBind
 
-	Payload Entity `json:"payload,omitempty"`
+	Payload Entity `json:"payload,omitempty" yaml:"payload,omitempty"`
 }
 
 func init() {
@@ -138,8 +138,8 @@ func (lc *LUKSContainer) UnmarshalJSON(data []byte) (err error) {
 	type alias LUKSContainer
 	var withoutPayload struct {
 		alias
-		Payload     json.RawMessage `json:"payload"`
-		PayloadType string          `json:"payload_type"`
+		Payload     json.RawMessage `json:"payload" yaml:"payload"`
+		PayloadType string          `json:"payload_type" yaml:"payload_type"`
 	}
 	if err := jsonUnmarshalStrict(data, &withoutPayload); err != nil {
 		return fmt.Errorf("cannot unmarshal %q: %w", data, err)

--- a/pkg/disk/lvm.go
+++ b/pkg/disk/lvm.go
@@ -14,8 +14,8 @@ import (
 const LVMDefaultExtentSize = 4 * datasizes.MebiByte
 
 type LVMVolumeGroup struct {
-	Name        string
-	Description string
+	Name        string `json:"name,omitempty" yaml:"name,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	LogicalVolumes []LVMLogicalVolume `json:"logical_volumes,omitempty" yaml:"logical_volumes,omitempty"`
 }
@@ -186,9 +186,9 @@ func (vg *LVMVolumeGroup) UnmarshalJSON(data []byte) error {
 }
 
 type LVMLogicalVolume struct {
-	Name    string
-	Size    uint64
-	Payload Entity
+	Name    string `json:"name,omitempty" yaml:"name,omitempty"`
+	Size    uint64 `json:"size,omitempty" yaml:"size,omitempty"`
+	Payload Entity `json:"payload,omitempty" yaml:"payload,omitempty"`
 }
 
 func (lv *LVMLogicalVolume) Clone() Entity {

--- a/pkg/disk/lvm.go
+++ b/pkg/disk/lvm.go
@@ -17,7 +17,7 @@ type LVMVolumeGroup struct {
 	Name        string
 	Description string
 
-	LogicalVolumes []LVMLogicalVolume `json:"logical_volumes,omitempty"`
+	LogicalVolumes []LVMLogicalVolume `json:"logical_volumes,omitempty" yaml:"logical_volumes,omitempty"`
 }
 
 func init() {
@@ -249,8 +249,8 @@ func (lv *LVMLogicalVolume) UnmarshalJSON(data []byte) (err error) {
 	type alias LVMLogicalVolume
 	var withoutPayload struct {
 		alias
-		Payload     json.RawMessage `json:"payload"`
-		PayloadType string          `json:"payload_type"`
+		Payload     json.RawMessage `json:"payload" yaml:"payload"`
+		PayloadType string          `json:"payload_type" yaml:"payload_type"`
 	}
 	if err := jsonUnmarshalStrict(data, &withoutPayload); err != nil {
 		return fmt.Errorf("cannot unmarshal %q: %w", data, err)

--- a/pkg/disk/partition.go
+++ b/pkg/disk/partition.go
@@ -7,7 +7,7 @@ import (
 
 type Partition struct {
 	// Start of the partition in bytes
-	Start uint64 `json:"start" yaml:"start"`
+	Start uint64 `json:"start,omitempty" yaml:"start,omitempty"`
 	// Size of the partition in bytes
 	Size uint64 `json:"size" yaml:"size"`
 	// Partition type, e.g. 0x83 for MBR or a UUID for gpt

--- a/pkg/disk/partition.go
+++ b/pkg/disk/partition.go
@@ -7,20 +7,20 @@ import (
 
 type Partition struct {
 	// Start of the partition in bytes
-	Start uint64 `json:"start"`
+	Start uint64 `json:"start" yaml:"start"`
 	// Size of the partition in bytes
-	Size uint64 `json:"size"`
+	Size uint64 `json:"size" yaml:"size"`
 	// Partition type, e.g. 0x83 for MBR or a UUID for gpt
-	Type string `json:"type,omitempty"`
+	Type string `json:"type,omitempty" yaml:"type,omitempty"`
 	// `Legacy BIOS bootable` (GPT) or `active` (DOS) flag
-	Bootable bool `json:"bootable,omitempty"`
+	Bootable bool `json:"bootable,omitempty" yaml:"bootable,omitempty"`
 
 	// ID of the partition, dos doesn't use traditional UUIDs, therefore this
 	// is just a string.
-	UUID string `json:"uuid,omitempty"`
+	UUID string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 
 	// If nil, the partition is raw; It doesn't contain a payload.
-	Payload PayloadEntity `json:"payload,omitempty"`
+	Payload PayloadEntity `json:"payload,omitempty" yaml:"payload,omitempty"`
 }
 
 func (p *Partition) Clone() Entity {
@@ -110,7 +110,7 @@ func (p *Partition) MarshalJSON() ([]byte, error) {
 
 	partWithPayloadType := struct {
 		partAlias
-		PayloadType string `json:"payload_type,omitempty"`
+		PayloadType string `json:"payload_type,omitempty" yaml:"payload_type,omitempty"`
 	}{
 		partAlias(*p),
 		entityName,
@@ -124,8 +124,8 @@ func (p *Partition) UnmarshalJSON(data []byte) (err error) {
 	type alias Partition
 	var withoutPayload struct {
 		alias
-		Payload     json.RawMessage `json:"payload"`
-		PayloadType string          `json:"payload_type"`
+		Payload     json.RawMessage `json:"payload" yaml:"payload"`
+		PayloadType string          `json:"payload_type" yaml:"payload_type"`
 	}
 	if err := jsonUnmarshalStrict(data, &withoutPayload); err != nil {
 		return fmt.Errorf("cannot unmarshal %q: %w", data, err)

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -15,7 +15,7 @@ import (
 
 type PartitionTable struct {
 	// Size of the disk (in bytes).
-	Size uint64 `json:"size" yaml:"size"`
+	Size uint64 `json:"size,omitempty" yaml:"size,omitempty"`
 	// Unique identifier of the partition table (GPT only).
 	UUID string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 	// Partition table type, e.g. dos, gpt.

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -15,17 +15,17 @@ import (
 
 type PartitionTable struct {
 	// Size of the disk (in bytes).
-	Size uint64 `json:"size"`
+	Size uint64 `json:"size" yaml:"size"`
 	// Unique identifier of the partition table (GPT only).
-	UUID string `json:"uuid,omitempty"`
+	UUID string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 	// Partition table type, e.g. dos, gpt.
-	Type       PartitionTableType `json:"type"`
-	Partitions []Partition        `json:"partitions"`
+	Type       PartitionTableType `json:"type" yaml:"type"`
+	Partitions []Partition        `json:"partitions" yaml:"partitions"`
 
 	// Sector size in bytes
-	SectorSize uint64 `json:"sector_size,omitempty"`
+	SectorSize uint64 `json:"sector_size,omitempty" yaml:"sector_size,omitempty"`
 	// Extra space at the end of the partition table (sectors)
-	ExtraPadding uint64 `json:"extra_padding,omitempty"`
+	ExtraPadding uint64 `json:"extra_padding,omitempty" yaml:"extra_padding,omitempty"`
 	// Starting offset of the first partition in the table (Mb)
 	StartOffset uint64 `json:"start_offset,omitempty" yaml:"start_offset,omitempty"`
 }


### PR DESCRIPTION
This commit adds missing keys for to our disk structures. This is
useful for https://github.com/osbuild/image-builder-cli/pull/183
