### PR TITLE
ci: dependency updater via gobump

### DIFF
--- a/.github/workflows/gobump.yml
+++ b/.github/workflows/gobump.yml
@@ -1,0 +1,43 @@
+---
+name: "Updates Go dependencies via gobump"
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+  schedule:
+    # Every Sunday at 15:00
+    - cron: "0 15 * * 0"
+
+jobs:
+  update-and-push:
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:41
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+
+      - name: Update go.mod
+          sudo dnf -y install gpgme-devel btrfs-progs-devel krb5-devel
+          echo -e '## gobump output:\n\n```' > github_pr_body.txt
+          go run github.com/lzap/gobump@latest -exec "go build ./..." -exec "go test ./..." 2>&1 | tee -a github_pr_body.txt
+          echo -e '\n```' >> github_pr_body.txt
+          ./tools/prepare-source.sh
+
+      - name: Open PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+        run: |
+          if git diff --exit-code; then echo "No changes"; exit 0; fi
+          git config --unset-all http.https://github.com/.extraheader
+          git config user.name "schutzbot"
+          git config user.email "schutzbot@gmail.com"
+          branch="schutz-gobump-$(date -I)"
+          git checkout -b "${branch}"
+          git add -A
+          git commit -m "build(deps): Update dependencies via gobump"
+          git push -f https://"$GITHUB_TOKEN"@github.com/schutzbot/images.git
+          gh pr create \
+            -t "Update dependencies $(date -I)" \
+            -F "github_pr_body.txt" \
+            --repo "osbuild/images" \
+            --base "main" \
+            --head "schutzbot:${branch}"

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -2,18 +2,14 @@
 
 ## Local development environment
 
-To build most binaries defined in `cmd` and run tests you will need to install `gpgme-devel`.
-To generate manifests, you will need to install the `osbuild-depsolve-dnf` package.
-To build images, you will also need to install `osbuild` and its sub-packages.
+To build most binaries defined in `cmd` and run tests you will need to install
+the following dependencies:
 
-The full list of dependencies is:
-- `gpgme-devel`
-- `osbuild`
-- `osbuild-depsolve-dnf`
-- `osbuild-luks2`
-- `osbuild-lvm2`
-- `osbuild-ostree`
-- `osbuild-selinux`
+    dnf -y install gpgme-devel btrfs-progs-devel krb5-devel
+
+To generate manifests, you will need to install the following dependencies:
+
+    dnf -y install osbuild osbuild-depsolve-dnf osbuild-luks2 osbuild-lvm2 osbuild-ostree osbuild-selinux
 
 ## Commits and Pull Requests
 


### PR DESCRIPTION
Please review carefully, I did not test this locally as I have no idea how to do that. My assumption is we would merge this and then test it by manually triggering it?

To get more info about `gobump` please read: https://github.com/lzap/gobump

I can either move the project into osbuild GH org or give maintainer permissions to anyone interested just in case. My account is 2FA protected.