### PR TITLE
manifesttest: add helper to find stages in a pipeline

### DIFF
--- a/pkg/osbuild/manifesttest/manifesttest.go
+++ b/pkg/osbuild/manifesttest/manifesttest.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 )
 
-// PipelineNamesFrom will return all pipeline names from an osbuild
-// json manifest. It will error on missing pipelines.
-func PipelineNamesFrom(osbuildManifest []byte) ([]string, error) {
+func pipelinesFrom(osbuildManifest []byte) ([]interface{}, error) {
 	var manifest map[string]interface{}
 
 	if err := json.Unmarshal(osbuildManifest, &manifest); err != nil {
@@ -16,10 +14,58 @@ func PipelineNamesFrom(osbuildManifest []byte) ([]string, error) {
 	if manifest["pipelines"] == nil {
 		return nil, fmt.Errorf("cannot find any pipelines in %v", manifest)
 	}
-	pipelines := manifest["pipelines"].([]interface{})
+	pipelines, ok := manifest["pipelines"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("pipelines must be a list, got %T", pipelines)
+	}
+	return pipelines, nil
+}
+
+// PipelineNamesFrom will return all pipeline names from an osbuild
+// json manifest. It will error on missing pipelines.
+func PipelineNamesFrom(osbuildManifest []byte) ([]string, error) {
+	pipelines, err := pipelinesFrom(osbuildManifest)
+	if err != nil {
+		return nil, err
+	}
+
 	pipelineNames := make([]string, len(pipelines))
 	for idx, pi := range pipelines {
 		pipelineNames[idx] = pi.(map[string]interface{})["name"].(string)
 	}
 	return pipelineNames, nil
+}
+
+// StagesForPipeline return the stages for the given a pipeline name. Only v2
+// manifests are supported.
+func StagesForPipeline(osbuildManifest []byte, searchedPipeline string) ([]string, error) {
+	pipelines, err := pipelinesFrom(osbuildManifest)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pi := range pipelines {
+		pipeline, ok := pi.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("pipeline must be an object, got %T", pi)
+		}
+		if pipeline["name"] == searchedPipeline {
+			stageNames := make([]string, 0, len(pipeline))
+			stages, ok := pipeline["stages"].([]interface{})
+			if !ok {
+				return nil, fmt.Errorf("stages must be a list, got %T", pipeline["stages"])
+			}
+			for _, stageIf := range stages {
+				stage, ok := stageIf.(map[string]interface{})
+				if !ok {
+					return nil, fmt.Errorf("stage must be an object, got %T", stageIf)
+				}
+				stageNames = append(stageNames, stage["type"].(string))
+			}
+			return stageNames, nil
+		}
+	}
+
+	return nil, fmt.Errorf("cannot find pipeline %q in %v", searchedPipeline, pipelines)
+
 }

--- a/pkg/osbuild/manifesttest/manifesttest_test.go
+++ b/pkg/osbuild/manifesttest/manifesttest_test.go
@@ -33,3 +33,31 @@ func TestPipelineNamesFromSad(t *testing.T) {
 	_, err = manifesttest.PipelineNamesFrom([]byte("{}"))
 	assert.ErrorContains(t, err, "cannot find any pipelines in map[]")
 }
+
+var fakeOsbuildManifestWithStages = []byte(`{
+  "version": "2",
+  "pipelines": [
+    {
+       "name": "build",
+       "stages": [
+         {
+            "type": "org.osbuild.rpm"
+         },
+         {
+            "type": "org.osbuild.mkdir"
+         }
+       ]
+    }
+  ]
+}`)
+
+func TestStageNamesForPipelineHappy(t *testing.T) {
+	names, err := manifesttest.StagesForPipeline(fakeOsbuildManifestWithStages, "build")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"org.osbuild.rpm", "org.osbuild.mkdir"}, names)
+}
+
+func TestStageNamesForPipelineSad(t *testing.T) {
+	_, err := manifesttest.StagesForPipeline(fakeOsbuildManifestWithStages, "non-existing")
+	assert.ErrorContains(t, err, `cannot find pipeline "non-existing" in `)
+}


### PR DESCRIPTION
This adds a new manifesttest.StagesForPipeline() that can help extract the names of the stages for a pipeline. This will help with
https://github.com/osbuild/image-builder-cli/pull/201/files#r2037909740