### PR TITLE
ci: dependency updater gobump golang fix

### DIFF
--- a/.github/workflows/gobump.yml
+++ b/.github/workflows/gobump.yml
@@ -13,11 +13,10 @@ jobs:
     container: registry.fedoraproject.org/fedora:41
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
 
       - name: Update go.mod
         run: |
-          sudo dnf -y install gpgme-devel btrfs-progs-devel krb5-devel
+          sudo dnf -y install golang gpgme-devel btrfs-progs-devel krb5-devel
           echo -e '## gobump output:\n\n```' > github_pr_body.txt
           go run github.com/lzap/gobump@latest -exec "go build ./..." -exec "go test ./..." 2>&1 | tee -a github_pr_body.txt
           echo -e '\n```' >> github_pr_body.txt


### PR DESCRIPTION
Haven't realized I must use Go from Fedora when Fedora container is in use.

https://github.com/osbuild/images/pull/1439