### PR TITLE
[RFC] distro: unify OsCustomizations()

### DIFF
--- a/cmd/osbuild-playground/my-container.go
+++ b/cmd/osbuild-playground/my-container.go
@@ -51,7 +51,7 @@ func (img *MyContainer) InstantiateManifest(m *manifest.Manifest,
 
 	// create a minimal non-bootable OS tree
 	os := manifest.NewOS(build, &platform.X86{}, repos)
-	os.BasePackages = []string{"@core"}
+	os.OSCustomizations.BasePackages = []string{"@core"}
 	os.OSCustomizations.Language = "en_US.UTF-8"
 	os.OSCustomizations.Hostname = "my-host"
 	os.OSCustomizations.Timezone = "UTC"

--- a/cmd/osbuild-playground/my-image.go
+++ b/cmd/osbuild-playground/my-image.go
@@ -46,8 +46,8 @@ func (img *MyImage) InstantiateManifest(m *manifest.Manifest,
 
 	// create a minimal bootable OS tree
 	os := manifest.NewOS(build, platform, repos)
-	os.PartitionTable = pt   // we need a partition table
-	os.KernelName = "kernel" // use the default fedora kernel
+	os.PartitionTable = pt                    // we need a partition table
+	os.OSCustomizations.KernelName = "kernel" // use the default fedora kernel
 
 	// create a raw image containing the OS tree created above
 	raw := manifest.NewRawImage(build, os)

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -84,10 +84,12 @@ func mkImageInstallerImgType(d distribution) imageType {
 		defaultImageConfig: &distro.ImageConfig{
 			Locale: common.ToPtr("en_US.UTF-8"),
 		},
-		bootable:  true,
-		bootISO:   true,
-		rpmOstree: false,
-		image:     imageInstallerImage,
+		distroConfig: distro.ImageTypeConfig{
+			Bootable:  true,
+			BootISO:   true,
+			RpmOstree: false,
+		},
+		image: imageInstallerImage,
 		// We don't know the variant of the OS pipeline being installed
 		isoLabel:               getISOLabelFunc("Unknown"),
 		buildPipelines:         []string{"build"},
@@ -109,9 +111,11 @@ func mkLiveInstallerImgType(d distribution) imageType {
 		defaultImageConfig: &distro.ImageConfig{
 			Locale: common.ToPtr("en_US.UTF-8"),
 		},
-		bootable:               true,
-		bootISO:                true,
-		rpmOstree:              false,
+		distroConfig: distro.ImageTypeConfig{
+			Bootable:  true,
+			BootISO:   true,
+			RpmOstree: false,
+		},
 		image:                  liveInstallerImage,
 		isoLabel:               getISOLabelFunc("Workstation"),
 		buildPipelines:         []string{"build"},
@@ -135,7 +139,9 @@ func mkIotCommitImgType(d distribution) imageType {
 			DracutConf:             []*osbuild.DracutConfStageOptions{osbuild.FIPSDracutConfStageOptions},
 			MachineIdUninitialized: common.ToPtr(false),
 		},
-		rpmOstree:              true,
+		distroConfig: distro.ImageTypeConfig{
+			RpmOstree: true,
+		},
 		image:                  iotCommitImage,
 		buildPipelines:         []string{"build"},
 		payloadPipelines:       []string{"os", "ostree-commit", "commit-archive"},
@@ -155,7 +161,9 @@ func mkIotBootableContainer(d distribution) imageType {
 		defaultImageConfig: &distro.ImageConfig{
 			MachineIdUninitialized: common.ToPtr(false),
 		},
-		rpmOstree:              true,
+		distroConfig: distro.ImageTypeConfig{
+			RpmOstree: true,
+		},
 		image:                  bootableContainerImage,
 		buildPipelines:         []string{"build"},
 		payloadPipelines:       []string{"os", "ostree-commit", "ostree-encapsulate"},
@@ -181,8 +189,10 @@ func mkIotOCIImgType(d distribution) imageType {
 			DracutConf:             []*osbuild.DracutConfStageOptions{osbuild.FIPSDracutConfStageOptions},
 			MachineIdUninitialized: common.ToPtr(false),
 		},
-		rpmOstree:              true,
-		bootISO:                false,
+		distroConfig: distro.ImageTypeConfig{
+			RpmOstree: true,
+			BootISO:   false,
+		},
 		image:                  iotContainerImage,
 		buildPipelines:         []string{"build"},
 		payloadPipelines:       []string{"os", "ostree-commit", "container-tree", "container"},
@@ -204,8 +214,10 @@ func mkIotInstallerImgType(d distribution) imageType {
 			EnabledServices: iotServicesForVersion(&d),
 			Locale:          common.ToPtr("en_US.UTF-8"),
 		},
-		rpmOstree:              true,
-		bootISO:                true,
+		distroConfig: distro.ImageTypeConfig{
+			RpmOstree: true,
+			BootISO:   true,
+		},
 		image:                  iotInstallerImage,
 		isoLabel:               getISOLabelFunc("IoT"),
 		buildPipelines:         []string{"build"},
@@ -233,16 +245,18 @@ func mkIotSimplifiedInstallerImgType(d distribution) imageType {
 			LockRootUser:              common.ToPtr(true),
 			IgnitionPlatform:          common.ToPtr("metal"),
 		},
-		defaultSize:            10 * datasizes.GibiByte,
-		rpmOstree:              true,
-		bootable:               true,
-		bootISO:                true,
+		defaultSize: 10 * datasizes.GibiByte,
+		distroConfig: distro.ImageTypeConfig{
+			RpmOstree:     true,
+			Bootable:      true,
+			BootISO:       true,
+			KernelOptions: ostreeDeploymentKernelOptions(),
+		},
 		image:                  iotSimplifiedInstallerImage,
 		isoLabel:               getISOLabelFunc("IoT"),
 		buildPipelines:         []string{"build"},
 		payloadPipelines:       []string{"ostree-deployment", "image", "xz", "coi-tree", "efiboot-tree", "bootiso-tree", "bootiso"},
 		exports:                []string{"bootiso"},
-		kernelOptions:          ostreeDeploymentKernelOptions(),
 		requiredPartitionSizes: requiredDirectorySizes,
 	}
 }
@@ -264,14 +278,16 @@ func mkIotRawImgType(d distribution) imageType {
 			LockRootUser:              common.ToPtr(true),
 			IgnitionPlatform:          common.ToPtr("metal"),
 		},
-		defaultSize:      4 * datasizes.GibiByte,
-		rpmOstree:        true,
-		bootable:         true,
+		defaultSize: 4 * datasizes.GibiByte,
+		distroConfig: distro.ImageTypeConfig{
+			RpmOstree:     true,
+			Bootable:      true,
+			KernelOptions: ostreeDeploymentKernelOptions(),
+		},
 		image:            iotImage,
 		buildPipelines:   []string{"build"},
 		payloadPipelines: []string{"ostree-deployment", "image", "xz"},
 		exports:          []string{"xz"},
-		kernelOptions:    ostreeDeploymentKernelOptions(),
 
 		// Passing an empty map into the required partition sizes disables the
 		// default partition sizes normally set so our `basePartitionTables` can
@@ -295,14 +311,16 @@ func mkIotQcow2ImgType(d distribution) imageType {
 			LockRootUser:              common.ToPtr(true),
 			IgnitionPlatform:          common.ToPtr("qemu"),
 		},
-		defaultSize:            10 * datasizes.GibiByte,
-		rpmOstree:              true,
-		bootable:               true,
+		defaultSize: 10 * datasizes.GibiByte,
+		distroConfig: distro.ImageTypeConfig{
+			RpmOstree:     true,
+			Bootable:      true,
+			KernelOptions: ostreeDeploymentKernelOptions(),
+		},
 		image:                  iotImage,
 		buildPipelines:         []string{"build"},
 		payloadPipelines:       []string{"ostree-deployment", "image", "qcow2"},
 		exports:                []string{"qcow2"},
-		kernelOptions:          ostreeDeploymentKernelOptions(),
 		requiredPartitionSizes: requiredDirectorySizes,
 	}
 }
@@ -319,8 +337,10 @@ func mkQcow2ImgType(d distribution) imageType {
 		defaultImageConfig: &distro.ImageConfig{
 			DefaultTarget: common.ToPtr("multi-user.target"),
 		},
-		kernelOptions:          cloudKernelOptions(),
-		bootable:               true,
+		distroConfig: distro.ImageTypeConfig{
+			KernelOptions: cloudKernelOptions(),
+			Bootable:      true,
+		},
 		defaultSize:            5 * datasizes.GibiByte,
 		image:                  diskImage,
 		buildPipelines:         []string{"build"},
@@ -350,9 +370,11 @@ func mkVmdkImgType(d distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: packageSetLoader,
 		},
-		defaultImageConfig:     vmdkDefaultImageConfig,
-		kernelOptions:          cloudKernelOptions(),
-		bootable:               true,
+		defaultImageConfig: vmdkDefaultImageConfig,
+		distroConfig: distro.ImageTypeConfig{
+			KernelOptions: cloudKernelOptions(),
+			Bootable:      true,
+		},
 		defaultSize:            2 * datasizes.GibiByte,
 		image:                  diskImage,
 		buildPipelines:         []string{"build"},
@@ -370,9 +392,11 @@ func mkOvaImgType(d distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: packageSetLoader,
 		},
-		defaultImageConfig:     vmdkDefaultImageConfig,
-		kernelOptions:          cloudKernelOptions(),
-		bootable:               true,
+		defaultImageConfig: vmdkDefaultImageConfig,
+		distroConfig: distro.ImageTypeConfig{
+			KernelOptions: cloudKernelOptions(),
+			Bootable:      true,
+		},
 		defaultSize:            2 * datasizes.GibiByte,
 		image:                  diskImage,
 		buildPipelines:         []string{"build"},
@@ -396,8 +420,10 @@ func mkContainerImgType(d distribution) imageType {
 			Locale:      common.ToPtr("C.UTF-8"),
 			Timezone:    common.ToPtr("Etc/UTC"),
 		},
-		image:                  containerImage,
-		bootable:               false,
+		image: containerImage,
+		distroConfig: distro.ImageTypeConfig{
+			Bootable: false,
+		},
 		buildPipelines:         []string{"build"},
 		payloadPipelines:       []string{"os", "container"},
 		exports:                []string{"container"},
@@ -436,8 +462,10 @@ func mkWslImgType(d distribution) imageType {
 				BootSystemd: true,
 			},
 		},
-		image:                  containerImage,
-		bootable:               false,
+		image: containerImage,
+		distroConfig: distro.ImageTypeConfig{
+			Bootable: false,
+		},
 		buildPipelines:         []string{"build"},
 		payloadPipelines:       []string{"os", "container"},
 		exports:                []string{"container"},
@@ -465,9 +493,11 @@ func mkMinimalRawImgType(d distribution) imageType {
 			},
 			InstallWeakDeps: common.ToPtr(common.VersionLessThan(d.osVersion, VERSION_MINIMAL_WEAKDEPS)),
 		},
-		rpmOstree:              false,
-		kernelOptions:          defaultKernelOptions(),
-		bootable:               true,
+		distroConfig: distro.ImageTypeConfig{
+			RpmOstree:     false,
+			KernelOptions: defaultKernelOptions(),
+			Bootable:      true,
+		},
 		defaultSize:            2 * datasizes.GibiByte,
 		image:                  diskImage,
 		buildPipelines:         []string{"build"},
@@ -482,7 +512,7 @@ func mkMinimalRawImgType(d distribution) imageType {
 
 		// when using systemd mount units we also want them to be mounted rw
 		// while the default options are not
-		it.kernelOptions = []string{"rw"}
+		it.distroConfig.KernelOptions = []string{"rw"}
 	}
 	return it
 }
@@ -638,10 +668,12 @@ func (a *architecture) addImageTypes(platform platform.Platform, imageTypes ...i
 	if a.imageTypes == nil {
 		a.imageTypes = map[string]distro.ImageType{}
 	}
-	for idx := range imageTypes {
-		it := imageTypes[idx]
+	for _, it := range imageTypes {
 		it.arch = a
 		it.platform = platform
+		// XXX: find a better way/better place to set distro
+		// default image config (maybe sort itself via YAML)
+		it.distroConfig.DefaultImageConfig = it.getDefaultImageConfig()
 		a.imageTypes[it.name] = &it
 		for _, alias := range it.nameAliases {
 			if a.imageTypeAliases == nil {

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -15,7 +15,6 @@ import (
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/ignition"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
-	"github.com/osbuild/images/pkg/customizations/oscap"
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/image"
@@ -26,232 +25,6 @@ import (
 )
 
 // HELPERS
-
-func osCustomizations(
-	t *distro.ImageTypeConfig,
-	osPackageSet rpmmd.PackageSet,
-	containers []container.SourceSpec,
-	c *blueprint.Customizations) (manifest.OSCustomizations, error) {
-
-	imageConfig := t.DefaultImageConfig
-
-	osc := manifest.OSCustomizations{}
-
-	if t.Bootable || t.RpmOstree {
-		// XXX: the default kernel name sould come from
-		// DistroConfig first, it is currently hardcoded in
-		// blueprints as a fallback
-		osc.KernelName = c.GetKernel().Name
-
-		var kernelOptions []string
-		if len(t.KernelOptions) > 0 {
-			kernelOptions = append(kernelOptions, t.KernelOptions...)
-		}
-		if bpKernel := c.GetKernel(); bpKernel.Append != "" {
-			kernelOptions = append(kernelOptions, bpKernel.Append)
-		}
-		osc.KernelOptionsAppend = kernelOptions
-	}
-
-	osc.FIPS = c.GetFIPS()
-
-	osc.BasePackages = osPackageSet.Include
-	osc.ExcludeBasePackages = osPackageSet.Exclude
-	osc.ExtraBaseRepos = osPackageSet.Repositories
-
-	osc.Containers = containers
-
-	osc.GPGKeyFiles = imageConfig.GPGKeyFiles
-	if rpm := c.GetRPM(); rpm != nil && rpm.ImportKeys != nil {
-		osc.GPGKeyFiles = append(osc.GPGKeyFiles, rpm.ImportKeys.Files...)
-	}
-
-	if imageConfig.ExcludeDocs != nil {
-		osc.ExcludeDocs = *imageConfig.ExcludeDocs
-	}
-
-	if !t.BootISO {
-		// don't put users and groups in the payload of an installer
-		// add them via kickstart instead
-		osc.Groups = users.GroupsFromBP(c.GetGroups())
-		osc.Users = users.UsersFromBP(c.GetUsers())
-	}
-
-	osc.EnabledServices = imageConfig.EnabledServices
-	osc.DisabledServices = imageConfig.DisabledServices
-	osc.MaskedServices = imageConfig.MaskedServices
-	if imageConfig.DefaultTarget != nil {
-		osc.DefaultTarget = *imageConfig.DefaultTarget
-	}
-
-	if fw := c.GetFirewall(); fw != nil {
-		options := osbuild.FirewallStageOptions{
-			Ports: fw.Ports,
-		}
-
-		if fw.Services != nil {
-			options.EnabledServices = fw.Services.Enabled
-			options.DisabledServices = fw.Services.Disabled
-		}
-		osc.Firewall = &options
-	}
-
-	language, keyboard := c.GetPrimaryLocale()
-	if language != nil {
-		osc.Language = *language
-	} else if imageConfig.Locale != nil {
-		osc.Language = *imageConfig.Locale
-	}
-	if keyboard != nil {
-		osc.Keyboard = keyboard
-	} else if imageConfig.Keyboard != nil {
-		osc.Keyboard = &imageConfig.Keyboard.Keymap
-	}
-
-	if hostname := c.GetHostname(); hostname != nil {
-		osc.Hostname = *hostname
-	} else if imageConfig.Hostname != nil {
-		osc.Hostname = *imageConfig.Hostname
-	}
-
-	if imageConfig.InstallWeakDeps != nil {
-		osc.InstallWeakDeps = *imageConfig.InstallWeakDeps
-	}
-
-	timezone, ntpServers := c.GetTimezoneSettings()
-	if timezone != nil {
-		osc.Timezone = *timezone
-	} else if imageConfig.Timezone != nil {
-		osc.Timezone = *imageConfig.Timezone
-	}
-
-	if len(ntpServers) > 0 {
-		for _, server := range ntpServers {
-			osc.NTPServers = append(osc.NTPServers, osbuild.ChronyConfigServer{Hostname: server})
-		}
-	} else if imageConfig.TimeSynchronization != nil {
-		osc.NTPServers = imageConfig.TimeSynchronization.Servers
-	}
-
-	// Relabel the tree, unless the `NoSElinux` flag is explicitly set to `true`
-	if imageConfig.NoSElinux == nil || imageConfig.NoSElinux != nil && !*imageConfig.NoSElinux {
-		osc.SElinux = "targeted"
-	}
-
-	var err error
-	osc.Directories, err = blueprint.DirectoryCustomizationsToFsNodeDirectories(c.GetDirectories())
-	if err != nil {
-		// In theory this should never happen, because the blueprint directory customizations
-		// should have been validated before this point.
-		panic(fmt.Sprintf("failed to convert directory customizations to fs node directories: %v", err))
-	}
-
-	osc.Files, err = blueprint.FileCustomizationsToFsNodeFiles(c.GetFiles())
-	if err != nil {
-		// In theory this should never happen, because the blueprint file customizations
-		// should have been validated before this point.
-		panic(fmt.Sprintf("failed to convert file customizations to fs node files: %v", err))
-	}
-
-	// OSTree commits do not include data in `/var` since that is tied to the
-	// deployment, rather than the commit. Therefore the containers need to be
-	// stored in a different location, like `/usr/share`, and the container
-	// storage engine configured accordingly.
-	if t.RpmOstree && len(containers) > 0 {
-		storagePath := "/usr/share/containers/storage"
-		osc.ContainersStorage = &storagePath
-	}
-
-	if containerStorage := c.GetContainerStorage(); containerStorage != nil {
-		osc.ContainersStorage = containerStorage.StoragePath
-	}
-
-	customRepos, err := c.GetRepositories()
-	if err != nil {
-		// This shouldn't happen and since the repos
-		// should have already been validated
-		panic(fmt.Sprintf("failed to get custom repos: %v", err))
-	}
-
-	// This function returns a map of filename and corresponding yum repos
-	// and a list of fs node files for the inline gpg keys so we can save
-	// them to disk. This step also swaps the inline gpg key with the path
-	// to the file in the os file tree
-	yumRepos, gpgKeyFiles, err := blueprint.RepoCustomizationsToRepoConfigAndGPGKeyFiles(customRepos)
-	if err != nil {
-		panic(fmt.Sprintf("failed to convert inline gpgkeys to fs node files: %v", err))
-	}
-
-	// add the gpg key files to the list of files to be added to the tree
-	if len(gpgKeyFiles) > 0 {
-		osc.Files = append(osc.Files, gpgKeyFiles...)
-	}
-
-	for filename, repos := range yumRepos {
-		osc.YUMRepos = append(osc.YUMRepos, osbuild.NewYumReposStageOptions(filename, repos))
-	}
-
-	if oscapConfig := c.GetOpenSCAP(); oscapConfig != nil {
-		if t.RpmOstree {
-			panic("unexpected oscap options for ostree image type")
-		}
-
-		oscapDataNode, err := fsnode.NewDirectory(oscap.DataDir, nil, nil, nil, true)
-		if err != nil {
-			panic(fmt.Sprintf("unexpected error creating required OpenSCAP directory: %s", oscap.DataDir))
-		}
-		osc.Directories = append(osc.Directories, oscapDataNode)
-
-		remediationConfig, err := oscap.NewConfigs(*oscapConfig, imageConfig.DefaultOSCAPDatastream)
-		if err != nil {
-			panic(fmt.Errorf("error creating OpenSCAP configs: %w", err))
-		}
-
-		osc.OpenSCAPRemediationConfig = remediationConfig
-	}
-
-	osc.ShellInit = imageConfig.ShellInit
-
-	osc.Grub2Config = imageConfig.Grub2Config
-	osc.Sysconfig = imageConfig.SysconfigStageOptions()
-	osc.SystemdLogind = imageConfig.SystemdLogind
-	osc.CloudInit = imageConfig.CloudInit
-	osc.Modprobe = imageConfig.Modprobe
-	osc.DracutConf = imageConfig.DracutConf
-	osc.SystemdUnit = imageConfig.SystemdUnit
-	osc.Authselect = imageConfig.Authselect
-	osc.SELinuxConfig = imageConfig.SELinuxConfig
-	osc.Tuned = imageConfig.Tuned
-	osc.Tmpfilesd = imageConfig.Tmpfilesd
-	osc.PamLimitsConf = imageConfig.PamLimitsConf
-	osc.Sysctld = imageConfig.Sysctld
-	osc.DNFConfig = imageConfig.DNFConfig
-	osc.SshdConfig = imageConfig.SshdConfig
-	osc.AuthConfig = imageConfig.Authconfig
-	osc.PwQuality = imageConfig.PwQuality
-	osc.WSLConfig = imageConfig.WSLConfStageOptions()
-
-	osc.Files = append(osc.Files, imageConfig.Files...)
-	osc.Directories = append(osc.Directories, imageConfig.Directories...)
-
-	ca, err := c.GetCACerts()
-	if err != nil {
-		panic(fmt.Sprintf("unexpected error checking CA certs: %v", err))
-	}
-	if ca != nil {
-		osc.CACerts = ca.PEMCerts
-	}
-
-	if imageConfig.MachineIdUninitialized != nil {
-		osc.MachineIdUninitialized = *imageConfig.MachineIdUninitialized
-	}
-
-	if imageConfig.MountUnits != nil {
-		osc.MountUnits = *imageConfig.MountUnits
-	}
-
-	return osc, nil
-}
 
 func ostreeDeploymentCustomizations(
 	t *imageType,
@@ -340,7 +113,7 @@ func diskImage(workload workload.Workload,
 	img.Platform = t.platform
 
 	var err error
-	img.OSCustomizations, err = osCustomizations(&t.distroConfig, packageSets[osPkgsKey], containers, bp.Customizations)
+	img.OSCustomizations, err = distro.OsCustomizations(&t.distroConfig, packageSets[osPkgsKey], distro.ImageOptions{}, containers, bp.Customizations)
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +149,7 @@ func containerImage(workload workload.Workload,
 	img.Platform = t.platform
 
 	var err error
-	img.OSCustomizations, err = osCustomizations(&t.distroConfig, packageSets[osPkgsKey], containers, bp.Customizations)
+	img.OSCustomizations, err = distro.OsCustomizations(&t.distroConfig, packageSets[osPkgsKey], distro.ImageOptions{}, containers, bp.Customizations)
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +231,7 @@ func imageInstallerImage(workload workload.Workload,
 	img := image.NewAnacondaTarInstaller()
 
 	var err error
-	img.OSCustomizations, err = osCustomizations(&t.distroConfig, packageSets[osPkgsKey], containers, bp.Customizations)
+	img.OSCustomizations, err = distro.OsCustomizations(&t.distroConfig, packageSets[osPkgsKey], distro.ImageOptions{}, containers, bp.Customizations)
 	if err != nil {
 		return nil, err
 	}
@@ -553,7 +326,7 @@ func iotCommitImage(workload workload.Workload,
 	img.Platform = t.platform
 
 	var err error
-	img.OSCustomizations, err = osCustomizations(&t.distroConfig, packageSets[osPkgsKey], containers, bp.Customizations)
+	img.OSCustomizations, err = distro.OsCustomizations(&t.distroConfig, packageSets[osPkgsKey], distro.ImageOptions{}, containers, bp.Customizations)
 	if err != nil {
 		return nil, err
 	}
@@ -600,7 +373,7 @@ func bootableContainerImage(workload workload.Workload,
 	img.Platform = t.platform
 
 	var err error
-	img.OSCustomizations, err = osCustomizations(&t.distroConfig, packageSets[osPkgsKey], containers, bp.Customizations)
+	img.OSCustomizations, err = distro.OsCustomizations(&t.distroConfig, packageSets[osPkgsKey], distro.ImageOptions{}, containers, bp.Customizations)
 	if err != nil {
 		return nil, err
 	}
@@ -634,7 +407,7 @@ func iotContainerImage(workload workload.Workload,
 	img.Platform = t.platform
 
 	var err error
-	img.OSCustomizations, err = osCustomizations(&t.distroConfig, packageSets[osPkgsKey], containers, bp.Customizations)
+	img.OSCustomizations, err = distro.OsCustomizations(&t.distroConfig, packageSets[osPkgsKey], distro.ImageOptions{}, containers, bp.Customizations)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distro/img_type_config.go
+++ b/pkg/distro/img_type_config.go
@@ -1,0 +1,13 @@
+package distro
+
+type ImageTypeConfig struct {
+	Bootable  bool
+	RpmOstree bool
+	BootISO   bool
+
+	DefaultImageConfig *ImageConfig
+	KernelOptions      []string
+
+	// XXX: replace with something better
+	IsRHEL bool
+}

--- a/pkg/distro/os_customizations.go
+++ b/pkg/distro/os_customizations.go
@@ -1,0 +1,288 @@
+package distro
+
+import (
+	"fmt"
+
+	"github.com/osbuild/images/pkg/blueprint"
+	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/customizations/fsnode"
+	"github.com/osbuild/images/pkg/customizations/oscap"
+	"github.com/osbuild/images/pkg/customizations/subscription"
+	"github.com/osbuild/images/pkg/customizations/users"
+	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/osbuild"
+	"github.com/osbuild/images/pkg/rpmmd"
+)
+
+func OsCustomizations(t *ImageTypeConfig, osPackageSet rpmmd.PackageSet, options ImageOptions, containers []container.SourceSpec, c *blueprint.Customizations) (manifest.OSCustomizations, error) {
+
+	imageConfig := t.DefaultImageConfig
+
+	osc := manifest.OSCustomizations{}
+
+	if t.Bootable || t.RpmOstree {
+		// XXX: the default kernel name sould come from
+		// DistroConfig first, it is currently hardcoded in
+		// blueprints as a fallback
+		osc.KernelName = c.GetKernel().Name
+
+		var kernelOptions []string
+		if len(t.KernelOptions) > 0 {
+			kernelOptions = append(kernelOptions, t.KernelOptions...)
+		}
+		if bpKernel := c.GetKernel(); bpKernel.Append != "" {
+			kernelOptions = append(kernelOptions, bpKernel.Append)
+		}
+		osc.KernelOptionsAppend = kernelOptions
+		if imageConfig.KernelOptionsBootloader != nil {
+			osc.KernelOptionsBootloader = *imageConfig.KernelOptionsBootloader
+		}
+	}
+
+	osc.FIPS = c.GetFIPS()
+
+	osc.BasePackages = osPackageSet.Include
+	osc.ExcludeBasePackages = osPackageSet.Exclude
+	osc.ExtraBaseRepos = osPackageSet.Repositories
+
+	osc.Containers = containers
+
+	osc.GPGKeyFiles = imageConfig.GPGKeyFiles
+	if rpm := c.GetRPM(); rpm != nil && rpm.ImportKeys != nil {
+		osc.GPGKeyFiles = append(osc.GPGKeyFiles, rpm.ImportKeys.Files...)
+	}
+
+	if imageConfig.ExcludeDocs != nil {
+		osc.ExcludeDocs = *imageConfig.ExcludeDocs
+	}
+
+	if !t.BootISO {
+		// don't put users and groups in the payload of an installer
+		// add them via kickstart instead
+		osc.Groups = users.GroupsFromBP(c.GetGroups())
+		osc.Users = users.UsersFromBP(c.GetUsers())
+	}
+
+	osc.EnabledServices = imageConfig.EnabledServices
+	osc.DisabledServices = imageConfig.DisabledServices
+	osc.MaskedServices = imageConfig.MaskedServices
+	if imageConfig.DefaultTarget != nil {
+		osc.DefaultTarget = *imageConfig.DefaultTarget
+	}
+
+	osc.Firewall = imageConfig.Firewall
+	if fw := c.GetFirewall(); fw != nil {
+		options := osbuild.FirewallStageOptions{
+			Ports: fw.Ports,
+		}
+
+		if fw.Services != nil {
+			options.EnabledServices = fw.Services.Enabled
+			options.DisabledServices = fw.Services.Disabled
+		}
+		if fw.Zones != nil {
+			for _, z := range fw.Zones {
+				options.Zones = append(options.Zones, osbuild.FirewallZone{
+					Name:    *z.Name,
+					Sources: z.Sources,
+				})
+			}
+		}
+		osc.Firewall = &options
+	}
+
+	language, keyboard := c.GetPrimaryLocale()
+	if language != nil {
+		osc.Language = *language
+	} else if imageConfig.Locale != nil {
+		osc.Language = *imageConfig.Locale
+	}
+	if keyboard != nil {
+		osc.Keyboard = keyboard
+	} else if imageConfig.Keyboard != nil {
+		osc.Keyboard = &imageConfig.Keyboard.Keymap
+		if imageConfig.Keyboard.X11Keymap != nil {
+			osc.X11KeymapLayouts = imageConfig.Keyboard.X11Keymap.Layouts
+		}
+	}
+
+	if hostname := c.GetHostname(); hostname != nil {
+		osc.Hostname = *hostname
+	} else if imageConfig.Hostname != nil {
+		osc.Hostname = *imageConfig.Hostname
+	}
+
+	timezone, ntpServers := c.GetTimezoneSettings()
+	if timezone != nil {
+		osc.Timezone = *timezone
+	} else if imageConfig.Timezone != nil {
+		osc.Timezone = *imageConfig.Timezone
+	}
+
+	if len(ntpServers) > 0 {
+		for _, server := range ntpServers {
+			osc.NTPServers = append(osc.NTPServers, osbuild.ChronyConfigServer{Hostname: server})
+		}
+	} else if imageConfig.TimeSynchronization != nil {
+		osc.NTPServers = imageConfig.TimeSynchronization.Servers
+		osc.LeapSecTZ = imageConfig.TimeSynchronization.LeapsecTz
+	}
+
+	// Relabel the tree, unless the `NoSElinux` flag is explicitly set to `true`
+	if imageConfig.NoSElinux == nil || imageConfig.NoSElinux != nil && !*imageConfig.NoSElinux {
+		osc.SElinux = "targeted"
+		osc.SELinuxForceRelabel = imageConfig.SELinuxForceRelabel
+	}
+
+	if t.IsRHEL && options.Facts != nil {
+		osc.RHSMFacts = options.Facts
+	}
+
+	var err error
+	osc.Directories, err = blueprint.DirectoryCustomizationsToFsNodeDirectories(c.GetDirectories())
+	if err != nil {
+		// In theory this should never happen, because the blueprint directory customizations
+		// should have been validated before this point.
+		panic(fmt.Sprintf("failed to convert directory customizations to fs node directories: %v", err))
+	}
+
+	osc.Files, err = blueprint.FileCustomizationsToFsNodeFiles(c.GetFiles())
+	if err != nil {
+		// In theory this should never happen, because the blueprint file customizations
+		// should have been validated before this point.
+		panic(fmt.Sprintf("failed to convert file customizations to fs node files: %v", err))
+	}
+
+	// OSTree commits do not include data in `/var` since that is tied to the
+	// deployment, rather than the commit. Therefore the containers need to be
+	// stored in a different location, like `/usr/share`, and the container
+	// storage engine configured accordingly.
+	if t.RpmOstree && len(containers) > 0 {
+		storagePath := "/usr/share/containers/storage"
+		osc.ContainersStorage = &storagePath
+	}
+
+	if containerStorage := c.GetContainerStorage(); containerStorage != nil {
+		osc.ContainersStorage = containerStorage.StoragePath
+	}
+
+	// set yum repos first, so it doesn't get overridden by
+	// imageConfig.YUMRepos
+	osc.YUMRepos = imageConfig.YUMRepos
+
+	customRepos, err := c.GetRepositories()
+	if err != nil {
+		// This shouldn't happen and since the repos
+		// should have already been validated
+		panic(fmt.Sprintf("failed to get custom repos: %v", err))
+	}
+
+	// This function returns a map of filename and corresponding yum repos
+	// and a list of fs node files for the inline gpg keys so we can save
+	// them to disk. This step also swaps the inline gpg key with the path
+	// to the file in the os file tree
+	yumRepos, gpgKeyFiles, err := blueprint.RepoCustomizationsToRepoConfigAndGPGKeyFiles(customRepos)
+	if err != nil {
+		panic(fmt.Sprintf("failed to convert inline gpgkeys to fs node files: %v", err))
+	}
+
+	// add the gpg key files to the list of files to be added to the tree
+	if len(gpgKeyFiles) > 0 {
+		osc.Files = append(osc.Files, gpgKeyFiles...)
+	}
+
+	for filename, repos := range yumRepos {
+		osc.YUMRepos = append(osc.YUMRepos, osbuild.NewYumReposStageOptions(filename, repos))
+	}
+
+	if oscapConfig := c.GetOpenSCAP(); oscapConfig != nil {
+		if t.RpmOstree {
+			panic("unexpected oscap options for ostree image type")
+		}
+
+		oscapDataNode, err := fsnode.NewDirectory(oscap.DataDir, nil, nil, nil, true)
+		if err != nil {
+			panic(fmt.Sprintf("unexpected error creating required OpenSCAP directory: %s", oscap.DataDir))
+		}
+		osc.Directories = append(osc.Directories, oscapDataNode)
+
+		remediationConfig, err := oscap.NewConfigs(*oscapConfig, imageConfig.DefaultOSCAPDatastream)
+		if err != nil {
+			panic(fmt.Errorf("error creating OpenSCAP configs: %w", err))
+		}
+
+		osc.OpenSCAPRemediationConfig = remediationConfig
+	}
+
+	var subscriptionStatus subscription.RHSMStatus
+	if options.Subscription != nil {
+		subscriptionStatus = subscription.RHSMConfigWithSubscription
+		if options.Subscription.Proxy != "" {
+			osc.InsightsClientConfig = &osbuild.InsightsClientConfigStageOptions{Proxy: options.Subscription.Proxy}
+		}
+	} else {
+		subscriptionStatus = subscription.RHSMConfigNoSubscription
+	}
+	if rhsmConfig, exists := imageConfig.RHSMConfig[subscriptionStatus]; exists {
+		osc.RHSMConfig = rhsmConfig
+	}
+
+	if bpRhsmConfig := subscription.RHSMConfigFromBP(c.GetRHSM()); bpRhsmConfig != nil {
+		osc.RHSMConfig = osc.RHSMConfig.Update(bpRhsmConfig)
+	}
+
+	osc.ShellInit = imageConfig.ShellInit
+	osc.Grub2Config = imageConfig.Grub2Config
+	osc.Sysconfig = imageConfig.SysconfigStageOptions()
+	osc.SystemdLogind = imageConfig.SystemdLogind
+	osc.CloudInit = imageConfig.CloudInit
+	osc.Modprobe = imageConfig.Modprobe
+	osc.DracutConf = imageConfig.DracutConf
+	osc.SystemdUnit = imageConfig.SystemdUnit
+	osc.Authselect = imageConfig.Authselect
+	osc.SELinuxConfig = imageConfig.SELinuxConfig
+	osc.Tuned = imageConfig.Tuned
+	osc.Tmpfilesd = imageConfig.Tmpfilesd
+	osc.PamLimitsConf = imageConfig.PamLimitsConf
+	osc.Sysctld = imageConfig.Sysctld
+	osc.DNFConfig = imageConfig.DNFConfig
+	osc.DNFAutomaticConfig = imageConfig.DNFAutomaticConfig
+	osc.YUMConfig = imageConfig.YumConfig
+	osc.SshdConfig = imageConfig.SshdConfig
+	osc.AuthConfig = imageConfig.Authconfig
+	osc.PwQuality = imageConfig.PwQuality
+	osc.Subscription = options.Subscription
+	osc.WAAgentConfig = imageConfig.WAAgentConfig
+	osc.UdevRules = imageConfig.UdevRules
+	osc.GCPGuestAgentConfig = imageConfig.GCPGuestAgentConfig
+	osc.WSLConfig = imageConfig.WSLConfStageOptions()
+
+	osc.Files = append(osc.Files, imageConfig.Files...)
+	osc.Directories = append(osc.Directories, imageConfig.Directories...)
+
+	if imageConfig.NoBLS != nil {
+		osc.NoBLS = *imageConfig.NoBLS
+	}
+
+	ca, err := c.GetCACerts()
+	if err != nil {
+		panic(fmt.Sprintf("unexpected error checking CA certs: %v", err))
+	}
+	if ca != nil {
+		osc.CACerts = ca.PEMCerts
+	}
+
+	if imageConfig.InstallWeakDeps != nil {
+		osc.InstallWeakDeps = *imageConfig.InstallWeakDeps
+	}
+
+	if imageConfig.MachineIdUninitialized != nil {
+		osc.MachineIdUninitialized = *imageConfig.MachineIdUninitialized
+	}
+
+	if imageConfig.MountUnits != nil {
+		osc.MountUnits = *imageConfig.MountUnits
+	}
+
+	return osc, nil
+}

--- a/pkg/distro/rhel/arch.go
+++ b/pkg/distro/rhel/arch.go
@@ -53,10 +53,13 @@ func (a *Architecture) AddImageTypes(platform platform.Platform, imageTypes ...*
 	if a.imageTypes == nil {
 		a.imageTypes = map[string]distro.ImageType{}
 	}
-	for idx := range imageTypes {
-		it := imageTypes[idx]
+	for _, it := range imageTypes {
 		it.arch = a
 		it.platform = platform
+		// XXX: find a better way/better place to set distro
+		// default image config (maybe sort itself via YAML)
+		it.DistroConfig.DefaultImageConfig = it.getDefaultImageConfig()
+		it.DistroConfig.IsRHEL = it.IsRHEL()
 		a.imageTypes[it.name] = it
 		for _, alias := range it.NameAliases {
 			if a.imageTypeAliases == nil {

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -10,11 +10,8 @@ import (
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/customizations/fdo"
-	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/ignition"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
-	"github.com/osbuild/images/pkg/customizations/oscap"
-	"github.com/osbuild/images/pkg/customizations/subscription"
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/image"
@@ -23,279 +20,6 @@ import (
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
-
-func osCustomizations(
-	t *distro.ImageTypeConfig,
-	osPackageSet rpmmd.PackageSet,
-	options distro.ImageOptions,
-	containers []container.SourceSpec,
-	c *blueprint.Customizations,
-) (manifest.OSCustomizations, error) {
-
-	imageConfig := t.DefaultImageConfig
-
-	osc := manifest.OSCustomizations{}
-
-	if t.Bootable || t.RpmOstree {
-		// XXX: the default kernel name sould come from
-		// DistroConfig first, it is currently hardcoded in
-		// blueprints as a fallback
-		osc.KernelName = c.GetKernel().Name
-
-		var kernelOptions []string
-		if len(t.KernelOptions) > 0 {
-			kernelOptions = append(kernelOptions, t.KernelOptions...)
-		}
-		if bpKernel := c.GetKernel(); bpKernel.Append != "" {
-			kernelOptions = append(kernelOptions, bpKernel.Append)
-		}
-		osc.KernelOptionsAppend = kernelOptions
-		if imageConfig.KernelOptionsBootloader != nil {
-			osc.KernelOptionsBootloader = *imageConfig.KernelOptionsBootloader
-		}
-	}
-
-	osc.FIPS = c.GetFIPS()
-
-	osc.BasePackages = osPackageSet.Include
-	osc.ExcludeBasePackages = osPackageSet.Exclude
-	osc.ExtraBaseRepos = osPackageSet.Repositories
-
-	osc.Containers = containers
-
-	osc.GPGKeyFiles = imageConfig.GPGKeyFiles
-	if rpm := c.GetRPM(); rpm != nil && rpm.ImportKeys != nil {
-		osc.GPGKeyFiles = append(osc.GPGKeyFiles, rpm.ImportKeys.Files...)
-	}
-
-	if imageConfig.ExcludeDocs != nil {
-		osc.ExcludeDocs = *imageConfig.ExcludeDocs
-	}
-
-	if !t.BootISO {
-		// don't put users and groups in the payload of an installer
-		// add them via kickstart instead
-		osc.Groups = users.GroupsFromBP(c.GetGroups())
-		osc.Users = users.UsersFromBP(c.GetUsers())
-	}
-
-	osc.EnabledServices = imageConfig.EnabledServices
-	osc.DisabledServices = imageConfig.DisabledServices
-	osc.MaskedServices = imageConfig.MaskedServices
-	if imageConfig.DefaultTarget != nil {
-		osc.DefaultTarget = *imageConfig.DefaultTarget
-	}
-
-	osc.Firewall = imageConfig.Firewall
-	if fw := c.GetFirewall(); fw != nil {
-		options := osbuild.FirewallStageOptions{
-			Ports: fw.Ports,
-		}
-
-		if fw.Services != nil {
-			options.EnabledServices = fw.Services.Enabled
-			options.DisabledServices = fw.Services.Disabled
-		}
-		if fw.Zones != nil {
-			for _, z := range fw.Zones {
-				options.Zones = append(options.Zones, osbuild.FirewallZone{
-					Name:    *z.Name,
-					Sources: z.Sources,
-				})
-			}
-		}
-		osc.Firewall = &options
-	}
-
-	language, keyboard := c.GetPrimaryLocale()
-	if language != nil {
-		osc.Language = *language
-	} else if imageConfig.Locale != nil {
-		osc.Language = *imageConfig.Locale
-	}
-	if keyboard != nil {
-		osc.Keyboard = keyboard
-	} else if imageConfig.Keyboard != nil {
-		osc.Keyboard = &imageConfig.Keyboard.Keymap
-		if imageConfig.Keyboard.X11Keymap != nil {
-			osc.X11KeymapLayouts = imageConfig.Keyboard.X11Keymap.Layouts
-		}
-	}
-
-	if hostname := c.GetHostname(); hostname != nil {
-		osc.Hostname = *hostname
-	}
-
-	timezone, ntpServers := c.GetTimezoneSettings()
-	if timezone != nil {
-		osc.Timezone = *timezone
-	} else if imageConfig.Timezone != nil {
-		osc.Timezone = *imageConfig.Timezone
-	}
-
-	if len(ntpServers) > 0 {
-		for _, server := range ntpServers {
-			osc.NTPServers = append(osc.NTPServers, osbuild.ChronyConfigServer{Hostname: server})
-		}
-	} else if imageConfig.TimeSynchronization != nil {
-		osc.NTPServers = imageConfig.TimeSynchronization.Servers
-		osc.LeapSecTZ = imageConfig.TimeSynchronization.LeapsecTz
-	}
-
-	// Relabel the tree, unless the `NoSElinux` flag is explicitly set to `true`
-	if imageConfig.NoSElinux == nil || imageConfig.NoSElinux != nil && !*imageConfig.NoSElinux {
-		osc.SElinux = "targeted"
-		osc.SELinuxForceRelabel = imageConfig.SELinuxForceRelabel
-	}
-
-	if t.IsRHEL && options.Facts != nil {
-		osc.RHSMFacts = options.Facts
-	}
-
-	var err error
-	osc.Directories, err = blueprint.DirectoryCustomizationsToFsNodeDirectories(c.GetDirectories())
-	if err != nil {
-		// In theory this should never happen, because the blueprint directory customizations
-		// should have been validated before this point.
-		panic(fmt.Sprintf("failed to convert directory customizations to fs node directories: %v", err))
-	}
-
-	osc.Files, err = blueprint.FileCustomizationsToFsNodeFiles(c.GetFiles())
-	if err != nil {
-		// In theory this should never happen, because the blueprint file customizations
-		// should have been validated before this point.
-		panic(fmt.Sprintf("failed to convert file customizations to fs node files: %v", err))
-	}
-
-	// OSTree commits do not include data in `/var` since that is tied to the
-	// deployment, rather than the commit. Therefore the containers need to be
-	// stored in a different location, like `/usr/share`, and the container
-	// storage engine configured accordingly.
-	if t.RpmOstree && len(containers) > 0 {
-		storagePath := "/usr/share/containers/storage"
-		osc.ContainersStorage = &storagePath
-	}
-
-	if containerStorage := c.GetContainerStorage(); containerStorage != nil {
-		osc.ContainersStorage = containerStorage.StoragePath
-	}
-
-	// set yum repos first, so it doesn't get overridden by
-	// imageConfig.YUMRepos
-	osc.YUMRepos = imageConfig.YUMRepos
-
-	customRepos, err := c.GetRepositories()
-	if err != nil {
-		// This shouldn't happen and since the repos
-		// should have already been validated
-		panic(fmt.Sprintf("failed to get custom repos: %v", err))
-	}
-
-	// This function returns a map of filename and corresponding yum repos
-	// and a list of fs node files for the inline gpg keys so we can save
-	// them to disk. This step also swaps the inline gpg key with the path
-	// to the file in the os file tree
-	yumRepos, gpgKeyFiles, err := blueprint.RepoCustomizationsToRepoConfigAndGPGKeyFiles(customRepos)
-	if err != nil {
-		panic(fmt.Sprintf("failed to convert inline gpgkeys to fs node files: %v", err))
-	}
-
-	// add the gpg key files to the list of files to be added to the tree
-	if len(gpgKeyFiles) > 0 {
-		osc.Files = append(osc.Files, gpgKeyFiles...)
-	}
-
-	for filename, repos := range yumRepos {
-		osc.YUMRepos = append(osc.YUMRepos, osbuild.NewYumReposStageOptions(filename, repos))
-	}
-
-	if oscapConfig := c.GetOpenSCAP(); oscapConfig != nil {
-		if t.RpmOstree {
-			panic("unexpected oscap options for ostree image type")
-		}
-
-		oscapDataNode, err := fsnode.NewDirectory(oscap.DataDir, nil, nil, nil, true)
-		if err != nil {
-			panic(fmt.Sprintf("unexpected error creating required OpenSCAP directory: %s", oscap.DataDir))
-		}
-		osc.Directories = append(osc.Directories, oscapDataNode)
-
-		remediationConfig, err := oscap.NewConfigs(*oscapConfig, imageConfig.DefaultOSCAPDatastream)
-		if err != nil {
-			panic(fmt.Errorf("error creating OpenSCAP configs: %w", err))
-		}
-
-		osc.OpenSCAPRemediationConfig = remediationConfig
-	}
-
-	var subscriptionStatus subscription.RHSMStatus
-	if options.Subscription != nil {
-		subscriptionStatus = subscription.RHSMConfigWithSubscription
-		if options.Subscription.Proxy != "" {
-			osc.InsightsClientConfig = &osbuild.InsightsClientConfigStageOptions{Proxy: options.Subscription.Proxy}
-		}
-	} else {
-		subscriptionStatus = subscription.RHSMConfigNoSubscription
-	}
-	if rhsmConfig, exists := imageConfig.RHSMConfig[subscriptionStatus]; exists {
-		osc.RHSMConfig = rhsmConfig
-	}
-
-	if bpRhsmConfig := subscription.RHSMConfigFromBP(c.GetRHSM()); bpRhsmConfig != nil {
-		osc.RHSMConfig = osc.RHSMConfig.Update(bpRhsmConfig)
-	}
-
-	osc.ShellInit = imageConfig.ShellInit
-	osc.Grub2Config = imageConfig.Grub2Config
-	osc.Sysconfig = imageConfig.SysconfigStageOptions()
-	osc.SystemdLogind = imageConfig.SystemdLogind
-	osc.CloudInit = imageConfig.CloudInit
-	osc.Modprobe = imageConfig.Modprobe
-	osc.DracutConf = imageConfig.DracutConf
-	osc.SystemdUnit = imageConfig.SystemdUnit
-	osc.Authselect = imageConfig.Authselect
-	osc.SELinuxConfig = imageConfig.SELinuxConfig
-	osc.Tuned = imageConfig.Tuned
-	osc.Tmpfilesd = imageConfig.Tmpfilesd
-	osc.PamLimitsConf = imageConfig.PamLimitsConf
-	osc.Sysctld = imageConfig.Sysctld
-	osc.DNFConfig = imageConfig.DNFConfig
-	osc.DNFAutomaticConfig = imageConfig.DNFAutomaticConfig
-	osc.YUMConfig = imageConfig.YumConfig
-	osc.SshdConfig = imageConfig.SshdConfig
-	osc.AuthConfig = imageConfig.Authconfig
-	osc.PwQuality = imageConfig.PwQuality
-	osc.Subscription = options.Subscription
-	osc.WAAgentConfig = imageConfig.WAAgentConfig
-	osc.UdevRules = imageConfig.UdevRules
-	osc.GCPGuestAgentConfig = imageConfig.GCPGuestAgentConfig
-	osc.WSLConfig = imageConfig.WSLConfStageOptions()
-
-	osc.Files = append(osc.Files, imageConfig.Files...)
-	osc.Directories = append(osc.Directories, imageConfig.Directories...)
-
-	if imageConfig.NoBLS != nil {
-		osc.NoBLS = *imageConfig.NoBLS
-	}
-
-	ca, err := c.GetCACerts()
-	if err != nil {
-		panic(fmt.Sprintf("unexpected error checking CA certs: %v", err))
-	}
-	if ca != nil {
-		osc.CACerts = ca.PEMCerts
-	}
-
-	if imageConfig.InstallWeakDeps != nil {
-		osc.InstallWeakDeps = *imageConfig.InstallWeakDeps
-	}
-
-	if imageConfig.MountUnits != nil {
-		osc.MountUnits = *imageConfig.MountUnits
-	}
-
-	return osc, nil
-}
 
 func ostreeDeploymentCustomizations(
 	t *distro.ImageTypeConfig,
@@ -387,7 +111,7 @@ func DiskImage(workload workload.Workload,
 	img.Platform = t.platform
 
 	var err error
-	img.OSCustomizations, err = osCustomizations(&t.DistroConfig, packageSets[OSPkgsKey], options, containers, customizations)
+	img.OSCustomizations, err = distro.OsCustomizations(&t.DistroConfig, packageSets[OSPkgsKey], options, containers, customizations)
 	if err != nil {
 		return nil, err
 	}
@@ -433,7 +157,7 @@ func EdgeCommitImage(workload workload.Workload,
 	img.Platform = t.platform
 
 	var err error
-	img.OSCustomizations, err = osCustomizations(&t.DistroConfig, packageSets[OSPkgsKey], options, containers, customizations)
+	img.OSCustomizations, err = distro.OsCustomizations(&t.DistroConfig, packageSets[OSPkgsKey], options, containers, customizations)
 	if err != nil {
 		return nil, err
 	}
@@ -461,7 +185,7 @@ func EdgeContainerImage(workload workload.Workload,
 	img.Platform = t.platform
 
 	var err error
-	img.OSCustomizations, err = osCustomizations(&t.DistroConfig, packageSets[OSPkgsKey], options, containers, customizations)
+	img.OSCustomizations, err = distro.OsCustomizations(&t.DistroConfig, packageSets[OSPkgsKey], options, containers, customizations)
 	if err != nil {
 		return nil, err
 	}
@@ -711,7 +435,7 @@ func ImageInstallerImage(workload workload.Workload,
 	img.Workload = workload
 
 	var err error
-	img.OSCustomizations, err = osCustomizations(&t.DistroConfig, packageSets[OSPkgsKey], options, containers, customizations)
+	img.OSCustomizations, err = distro.OsCustomizations(&t.DistroConfig, packageSets[OSPkgsKey], options, containers, customizations)
 	if err != nil {
 		return nil, err
 	}
@@ -797,7 +521,7 @@ func TarImage(workload workload.Workload,
 	img.Platform = t.platform
 
 	var err error
-	img.OSCustomizations, err = osCustomizations(&t.DistroConfig, packageSets[OSPkgsKey], options, containers, customizations)
+	img.OSCustomizations, err = distro.OsCustomizations(&t.DistroConfig, packageSets[OSPkgsKey], options, containers, customizations)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distro/rhel/images_test.go
+++ b/pkg/distro/rhel/images_test.go
@@ -434,7 +434,7 @@ func TestOsCustomizationsRHSM(t *testing.T) {
 			it := &ImageType{DefaultImageConfig: tc.ic}
 			testArch.AddImageTypes(&platform.X86{}, it)
 
-			osc, err := osCustomizations(&it.DistroConfig, rpmmd.PackageSet{}, *tc.io, nil, tc.bpc)
+			osc, err := distro.OsCustomizations(&it.DistroConfig, rpmmd.PackageSet{}, *tc.io, nil, tc.bpc)
 			assert.NoError(t, err)
 			assert.EqualValues(t, tc.expectedOsc.RHSMConfig, osc.RHSMConfig)
 		})

--- a/pkg/distro/rhel/images_test.go
+++ b/pkg/distro/rhel/images_test.go
@@ -434,7 +434,7 @@ func TestOsCustomizationsRHSM(t *testing.T) {
 			it := &ImageType{DefaultImageConfig: tc.ic}
 			testArch.AddImageTypes(&platform.X86{}, it)
 
-			osc, err := osCustomizations(it, rpmmd.PackageSet{}, *tc.io, nil, tc.bpc)
+			osc, err := osCustomizations(&it.DistroConfig, rpmmd.PackageSet{}, *tc.io, nil, tc.bpc)
 			assert.NoError(t, err)
 			assert.EqualValues(t, tc.expectedOsc.RHSMConfig, osc.RHSMConfig)
 		})

--- a/pkg/distro/rhel/rhel10/ami.go
+++ b/pkg/distro/rhel/rhel10/ami.go
@@ -36,8 +36,8 @@ func mkAMIImgTypeX86_64() *rhel.ImageType {
 		[]string{"image"},
 	)
 
-	it.KernelOptions = amiKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = amiKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -59,8 +59,8 @@ func mkAMIImgTypeAarch64() *rhel.ImageType {
 		[]string{"image"},
 	)
 
-	it.KernelOptions = amiAarch64KernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = amiAarch64KernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfig()
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -84,8 +84,8 @@ func mkEc2ImgTypeX86_64() *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = amiKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = amiKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -109,8 +109,8 @@ func mkEC2ImgTypeAarch64() *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = amiAarch64KernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = amiAarch64KernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfig()
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -134,8 +134,8 @@ func mkEc2HaImgTypeX86_64() *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = amiKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = amiKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -158,8 +158,8 @@ func mkEC2SapImgTypeX86_64(osVersion string) *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = amiSapKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = amiSapKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = sapImageConfig(osVersion).InheritFrom(defaultEc2ImageConfigX86_64())
 	it.BasePartitionTables = defaultBasePartitionTables

--- a/pkg/distro/rhel/rhel10/azure.go
+++ b/pkg/distro/rhel/rhel10/azure.go
@@ -25,8 +25,8 @@ func mkAzureImgType(rd *rhel.Distribution) *rhel.ImageType {
 		[]string{"vpc"},
 	)
 
-	it.KernelOptions = defaultAzureKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = defaultAzureKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultAzureImageConfig(rd)
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -50,8 +50,8 @@ func mkAzureInternalImgType(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = defaultAzureKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = defaultAzureKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultAzureImageConfig(rd)
 	it.BasePartitionTables = azureInternalBasePartitionTables
@@ -74,8 +74,8 @@ func mkAzureSapInternalImgType(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = defaultAzureKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = defaultAzureKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.DefaultImageConfig = sapAzureImageConfig(rd)
 	it.BasePartitionTables = azureInternalBasePartitionTables

--- a/pkg/distro/rhel/rhel10/bare_metal.go
+++ b/pkg/distro/rhel/rhel10/bare_metal.go
@@ -39,8 +39,8 @@ func mkImageInstallerImgType() *rhel.ImageType {
 		[]string{"bootiso"},
 	)
 
-	it.BootISO = true
-	it.Bootable = true
+	it.DistroConfig.BootISO = true
+	it.DistroConfig.Bootable = true
 	it.ISOLabelFn = distroISOLabelFunc
 
 	it.DefaultInstallerConfig = &distro.InstallerConfig{

--- a/pkg/distro/rhel/rhel10/distro_test.go
+++ b/pkg/distro/rhel/rhel10/distro_test.go
@@ -405,7 +405,7 @@ func TestRhel10_KernelOption_NoIfnames(t *testing.T) {
 			for _, imgTypeName := range arch.ListImageTypes() {
 				imgType, err := arch.GetImageType(imgTypeName)
 				assert.NoError(t, err)
-				assert.NotContains(t, imgType.(*rhel.ImageType).KernelOptions, "net.ifnames=0", "type %s contains unwanted net.ifnames=0", imgType.Name())
+				assert.NotContains(t, imgType.(*rhel.ImageType).DistroConfig.KernelOptions, "net.ifnames=0", "type %s contains unwanted net.ifnames=0", imgType.Name())
 			}
 		}
 	}

--- a/pkg/distro/rhel/rhel10/gce.go
+++ b/pkg/distro/rhel/rhel10/gce.go
@@ -27,9 +27,9 @@ func mkGCEImageType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = baseGCEImageConfig()
-	it.KernelOptions = gceKernelOptions()
+	it.DistroConfig.KernelOptions = gceKernelOptions()
 	it.DefaultSize = 20 * datasizes.GibiByte
-	it.Bootable = true
+	it.DistroConfig.Bootable = true
 	// TODO: the base partition table still contains the BIOS boot partition, but the image is UEFI-only
 	it.BasePartitionTables = defaultBasePartitionTables
 

--- a/pkg/distro/rhel/rhel10/options.go
+++ b/pkg/distro/rhel/rhel10/options.go
@@ -68,7 +68,7 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 	dcp := policies.CustomDirectoriesPolicies
 	fcp := policies.CustomFilesPolicies
 
-	if t.RPMOSTree {
+	if t.DistroConfig.RpmOstree {
 		dcp = policies.OstreeCustomDirectoriesPolicies
 		fcp = policies.OstreeCustomFilesPolicies
 	}

--- a/pkg/distro/rhel/rhel10/qcow2.go
+++ b/pkg/distro/rhel/rhel10/qcow2.go
@@ -23,9 +23,9 @@ func mkQcow2ImgType(d *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = qcowImageConfig(d)
-	it.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check"}
+	it.DistroConfig.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check"}
 	it.DefaultSize = 10 * datasizes.GibiByte
-	it.Bootable = true
+	it.DistroConfig.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -46,9 +46,9 @@ func mkOCIImgType(d *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = qcowImageConfig(d)
-	it.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check"}
+	it.DistroConfig.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check"}
 	it.DefaultSize = 10 * datasizes.GibiByte
-	it.Bootable = true
+	it.DistroConfig.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it

--- a/pkg/distro/rhel/rhel10/vmdk.go
+++ b/pkg/distro/rhel/rhel10/vmdk.go
@@ -23,8 +23,8 @@ func mkVMDKImgType() *rhel.ImageType {
 		[]string{"vmdk"},
 	)
 
-	it.KernelOptions = vmdkKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = vmdkKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -45,8 +45,8 @@ func mkOVAImgType() *rhel.ImageType {
 		[]string{"archive"},
 	)
 
-	it.KernelOptions = vmdkKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = vmdkKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 

--- a/pkg/distro/rhel/rhel7/ami.go
+++ b/pkg/distro/rhel/rhel7/ami.go
@@ -36,8 +36,8 @@ func mkEc2ImgTypeX86_64() *rhel.ImageType {
 
 	it.Compression = "xz"
 	it.DefaultImageConfig = ec2ImageConfig()
-	it.KernelOptions = ec2KernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = ec2KernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = ec2PartitionTables
 

--- a/pkg/distro/rhel/rhel7/azure.go
+++ b/pkg/distro/rhel/rhel7/azure.go
@@ -31,9 +31,9 @@ func mkAzureRhuiImgType() *rhel.ImageType {
 	it.DiskImageVPCForceSize = common.ToPtr(false)
 
 	it.Compression = "xz"
-	it.KernelOptions = []string{"ro", "crashkernel=auto", "console=tty1", "console=ttyS0", "earlyprintk=ttyS0", "rootdelay=300", "scsi_mod.use_blk_mq=y"}
+	it.DistroConfig.KernelOptions = []string{"ro", "crashkernel=auto", "console=tty1", "console=ttyS0", "earlyprintk=ttyS0", "rootdelay=300", "scsi_mod.use_blk_mq=y"}
 	it.DefaultImageConfig = azureDefaultImgConfig
-	it.Bootable = true
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.BasePartitionTables = azureRhuiBasePartitionTables
 

--- a/pkg/distro/rhel/rhel7/qcow2.go
+++ b/pkg/distro/rhel/rhel7/qcow2.go
@@ -26,8 +26,8 @@ func mkQcow2ImgType() *rhel.ImageType {
 	// all RHEL 7 images should use sgdisk
 	it.DiskImagePartTool = common.ToPtr(osbuild.PTSgdisk)
 
-	it.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0", "crashkernel=auto"}
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0", "crashkernel=auto"}
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = qcow2DefaultImgConfig
 	it.BasePartitionTables = defaultBasePartitionTables

--- a/pkg/distro/rhel/rhel8/ami.go
+++ b/pkg/distro/rhel/rhel8/ami.go
@@ -36,8 +36,8 @@ func mkAmiImgTypeX86_64() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = defaultAMIImageConfigX86_64()
-	it.KernelOptions = amiX86KernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = amiX86KernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = ec2PartitionTables
 
@@ -60,8 +60,8 @@ func mkEc2ImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 
 	it.Compression = "xz"
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64(rd)
-	it.KernelOptions = amiX86KernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = amiX86KernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = ec2PartitionTables
 
@@ -84,8 +84,8 @@ func mkEc2HaImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 
 	it.Compression = "xz"
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64(rd)
-	it.KernelOptions = amiX86KernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = amiX86KernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = ec2PartitionTables
 
@@ -107,8 +107,8 @@ func mkAmiImgTypeAarch64() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = defaultAMIImageConfig()
-	it.KernelOptions = amiAarch64KernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = amiAarch64KernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = ec2PartitionTables
 
@@ -131,8 +131,8 @@ func mkEc2ImgTypeAarch64(rd *rhel.Distribution) *rhel.ImageType {
 
 	it.Compression = "xz"
 	it.DefaultImageConfig = defaultEc2ImageConfig(rd)
-	it.KernelOptions = amiAarch64KernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = amiAarch64KernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = ec2PartitionTables
 
@@ -155,8 +155,8 @@ func mkEc2SapImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 
 	it.Compression = "xz"
 	it.DefaultImageConfig = defaultEc2SapImageConfigX86_64(rd)
-	it.KernelOptions = amiSapKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = amiSapKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = ec2PartitionTables
 

--- a/pkg/distro/rhel/rhel8/azure.go
+++ b/pkg/distro/rhel/rhel8/azure.go
@@ -33,8 +33,8 @@ func mkAzureRhuiImgType() *rhel.ImageType {
 
 	it.Compression = "xz"
 	it.DefaultImageConfig = defaultAzureRhuiImageConfig.InheritFrom(defaultVhdImageConfig())
-	it.KernelOptions = defaultAzureKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = defaultAzureKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.BasePartitionTables = azureRhuiBasePartitionTables
 
@@ -57,8 +57,8 @@ func mkAzureSapRhuiImgType(rd *rhel.Distribution) *rhel.ImageType {
 
 	it.Compression = "xz"
 	it.DefaultImageConfig = defaultAzureRhuiImageConfig.InheritFrom(sapAzureImageConfig(rd))
-	it.KernelOptions = defaultAzureKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = defaultAzureKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.BasePartitionTables = azureRhuiBasePartitionTables
 
@@ -80,8 +80,8 @@ func mkAzureByosImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = defaultAzureByosImageConfig.InheritFrom(defaultVhdImageConfig())
-	it.KernelOptions = defaultAzureKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = defaultAzureKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -104,8 +104,8 @@ func mkAzureImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = defaultVhdImageConfig()
-	it.KernelOptions = defaultAzureKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = defaultAzureKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -128,8 +128,8 @@ func mkAzureEap7RhuiImgType() *rhel.ImageType {
 
 	it.Compression = "xz"
 	it.DefaultImageConfig = defaultAzureEapImageConfig.InheritFrom(defaultAzureRhuiImageConfig.InheritFrom(defaultAzureImageConfig))
-	it.KernelOptions = defaultAzureKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = defaultAzureKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.BasePartitionTables = azureRhuiBasePartitionTables
 	it.Workload = eapWorkload()

--- a/pkg/distro/rhel/rhel8/bare_metal.go
+++ b/pkg/distro/rhel/rhel8/bare_metal.go
@@ -24,8 +24,8 @@ func mkImageInstaller() *rhel.ImageType {
 		[]string{"bootiso"},
 	)
 
-	it.BootISO = true
-	it.Bootable = true
+	it.DistroConfig.BootISO = true
+	it.DistroConfig.Bootable = true
 	it.ISOLabelFn = distroISOLabelFunc
 
 	it.DefaultInstallerConfig = &distro.InstallerConfig{

--- a/pkg/distro/rhel/rhel8/edge.go
+++ b/pkg/distro/rhel/rhel8/edge.go
@@ -31,7 +31,7 @@ func mkEdgeCommitImgType(rd *rhel.Distribution) *rhel.ImageType {
 		EnabledServices: edgeServices(rd),
 		DracutConf:      []*osbuild.DracutConfStageOptions{osbuild.FIPSDracutConfStageOptions},
 	}
-	it.RPMOSTree = true
+	it.DistroConfig.RpmOstree = true
 
 	return it
 }
@@ -58,7 +58,7 @@ func mkEdgeOCIImgType(rd *rhel.Distribution) *rhel.ImageType {
 		EnabledServices: edgeServices(rd),
 		DracutConf:      []*osbuild.DracutConfStageOptions{osbuild.FIPSDracutConfStageOptions},
 	}
-	it.RPMOSTree = true
+	it.DistroConfig.RpmOstree = true
 
 	return it
 }
@@ -77,7 +77,7 @@ func mkEdgeRawImgType() *rhel.ImageType {
 
 	it.NameAliases = []string{"rhel-edge-raw-image"}
 	it.Compression = "xz"
-	it.KernelOptions = []string{"modprobe.blacklist=vc4"}
+	it.DistroConfig.KernelOptions = []string{"modprobe.blacklist=vc4"}
 	it.DefaultImageConfig = &distro.ImageConfig{
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",
@@ -86,8 +86,8 @@ func mkEdgeRawImgType() *rhel.ImageType {
 		LockRootUser: common.ToPtr(true),
 	}
 	it.DefaultSize = 10 * datasizes.GibiByte
-	it.RPMOSTree = true
-	it.Bootable = true
+	it.DistroConfig.RpmOstree = true
+	it.DistroConfig.Bootable = true
 	it.BasePartitionTables = edgeBasePartitionTables
 	it.UnsupportedPartitioningModes = []disk.PartitioningMode{
 		disk.AutoLVMPartitioningMode,
@@ -122,8 +122,8 @@ func mkEdgeInstallerImgType(rd *rhel.Distribution) *rhel.ImageType {
 			"ifcfg",
 		},
 	}
-	it.RPMOSTree = true
-	it.BootISO = true
+	it.DistroConfig.RpmOstree = true
+	it.DistroConfig.BootISO = true
 	it.ISOLabelFn = distroISOLabelFunc
 
 	return it
@@ -144,7 +144,7 @@ func mkEdgeSimplifiedInstallerImgType(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.NameAliases = []string{"rhel-edge-simplified-installer"}
-	it.KernelOptions = []string{"modprobe.blacklist=vc4"}
+	it.DistroConfig.KernelOptions = []string{"modprobe.blacklist=vc4"}
 	it.DefaultImageConfig = &distro.ImageConfig{
 		EnabledServices: edgeServices(rd),
 		Keyboard: &osbuild.KeymapStageOptions{
@@ -160,9 +160,9 @@ func mkEdgeSimplifiedInstallerImgType(rd *rhel.Distribution) *rhel.ImageType {
 		},
 	}
 	it.DefaultSize = 10 * datasizes.GibiByte
-	it.RPMOSTree = true
-	it.Bootable = true
-	it.BootISO = true
+	it.DistroConfig.RpmOstree = true
+	it.DistroConfig.Bootable = true
+	it.DistroConfig.BootISO = true
 	it.ISOLabelFn = distroISOLabelFunc
 	it.BasePartitionTables = edgeBasePartitionTables
 	it.UnsupportedPartitioningModes = []disk.PartitioningMode{
@@ -194,8 +194,8 @@ func mkMinimalRawImgType() *rhel.ImageType {
 		// requires a kickstart file in the root directory.
 		Files: []*fsnode.File{initialSetupKickstart()},
 	}
-	it.KernelOptions = []string{"ro"}
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = []string{"ro"}
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 2 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 

--- a/pkg/distro/rhel/rhel8/gce.go
+++ b/pkg/distro/rhel/rhel8/gce.go
@@ -28,8 +28,8 @@ func mkGceImgType(rd distro.Distro) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = defaultGceByosImageConfig(rd)
-	it.KernelOptions = gceKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = gceKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 20 * datasizes.GibiByte
 	// TODO: the base partition table still contains the BIOS boot partition, but the image is UEFI-only
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -52,8 +52,8 @@ func mkGceRhuiImgType(rd distro.Distro) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = defaultGceRhuiImageConfig(rd)
-	it.KernelOptions = gceKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = gceKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 20 * datasizes.GibiByte
 	// TODO: the base partition table still contains the BIOS boot partition, but the image is UEFI-only
 	it.BasePartitionTables = defaultBasePartitionTables

--- a/pkg/distro/rhel/rhel8/options.go
+++ b/pkg/distro/rhel/rhel8/options.go
@@ -23,7 +23,7 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 	var warnings []string
 
 	// we do not support embedding containers on ostree-derived images, only on commits themselves
-	if len(bp.Containers) > 0 && t.RPMOSTree && (t.Name() != "edge-commit" && t.Name() != "edge-container") {
+	if len(bp.Containers) > 0 && t.DistroConfig.RpmOstree && (t.Name() != "edge-commit" && t.Name() != "edge-container") {
 		return warnings, fmt.Errorf("embedding containers is not supported for %s on %s", t.Name(), t.Arch().Distro().Name())
 	}
 
@@ -33,7 +33,7 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 		}
 	}
 
-	if t.BootISO && t.RPMOSTree {
+	if t.DistroConfig.BootISO && t.DistroConfig.RpmOstree {
 		// ostree-based ISOs require a URL from which to pull a payload commit
 		if options.OSTree == nil || options.OSTree.URL == "" {
 			return warnings, fmt.Errorf("boot ISO image type %q requires specifying a URL from which to retrieve the OSTree commit", t.Name())
@@ -98,7 +98,7 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 		}
 	}
 
-	if kernelOpts := customizations.GetKernel(); kernelOpts.Append != "" && t.RPMOSTree && t.Name() != "edge-raw-image" && t.Name() != "edge-simplified-installer" {
+	if kernelOpts := customizations.GetKernel(); kernelOpts.Append != "" && t.DistroConfig.RpmOstree && t.Name() != "edge-raw-image" && t.Name() != "edge-simplified-installer" {
 		return warnings, fmt.Errorf("kernel boot parameter customizations are not supported for ostree types")
 	}
 
@@ -127,7 +127,7 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 		}
 	}
 
-	if mountpoints != nil && t.RPMOSTree {
+	if mountpoints != nil && t.DistroConfig.RpmOstree {
 		return warnings, fmt.Errorf("custom mountpoints are not supported for ostree types")
 	}
 
@@ -150,7 +150,7 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 		if !oscap.IsProfileAllowed(osc.ProfileID, oscapProfileAllowList) {
 			return warnings, fmt.Errorf("OpenSCAP unsupported profile: %s", osc.ProfileID)
 		}
-		if t.RPMOSTree {
+		if t.DistroConfig.RpmOstree {
 			return warnings, fmt.Errorf("OpenSCAP customizations are not supported for ostree types")
 		}
 		if osc.ProfileID == "" {
@@ -170,7 +170,7 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 	dcp := policies.CustomDirectoriesPolicies
 	fcp := policies.CustomFilesPolicies
 
-	if t.RPMOSTree {
+	if t.DistroConfig.RpmOstree {
 		dcp = policies.OstreeCustomDirectoriesPolicies
 		fcp = policies.OstreeCustomFilesPolicies
 	}

--- a/pkg/distro/rhel/rhel8/qcow2.go
+++ b/pkg/distro/rhel/rhel8/qcow2.go
@@ -23,8 +23,8 @@ func mkQcow2ImgType(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = qcowImageConfig(rd)
-	it.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0", "crashkernel=auto"}
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0", "crashkernel=auto"}
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -46,8 +46,8 @@ func mkOCIImgType(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = qcowImageConfig(rd)
-	it.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0", "crashkernel=auto"}
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0", "crashkernel=auto"}
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -68,9 +68,9 @@ func mkOpenstackImgType() *rhel.ImageType {
 		[]string{"qcow2"},
 	)
 
-	it.KernelOptions = []string{"ro", "net.ifnames=0"}
+	it.DistroConfig.KernelOptions = []string{"ro", "net.ifnames=0"}
 	it.DefaultSize = 4 * datasizes.GibiByte
-	it.Bootable = true
+	it.DistroConfig.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it

--- a/pkg/distro/rhel/rhel8/vmdk.go
+++ b/pkg/distro/rhel/rhel8/vmdk.go
@@ -23,8 +23,8 @@ func mkVmdkImgType() *rhel.ImageType {
 		[]string{"vmdk"},
 	)
 
-	it.KernelOptions = vmdkKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = vmdkKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -45,8 +45,8 @@ func mkOvaImgType() *rhel.ImageType {
 		[]string{"archive"},
 	)
 
-	it.KernelOptions = vmdkKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = vmdkKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 

--- a/pkg/distro/rhel/rhel9/ami.go
+++ b/pkg/distro/rhel/rhel9/ami.go
@@ -161,8 +161,8 @@ func mkEc2ImgTypeX86_64() *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = amiKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = amiKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -184,8 +184,8 @@ func mkAMIImgTypeX86_64() *rhel.ImageType {
 		[]string{"image"},
 	)
 
-	it.KernelOptions = amiKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = amiKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -208,8 +208,8 @@ func mkEC2SapImgTypeX86_64(osVersion string) *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = []string{"console=ttyS0,115200n8", "console=tty0", "net.ifnames=0", "nvme_core.io_timeout=4294967295", "processor.max_cstate=1", "intel_idle.max_cstate=1"}
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = []string{"console=ttyS0,115200n8", "console=tty0", "net.ifnames=0", "nvme_core.io_timeout=4294967295", "processor.max_cstate=1", "intel_idle.max_cstate=1"}
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = sapImageConfig(osVersion).InheritFrom(defaultEc2ImageConfigX86_64())
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -232,8 +232,8 @@ func mkEc2HaImgTypeX86_64() *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = amiKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = amiKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -255,8 +255,8 @@ func mkAMIImgTypeAarch64() *rhel.ImageType {
 		[]string{"image"},
 	)
 
-	it.KernelOptions = []string{"console=ttyS0,115200n8", "console=tty0", "net.ifnames=0", "nvme_core.io_timeout=4294967295", "iommu.strict=0"}
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = []string{"console=ttyS0,115200n8", "console=tty0", "net.ifnames=0", "nvme_core.io_timeout=4294967295", "iommu.strict=0"}
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfig()
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -279,8 +279,8 @@ func mkEC2ImgTypeAarch64() *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = []string{"console=ttyS0,115200n8", "console=tty0", "net.ifnames=0", "nvme_core.io_timeout=4294967295", "iommu.strict=0"}
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = []string{"console=ttyS0,115200n8", "console=tty0", "net.ifnames=0", "nvme_core.io_timeout=4294967295", "iommu.strict=0"}
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfig()
 	it.BasePartitionTables = defaultBasePartitionTables

--- a/pkg/distro/rhel/rhel9/azure.go
+++ b/pkg/distro/rhel/rhel9/azure.go
@@ -25,8 +25,8 @@ func mkAzureImgType(rd *rhel.Distribution) *rhel.ImageType {
 		[]string{"vpc"},
 	)
 
-	it.KernelOptions = defaultAzureKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = defaultAzureKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultAzureImageConfig(rd)
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -50,8 +50,8 @@ func mkAzureInternalImgType(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = defaultAzureKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = defaultAzureKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultAzureImageConfig(rd)
 	it.BasePartitionTables = azureInternalBasePartitionTables
@@ -74,8 +74,8 @@ func mkAzureSapInternalImgType(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = defaultAzureKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = defaultAzureKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.DefaultImageConfig = sapAzureImageConfig(rd)
 	it.BasePartitionTables = azureInternalBasePartitionTables

--- a/pkg/distro/rhel/rhel9/bare_metal.go
+++ b/pkg/distro/rhel/rhel9/bare_metal.go
@@ -40,8 +40,8 @@ func mkImageInstallerImgType() *rhel.ImageType {
 		[]string{"bootiso"},
 	)
 
-	it.BootISO = true
-	it.Bootable = true
+	it.DistroConfig.BootISO = true
+	it.DistroConfig.Bootable = true
 	it.ISOLabelFn = distroISOLabelFunc
 
 	it.DefaultInstallerConfig = &distro.InstallerConfig{

--- a/pkg/distro/rhel/rhel9/edge.go
+++ b/pkg/distro/rhel/rhel9/edge.go
@@ -29,7 +29,7 @@ func mkEdgeCommitImgType(d *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.NameAliases = []string{"rhel-edge-commit"}
-	it.RPMOSTree = true
+	it.DistroConfig.RpmOstree = true
 
 	it.DefaultImageConfig = &distro.ImageConfig{
 		EnabledServices: edgeServices,
@@ -64,7 +64,7 @@ func mkEdgeOCIImgType(d *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.NameAliases = []string{"rhel-edge-container"}
-	it.RPMOSTree = true
+	it.DistroConfig.RpmOstree = true
 
 	it.DefaultImageConfig = &distro.ImageConfig{
 		EnabledServices: edgeServices,
@@ -107,14 +107,14 @@ func mkEdgeRawImgType(d *rhel.Distribution) *rhel.ImageType {
 		it.DefaultImageConfig.IgnitionPlatform = common.ToPtr("metal")
 	}
 
-	it.KernelOptions = []string{"modprobe.blacklist=vc4"}
+	it.DistroConfig.KernelOptions = []string{"modprobe.blacklist=vc4"}
 	if common.VersionGreaterThanOrEqual(d.OsVersion(), "9.2") || !d.IsRHEL() {
-		it.KernelOptions = append(it.KernelOptions, "rw", "coreos.no_persist_ip")
+		it.DistroConfig.KernelOptions = append(it.DistroConfig.KernelOptions, "rw", "coreos.no_persist_ip")
 	}
 
 	it.DefaultSize = 10 * datasizes.GibiByte
-	it.RPMOSTree = true
-	it.Bootable = true
+	it.DistroConfig.RpmOstree = true
+	it.DistroConfig.Bootable = true
 	it.BasePartitionTables = edgeBasePartitionTables
 	it.UnsupportedPartitioningModes = []disk.PartitioningMode{disk.RawPartitioningMode}
 
@@ -153,8 +153,8 @@ func mkEdgeInstallerImgType() *rhel.ImageType {
 			"ipmi_msghandler",
 		},
 	}
-	it.RPMOSTree = true
-	it.BootISO = true
+	it.DistroConfig.RpmOstree = true
+	it.DistroConfig.BootISO = true
 	it.ISOLabelFn = distroISOLabelFunc
 
 	return it
@@ -203,16 +203,16 @@ func mkEdgeSimplifiedInstallerImgType(d *rhel.Distribution) *rhel.ImageType {
 	}
 
 	it.DefaultSize = 10 * datasizes.GibiByte
-	it.RPMOSTree = true
-	it.BootISO = true
-	it.Bootable = true
+	it.DistroConfig.RpmOstree = true
+	it.DistroConfig.BootISO = true
+	it.DistroConfig.Bootable = true
 	it.ISOLabelFn = distroISOLabelFunc
 	it.BasePartitionTables = edgeBasePartitionTables
 	it.UnsupportedPartitioningModes = []disk.PartitioningMode{disk.RawPartitioningMode}
 
-	it.KernelOptions = []string{"modprobe.blacklist=vc4"}
+	it.DistroConfig.KernelOptions = []string{"modprobe.blacklist=vc4"}
 	if common.VersionGreaterThanOrEqual(d.OsVersion(), "9.2") || !d.IsRHEL() {
-		it.KernelOptions = append(it.KernelOptions, "rw", "coreos.no_persist_ip")
+		it.DistroConfig.KernelOptions = append(it.DistroConfig.KernelOptions, "rw", "coreos.no_persist_ip")
 	}
 
 	return it
@@ -242,14 +242,14 @@ func mkEdgeAMIImgType(d *rhel.Distribution) *rhel.ImageType {
 		it.DefaultImageConfig.IgnitionPlatform = common.ToPtr("metal")
 	}
 
-	it.KernelOptions = append(amiKernelOptions(), "modprobe.blacklist=vc4")
+	it.DistroConfig.KernelOptions = append(amiKernelOptions(), "modprobe.blacklist=vc4")
 	if common.VersionGreaterThanOrEqual(d.OsVersion(), "9.2") || !d.IsRHEL() {
-		it.KernelOptions = append(it.KernelOptions, "rw", "coreos.no_persist_ip")
+		it.DistroConfig.KernelOptions = append(it.DistroConfig.KernelOptions, "rw", "coreos.no_persist_ip")
 	}
 
 	it.DefaultSize = 10 * datasizes.GibiByte
-	it.RPMOSTree = true
-	it.Bootable = true
+	it.DistroConfig.RpmOstree = true
+	it.DistroConfig.Bootable = true
 	it.BasePartitionTables = edgeBasePartitionTables
 	it.UnsupportedPartitioningModes = []disk.PartitioningMode{disk.RawPartitioningMode}
 	it.Environment = &environment.EC2{}
@@ -281,14 +281,14 @@ func mkEdgeVsphereImgType(d *rhel.Distribution) *rhel.ImageType {
 		it.DefaultImageConfig.IgnitionPlatform = common.ToPtr("metal")
 	}
 
-	it.KernelOptions = []string{"modprobe.blacklist=vc4"}
+	it.DistroConfig.KernelOptions = []string{"modprobe.blacklist=vc4"}
 	if common.VersionGreaterThanOrEqual(d.OsVersion(), "9.2") || !d.IsRHEL() {
-		it.KernelOptions = append(it.KernelOptions, "rw", "coreos.no_persist_ip")
+		it.DistroConfig.KernelOptions = append(it.DistroConfig.KernelOptions, "rw", "coreos.no_persist_ip")
 	}
 
 	it.DefaultSize = 10 * datasizes.GibiByte
-	it.RPMOSTree = true
-	it.Bootable = true
+	it.DistroConfig.RpmOstree = true
+	it.DistroConfig.Bootable = true
 	it.BasePartitionTables = edgeBasePartitionTables
 	it.UnsupportedPartitioningModes = []disk.PartitioningMode{disk.RawPartitioningMode}
 
@@ -317,9 +317,9 @@ func mkMinimalrawImgType() *rhel.ImageType {
 		// requires a kickstart file in the root directory.
 		Files: []*fsnode.File{initialSetupKickstart()},
 	}
-	it.KernelOptions = []string{"ro"}
+	it.DistroConfig.KernelOptions = []string{"ro"}
 	it.DefaultSize = 2 * datasizes.GibiByte
-	it.Bootable = true
+	it.DistroConfig.Bootable = true
 	it.BasePartitionTables = minimalrawPartitionTables
 
 	return it

--- a/pkg/distro/rhel/rhel9/gce.go
+++ b/pkg/distro/rhel/rhel9/gce.go
@@ -30,9 +30,9 @@ func mkGCEImageType() *rhel.ImageType {
 	// The configuration for non-RHUI images does not touch the RHSM configuration at all.
 	// https://issues.redhat.com/browse/COMPOSER-2157
 	it.DefaultImageConfig = baseGCEImageConfig()
-	it.KernelOptions = gceKernelOptions()
+	it.DistroConfig.KernelOptions = gceKernelOptions()
 	it.DefaultSize = 20 * datasizes.GibiByte
-	it.Bootable = true
+	it.DistroConfig.Bootable = true
 	// TODO: the base partition table still contains the BIOS boot partition, but the image is UEFI-only
 	it.BasePartitionTables = defaultBasePartitionTables
 

--- a/pkg/distro/rhel/rhel9/options.go
+++ b/pkg/distro/rhel/rhel9/options.go
@@ -24,7 +24,7 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 	var warnings []string
 
 	// we do not support embedding containers on ostree-derived images, only on commits themselves
-	if len(bp.Containers) > 0 && t.RPMOSTree && (t.Name() != "edge-commit" && t.Name() != "edge-container") {
+	if len(bp.Containers) > 0 && t.DistroConfig.RpmOstree && (t.Name() != "edge-commit" && t.Name() != "edge-container") {
 		return warnings, fmt.Errorf("embedding containers is not supported for %s on %s", t.Name(), t.Arch().Distro().Name())
 	}
 
@@ -34,7 +34,7 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 		}
 	}
 
-	if t.BootISO && t.RPMOSTree {
+	if t.DistroConfig.BootISO && t.DistroConfig.RpmOstree {
 		// ostree-based ISOs require a URL from which to pull a payload commit
 		if options.OSTree == nil || options.OSTree.URL == "" {
 			return warnings, fmt.Errorf("boot ISO image type %q requires specifying a URL from which to retrieve the OSTree commit", t.Name())
@@ -110,7 +110,7 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 		}
 	}
 
-	if kernelOpts := customizations.GetKernel(); kernelOpts.Append != "" && t.RPMOSTree && t.Name() != "edge-raw-image" && t.Name() != "edge-simplified-installer" {
+	if kernelOpts := customizations.GetKernel(); kernelOpts.Append != "" && t.DistroConfig.RpmOstree && t.Name() != "edge-raw-image" && t.Name() != "edge-simplified-installer" {
 		return warnings, fmt.Errorf("kernel boot parameter customizations are not supported for ostree types")
 	}
 
@@ -123,9 +123,9 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 	if err != nil {
 		return nil, err
 	}
-	if (mountpoints != nil || partitioning != nil) && t.RPMOSTree && (t.Name() == "edge-container" || t.Name() == "edge-commit") {
+	if (mountpoints != nil || partitioning != nil) && t.DistroConfig.RpmOstree && (t.Name() == "edge-container" || t.Name() == "edge-commit") {
 		return warnings, fmt.Errorf("custom mountpoints and partitioning are not supported for ostree types")
-	} else if (mountpoints != nil || partitioning != nil) && t.RPMOSTree && !(t.Name() == "edge-container" || t.Name() == "edge-commit") {
+	} else if (mountpoints != nil || partitioning != nil) && t.DistroConfig.RpmOstree && !(t.Name() == "edge-container" || t.Name() == "edge-commit") {
 		//customization allowed for edge-raw-image,edge-ami,edge-vsphere,edge-simplified-installer
 		err := blueprint.CheckMountpointsPolicy(mountpoints, policies.OstreeMountpointPolicies)
 		if err != nil {
@@ -156,7 +156,7 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 		if !oscap.IsProfileAllowed(osc.ProfileID, oscapProfileAllowList) {
 			return warnings, fmt.Errorf("OpenSCAP unsupported profile: %s", osc.ProfileID)
 		}
-		if t.RPMOSTree {
+		if t.DistroConfig.RpmOstree {
 			return warnings, fmt.Errorf("OpenSCAP customizations are not supported for ostree types")
 		}
 		if osc.ProfileID == "" {
@@ -176,7 +176,7 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 	dcp := policies.CustomDirectoriesPolicies
 	fcp := policies.CustomFilesPolicies
 
-	if t.RPMOSTree {
+	if t.DistroConfig.RpmOstree {
 		dcp = policies.OstreeCustomDirectoriesPolicies
 		fcp = policies.OstreeCustomFilesPolicies
 	}

--- a/pkg/distro/rhel/rhel9/qcow2.go
+++ b/pkg/distro/rhel/rhel9/qcow2.go
@@ -23,9 +23,9 @@ func mkQcow2ImgType(d *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = qcowImageConfig(d)
-	it.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0"}
+	it.DistroConfig.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0"}
 	it.DefaultSize = 10 * datasizes.GibiByte
-	it.Bootable = true
+	it.DistroConfig.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -46,9 +46,9 @@ func mkOCIImgType(d *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = qcowImageConfig(d)
-	it.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0"}
+	it.DistroConfig.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0"}
 	it.DefaultSize = 10 * datasizes.GibiByte
-	it.Bootable = true
+	it.DistroConfig.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -71,9 +71,9 @@ func mkOpenstackImgType() *rhel.ImageType {
 	it.DefaultImageConfig = &distro.ImageConfig{
 		Locale: common.ToPtr("en_US.UTF-8"),
 	}
-	it.KernelOptions = []string{"ro", "net.ifnames=0"}
+	it.DistroConfig.KernelOptions = []string{"ro", "net.ifnames=0"}
 	it.DefaultSize = 4 * datasizes.GibiByte
-	it.Bootable = true
+	it.DistroConfig.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it

--- a/pkg/distro/rhel/rhel9/vmdk.go
+++ b/pkg/distro/rhel/rhel9/vmdk.go
@@ -28,8 +28,8 @@ func mkVMDKImgType() *rhel.ImageType {
 	it.DefaultImageConfig = &distro.ImageConfig{
 		Locale: common.ToPtr("en_US.UTF-8"),
 	}
-	it.KernelOptions = vmdkKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = vmdkKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 
@@ -53,8 +53,8 @@ func mkOVAImgType() *rhel.ImageType {
 	it.DefaultImageConfig = &distro.ImageConfig{
 		Locale: common.ToPtr("en_US.UTF-8"),
 	}
-	it.KernelOptions = vmdkKernelOptions()
-	it.Bootable = true
+	it.DistroConfig.KernelOptions = vmdkKernelOptions()
+	it.DistroConfig.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
 

--- a/pkg/image/disk.go
+++ b/pkg/image/disk.go
@@ -66,7 +66,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.OSNick = img.OSNick
 
 	if img.InstallWeakDeps != nil {
-		osPipeline.InstallWeakDeps = *img.InstallWeakDeps
+		osPipeline.OSCustomizations.InstallWeakDeps = *img.InstallWeakDeps
 	}
 
 	rawImagePipeline := manifest.NewRawImage(buildPipeline, osPipeline)

--- a/pkg/image/ostree_archive.go
+++ b/pkg/image/ostree_archive.go
@@ -62,7 +62,7 @@ func (img *OSTreeArchive) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.Workload = img.Workload
 	osPipeline.OSTreeParent = img.OSTreeParent
 	osPipeline.OSTreeRef = img.OSTreeRef
-	osPipeline.InstallWeakDeps = img.InstallWeakDeps
+	osPipeline.OSCustomizations.InstallWeakDeps = img.InstallWeakDeps
 
 	ostreeCommitPipeline := manifest.NewOSTreeCommit(buildPipeline, osPipeline, img.OSTreeRef)
 	ostreeCommitPipeline.OSVersion = img.OSVersion

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -168,8 +168,10 @@ type OSCustomizations struct {
 // corresponds to the root filesystem once an instance of the image is running.
 type OS struct {
 	Base
-	// Customizations to apply to the base OS
-	OSCustomizations
+
+	// OSCustomizations to apply to the base OS
+	OSCustomizations OSCustomizations
+
 	// Environment the system will run in
 	Environment environment.Environment
 	// Workload to install on top of the base system
@@ -232,37 +234,37 @@ func (p *OS) getPackageSetChain(Distro) []rpmmd.PackageSet {
 		partitionTablePackages = p.PartitionTable.GetBuildPackages()
 	}
 
-	if p.KernelName != "" {
+	if p.OSCustomizations.KernelName != "" {
 		// kernel is considered part of the platform package set
-		platformPackages = append(platformPackages, p.KernelName)
+		platformPackages = append(platformPackages, p.OSCustomizations.KernelName)
 	}
 
 	customizationPackages := make([]string, 0)
-	if len(p.NTPServers) > 0 {
+	if len(p.OSCustomizations.NTPServers) > 0 {
 		customizationPackages = append(customizationPackages, "chrony")
 	}
 
-	if p.SElinux != "" {
-		customizationPackages = append(customizationPackages, fmt.Sprintf("selinux-policy-%s", p.SElinux))
+	if p.OSCustomizations.SElinux != "" {
+		customizationPackages = append(customizationPackages, fmt.Sprintf("selinux-policy-%s", p.OSCustomizations.SElinux))
 	}
 
-	if p.OpenSCAPRemediationConfig != nil {
+	if p.OSCustomizations.OpenSCAPRemediationConfig != nil {
 		customizationPackages = append(customizationPackages, "openscap-scanner", "scap-security-guide", "xz")
 	}
 
 	// Make sure the right packages are included for subscriptions
 	// rhc always uses insights, and depends on subscription-manager
 	// non-rhc uses subscription-manager and optionally includes Insights
-	if p.Subscription != nil {
+	if p.OSCustomizations.Subscription != nil {
 		customizationPackages = append(customizationPackages, "subscription-manager")
-		if p.Subscription.Rhc {
+		if p.OSCustomizations.Subscription.Rhc {
 			customizationPackages = append(customizationPackages, "rhc", "insights-client", "rhc-worker-playbook")
-		} else if p.Subscription.Insights {
+		} else if p.OSCustomizations.Subscription.Insights {
 			customizationPackages = append(customizationPackages, "insights-client")
 		}
 	}
 
-	if len(p.Users) > 0 {
+	if len(p.OSCustomizations.Users) > 0 {
 		// org.osbuild.users runs useradd, usermod, passwd, and
 		// mkhomedir_helper in the os tree using chroot. Most image types
 		// should already have the required packages, but some minimal image
@@ -272,28 +274,28 @@ func (p *OS) getPackageSetChain(Distro) []rpmmd.PackageSet {
 
 	}
 
-	if p.Firewall != nil {
+	if p.OSCustomizations.Firewall != nil {
 		// Make sure firewalld is available in the image.
 		// org.osbuild.firewall runs 'firewall-offline-cmd' in the os tree
 		// using chroot, so we don't need a build package for this.
 		customizationPackages = append(customizationPackages, "firewalld")
 	}
 
-	osRepos := append(p.repos, p.ExtraBaseRepos...)
+	osRepos := append(p.repos, p.OSCustomizations.ExtraBaseRepos...)
 
 	// merge all package lists for the pipeline
 	baseOSPackages := make([]string, 0)
 	baseOSPackages = append(baseOSPackages, platformPackages...)
 	baseOSPackages = append(baseOSPackages, environmentPackages...)
 	baseOSPackages = append(baseOSPackages, partitionTablePackages...)
-	baseOSPackages = append(baseOSPackages, p.BasePackages...)
+	baseOSPackages = append(baseOSPackages, p.OSCustomizations.BasePackages...)
 
 	chain := []rpmmd.PackageSet{
 		{
 			Include:         baseOSPackages,
-			Exclude:         p.ExcludeBasePackages,
+			Exclude:         p.OSCustomizations.ExcludeBasePackages,
 			Repositories:    osRepos,
-			InstallWeakDeps: p.InstallWeakDeps,
+			InstallWeakDeps: p.OSCustomizations.InstallWeakDeps,
 		},
 		{
 			// Depsolve customization packages separately to avoid conflicts with base
@@ -361,10 +363,10 @@ func (p *OS) getBuildPackages(distro Distro) []string {
 	if p.OSTreeRef != "" {
 		packages = append(packages, "rpm-ostree")
 	}
-	if p.SElinux != "" {
-		packages = append(packages, "policycoreutils", fmt.Sprintf("selinux-policy-%s", p.SElinux))
+	if p.OSCustomizations.SElinux != "" {
+		packages = append(packages, "policycoreutils", fmt.Sprintf("selinux-policy-%s", p.OSCustomizations.SElinux))
 	}
-	if len(p.CloudInit) > 0 {
+	if len(p.OSCustomizations.CloudInit) > 0 {
 		switch distro {
 		case DISTRO_EL7:
 			packages = append(packages, "python3-PyYAML")
@@ -372,7 +374,7 @@ func (p *OS) getBuildPackages(distro Distro) []string {
 			packages = append(packages, "python3-pyyaml")
 		}
 	}
-	if len(p.DNFConfig) > 0 || p.RHSMConfig != nil || p.WSLConfig != nil {
+	if len(p.OSCustomizations.DNFConfig) > 0 || p.OSCustomizations.RHSMConfig != nil || p.OSCustomizations.WSLConfig != nil {
 		packages = append(packages, "python3-iniparse")
 	}
 
@@ -383,7 +385,7 @@ func (p *OS) getBuildPackages(distro Distro) []string {
 		packages = append(packages, "skopeo")
 	}
 
-	if p.OpenSCAPRemediationConfig != nil && p.OpenSCAPRemediationConfig.TailoringConfig != nil {
+	if p.OSCustomizations.OpenSCAPRemediationConfig != nil && p.OSCustomizations.OpenSCAPRemediationConfig.TailoringConfig != nil {
 		packages = append(packages, "openscap-utils")
 	}
 
@@ -434,8 +436,8 @@ func (p *OS) serializeStart(inputs Inputs) {
 		p.ostreeParentSpec = &inputs.Commits[0]
 	}
 
-	if p.KernelName != "" {
-		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.KernelName)
+	if p.OSCustomizations.KernelName != "" {
+		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.OSCustomizations.KernelName)
 	}
 
 	p.repos = append(p.repos, inputs.Depsolved.Repos...)
@@ -463,18 +465,18 @@ func (p *OS) serialize() osbuild.Pipeline {
 	}
 
 	// collect all repos for this pipeline to create the repository options
-	allRepos := append(p.repos, p.ExtraBaseRepos...)
+	allRepos := append(p.repos, p.OSCustomizations.ExtraBaseRepos...)
 	if p.Workload != nil {
 		allRepos = append(allRepos, p.Workload.GetRepos()...)
 	}
 	rpmOptions := osbuild.NewRPMStageOptions(allRepos)
-	if p.ExcludeDocs {
+	if p.OSCustomizations.ExcludeDocs {
 		if rpmOptions.Exclude == nil {
 			rpmOptions.Exclude = &osbuild.Exclude{}
 		}
 		rpmOptions.Exclude.Docs = true
 	}
-	rpmOptions.GPGKeysFromTree = p.GPGKeyFiles
+	rpmOptions.GPGKeysFromTree = p.OSCustomizations.GPGKeyFiles
 	if p.OSTreeRef != "" {
 		rpmOptions.OSTreeBooted = common.ToPtr(true)
 		rpmOptions.DBPath = "/usr/share/rpm"
@@ -488,7 +490,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 	}
 	pipeline.AddStage(osbuild.NewRPMStage(rpmOptions, osbuild.NewRpmStageSourceFilesInputs(p.packageSpecs)))
 
-	if !p.NoBLS {
+	if !p.OSCustomizations.NoBLS {
 		// If the /boot is on a separate partition, the prefix for the BLS stage must be ""
 		if p.PartitionTable == nil || p.PartitionTable.FindMountable("/boot") == nil {
 			pipeline.AddStage(osbuild.NewFixBLSStage(&osbuild.FixBLSStageOptions{}))
@@ -508,52 +510,52 @@ func (p *OS) serialize() osbuild.Pipeline {
 		}
 	}
 
-	if p.Language != "" {
-		pipeline.AddStage(osbuild.NewLocaleStage(&osbuild.LocaleStageOptions{Language: p.Language}))
+	if p.OSCustomizations.Language != "" {
+		pipeline.AddStage(osbuild.NewLocaleStage(&osbuild.LocaleStageOptions{Language: p.OSCustomizations.Language}))
 	}
 
-	if p.Keyboard != nil {
-		keymapOptions := &osbuild.KeymapStageOptions{Keymap: *p.Keyboard}
-		if len(p.X11KeymapLayouts) > 0 {
-			keymapOptions.X11Keymap = &osbuild.X11KeymapOptions{Layouts: p.X11KeymapLayouts}
+	if p.OSCustomizations.Keyboard != nil {
+		keymapOptions := &osbuild.KeymapStageOptions{Keymap: *p.OSCustomizations.Keyboard}
+		if len(p.OSCustomizations.X11KeymapLayouts) > 0 {
+			keymapOptions.X11Keymap = &osbuild.X11KeymapOptions{Layouts: p.OSCustomizations.X11KeymapLayouts}
 		}
 		pipeline.AddStage(osbuild.NewKeymapStage(keymapOptions))
 	}
 
-	if p.Hostname != "" {
-		pipeline.AddStage(osbuild.NewHostnameStage(&osbuild.HostnameStageOptions{Hostname: p.Hostname}))
+	if p.OSCustomizations.Hostname != "" {
+		pipeline.AddStage(osbuild.NewHostnameStage(&osbuild.HostnameStageOptions{Hostname: p.OSCustomizations.Hostname}))
 	}
 
-	if p.Timezone != "" {
-		pipeline.AddStage(osbuild.NewTimezoneStage(&osbuild.TimezoneStageOptions{Zone: p.Timezone}))
+	if p.OSCustomizations.Timezone != "" {
+		pipeline.AddStage(osbuild.NewTimezoneStage(&osbuild.TimezoneStageOptions{Zone: p.OSCustomizations.Timezone}))
 	}
 
-	if len(p.NTPServers) > 0 {
-		chronyOptions := &osbuild.ChronyStageOptions{Servers: p.NTPServers}
-		if p.LeapSecTZ != nil {
-			chronyOptions.LeapsecTz = p.LeapSecTZ
+	if len(p.OSCustomizations.NTPServers) > 0 {
+		chronyOptions := &osbuild.ChronyStageOptions{Servers: p.OSCustomizations.NTPServers}
+		if p.OSCustomizations.LeapSecTZ != nil {
+			chronyOptions.LeapsecTz = p.OSCustomizations.LeapSecTZ
 		}
 		pipeline.AddStage(osbuild.NewChronyStage(chronyOptions))
 	}
 
-	if len(p.Groups) > 0 {
-		pipeline.AddStage(osbuild.GenGroupsStage(p.Groups))
+	if len(p.OSCustomizations.Groups) > 0 {
+		pipeline.AddStage(osbuild.GenGroupsStage(p.OSCustomizations.Groups))
 	}
 
-	if len(p.Users) > 0 {
+	if len(p.OSCustomizations.Users) > 0 {
 		if p.OSTreeRef != "" {
 			// for ostree, writing the key during user creation is
 			// redundant and can cause issues so create users without keys
 			// and write them on first boot
-			usersStageSansKeys, err := osbuild.GenUsersStage(p.Users, true)
+			usersStageSansKeys, err := osbuild.GenUsersStage(p.OSCustomizations.Users, true)
 			if err != nil {
 				// TODO: move encryption into weldr
 				panic("password encryption failed")
 			}
 			pipeline.AddStage(usersStageSansKeys)
-			pipeline.AddStage(osbuild.NewFirstBootStage(usersFirstBootOptions(p.Users)))
+			pipeline.AddStage(osbuild.NewFirstBootStage(usersFirstBootOptions(p.OSCustomizations.Users)))
 		} else {
-			usersStage, err := osbuild.GenUsersStage(p.Users, false)
+			usersStage, err := osbuild.GenUsersStage(p.OSCustomizations.Users, false)
 			if err != nil {
 				// TODO: move encryption into weldr
 				panic("password encryption failed")
@@ -562,125 +564,125 @@ func (p *OS) serialize() osbuild.Pipeline {
 		}
 	}
 
-	if p.Firewall != nil {
-		pipeline.AddStage(osbuild.NewFirewallStage(p.Firewall))
+	if p.OSCustomizations.Firewall != nil {
+		pipeline.AddStage(osbuild.NewFirewallStage(p.OSCustomizations.Firewall))
 	}
 
-	for _, sysconfigConfig := range p.Sysconfig {
+	for _, sysconfigConfig := range p.OSCustomizations.Sysconfig {
 		pipeline.AddStage(osbuild.NewSysconfigStage(sysconfigConfig))
 	}
 
-	for _, systemdLogindConfig := range p.SystemdLogind {
+	for _, systemdLogindConfig := range p.OSCustomizations.SystemdLogind {
 		pipeline.AddStage(osbuild.NewSystemdLogindStage(systemdLogindConfig))
 	}
 
-	for _, cloudInitConfig := range p.CloudInit {
+	for _, cloudInitConfig := range p.OSCustomizations.CloudInit {
 		pipeline.AddStage(osbuild.NewCloudInitStage(cloudInitConfig))
 	}
 
-	for _, modprobeConfig := range p.Modprobe {
+	for _, modprobeConfig := range p.OSCustomizations.Modprobe {
 		pipeline.AddStage(osbuild.NewModprobeStage(modprobeConfig))
 	}
 
-	for _, dracutConfConfig := range p.DracutConf {
+	for _, dracutConfConfig := range p.OSCustomizations.DracutConf {
 		pipeline.AddStage(osbuild.NewDracutConfStage(dracutConfConfig))
 	}
 
-	for _, systemdUnitConfig := range p.SystemdUnit {
+	for _, systemdUnitConfig := range p.OSCustomizations.SystemdUnit {
 		pipeline.AddStage(osbuild.NewSystemdUnitStage(systemdUnitConfig))
 	}
 
-	if p.Authselect != nil {
-		pipeline.AddStage(osbuild.NewAuthselectStage(p.Authselect))
+	if p.OSCustomizations.Authselect != nil {
+		pipeline.AddStage(osbuild.NewAuthselectStage(p.OSCustomizations.Authselect))
 	}
 
-	if p.SELinuxConfig != nil {
-		pipeline.AddStage(osbuild.NewSELinuxConfigStage(p.SELinuxConfig))
+	if p.OSCustomizations.SELinuxConfig != nil {
+		pipeline.AddStage(osbuild.NewSELinuxConfigStage(p.OSCustomizations.SELinuxConfig))
 	}
 
-	if p.Tuned != nil {
-		pipeline.AddStage(osbuild.NewTunedStage(p.Tuned))
+	if p.OSCustomizations.Tuned != nil {
+		pipeline.AddStage(osbuild.NewTunedStage(p.OSCustomizations.Tuned))
 	}
 
-	for _, tmpfilesdConfig := range p.Tmpfilesd {
+	for _, tmpfilesdConfig := range p.OSCustomizations.Tmpfilesd {
 		pipeline.AddStage(osbuild.NewTmpfilesdStage(tmpfilesdConfig))
 	}
 
-	for _, pamLimitsConfConfig := range p.PamLimitsConf {
+	for _, pamLimitsConfConfig := range p.OSCustomizations.PamLimitsConf {
 		pipeline.AddStage(osbuild.NewPamLimitsConfStage(pamLimitsConfConfig))
 	}
 
-	for _, sysctldConfig := range p.Sysctld {
+	for _, sysctldConfig := range p.OSCustomizations.Sysctld {
 		pipeline.AddStage(osbuild.NewSysctldStage(sysctldConfig))
 	}
 
-	for _, dnfConfig := range p.DNFConfig {
+	for _, dnfConfig := range p.OSCustomizations.DNFConfig {
 		pipeline.AddStage(osbuild.NewDNFConfigStage(dnfConfig))
 	}
 
-	if p.DNFAutomaticConfig != nil {
-		pipeline.AddStage(osbuild.NewDNFAutomaticConfigStage(p.DNFAutomaticConfig))
+	if p.OSCustomizations.DNFAutomaticConfig != nil {
+		pipeline.AddStage(osbuild.NewDNFAutomaticConfigStage(p.OSCustomizations.DNFAutomaticConfig))
 	}
 
-	for _, yumRepo := range p.YUMRepos {
+	for _, yumRepo := range p.OSCustomizations.YUMRepos {
 		pipeline.AddStage(osbuild.NewYumReposStage(yumRepo))
 	}
 
-	if p.YUMConfig != nil {
-		pipeline.AddStage(osbuild.NewYumConfigStage(p.YUMConfig))
+	if p.OSCustomizations.YUMConfig != nil {
+		pipeline.AddStage(osbuild.NewYumConfigStage(p.OSCustomizations.YUMConfig))
 	}
 
-	if p.GCPGuestAgentConfig != nil {
-		pipeline.AddStage(osbuild.NewGcpGuestAgentConfigStage(p.GCPGuestAgentConfig))
+	if p.OSCustomizations.GCPGuestAgentConfig != nil {
+		pipeline.AddStage(osbuild.NewGcpGuestAgentConfigStage(p.OSCustomizations.GCPGuestAgentConfig))
 	}
 
-	if p.SshdConfig != nil {
-		pipeline.AddStage(osbuild.NewSshdConfigStage(p.SshdConfig))
+	if p.OSCustomizations.SshdConfig != nil {
+		pipeline.AddStage(osbuild.NewSshdConfigStage(p.OSCustomizations.SshdConfig))
 	}
 
-	if p.InsightsClientConfig != nil {
-		pipeline.AddStage(osbuild.NewInsightsClientConfigStage(p.InsightsClientConfig))
+	if p.OSCustomizations.InsightsClientConfig != nil {
+		pipeline.AddStage(osbuild.NewInsightsClientConfigStage(p.OSCustomizations.InsightsClientConfig))
 	}
 
-	if p.AuthConfig != nil {
-		pipeline.AddStage(osbuild.NewAuthconfigStage(p.AuthConfig))
+	if p.OSCustomizations.AuthConfig != nil {
+		pipeline.AddStage(osbuild.NewAuthconfigStage(p.OSCustomizations.AuthConfig))
 	}
 
-	if p.PwQuality != nil {
-		pipeline.AddStage(osbuild.NewPwqualityConfStage(p.PwQuality))
+	if p.OSCustomizations.PwQuality != nil {
+		pipeline.AddStage(osbuild.NewPwqualityConfStage(p.OSCustomizations.PwQuality))
 	}
 
-	if p.Subscription != nil {
-		subStage, subDirs, subFiles, subServices, err := subscriptionService(*p.Subscription, &subscriptionServiceOptions{InsightsOnBoot: p.OSTreeRef != ""})
+	if p.OSCustomizations.Subscription != nil {
+		subStage, subDirs, subFiles, subServices, err := subscriptionService(*p.OSCustomizations.Subscription, &subscriptionServiceOptions{InsightsOnBoot: p.OSTreeRef != ""})
 		if err != nil {
 			panic(err)
 		}
 		pipeline.AddStage(subStage)
-		p.Directories = append(p.Directories, subDirs...)
-		p.Files = append(p.Files, subFiles...)
-		p.EnabledServices = append(p.EnabledServices, subServices...)
+		p.OSCustomizations.Directories = append(p.OSCustomizations.Directories, subDirs...)
+		p.OSCustomizations.Files = append(p.OSCustomizations.Files, subFiles...)
+		p.OSCustomizations.EnabledServices = append(p.OSCustomizations.EnabledServices, subServices...)
 	}
 
-	if p.RHSMConfig != nil {
-		pipeline.AddStage(osbuild.NewRHSMStage(osbuild.NewRHSMStageOptions(p.RHSMConfig)))
+	if p.OSCustomizations.RHSMConfig != nil {
+		pipeline.AddStage(osbuild.NewRHSMStage(osbuild.NewRHSMStageOptions(p.OSCustomizations.RHSMConfig)))
 	}
 
-	if p.WAAgentConfig != nil {
-		pipeline.AddStage(osbuild.NewWAAgentConfStage(p.WAAgentConfig))
+	if p.OSCustomizations.WAAgentConfig != nil {
+		pipeline.AddStage(osbuild.NewWAAgentConfStage(p.OSCustomizations.WAAgentConfig))
 	}
 
-	if p.UdevRules != nil {
-		pipeline.AddStage(osbuild.NewUdevRulesStage(p.UdevRules))
+	if p.OSCustomizations.UdevRules != nil {
+		pipeline.AddStage(osbuild.NewUdevRulesStage(p.OSCustomizations.UdevRules))
 	}
 
 	if pt := p.PartitionTable; pt != nil {
-		rootUUID, kernelOptions, err := osbuild.GenImageKernelOptions(p.PartitionTable, p.MountUnits)
+		rootUUID, kernelOptions, err := osbuild.GenImageKernelOptions(p.PartitionTable, p.OSCustomizations.MountUnits)
 		if err != nil {
 			panic(err)
 		}
-		kernelOptions = append(kernelOptions, p.KernelOptionsAppend...)
+		kernelOptions = append(kernelOptions, p.OSCustomizations.KernelOptionsAppend...)
 
-		if p.FIPS {
+		if p.OSCustomizations.FIPS {
 			kernelOptions = append(kernelOptions, osbuild.GenFIPSKernelOptions(p.PartitionTable)...)
 			pipeline.AddStage(osbuild.NewDracutStage(&osbuild.DracutStageOptions{
 				Kernel:     []string{p.kernelVer},
@@ -688,7 +690,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 			}))
 		}
 
-		fsCfgStages, err := filesystemConfigStages(pt, p.MountUnits)
+		fsCfgStages, err := filesystemConfigStages(pt, p.OSCustomizations.MountUnits)
 		if err != nil {
 			panic(err)
 		}
@@ -699,7 +701,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 		case arch.ARCH_S390X:
 			bootloader = osbuild.NewZiplStage(new(osbuild.ZiplStageOptions))
 		default:
-			if p.NoBLS {
+			if p.OSCustomizations.NoBLS {
 				// BLS entries not supported: use grub2.legacy
 				id := "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
 				product := osbuild.GRUB2Product{
@@ -712,7 +714,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 				hasRescue := err == nil
 				bootloader = osbuild.NewGrub2LegacyStage(
 					osbuild.NewGrub2LegacyStageOptions(
-						p.Grub2Config,
+						p.OSCustomizations.Grub2Config,
 						p.PartitionTable,
 						kernelOptions,
 						p.platform.GetBIOSPlatform(),
@@ -727,7 +729,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 					p.platform.GetUEFIVendor() != "",
 					p.platform.GetBIOSPlatform(),
 					p.platform.GetUEFIVendor(), false)
-				if cfg := p.Grub2Config; cfg != nil {
+				if cfg := p.OSCustomizations.Grub2Config; cfg != nil {
 					// TODO: don't store Grub2Config in OSPipeline, making the overrides unnecessary
 					// grub2.Config.Default is owned and set by `NewGrub2StageOptionsUnified`
 					// and thus we need to preserve it
@@ -737,7 +739,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 
 					options.Config = cfg
 				}
-				if p.KernelOptionsBootloader {
+				if p.OSCustomizations.KernelOptionsBootloader {
 					options.WriteCmdLine = nil
 					if options.UEFI != nil {
 						options.UEFI.Unified = false
@@ -749,22 +751,22 @@ func (p *OS) serialize() osbuild.Pipeline {
 
 		pipeline.AddStage(bootloader)
 
-		if !p.KernelOptionsBootloader || p.platform.GetArch() == arch.ARCH_S390X {
+		if !p.OSCustomizations.KernelOptionsBootloader || p.platform.GetArch() == arch.ARCH_S390X {
 			pipeline = prependKernelCmdlineStage(pipeline, rootUUID, kernelOptions)
 		}
 	}
 
-	if p.RHSMFacts != nil {
+	if p.OSCustomizations.RHSMFacts != nil {
 		rhsmFacts := osbuild.RHSMFacts{
-			ApiType: p.RHSMFacts.APIType.String(),
+			ApiType: p.OSCustomizations.RHSMFacts.APIType.String(),
 		}
 
-		if p.RHSMFacts.OpenSCAPProfileID != "" {
-			rhsmFacts.OpenSCAPProfileID = p.RHSMFacts.OpenSCAPProfileID
+		if p.OSCustomizations.RHSMFacts.OpenSCAPProfileID != "" {
+			rhsmFacts.OpenSCAPProfileID = p.OSCustomizations.RHSMFacts.OpenSCAPProfileID
 		}
 
-		if p.RHSMFacts.CompliancePolicyID != uuid.Nil {
-			rhsmFacts.CompliancePolicyID = p.RHSMFacts.CompliancePolicyID.String()
+		if p.OSCustomizations.RHSMFacts.CompliancePolicyID != uuid.Nil {
+			rhsmFacts.CompliancePolicyID = p.OSCustomizations.RHSMFacts.CompliancePolicyID.String()
 		}
 
 		pipeline.AddStage(osbuild.NewRHSMFactsStage(&osbuild.RHSMFactsStageOptions{
@@ -785,12 +787,12 @@ func (p *OS) serialize() osbuild.Pipeline {
 	}
 
 	// First create custom directories, because some of the custom files may depend on them
-	if len(p.Directories) > 0 {
-		pipeline.AddStages(osbuild.GenDirectoryNodesStages(p.Directories)...)
+	if len(p.OSCustomizations.Directories) > 0 {
+		pipeline.AddStages(osbuild.GenDirectoryNodesStages(p.OSCustomizations.Directories)...)
 	}
 
-	if len(p.Files) > 0 {
-		pipeline.AddStages(osbuild.GenFileNodesStages(p.Files)...)
+	if len(p.OSCustomizations.Files) > 0 {
+		pipeline.AddStages(osbuild.GenFileNodesStages(p.OSCustomizations.Files)...)
 	}
 
 	// write modularity related configuration files
@@ -820,15 +822,15 @@ func (p *OS) serialize() osbuild.Pipeline {
 		pipeline.AddStages(osbuild.GenDirectoryNodesStages([]*fsnode.Directory{failsafeDir})...)
 		pipeline.AddStages(osbuild.GenFileNodesStages(failsafeFiles)...)
 
-		p.Files = append(p.Files, failsafeFiles...)
+		p.OSCustomizations.Files = append(p.OSCustomizations.Files, failsafeFiles...)
 	}
 
 	enabledServices := []string{}
 	disabledServices := []string{}
 	maskedServices := []string{}
-	enabledServices = append(enabledServices, p.EnabledServices...)
-	disabledServices = append(disabledServices, p.DisabledServices...)
-	maskedServices = append(maskedServices, p.MaskedServices...)
+	enabledServices = append(enabledServices, p.OSCustomizations.EnabledServices...)
+	disabledServices = append(disabledServices, p.OSCustomizations.DisabledServices...)
+	maskedServices = append(maskedServices, p.OSCustomizations.MaskedServices...)
 	if p.Environment != nil {
 		enabledServices = append(enabledServices, p.Environment.GetServices()...)
 	}
@@ -838,24 +840,24 @@ func (p *OS) serialize() osbuild.Pipeline {
 	}
 	if len(enabledServices) != 0 ||
 		len(disabledServices) != 0 ||
-		len(maskedServices) != 0 || p.DefaultTarget != "" {
+		len(maskedServices) != 0 || p.OSCustomizations.DefaultTarget != "" {
 		pipeline.AddStage(osbuild.NewSystemdStage(&osbuild.SystemdStageOptions{
 			EnabledServices:  enabledServices,
 			DisabledServices: disabledServices,
 			MaskedServices:   maskedServices,
-			DefaultTarget:    p.DefaultTarget,
+			DefaultTarget:    p.OSCustomizations.DefaultTarget,
 		}))
 	}
-	if len(p.ShellInit) > 0 {
-		pipeline.AddStage(osbuild.GenShellInitStage(p.ShellInit))
+	if len(p.OSCustomizations.ShellInit) > 0 {
+		pipeline.AddStage(osbuild.GenShellInitStage(p.OSCustomizations.ShellInit))
 	}
 
-	if p.WSLConfig != nil {
-		pipeline.AddStage(osbuild.NewWSLConfStage(p.WSLConfig))
+	if p.OSCustomizations.WSLConfig != nil {
+		pipeline.AddStage(osbuild.NewWSLConfStage(p.OSCustomizations.WSLConfig))
 	}
 
-	if p.FIPS {
-		p.Files = append(p.Files, osbuild.GenFIPSFiles()...)
+	if p.OSCustomizations.FIPS {
+		p.OSCustomizations.Files = append(p.OSCustomizations.Files, osbuild.GenFIPSFiles()...)
 		for _, stage := range osbuild.GenFIPSStages() {
 			pipeline.AddStage(stage)
 		}
@@ -864,7 +866,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 	// NOTE: We need to run the OpenSCAP stages as the last stage before SELinux
 	// since the remediation may change file permissions and other aspects of the
 	// hardened image
-	if remediationConfig := p.OpenSCAPRemediationConfig; remediationConfig != nil {
+	if remediationConfig := p.OSCustomizations.OpenSCAPRemediationConfig; remediationConfig != nil {
 		if remediationConfig.TailoringConfig != nil {
 			tailoringStageOpts := osbuild.NewOscapAutotailorStageOptions(remediationConfig)
 			pipeline.AddStage(osbuild.NewOscapAutotailorStage(tailoringStageOpts))
@@ -873,37 +875,37 @@ func (p *OS) serialize() osbuild.Pipeline {
 		pipeline.AddStage(osbuild.NewOscapRemediationStage(remediationStageOpts))
 	}
 
-	if len(p.Presets) != 0 {
+	if len(p.OSCustomizations.Presets) != 0 {
 		pipeline.AddStage(osbuild.NewSystemdPresetStage(&osbuild.SystemdPresetStageOptions{
-			Presets: p.Presets,
+			Presets: p.OSCustomizations.Presets,
 		}))
 	}
 
-	if len(p.CACerts) > 0 {
-		for _, cc := range p.CACerts {
+	if len(p.OSCustomizations.CACerts) > 0 {
+		for _, cc := range p.OSCustomizations.CACerts {
 			files, err := osbuild.NewCAFileNodes(cc)
 			if err != nil {
 				panic(err.Error())
 			}
 
 			if len(files) > 0 {
-				p.Files = append(p.Files, files...)
+				p.OSCustomizations.Files = append(p.OSCustomizations.Files, files...)
 				pipeline.AddStages(osbuild.GenFileNodesStages(files)...)
 			}
 		}
 		pipeline.AddStage(osbuild.NewCAStageStage())
 	}
 
-	if p.MachineIdUninitialized {
+	if p.OSCustomizations.MachineIdUninitialized {
 		pipeline.AddStage(osbuild.NewMachineIdStage(&osbuild.MachineIdStageOptions{
 			FirstBoot: osbuild.MachineIdFirstBootYes,
 		}))
 	}
 
-	if p.SElinux != "" {
+	if p.OSCustomizations.SElinux != "" {
 		pipeline.AddStage(osbuild.NewSELinuxStage(&osbuild.SELinuxStageOptions{
-			FileContexts:     fmt.Sprintf("etc/selinux/%s/contexts/files/file_contexts", p.SElinux),
-			ForceAutorelabel: p.SELinuxForceRelabel,
+			FileContexts:     fmt.Sprintf("etc/selinux/%s/contexts/files/file_contexts", p.OSCustomizations.SElinux),
+			ForceAutorelabel: p.OSCustomizations.SELinuxForceRelabel,
 		}))
 	}
 
@@ -983,7 +985,7 @@ func (p *OS) getInline() []string {
 	inlineData := []string{}
 
 	// inline data for custom files
-	for _, file := range p.Files {
+	for _, file := range p.OSCustomizations.Files {
 		inlineData = append(inlineData, string(file.Data()))
 	}
 

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -73,7 +73,7 @@ func CheckPkgSetInclude(t *testing.T, pkgSetChain []rpmmd.PackageSet, pkgs []str
 
 func TestSubscriptionManagerCommands(t *testing.T) {
 	os := manifest.NewTestOS()
-	os.Subscription = &subscription.ImageOptions{
+	os.OSCustomizations.Subscription = &subscription.ImageOptions{
 		Organization:  "2040324",
 		ActivationKey: "my-secret-key",
 		ServerUrl:     "subscription.rhsm.redhat.com",
@@ -87,7 +87,7 @@ func TestSubscriptionManagerCommands(t *testing.T) {
 
 func TestSubscriptionManagerInsightsCommands(t *testing.T) {
 	os := manifest.NewTestOS()
-	os.Subscription = &subscription.ImageOptions{
+	os.OSCustomizations.Subscription = &subscription.ImageOptions{
 		Organization:  "2040324",
 		ActivationKey: "my-secret-key",
 		ServerUrl:     "subscription.rhsm.redhat.com",
@@ -104,7 +104,7 @@ func TestSubscriptionManagerInsightsCommands(t *testing.T) {
 
 func TestRhcInsightsCommands(t *testing.T) {
 	os := manifest.NewTestOS()
-	os.Subscription = &subscription.ImageOptions{
+	os.OSCustomizations.Subscription = &subscription.ImageOptions{
 		Organization:  "2040324",
 		ActivationKey: "my-secret-key",
 		ServerUrl:     "subscription.rhsm.redhat.com",
@@ -122,7 +122,7 @@ func TestRhcInsightsCommands(t *testing.T) {
 
 func TestSubscriptionManagerPackages(t *testing.T) {
 	os := manifest.NewTestOS()
-	os.Subscription = &subscription.ImageOptions{
+	os.OSCustomizations.Subscription = &subscription.ImageOptions{
 		Organization:  "2040324",
 		ActivationKey: "my-secret-key",
 		ServerUrl:     "subscription.rhsm.redhat.com",
@@ -134,7 +134,7 @@ func TestSubscriptionManagerPackages(t *testing.T) {
 
 func TestSubscriptionManagerInsightsPackages(t *testing.T) {
 	os := manifest.NewTestOS()
-	os.Subscription = &subscription.ImageOptions{
+	os.OSCustomizations.Subscription = &subscription.ImageOptions{
 		Organization:  "2040324",
 		ActivationKey: "my-secret-key",
 		ServerUrl:     "subscription.rhsm.redhat.com",
@@ -146,7 +146,7 @@ func TestSubscriptionManagerInsightsPackages(t *testing.T) {
 
 func TestRhcInsightsPackages(t *testing.T) {
 	os := manifest.NewTestOS()
-	os.Subscription = &subscription.ImageOptions{
+	os.OSCustomizations.Subscription = &subscription.ImageOptions{
 		Organization:  "2040324",
 		ActivationKey: "my-secret-key",
 		ServerUrl:     "subscription.rhsm.redhat.com",
@@ -220,7 +220,7 @@ func testTomlPkgsFor(t *testing.T, os *manifest.OS) {
 func TestMachineIdUninitializedIncludesMachineIdStage(t *testing.T) {
 	os := manifest.NewTestOS()
 
-	os.MachineIdUninitialized = true
+	os.OSCustomizations.MachineIdUninitialized = true
 
 	pipeline := os.Serialize()
 	st := manifest.FindStage("org.osbuild.machine-id", pipeline.Stages)
@@ -312,7 +312,7 @@ func TestOSPipelineFStabStage(t *testing.T) {
 	os := manifest.NewTestOS()
 
 	os.PartitionTable = testdisk.MakeFakePartitionTable("/") // PT specifics don't matter
-	os.MountUnits = false                                    // set it explicitly just to be sure
+	os.OSCustomizations.MountUnits = false                   // set it explicitly just to be sure
 
 	checkStagesForFSTab(t, os.Serialize().Stages)
 }
@@ -322,7 +322,7 @@ func TestOSPipelineMountUnitStages(t *testing.T) {
 
 	expectedUnits := []string{"-.mount", "home.mount"}
 	os.PartitionTable = testdisk.MakeFakePartitionTable("/", "/home")
-	os.MountUnits = true
+	os.OSCustomizations.MountUnits = true
 
 	checkStagesForMountUnits(t, os.Serialize().Stages, expectedUnits)
 }
@@ -330,7 +330,7 @@ func TestOSPipelineMountUnitStages(t *testing.T) {
 func TestLanguageIncludesLocaleStage(t *testing.T) {
 	os := manifest.NewTestOS()
 
-	os.Language = "en_US.UTF-8"
+	os.OSCustomizations.Language = "en_US.UTF-8"
 
 	pipeline := os.Serialize()
 	st := manifest.FindStage("org.osbuild.locale", pipeline.Stages)
@@ -348,7 +348,7 @@ func TestLanguageDoesNotIncludeLocaleStage(t *testing.T) {
 func TestTimezoneIncludesTimezoneStage(t *testing.T) {
 	os := manifest.NewTestOS()
 
-	os.Timezone = "Etc/UTC"
+	os.OSCustomizations.Timezone = "Etc/UTC"
 
 	pipeline := os.Serialize()
 	st := manifest.FindStage("org.osbuild.timezone", pipeline.Stages)
@@ -366,7 +366,7 @@ func TestTimezoneDoesNotIncludeTimezoneStage(t *testing.T) {
 func TestHostnameIncludesHostnameStage(t *testing.T) {
 	os := manifest.NewTestOS()
 
-	os.Hostname = "funky.name"
+	os.OSCustomizations.Hostname = "funky.name"
 
 	pipeline := os.Serialize()
 	st := manifest.FindStage("org.osbuild.hostname", pipeline.Stages)


### PR DESCRIPTION
[draft as it needs comment and is build on top of https://github.com/osbuild/images/pull/1386]

This is an RFC to tweak the way we do the manifest.OSCustomizations and as a first
step I would like to remove the duplicated generators we currently have. Note that this
step is quite mechanical too and tries to keep the delta as smal as possible to make
reviewing this easier. It may go too far (see the invidual commit descriptions) but I think
its a step in the right direction (if that looks reasonable the next step is to do the same
for `ostreeDeploymentCustomizations)

---

distro: unify OsCustomizations()

This commit removes the two (almost) identical copies of
`OsCustomizations()` in {fedora,rhel} in favor of a single
implementation that takes the new ImageTypeConfig in additon
to the existing parameters.

This (hopefully) goes into the direction that Achilleas suggested
where we have a new single SuperConfig that is produced via
a smart merge of `ImageConfig`, `ImageTypeConfig`, `DistroConfig`,
Blueprints etc. But in order to make progress on this journey
we need to remove some duplication first :)

Along the way a subtle difference in the hostname handling was
unified and RHEL now also understands about `MachineIdUninitialized`
(which was previously only available for fedora probably because
of drift).

There is a tradeoff here of course, its slightly^W ugly that now
distro.OsCustomizations needs to understand about the details
of *all* distros/imageTypes we support. We could explore extracing
a common helper and then let the distro deal with specialized stuff
like subscriptions. But moving into this (other) extreme seems
a slightly better trade-off than the current duplicated ~300 lines
that we need to keep drift-free.
[edit: also OSCustomizations already contains fields for RHEL specific 
stuff so probably fine in this context]

---

distro: introduce new shared `distro.ImageTypeConfig` and use

This commit is a first step to eliminate the duplicated
`osCustomizations()` methods in fedora/rhel by extracting a new
`distro.ImageTypeConfig` that contains the configuration parts
of the distro image type.
