### PR TITLE
ci: add missing gh tool to gobump action

### DIFF
--- a/.github/workflows/gobump.yml
+++ b/.github/workflows/gobump.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
       - name: Update go.mod and open a PR
         env:
-          GITHUB_TOKEN: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
         run: |
           # Install deps
           set -x
-          sudo dnf -y install golang gpgme-devel btrfs-progs-devel krb5-devel
+          sudo dnf -y install git gh golang gpgme-devel btrfs-progs-devel krb5-devel
           # Checkout the project
           git clone --depth 1 https://github.com/osbuild/images
           cd images/


### PR DESCRIPTION
This is embarrassing but I am almost there. The `gh` tool was not installed in the container, also the env variable the tool expects should be named `GH_TOKEN` (from the man page). Hopefully env vars do carry over into containers, I could not find any documentation proof about that, so crossing my fingers.