### PR TITLE
manifest: register insights to template on boot (HMS-5994)

### DIFF
--- a/pkg/customizations/subscription/subscription.go
+++ b/pkg/customizations/subscription/subscription.go
@@ -16,6 +16,9 @@ type ImageOptions struct {
 	Insights      bool   `json:"insights"`
 	Rhc           bool   `json:"rhc"`
 	Proxy         string `json:"proxy"`
+	TemplateName  string `json:"template_name"`
+	TemplateUUID  string `json:"template_uuid"`
+	PatchURL      string `json:"patch_url"`
 }
 
 type RHSMStatus string


### PR DESCRIPTION
Supports registering with a content template on bootup

For RHEL 9.6 and 10, the rhc connect command can be used with the template to register. For RHEL 8, a curl command is used to associate the system to the template through the patch API

JIRA: [HMS-5994](https://issues.redhat.com/browse/HMS-5994)