### PR TITLE
tests: bump fedora versions to 41

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       matrix:
         fedora_version:
-          - 40
           - 41
+          - 42
       fail-fast: false  # if one fails, keep the other(s) running
     name: "🛃 Unit tests (Fedora ${{ matrix.fedora_version }})"
     runs-on: ubuntu-24.04

--- a/Schutzfile
+++ b/Schutzfile
@@ -20,13 +20,6 @@
       }
     }
   },
-  "fedora-40": {
-    "dependencies": {
-      "osbuild": {
-        "commit": "0ac83fd421ac669cb94f22f74fc32ac8167dbe70"
-      }
-    }
-  },
   "fedora-41": {
     "dependencies": {
       "osbuild": {
@@ -69,5 +62,12 @@
         ]
       }
     ]
+  },
+  "fedora-42": {
+    "dependencies": {
+      "osbuild": {
+        "commit": "f30174d9ba28454f0babd711db37972e84ddb57f"
+      }
+    }
   }
 }


### PR DESCRIPTION
This is probably too early and I am very likely doing it incorrectly, but F42 is ahead of us and F40 is the last with Go 1.22, this will enable us to bump Go to 1.23.

https://github.com/osbuild/images/pull/1433