### PR TITLE
build(deps): ensure toolbox is the latest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -172,9 +172,9 @@ jobs:
         run: sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.61.0
+          version: latest
           args: --verbose --timeout 5m0s
 
   shellcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,29 +1,40 @@
----
-linters-settings:
-  govet:
-    disable:
-      - shadow  # default value recommended by golangci
-      - composites
-  gosec:
-    excludes:
-      - G101
-
-linters:
-  enable:
-    - gosec
-
+version: "2"
 run:
   build-tags:
     - integration
-  timeout: 5m
-
+linters:
+  enable:
+    - gosec
+  settings:
+    gosec:
+      excludes:
+        - G101
+    govet:
+      disable:
+        - shadow
+        - composites
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gosec
+        path: ^(images/)?(pkg|internal)/.*_test\.go$
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0
-
-  # Maximum count of issues with the same text. Set to 0 to disable. Default
-  # is 3.
   max-same-issues: 0
-  exclude-rules:
-    - path: ^(images/)?(pkg|internal)/.*_test\.go$
-      linters: ["gosec"]
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/osbuild/images
 
-go 1.22.8
+go 1.22.9
 
-toolchain go1.22.11
+toolchain go1.24.2
 
 require (
 	cloud.google.com/go/compute v1.33.0

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -2,20 +2,22 @@
 
 set -eux
 
+# Figure out the latest and greatest Go version
+GO_LATEST=$(curl -s https://endoflife.date/api/go.json | jq -r '.[0].latest')
+
 # Go version must be consistent with image-builder which uses UBI
 # container that is typically few months behind
 GO_VERSION=1.22.9
-GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
 
-# this is the official way to get a different version of golang
-# see https://go.dev/doc/manage-install
-go install golang.org/dl/go$GO_VERSION@latest
-$GO_BINARY download
-
-# Ensure that go.mod and go.sum are up to date.
-$GO_BINARY mod tidy
+# Pin Go and toolchain versions at a reasonable versions
+go get "go@$GO_VERSION" "toolchain@$GO_LATEST"
 
 # Ensure the code is formatted correctly.
-$GO_BINARY fmt ./...
+go fmt ./...
 
+# Update go.mod and go.sum
+go mod tidy
+
+# Generate CI
 ./test/scripts/generate-gitlab-ci ./.gitlab-ci.yml
+


### PR DESCRIPTION
So we are fighting with dep bots, the problem is often that `toolchain` is different. Everytime you run a tool from [Go toolchain](https://go.dev/doc/toolchain) starting from Go 1.21 it will record the version in `go.mod`. It seems it is only upgrading this number, so here is an idea.

This patch detects latest and greatest upstream Go version and pins the `toolchain` setting to that version so it is always up-to-date. If my theory is correct, this will prevent Go bots from touching this value ever again (up until the point new Go version is released and we run the script again to bump it).

This also removes the need of running or installing `go1.XX` separate command because this is exactly what `toolchain` does. If you run any `go` command in a project that has `toolchain` set, Go will automatically download and use this particular version for all the commands.

This will ultimately do the same thing - we will all use the latest and greatest Go version for development, testing or running `go mod` commands but we will keep `go` major version at lower level. Currently it is set to 1.22.9, this also means we will not allow updates of this major version until it is available in RHEL. This is the limitation we cannot workaround in any way, sometimes bots will fail on this and there is nothing we can do about it.

I also moved `go mod tidy` as the last command, it must be the last as I learned the other day (e.g. running `go generate` after it will cause issues).

Note: when you initialy run this branch it will be downloading the latest 1.24.2 it takes a minute, then it is fast. Also note that from now on, everyone will use 1.24.2 for all the local work - that is not an issue it is the `go 1.22.X` statement in `go.mod` what makes the compatibility promise.