### PR TITLE
ci: remove unnecessary git config command

### DIFF
--- a/.github/workflows/gobump.yml
+++ b/.github/workflows/gobump.yml
@@ -10,13 +10,14 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   update-and-push:
     runs-on: ubuntu-latest
-    container: registry.fedoraproject.org/fedora:41
+    container: registry.fedoraproject.org/fedora:42
     steps:
       - name: Update go.mod and open a PR
         env:
           GITHUB_TOKEN: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
         run: |
           # Install deps
+          set -x
           sudo dnf -y install golang gpgme-devel btrfs-progs-devel krb5-devel
           # Checkout the project
           git clone --depth 1 https://github.com/osbuild/images
@@ -28,7 +29,6 @@ jobs:
           ./tools/prepare-source.sh
           # Make a PR when needed
           if git diff --exit-code; then echo "No changes"; exit 0; fi
-          git config --unset-all http.https://github.com/.extraheader
           git config user.name "schutzbot"
           git config user.email "schutzbot@gmail.com"
           branch="schutz-gobump-$(date -I)"


### PR DESCRIPTION
Getting back to where I left it off before holidays - I have found out that the `git config --unset-all` was exiting with 5 code. I blindly copy-pasted it from the other action, this is not necessary in a clean Fedora container, so removed. Also added shell command echo to see where it exactly fails.

It should work now (TM).