### PR TITLE
dnfjson: provide details if subscription cannot be found

### DIFF
--- a/pkg/dnfjson/dnfjson.go
+++ b/pkg/dnfjson/dnfjson.go
@@ -102,8 +102,7 @@ func (bs *BaseSolver) NewWithConfig(modulePlatformID, releaseVer, arch, distro s
 	s.arch = arch
 	s.releaseVer = releaseVer
 	s.distro = distro
-	subs, _ := rhsm.LoadSystemSubscriptions()
-	s.subscriptions = subs
+	s.subscriptions, s.subscriptionsErr = rhsm.LoadSystemSubscriptions()
 	return s
 }
 
@@ -154,7 +153,8 @@ type Solver struct {
 	// Proxy to use while depsolving. This is used in DNF's base configuration.
 	proxy string
 
-	subscriptions *rhsm.Subscriptions
+	subscriptions    *rhsm.Subscriptions
+	subscriptionsErr error
 
 	// Stderr is the stderr output from dnfjson, if unset os.Stderr
 	// will be used.
@@ -388,7 +388,7 @@ func (s *Solver) reposFromRPMMD(rpmRepos []rpmmd.RepoConfig) ([]repoConfig, erro
 
 		if rr.RHSM {
 			if s.subscriptions == nil {
-				return nil, fmt.Errorf("This system does not have any valid subscriptions. Subscribe it before specifying rhsm: true in sources.")
+				return nil, fmt.Errorf("This system does not have any valid subscriptions. Subscribe it before specifying rhsm: true in sources (error details: %w)", s.subscriptionsErr)
 			}
 			secrets, err := s.subscriptions.GetSecretsForBaseurl(rr.BaseURLs, s.arch, s.releaseVer)
 			if err != nil {

--- a/pkg/rhsm/secrets.go
+++ b/pkg/rhsm/secrets.go
@@ -101,6 +101,8 @@ func getConsumerSecrets() (*ConsumerSecrets, error) {
 func LoadSystemSubscriptions() (*Subscriptions, error) {
 	consumerSecrets, err := getConsumerSecrets()
 	if err != nil {
+		// Consumer secrets are only needed when resolving
+		// ostree content (see commit 632f272)
 		logrus.Warnf("Failed to load consumer certs: %v", err)
 	}
 


### PR DESCRIPTION
This commit tweaks the way error from subscription are handled in dnfjson. Current any error details are ignored when trying to load a subscription. But this is problematic as it makes diagnosing issues like:
https://github.com/osbuild/image-builder-collection/issues/3 more difficult.

So this commit includes the error details of trying to load the subscriptions in the error message of dnfjson.


I also added a XXX in the rhsm subscription loader, I wonder if we should already error when there are no cosumer keys found? That would give cleaner errors but if its really option to have consumer keys the warning is valid of course (but AIUI the consumer keys are needed for subscriptions, no?)