### PR TITLE
ci: keep GITHUB_TOKEN in gobump action

### DIFF
--- a/.github/workflows/gobump.yml
+++ b/.github/workflows/gobump.yml
@@ -35,7 +35,7 @@ jobs:
           git checkout -b "${branch}"
           git add -A
           git commit -m "build(deps): Update dependencies via gobump"
-          git push -f https://"$GITHUB_TOKEN"@github.com/schutzbot/images.git
+          git push -f "https://$GH_TOKEN@github.com/schutzbot/images.git"
           gh pr create \
             -t "Update dependencies $(date -I)" \
             -F "github_pr_body.txt" \


### PR DESCRIPTION
And it did not work because I deleted `GITHUB_TOKEN` which is still needed for `git`. So the action needs both this one and `GH_TOKEN` for `gh` tool.

```
git push -f https://@github.com/schutzbot/images.git
fatal: could not read Password for 'https://github.com/': No such device or address
```

https://github.com/osbuild/images/pull/1452