### PR TITLE
WIP: move imageConfig into YAML (fedora, rhel-10)

### DIFF
--- a/internal/common/unmarshal.go
+++ b/internal/common/unmarshal.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// UnmarshalYAMLviaJSON unmarshals via the JSON interface, this avoids code
+// duplication on the expense of slightly uglier errors
+func UnmarshalYAMLviaJSON(u json.Unmarshaler, unmarshal func(any) error) error {
+	var data any
+	if err := unmarshal(&data); err != nil {
+		return fmt.Errorf("cannot unmarshal to any: %w", err)
+	}
+
+	dataJSON, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("unmarshal yaml via json failed: %w", err)
+	}
+	if err := u.UnmarshalJSON(dataJSON); err != nil {
+		return fmt.Errorf("unmarshal yaml via json for %s failed: %w", dataJSON, err)
+	}
+	return nil
+}

--- a/pkg/customizations/fsnode/file.go
+++ b/pkg/customizations/fsnode/file.go
@@ -34,3 +34,17 @@ func NewFile(path string, mode *os.FileMode, user interface{}, group interface{}
 		data:       data,
 	}, nil
 }
+
+func (f *File) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var m map[string]interface{}
+	err := unmarshal(&m)
+	if err != nil {
+		return err
+	}
+	f.path = m["path"].(string)
+	f.user = m["user"].(string)
+	f.group = m["group"].(string)
+	f.data = []byte(m["data"].(string))
+
+	return nil
+}

--- a/pkg/customizations/subscription/subscription.go
+++ b/pkg/customizations/subscription/subscription.go
@@ -47,12 +47,12 @@ type DNFPluginConfig struct {
 }
 
 type SubManDNFPluginsConfig struct {
-	ProductID           DNFPluginConfig
-	SubscriptionManager DNFPluginConfig
+	ProductID           DNFPluginConfig `yaml:"product_id,omitempty"`
+	SubscriptionManager DNFPluginConfig `yaml:"subscription_manager,omitempty"`
 }
 
 type RHSMConfig struct {
-	DnfPlugins SubManDNFPluginsConfig
+	DnfPlugins SubManDNFPluginsConfig `yaml:"dnf_plugin,omitempty"`
 	YumPlugins SubManDNFPluginsConfig
 	SubMan     SubManConfig
 }

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 )
 
@@ -267,7 +268,7 @@ func (t *PartitionTableType) UnmarshalJSON(data []byte) error {
 }
 
 func (t *PartitionTableType) UnmarshalYAML(unmarshal func(any) error) error {
-	return unmarshalYAMLviaJSON(t, unmarshal)
+	return common.UnmarshalYAMLviaJSON(t, unmarshal)
 }
 
 func NewPartitionTableType(s string) (PartitionTableType, error) {

--- a/pkg/disk/luks.go
+++ b/pkg/disk/luks.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/datasizes"
 )
 
@@ -151,5 +152,5 @@ func (lc *LUKSContainer) UnmarshalJSON(data []byte) (err error) {
 }
 
 func (lc *LUKSContainer) UnmarshalYAML(unmarshal func(any) error) error {
-	return unmarshalYAMLviaJSON(lc, unmarshal)
+	return common.UnmarshalYAMLviaJSON(lc, unmarshal)
 }

--- a/pkg/disk/lvm.go
+++ b/pkg/disk/lvm.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/datasizes"
 )
 
@@ -262,5 +263,5 @@ func (lv *LVMLogicalVolume) UnmarshalJSON(data []byte) (err error) {
 }
 
 func (lv *LVMLogicalVolume) UnmarshalYAML(unmarshal func(any) error) error {
-	return unmarshalYAMLviaJSON(lv, unmarshal)
+	return common.UnmarshalYAMLviaJSON(lv, unmarshal)
 }

--- a/pkg/disk/partition.go
+++ b/pkg/disk/partition.go
@@ -3,6 +3,8 @@ package disk
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/osbuild/images/internal/common"
 )
 
 type Partition struct {
@@ -137,5 +139,5 @@ func (p *Partition) UnmarshalJSON(data []byte) (err error) {
 }
 
 func (t *Partition) UnmarshalYAML(unmarshal func(any) error) error {
-	return unmarshalYAMLviaJSON(t, unmarshal)
+	return common.UnmarshalYAMLviaJSON(t, unmarshal)
 }

--- a/pkg/disk/unmarshal.go
+++ b/pkg/disk/unmarshal.go
@@ -7,24 +7,6 @@ import (
 	"reflect"
 )
 
-// unmarshalYAMLviaJSON unmarshals via the JSON interface, this avoids code
-// duplication on the expense of slightly uglier errors
-func unmarshalYAMLviaJSON(u json.Unmarshaler, unmarshal func(any) error) error {
-	var data any
-	if err := unmarshal(&data); err != nil {
-		return fmt.Errorf("cannot unmarshal to any: %w", err)
-	}
-
-	dataJSON, err := json.Marshal(data)
-	if err != nil {
-		return fmt.Errorf("unmarshal yaml via json failed: %w", err)
-	}
-	if err := u.UnmarshalJSON(dataJSON); err != nil {
-		return fmt.Errorf("unmarshal yaml via json for %s failed: %w", dataJSON, err)
-	}
-	return nil
-}
-
 func unmarshalJSONPayload(data []byte) (PayloadEntity, error) {
 	var payload struct {
 		Payload     json.RawMessage `json:"payload"`

--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -941,9 +941,10 @@ image_types:
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       x86_64:
-        baseplatform: {}
       aarch64:
-        baseplatform: {}
+      ppc64le:
+      s390x:
+      riscv64:
     image_config: &image_config_container
       no_selinux: true
       exclude_docs: true

--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -12,6 +12,48 @@
       - "geolite2-country"
       - "plymouth"
 
+  image_config:
+    iot_enabled_services: &image_config_iot_enabled_services
+      enabled_services:
+        - "NetworkManager.service"
+        - "firewalld.service"
+        - "sshd.service"
+        - "greenboot-grub2-set-counter"
+        - "greenboot-grub2-set-success"
+        - "greenboot-healthcheck"
+        - "greenboot-rpm-ostree-grub2-check-fallback"
+        - "greenboot-status"
+        - "greenboot-task-runner"
+        - "redboot-auto-reboot"
+        - "redboot-task-runner"
+      condition:
+        version_less_than:
+          "42":
+            enabled_services:
+              - "NetworkManager.service"
+              - "firewalld.service"
+              - "sshd.service"
+              - "greenboot-grub2-set-counter"
+              - "greenboot-grub2-set-success"
+              - "greenboot-healthcheck"
+              - "greenboot-rpm-ostree-grub2-check-fallback"
+              - "greenboot-status"
+              - "greenboot-task-runner"
+              - "redboot-auto-reboot"
+              - "redboot-task-runner"
+              # only in < 42
+              - "zezere_ignition.timer"
+              - "zezere_ignition_banner.service"
+              - "parsec"
+              - "dbus-parsec"
+    iot: &image_config_iot
+      <<: *image_config_iot_enabled_services
+      keyboard:
+        keymap: "us"
+      locale: "C.UTF-8"
+      ostree_conf_sysroot_readonly: true
+      lock_root_user: true
+
   partitioning:
     ids:
       - &prep_partition_dosid "41"
@@ -273,6 +315,8 @@ image_config:
 
 image_types:
   qcow2: &qcow2
+    image_config: &image_config_qcow2
+      default_target: "multi-user.target"
     partition_table:
       <<: *default_partition_tables
     package_sets:
@@ -284,6 +328,11 @@ image_types:
   openstack: *qcow2
 
   vhd:
+    image_config:
+      <<: *image_config_qcow2
+      sshd_config:
+        config:
+          client_alive_interval: 120
     partition_table:
       <<: *default_partition_tables
     package_sets:
@@ -292,6 +341,13 @@ image_types:
           - "WALinuxAgent"
 
   vmdk: &vmdk
+    image_config:
+      locale: "en_US.UTF-8"
+      enabled_services:
+        - "cloud-init.service"
+        - "cloud-config.service"
+        - "cloud-final.service"
+        - "cloud-init-local.service"
     partition_table:
       <<: *default_partition_tables
     package_sets:
@@ -318,6 +374,14 @@ image_types:
   # NOTE: keep in sync with official fedora-iot definitions:
   # https://pagure.io/fedora-iot/ostree/blob/main/f/fedora-iot-base.yaml
   iot_commit: &iot_commit
+    image_config:
+      <<: *image_config_iot_enabled_services
+      dracut_conf:
+        - filename: "40-fips.conf"
+          config:
+            add_dracutmodules:
+              - "fips"
+      machine_id_uninitialized: false
     package_sets:
       - include:
           - "NetworkManager"
@@ -438,6 +502,9 @@ image_types:
   iot_container: *iot_commit
 
   iot_raw_image:
+    image_config:
+      <<: *image_config_iot
+      ignition_platform: "metal"
     partition_table:
       <<: *iot_base_partition_tables
     partition_table_override:
@@ -448,10 +515,15 @@ image_types:
               fstab_options: "defaults,ro"
 
   iot_qcow2_image:
+    image_config:
+      <<: *image_config_iot
+      ignition_platform: "qemu"
     partition_table:
       <<: *iot_base_partition_tables
 
   iot_bootable_container:
+    image_config:
+      machine_id_uninitialized: false
     package_sets:
       - include:
           - "acl"
@@ -578,6 +650,8 @@ image_types:
           - "xz"
 
   anaconda: &anaconda
+    image_config:
+      locale: "en_US.UTF-8"
     package_sets:
       - &anaconda_pkgset
         include:
@@ -717,12 +791,17 @@ image_types:
                 - "dmidecode"
 
   iot_installer:
+    image_config:
+      <<: *image_config_iot_enabled_services
+      locale: "en_US.UTF-8"
     package_sets:
       - *anaconda_pkgset
       - include:
           - "fedora-release-iot"
 
   live_installer:
+    image_config:
+      locale: "en_US.UTF-8"
     package_sets:
       - include:
           - "@workstation-product-environment"
@@ -757,6 +836,11 @@ image_types:
   image_installer: *anaconda
 
   container: &container
+    image_config: &image_config_container
+      no_selinux: true
+      exclude_docs: true
+      locale: "C.UTF-8"
+      timezone: "Etc/UTC"
     package_sets:
       - include:
           - "bash"
@@ -804,6 +888,18 @@ image_types:
           - "xkeyboard-config"
 
   wsl:
+    image_config:
+      <<: *image_config_container
+      cloud_init:
+        - filename: "99_wsl.cfg"
+          config:
+            datasource_list:
+              - "WSL"
+              - "None"
+            network:
+              config: "disabled"
+      wsl_config:
+        boot_systemd: true
     package_sets:
       - include:
           - "bash"
@@ -852,6 +948,35 @@ image_types:
                 - "fuse-libs"
 
   minimal_raw: &minimal_raw
+    image_config:
+      # NOTE: temporary workaround for a bug in initial-setup that
+      # requires a kickstart file in the root directory.
+      files:
+        - path: "/root/anaconda-ks.cfg"
+          user: "root"
+          group: "root"
+          data: |
+            # Run initial-setup on first boot
+            # Created by osbuild
+            firstboot --reconfig
+      grub2_config:
+        timeout: 5
+      install_weak_deps: false
+      mount_units: true      
+      enabled_services:
+        - "NetworkManager.service"
+        - "initial-setup.service"
+        - "sshd.service"
+      condition:
+        version_less_than:
+          "43":
+            install_weak_deps: true
+            mount_units: false
+            enabled_services:
+              - "NetworkManager.service"
+              - "initial-setup.service"
+              - "sshd.service"
+              - "firewalld.service"
     partition_table:
       <<: *minimal_raw_partition_tables
     package_sets:
@@ -880,6 +1005,9 @@ image_types:
   minimal_raw_zst: *minimal_raw
 
   iot_simplified_installer:
+    image_config:
+      <<: *image_config_iot
+      ignition_platform: "metal"
     partition_table:
       <<: *iot_simplified_installer_partition_tables
     package_sets:

--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -12,6 +12,20 @@
       - "geolite2-country"
       - "plymouth"
 
+  platforms:
+    qcow2_common: &platforms_qcow2_common
+      x86_64: &platform_qcow2_x86_64
+        bios: true
+        uefi_vendor: "fedora"
+        baseplatform:
+          imageformat: "qcow2"
+          qcow2compat: "1.1"
+      aarch64: &platform_qcow2_aarch64
+        uefi_vendor: "fedora"
+        baseplatform:
+          imageformat: "qcow2"
+          qcow2compat: "1.1"
+
   image_config:
     iot_enabled_services: &image_config_iot_enabled_services
       enabled_services:
@@ -339,19 +353,68 @@ image_types:
       - *cloud_base_pkgset
       - include:
           - "qemu-guest-agent"
-    # platforms:
-    #   x86_64:
-    #     # XXX: move to "common"
-    #     bios: true
-    #     uefi_vendor: "fedora"
-    #     baseplatform:
-    #       imageformat: "qcow2"
-    #       qcow2compat: "1.1"
-  ami: *qcow2
-  oci: *qcow2
-  openstack: *qcow2
+    platforms:
+      <<: *platforms_qcow2_common
+      ppc64le:
+        bios: true
+        baseplatform:
+          imageformat: "qcow2"
+          qcow2compat: "1.1"
+      s390x:
+        zipl: true
+        baseplatform:
+          imageformat: "qcow2"
+          qcow2compat: "1.1"
+
+  ami:
+    <<: *qcow2
+    name: "ami"
+    filename: "image.raw"
+    mime_type: "application/octet-stream"
+    payload_pipelines: ["os", "image"]
+    exports: ["image"]
+    environment: "ec2"
+    platforms:
+      x86_64:
+        <<: *platform_qcow2_x86_64
+        baseplatform:
+          imageformat: "raw"
+      aarch64:
+        <<: *platform_qcow2_aarch64
+        baseplatform:
+          imageformat: "raw"
+
+  oci:
+    <<: *qcow2
+    name: "oci"
+    platforms:
+      <<: *platforms_qcow2_common
+
+  openstack:
+    <<: *qcow2
+    name: "openstack"
+    platforms:
+      x86_64:
+        <<: *platform_qcow2_x86_64
+        baseplatform:
+          # XXX: no "qcow2compat" here, this is probably a bug in the
+          # original image definitions in the go code
+          imageformat: "qcow2"
+      aarch64:
+        <<: *platform_qcow2_aarch64
+        baseplatform:
+          # XXX: no "qcow2compat" here, this is probably a bug in the
+          # original image definitions in the go code
+          imageformat: "qcow2"
 
   vhd:
+    <<: *qcow2
+    name: "vhd"
+    filename: "disk.vhd"
+    mime_type: "application/x-vhd"
+    payload_pipelines: ["os", "image", "vpc"]
+    exports: ["vpc"]
+    environment: "azure"
     image_config:
       <<: *image_config_qcow2
       sshd_config:
@@ -363,6 +426,11 @@ image_types:
       - *cloud_base_pkgset
       - include:
           - "WALinuxAgent"
+    platforms:
+      x86_64:
+        <<: *platform_qcow2_x86_64
+        baseplatform:
+          imageformat: "vhd"
 
   vmdk: &vmdk
     image_config:
@@ -544,6 +612,8 @@ image_types:
       ignition_platform: "qemu"
     partition_table:
       <<: *iot_base_partition_tables
+    platforms:
+      <<: *platforms_qcow2_common
 
   iot_bootable_container:
     image_config:

--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -315,6 +315,22 @@ image_config:
 
 image_types:
   qcow2: &qcow2
+    name: "qcow2"
+    filename: "disk.qcow2"
+    mime_type: "application/x-qemu-disk"
+    environment: "kvm"
+    # XXX: move to "common" via cloudKernelOptions anchor
+    kernel_options: ["ro", "no_timer_check", "console=ttyS0,115200n8", "biosdevname=0", "net.ifnames=0"]
+    bootable: true
+    default_size: 5_368_709_120  # 5 * datasizes.GibiByte
+    image: "disk"
+    build_pipelines: ["build"]
+    payload_pipelines: ["os", "image", "qcow2"]
+    exports: ["qcow2"]
+    # XXX: move into "common"
+    required_partition_sizes:
+      "/": 1_073_741_824  # 1 * datasizes.GiB
+      "/usr": 2_147_483_648 # 2 * datasizes.GiB
     image_config: &image_config_qcow2
       default_target: "multi-user.target"
     partition_table:

--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -328,7 +328,7 @@ image_types:
     payload_pipelines: ["os", "image", "qcow2"]
     exports: ["qcow2"]
     # XXX: move into "common"
-    required_partition_sizes:
+    required_partition_sizes: &default_required_dir_sizes
       "/": 1_073_741_824  # 1 * datasizes.GiB
       "/usr": 2_147_483_648 # 2 * datasizes.GiB
     image_config: &image_config_qcow2
@@ -339,6 +339,14 @@ image_types:
       - *cloud_base_pkgset
       - include:
           - "qemu-guest-agent"
+    # platforms:
+    #   x86_64:
+    #     # XXX: move to "common"
+    #     bios: true
+    #     uefi_vendor: "fedora"
+    #     baseplatform:
+    #       imageformat: "qcow2"
+    #       qcow2compat: "1.1"
   ami: *qcow2
   oci: *qcow2
   openstack: *qcow2
@@ -852,6 +860,20 @@ image_types:
   image_installer: *anaconda
 
   container: &container
+    name: "container"
+    filename: "container.tar"
+    mime_type: "application/x-tar"
+    image: "container"
+    bootable: false
+    build_pipelines: ["build"]
+    payload_pipelines: ["os", "container"]
+    exports: ["container"]
+    required_partition_sizes: *default_required_dir_sizes
+    platforms:
+      x86_64:
+        baseplatform: {}
+      aarch64:
+        baseplatform: {}
     image_config: &image_config_container
       no_selinux: true
       exclude_docs: true
@@ -904,6 +926,18 @@ image_types:
           - "xkeyboard-config"
 
   wsl:
+    name: "wsl"
+    filename: "wsl.tar"
+    mime_type: "application/x-tar"
+    image: "container"
+    bootable: false
+    build_pipelines: ["build"]
+    payload_pipelines: ["os", "container"]
+    exports: ["container"]
+    required_partition_sizes: *default_required_dir_sizes
+    platforms:
+      x86_64:
+        baseplatform: {}
     image_config:
       <<: *image_config_container
       cloud_init:

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -78,7 +78,9 @@ type imageType struct {
 type ImagePlatform struct {
 	Arch string
 
-	BIOS       bool
+	BIOS bool
+	Zipl bool
+
 	UEFIVendor string `yaml:"uefi_vendor"`
 	platform.BasePlatform
 }

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -64,6 +64,7 @@ type imageConfig struct {
 }
 
 type conditionsImgConf struct {
+	Architecture    map[string]*distro.ImageConfig `yaml:"architecture,omitempty"`
 	DistroName      map[string]*distro.ImageConfig `yaml:"distro_name,omitempty"`
 	VersionLessThan map[string]*distro.ImageConfig `yaml:"version_less_than,omitempty"`
 }
@@ -163,7 +164,7 @@ func DistroImageConfig(distroNameVer string) (*distro.ImageConfig, error) {
 }
 
 // ImageConfig returns the image type specific ImageConfig
-func ImageConfig(distroNameVer, typeName string, replacements map[string]string) (*distro.ImageConfig, error) {
+func ImageConfig(distroNameVer, archName, typeName string, replacements map[string]string) (*distro.ImageConfig, error) {
 	toplevel, err := load(distroNameVer)
 	if err != nil {
 		return nil, err
@@ -180,6 +181,9 @@ func ImageConfig(distroNameVer, typeName string, replacements map[string]string)
 
 		if distroNameCnf, ok := cond.DistroName[distroName]; ok {
 			imgConfig = distroNameCnf.InheritFrom(imgConfig)
+		}
+		if archCnf, ok := cond.Architecture[archName]; ok {
+			imgConfig = archCnf.InheritFrom(imgConfig)
 		}
 		for ltVer, ltConf := range cond.VersionLessThan {
 			if r, ok := replacements[ltVer]; ok {

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -19,6 +19,7 @@ import (
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/experimentalflags"
+	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -70,6 +71,16 @@ type imageType struct {
 	PayloadPipelines       []string `yaml:"payload_pipelines"`
 	Exports                []string
 	RequiredPartitionSizes map[string]uint64 `yaml:"required_partition_sizes"`
+
+	Platforms map[string]ImagePlatform
+}
+
+type ImagePlatform struct {
+	Arch string
+
+	BIOS       bool
+	UEFIVendor string `yaml:"uefi_vendor"`
+	platform.BasePlatform
 }
 
 type imageConfig struct {
@@ -410,4 +421,12 @@ func ImageType(distroNameVer, typeName string) (*ImageTypeYAML, error) {
 		return nil, fmt.Errorf("%w: %q", ErrImageTypeNotFound, typeName)
 	}
 	return &imgType, nil
+}
+
+func ImageTypes(distroNameVer string) (map[string]ImageTypeYAML, error) {
+	toplevel, err := load(distroNameVer)
+	if err != nil {
+		return nil, err
+	}
+	return toplevel.ImageTypes, nil
 }

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -64,6 +64,7 @@ type imageConfig struct {
 }
 
 type conditionsImgConf struct {
+	DistroName      map[string]*distro.ImageConfig `yaml:"distro_name,omitempty"`
 	VersionLessThan map[string]*distro.ImageConfig `yaml:"version_less_than,omitempty"`
 }
 
@@ -175,8 +176,11 @@ func ImageConfig(distroNameVer, typeName string, replacements map[string]string)
 	imgConfig := imgType.ImageConfig.ImageConfig
 	cond := imgType.ImageConfig.Condition
 	if cond != nil {
-		_, distroVersion := splitDistroNameVer(distroNameVer)
+		distroName, distroVersion := splitDistroNameVer(distroNameVer)
 
+		if distroNameCnf, ok := cond.DistroName[distroName]; ok {
+			imgConfig = distroNameCnf.InheritFrom(imgConfig)
+		}
 		for ltVer, ltConf := range cond.VersionLessThan {
 			if r, ok := replacements[ltVer]; ok {
 				ltVer = r

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -162,10 +162,7 @@ func DistroImageConfig(distroNameVer string) (*distro.ImageConfig, error) {
 }
 
 // ImageConfig returns the image type specific ImageConfig
-func ImageConfig(it distro.ImageType, replacements map[string]string) (*distro.ImageConfig, error) {
-	typeName := it.Name()
-	distroNameVer := it.Arch().Distro().Name()
-	_, distroVersion := splitDistroNameVer(distroNameVer)
+func ImageConfig(distroNameVer, typeName string, replacements map[string]string) (*distro.ImageConfig, error) {
 	toplevel, err := load(distroNameVer)
 	if err != nil {
 		return nil, err
@@ -178,6 +175,8 @@ func ImageConfig(it distro.ImageType, replacements map[string]string) (*distro.I
 	imgConfig := imgType.ImageConfig.ImageConfig
 	cond := imgType.ImageConfig.Condition
 	if cond != nil {
+		_, distroVersion := splitDistroNameVer(distroNameVer)
+
 		for ltVer, ltConf := range cond.VersionLessThan {
 			if r, ok := replacements[ltVer]; ok {
 				ltVer = r

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -420,6 +420,9 @@ image_types:
         version_less_than:
           "2":
             timezone: "OverrideTZ"
+        distro_name:
+          "test-distro":
+            locale: "en_US.UTF-8"
 `
 	fakeDistroName := "test-distro"
 	baseDir := makeFakePkgsSet(t, fakeDistroName, fakeDistroYaml)
@@ -429,7 +432,7 @@ image_types:
 	imgConfig, err := defs.ImageConfig("test-distro-1", "test_type", nil)
 	require.NoError(t, err)
 	assert.Equal(t, &distro.ImageConfig{
-		Locale:   common.ToPtr("C.UTF-8"),
+		Locale:   common.ToPtr("en_US.UTF-8"),
 		Timezone: common.ToPtr("OverrideTZ"),
 	}, imgConfig)
 

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -410,7 +410,6 @@ image_types:
 }
 
 func TestImageTypeImageConfig(t *testing.T) {
-	it := makeTestImageType(t)
 	fakeDistroYaml := `
 image_types:
   test_type:
@@ -427,7 +426,7 @@ image_types:
 	restore := defs.MockDataFS(baseDir)
 	defer restore()
 
-	imgConfig, err := defs.ImageConfig(it, nil)
+	imgConfig, err := defs.ImageConfig("test-distro-1", "test_type", nil)
 	require.NoError(t, err)
 	assert.Equal(t, &distro.ImageConfig{
 		Locale:   common.ToPtr("C.UTF-8"),

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -414,6 +414,7 @@ func TestImageTypeImageConfig(t *testing.T) {
 image_types:
   test_type:
     image_config:
+      hostname: "foo"
       locale: "C.UTF-8"
       timezone: "DefaultTZ"
       condition:
@@ -423,15 +424,19 @@ image_types:
         distro_name:
           "test-distro":
             locale: "en_US.UTF-8"
+        architecture:
+          "test_arch":
+            hostname: "test-arch-hn"
 `
 	fakeDistroName := "test-distro"
 	baseDir := makeFakePkgsSet(t, fakeDistroName, fakeDistroYaml)
 	restore := defs.MockDataFS(baseDir)
 	defer restore()
 
-	imgConfig, err := defs.ImageConfig("test-distro-1", "test_type", nil)
+	imgConfig, err := defs.ImageConfig("test-distro-1", "test_arch", "test_type", nil)
 	require.NoError(t, err)
 	assert.Equal(t, &distro.ImageConfig{
+		Hostname: common.ToPtr("test-arch-hn"),
 		Locale:   common.ToPtr("en_US.UTF-8"),
 		Timezone: common.ToPtr("OverrideTZ"),
 	}, imgConfig)

--- a/pkg/distro/defs/rhel-10/distro.yaml
+++ b/pkg/distro/defs/rhel-10/distro.yaml
@@ -303,6 +303,18 @@ image_types:
                 - "subscription-manager-cockpit"
 
   qcow2: &qcow2
+    image_config:
+      default_target: "multi-user.target"
+      condition:
+        distro_name:
+          rhel:
+            rhsm_config:
+              "no-subscription":
+                dnf_plugin:
+                  product_id:
+                    enabled: false
+                  subscription_manager:
+                    enabled: false
     partition_table:
       <<: *default_partition_tables
     package_sets:
@@ -372,6 +384,119 @@ image_types:
   oci: *qcow2
 
   vhd: &vhd
+    # based on https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/deploying_rhel_9_on_microsoft_azure/assembly_deploying-a-rhel-image-as-a-virtual-machine-on-microsoft-azure_cloud-content-azure#making-configuration-changes_configure-the-image-azure
+    image_config: &image_config_vhd
+      keyboard:
+        keymap: "us"
+        x11_keymap:
+          layouts: ["us"]
+      update_default_kernel: true
+      default_kernel: "kernel-core"
+      sysconfig:
+        networking: true
+        no_zero_conf: true
+      enabled_services:
+        - "firewalld"
+        - "nm-cloud-setup.service"
+        - "nm-cloud-setup.timer"
+        - "sshd"
+        - "waagent"
+      sshd_config:
+        config:
+          client_alive_interval: 180
+      modprobe:
+        - filename: "blacklist-amdgpu.conf"
+          commands: 
+            - command: blacklist
+              modulename: "amdgpu"
+        - filename: "blacklist-intel-cstate.conf"
+          commands: 
+            - command: blacklist
+              modulename: "intel_cstate"
+        - filename: "blacklist-floppy.conf"
+          commands: 
+            - command: blacklist
+              modulename: "floppy"
+        - filename: "blacklist-nouveau.conf"
+          commands:
+            - command: blacklist
+              modulename: "nouveau"
+            - command: blacklist
+              modulename: "lbm-nouveau"
+        - filename: "blacklist-skylake-edac.conf"
+          commands:
+            - command: blacklist
+              modulename: "skx_edac"
+      cloud_init:
+        - filename: "10-azure-kvp.cfg"
+          config: 
+            reporting:
+              logging:
+                type: "log"
+              telemetry:
+                type: "hyperv"
+        - filename: "91-azure_datasource.cfg"
+          config:
+            datasource:
+              azure:
+                apply_network_config: false
+            datasource_list:
+              - "Azure"
+      pwquality:
+        config:
+          minlen: 6
+          minclass: 3
+          dcredit: 0
+          ucredit: 0
+          lcredit: 0
+          ocredit: 0
+      waagent_config:
+        config:
+          rd_format: false
+          rd_enable_swap: false
+      grub2_config:
+        disable_recovery: true
+        disable_submenu: true
+        distributor: "$(sed 's, release .*$,,g' /etc/system-release)"
+        terminal: ["serial", "console"]
+        serial: "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
+        timeout: 10
+        timeout_style: "countdown"
+      udev_rules:
+        filename: "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules"
+        rules:
+          - comment:
+              - "Accelerated Networking on Azure exposes a new SRIOV interface to the VM."
+              - "This interface is transparently bonded to the synthetic interface,"
+              - "so NetworkManager should just ignore any SRIOV interfaces."
+          - rule:
+            - K: "SUBSYSTEM"
+              O: "=="
+              V: "net"
+            - K: "DRIVERS"
+              O: "=="
+              V: "hv_pci"
+            - K: "ACTION"
+              O: "=="
+              V: "add"
+            - K: "ENV"
+              A: "NM_UNMANAGED"
+              O: "="
+              V: "1"
+      systemd_dropin:
+        - unit: "nm-cloud-setup.service"
+          dropin: "10-rh-enable-for-azure.conf"
+          config:
+            service:
+              environment:
+                - key: "NM_CLOUD_SETUP_AZURE"
+                  value: "yes"
+      default_target: "multi-user.target"
+      condition:
+        distro_name:
+          rhel:
+            gpgkey_files:
+              - "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
     partition_table:
       <<: *default_partition_tables
     package_sets:
@@ -455,6 +580,9 @@ image_types:
   azure_rhui: *vhd
 
   azure_sap_rhui:
+    # XXX: this still uses sapAzureImageConfig() 
+    image_config:
+      <<: *image_config_vhd
     package_sets:
       - *vhd_pkgset
       - *sap_pkgset
@@ -486,6 +614,86 @@ image_types:
   ova: *vmdk
 
   ami: &ami
+    image_config:
+      time_synchronization:
+        servers:
+          - hostname: "169.254.169.123"
+            prefer:   true
+            iburst:   true
+            minpoll:  4
+            maxpoll:  4
+        # empty string will remove any occurrences of the option
+        # from the configuration
+        leapsectz: ""
+      keyboard:
+        keymap: "us"
+        x11_keymap:
+          layouts: ["us"]
+      enabled_services:
+        - "sshd"
+        - "NetworkManager"
+        - "nm-cloud-setup.service"
+        - "nm-cloud-setup.timer"
+        - "cloud-init"
+        - "cloud-init-local"
+        - "cloud-config"
+        - "cloud-final"
+        - "reboot.target"
+        - "tuned"
+      default_target: "multi-user.target"
+      update_default_kernel: true
+      default_kernel: "kernel"
+      sysconfig:
+        networking: true
+        no_zero_conf: true
+      systemd_logind:
+        - filename: "00-getty-fixes.conf"
+          config:
+            login:
+              nautovts: 0
+      cloud_init:
+        - filename: "00-rhel-default-user.cfg"
+          config:
+            system_info:
+              default_user:
+                name: "ec2-user"
+      modprobe:
+        - filename: "blacklist-nouveau.conf"
+          commands:
+            - command: blacklist
+              modulename: "nouveau"
+        - filename: "blacklist-amdgpu.conf"
+          commands:
+            - command: blacklist
+              modulename: "amdgpu"
+        # https://issues.redhat.com/browse/RHEL-71926
+        - filename: "blacklist-i2c_piix4.conf"
+          commands:
+            - command: blacklist
+              modulename: "i2c_piix4"
+      systemd_dropin:
+        # RHBZ#1822863
+        - unit:   "nm-cloud-setup.service"
+          dropin: "10-rh-enable-for-ec2.conf"
+          config:
+            service:
+              environment:
+                - key: "NM_CLOUD_SETUP_EC2"
+                  value: "yes"
+      authselect:
+        profile: "sssd"
+      sshd_config:
+        config:
+          password_authentication: false
+      condition:
+        architecture:
+          x86_64:
+            dracut_conf:
+              - filename: "ec2.conf"
+                config:
+                  add_drivers:
+                    - "nvme"
+                    - "xen-blkfront"
     partition_table:
       <<: *default_partition_tables
     package_sets:
@@ -563,6 +771,18 @@ image_types:
       - *sap_pkgset
 
   wsl:
+    image_config:
+      cloud_init:
+        - filename: "99_wsl.cfg"
+          config:
+            datasource_list:
+              - "WSL"
+              - "None"
+            network:
+              config: "disabled"
+      no_selinux: true
+      wsl_config:
+        boot_systemd: true
     package_sets:
       - include:
           - "alternatives"
@@ -745,6 +965,75 @@ image_types:
                 - "dmidecode"
 
   gce:
+    image_config:
+      time_synchronization: 
+        servers:
+          - hostname: "metadata.google.internal"
+      firewall:
+        default_zone: "trusted"
+      enabled_services:
+        - "sshd"
+        - "rngd"
+        - "dnf-automatic.timer"
+        # TODO: remove cloud-init services once we switch back to GCP guest tools
+        - "cloud-init"
+        - "cloud-init-local"
+        - "cloud-config"
+        - "cloud-final"
+      disabled_services:
+        - "sshd-keygen@"
+        - "reboot.target"
+      default_target: "multi-user.target"
+      keyboard:
+        keymap: "us"
+      dnf_config:
+        - config:
+            main:
+              ipresolve: "4"
+      dnf_automatic_config:
+        config:
+          commands:
+            apply_updates: true
+            upgrade_type:  "security"
+      yum_repos:
+        - filename: "google-cloud.repo"
+          repos:
+            - id:   "google-compute-engine"
+              name: "Google Compute Engine"
+              # TODO: use el10 repo once it's available
+              baseurls:
+                - "https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable"
+              enabled:  true
+              # TODO: enable GPG check once Google stops using SHA-1 in their keys
+              # https://issuetracker.google.com/issues/360905189
+              gpgcheck: false
+              repo_gpgcheck: false
+              gpgkeys:
+                - "https://packages.cloud.google.com/yum/doc/yum-key.gpg"
+                - "https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg"
+      sshd_config:
+        config:
+          password_authentication: false
+          client_alive_interval: 420
+          permit_root_login: false
+      update_default_kernel: true
+      default_kernel: "kernel-core"
+      # XXX: ensure the "old" behavior is preserved (that is
+      # likely a bug) where for GCE the sysconfig network
+      # options are not set because the merge of imageConfig
+      # is shallow and the previous setup was changing the
+      # kernel without also changing the network options.
+      sysconfig: {}
+      modprobe:
+        - filename: "blacklist-floppy.conf"
+          commands: 
+            - command: blacklist
+              modulename: "floppy"
+      gcp_guest_agent_config:
+        config_scope: "distro"
+        config:
+          instance_setup:
+            set_boto_config: false
     partition_table:
       <<: *default_partition_tables
     package_sets:

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -264,24 +264,7 @@ func mkIotQcow2ImgType(d distribution) imageType {
 }
 
 func mkQcow2ImgType(d distribution) imageType {
-	return imageType{
-		name:        "qcow2",
-		filename:    "disk.qcow2",
-		mimeType:    "application/x-qemu-disk",
-		environment: &environment.KVM{},
-		packageSets: map[string]packageSetFunc{
-			osPkgsKey: packageSetLoader,
-		},
-		defaultImageConfig:     imageConfig(d, "qcow2"),
-		kernelOptions:          cloudKernelOptions(),
-		bootable:               true,
-		defaultSize:            5 * datasizes.GibiByte,
-		image:                  diskImage,
-		buildPipelines:         []string{"build"},
-		payloadPipelines:       []string{"os", "image", "qcow2"},
-		exports:                []string{"qcow2"},
-		requiredPartitionSizes: requiredDirectorySizes,
-	}
+	return newImageTypeFromYaml(d, "qcow2")
 }
 
 func mkVmdkImgType(d distribution) imageType {

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -302,24 +302,6 @@ func mkOvaImgType(d distribution) imageType {
 	}
 }
 
-func mkContainerImgType(d distribution) imageType {
-	return imageType{
-		name:     "container",
-		filename: "container.tar",
-		mimeType: "application/x-tar",
-		packageSets: map[string]packageSetFunc{
-			osPkgsKey: packageSetLoader,
-		},
-		defaultImageConfig:     imageConfig(d, "container"),
-		image:                  containerImage,
-		bootable:               false,
-		buildPipelines:         []string{"build"},
-		payloadPipelines:       []string{"os", "container"},
-		exports:                []string{"container"},
-		requiredPartitionSizes: requiredDirectorySizes,
-	}
-}
-
 func mkMinimalRawImgType(d distribution) imageType {
 	it := imageType{
 		name:        "minimal-raw",
@@ -615,6 +597,12 @@ func newDistro(version int) distro.Distro {
 					platform,
 					it,
 				)
+			case "riscv64":
+				platform := newPlatformFromYaml(arch, platformYAML)
+				riscv64.addImageTypes(
+					platform,
+					it,
+				)
 			default:
 				err := fmt.Errorf("unsupported arch: %v", arch)
 				panic(err)
@@ -878,22 +866,8 @@ func newDistro(version int) distro.Distro {
 		mkIotBootableContainer(rd),
 	)
 
-	ppc64le.addImageTypes(
-		&platform.PPC64LE{},
-		mkContainerImgType(rd),
-	)
-
-	s390x.addImageTypes(
-		&platform.S390X{},
-		mkContainerImgType(rd),
-	)
-
 	// XXX: there is no "qcow2" for riscv64 yet because there is
 	// no "@Fedora Cloud Server" group
-	riscv64.addImageTypes(
-		&platform.RISCV64{},
-		mkContainerImgType(rd),
-	)
 	riscv64.addImageTypes(
 		&platform.RISCV64{
 			UEFIVendor: "fedora",

--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -1,7 +1,10 @@
 package fedora
 
 import (
+	"fmt"
+
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/environment"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -15,4 +18,41 @@ func imageConfig(d distribution, imageType string) *distro.ImageConfig {
 	// arch is currently not used in fedora
 	arch := ""
 	return common.Must(defs.ImageConfig(d.name, arch, imageType, VersionReplacements()))
+}
+
+func newImageTypeFromYaml(d distribution, typeName string) imageType {
+	imgYAML, err := defs.ImageType(d.name, typeName)
+	if err != nil {
+		panic(err)
+	}
+	it := imageType{
+		name:                   imgYAML.Name,
+		filename:               imgYAML.Filename,
+		mimeType:               imgYAML.MimeType,
+		kernelOptions:          imgYAML.KernelOptions,
+		bootable:               imgYAML.Bootable,
+		defaultSize:            imgYAML.DefaultSize,
+		buildPipelines:         imgYAML.BuildPipelines,
+		payloadPipelines:       imgYAML.PayloadPipelines,
+		exports:                imgYAML.Exports,
+		requiredPartitionSizes: imgYAML.RequiredPartitionSizes,
+	}
+	it.defaultImageConfig = imageConfig(d, typeName)
+	switch imgYAML.Image {
+	case "disk":
+		it.image = diskImage
+	default:
+		err := fmt.Errorf("unknown image func: %v", imgYAML.Image)
+		panic(err)
+	}
+	switch imgYAML.Environment {
+	case "kvm":
+		it.environment = &environment.KVM{}
+	}
+	// XXX: fix for multiple loaders like the installers
+	it.packageSets = map[string]packageSetFunc{
+		osPkgsKey: packageSetLoader,
+	}
+
+	return it
 }

--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -45,6 +45,11 @@ func newPlatformFromYaml(arch string, d defs.ImagePlatform) (res platform.Platfo
 			Zipl:         d.Zipl,
 			BasePlatform: d.BasePlatform,
 		}
+	case "riscv64":
+		res = &platform.RISCV64{
+			UEFIVendor:   d.UEFIVendor,
+			BasePlatform: d.BasePlatform,
+		}
 	default:
 		err := fmt.Errorf("unsupported platform %v", arch)
 		panic(err)

--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -35,6 +35,16 @@ func newPlatformFromYaml(arch string, d defs.ImagePlatform) (res platform.Platfo
 			UEFIVendor:   d.UEFIVendor,
 			BasePlatform: d.BasePlatform,
 		}
+	case "ppc64le":
+		res = &platform.PPC64LE{
+			BIOS:         d.BIOS,
+			BasePlatform: d.BasePlatform,
+		}
+	case "s390x":
+		res = &platform.S390X{
+			Zipl:         d.Zipl,
+			BasePlatform: d.BasePlatform,
+		}
 	default:
 		err := fmt.Errorf("unsupported platform %v", arch)
 		panic(err)
@@ -71,8 +81,17 @@ func newImageTypeFromYaml(d distribution, typeName string) imageType {
 		panic(err)
 	}
 	switch imgYAML.Environment {
+	case "":
+		// nothing
+	case "azure":
+		it.environment = &environment.Azure{}
+	case "ec2":
+		it.environment = &environment.EC2{}
 	case "kvm":
 		it.environment = &environment.KVM{}
+	default:
+		err := fmt.Errorf("unknown env %q", imgYAML.Environment)
+		panic(err)
 	}
 	// XXX: fix for multiple loaders like the installers
 	it.packageSets = map[string]packageSetFunc{

--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -1,10 +1,18 @@
 package fedora
 
 import (
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 func packageSetLoader(t *imageType) (rpmmd.PackageSet, error) {
 	return defs.PackageSet(t, "", VersionReplacements())
+}
+
+func imageConfig(d distribution, imageType string) *distro.ImageConfig {
+	// arch is currently not used in fedora
+	arch := ""
+	return common.Must(defs.ImageConfig(d.name, arch, imageType, VersionReplacements()))
 }

--- a/pkg/distro/fedora/version.go
+++ b/pkg/distro/fedora/version.go
@@ -11,9 +11,6 @@ const VERSION_ROOTFS_SQUASHFS = "41"
 // other Fedora variants.
 const VERSION_FIRSTBOOT = "43"
 
-// Version at which we stop installing weak dependencies for Fedora Minimal
-const VERSION_MINIMAL_WEAKDEPS = "43"
-
 func VersionReplacements() map[string]string {
 	return map[string]string{
 		"VERSION_BRANCHED":        VERSION_BRANCHED,

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -13,13 +13,13 @@ import (
 
 // ImageConfig represents a (default) configuration applied to the image payload.
 type ImageConfig struct {
-	Hostname            *string `yaml:"hostname,omitempty"`
-	Timezone            *string `yaml:"timezone,omitempty"`
-	TimeSynchronization *osbuild.ChronyStageOptions
-	Locale              *string `yaml:"locale,omitempty"`
+	Hostname            *string                     `yaml:"hostname,omitempty"`
+	Timezone            *string                     `yaml:"timezone,omitempty"`
+	TimeSynchronization *osbuild.ChronyStageOptions `yaml:"time_synchronization,omitempty"`
+	Locale              *string                     `yaml:"locale,omitempty"`
 	Keyboard            *osbuild.KeymapStageOptions
 	EnabledServices     []string `yaml:"enabled_services,omitempty"`
-	DisabledServices    []string
+	DisabledServices    []string `yaml:"disabled_services,omitempty"`
 	MaskedServices      []string
 	DefaultTarget       *string `yaml:"default_target,omitempty"`
 
@@ -44,12 +44,12 @@ type ImageConfig struct {
 
 	// for RHSM configuration, we need to potentially distinguish the case
 	// when the user want the image to be subscribed on first boot and when not
-	RHSMConfig          map[subscription.RHSMStatus]*subscription.RHSMConfig
-	SystemdLogind       []*osbuild.SystemdLogindStageOptions
-	CloudInit           []*osbuild.CloudInitStageOptions `yaml:"cloud_init,omitempty"`
+	RHSMConfig          map[subscription.RHSMStatus]*subscription.RHSMConfig `yaml:"rhsm_config,omitempty"`
+	SystemdLogind       []*osbuild.SystemdLogindStageOptions                 `yaml:"systemd_logind,omitempty"`
+	CloudInit           []*osbuild.CloudInitStageOptions                     `yaml:"cloud_init,omitempty"`
 	Modprobe            []*osbuild.ModprobeStageOptions
-	DracutConf          []*osbuild.DracutConfStageOptions `yaml:"dracut_conf,omitempty"`
-	SystemdDropin       []*osbuild.SystemdUnitStageOptions
+	DracutConf          []*osbuild.DracutConfStageOptions  `yaml:"dracut_conf,omitempty"`
+	SystemdDropin       []*osbuild.SystemdUnitStageOptions `yaml:"systemd_dropin,omitempty"`
 	SystemdUnit         []*osbuild.SystemdUnitCreateStageOptions
 	Authselect          *osbuild.AuthselectStageOptions
 	SELinuxConfig       *osbuild.SELinuxConfigStageOptions
@@ -57,18 +57,18 @@ type ImageConfig struct {
 	Tmpfilesd           []*osbuild.TmpfilesdStageOptions
 	PamLimitsConf       []*osbuild.PamLimitsConfStageOptions
 	Sysctld             []*osbuild.SysctldStageOptions
-	DNFConfig           []*osbuild.DNFConfigStageOptions
-	SshdConfig          *osbuild.SshdConfigStageOptions `yaml:"sshd_config,omitempty"`
+	DNFConfig           []*osbuild.DNFConfigStageOptions `yaml:"dnf_config,omitempty"`
+	SshdConfig          *osbuild.SshdConfigStageOptions  `yaml:"sshd_config,omitempty"`
 	Authconfig          *osbuild.AuthconfigStageOptions
 	PwQuality           *osbuild.PwqualityConfStageOptions
-	WAAgentConfig       *osbuild.WAAgentConfStageOptions
-	Grub2Config         *osbuild.GRUB2Config `yaml:"grub2_config,omitempty"`
-	DNFAutomaticConfig  *osbuild.DNFAutomaticConfigStageOptions
+	WAAgentConfig       *osbuild.WAAgentConfStageOptions        `yaml:"waagent_config,omitempty"`
+	Grub2Config         *osbuild.GRUB2Config                    `yaml:"grub2_config,omitempty"`
+	DNFAutomaticConfig  *osbuild.DNFAutomaticConfigStageOptions `yaml:"dnf_automatic_config"`
 	YumConfig           *osbuild.YumConfigStageOptions
-	YUMRepos            []*osbuild.YumReposStageOptions
+	YUMRepos            []*osbuild.YumReposStageOptions `yaml:"yum_repos,omitempty"`
 	Firewall            *osbuild.FirewallStageOptions
-	UdevRules           *osbuild.UdevRulesStageOptions
-	GCPGuestAgentConfig *osbuild.GcpGuestAgentConfigOptions
+	UdevRules           *osbuild.UdevRulesStageOptions      `yaml:"udev_rules,omitempty"`
+	GCPGuestAgentConfig *osbuild.GcpGuestAgentConfigOptions `yaml:"gcp_guest_agent_config,omitempty"`
 	NetworkManager      *osbuild.NMConfStageOptions
 
 	WSLConfig *WSLConfig `yaml:"wsl_config,omitempty"`

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -18,10 +18,10 @@ type ImageConfig struct {
 	TimeSynchronization *osbuild.ChronyStageOptions
 	Locale              *string `yaml:"locale,omitempty"`
 	Keyboard            *osbuild.KeymapStageOptions
-	EnabledServices     []string
+	EnabledServices     []string `yaml:"enabled_services,omitempty"`
 	DisabledServices    []string
 	MaskedServices      []string
-	DefaultTarget       *string
+	DefaultTarget       *string `yaml:"default_target,omitempty"`
 
 	Sysconfig           *Sysconfig `yaml:"sysconfig,omitempty"`
 	DefaultKernel       *string    `yaml:"default_kernel,omitempty"`
@@ -31,14 +31,14 @@ type ImageConfig struct {
 	GPGKeyFiles []string `yaml:"gpgkey_files,omitempty"`
 
 	// Disable SELinux labelling
-	NoSElinux *bool
+	NoSElinux *bool `yaml:"no_selinux,omitempty"`
 
 	// Do not use. Forces auto-relabelling on first boot.
 	// See https://github.com/osbuild/osbuild/commit/52cb27631b587c1df177cd17625c5b473e1e85d2
 	SELinuxForceRelabel *bool
 
 	// Disable documentation
-	ExcludeDocs *bool
+	ExcludeDocs *bool `yaml:"exclude_docs,omitempty"`
 
 	ShellInit []shell.InitFile
 
@@ -46,9 +46,9 @@ type ImageConfig struct {
 	// when the user want the image to be subscribed on first boot and when not
 	RHSMConfig          map[subscription.RHSMStatus]*subscription.RHSMConfig
 	SystemdLogind       []*osbuild.SystemdLogindStageOptions
-	CloudInit           []*osbuild.CloudInitStageOptions
+	CloudInit           []*osbuild.CloudInitStageOptions `yaml:"cloud_init,omitempty"`
 	Modprobe            []*osbuild.ModprobeStageOptions
-	DracutConf          []*osbuild.DracutConfStageOptions
+	DracutConf          []*osbuild.DracutConfStageOptions `yaml:"dracut_conf,omitempty"`
 	SystemdDropin       []*osbuild.SystemdUnitStageOptions
 	SystemdUnit         []*osbuild.SystemdUnitCreateStageOptions
 	Authselect          *osbuild.AuthselectStageOptions
@@ -58,11 +58,11 @@ type ImageConfig struct {
 	PamLimitsConf       []*osbuild.PamLimitsConfStageOptions
 	Sysctld             []*osbuild.SysctldStageOptions
 	DNFConfig           []*osbuild.DNFConfigStageOptions
-	SshdConfig          *osbuild.SshdConfigStageOptions
+	SshdConfig          *osbuild.SshdConfigStageOptions `yaml:"sshd_config,omitempty"`
 	Authconfig          *osbuild.AuthconfigStageOptions
 	PwQuality           *osbuild.PwqualityConfStageOptions
 	WAAgentConfig       *osbuild.WAAgentConfStageOptions
-	Grub2Config         *osbuild.GRUB2Config
+	Grub2Config         *osbuild.GRUB2Config `yaml:"grub2_config,omitempty"`
 	DNFAutomaticConfig  *osbuild.DNFAutomaticConfigStageOptions
 	YumConfig           *osbuild.YumConfigStageOptions
 	YUMRepos            []*osbuild.YumReposStageOptions
@@ -71,7 +71,7 @@ type ImageConfig struct {
 	GCPGuestAgentConfig *osbuild.GcpGuestAgentConfigOptions
 	NetworkManager      *osbuild.NMConfStageOptions
 
-	WSLConfig *WSLConfig
+	WSLConfig *WSLConfig `yaml:"wsl_config,omitempty"`
 
 	Files       []*fsnode.File
 	Directories []*fsnode.Directory
@@ -95,13 +95,13 @@ type ImageConfig struct {
 	// OSTree specific configuration
 
 	// Read only sysroot and boot
-	OSTreeConfSysrootReadOnly *bool
+	OSTreeConfSysrootReadOnly *bool `yaml:"ostree_conf_sysroot_readonly,omitempty"`
 
 	// Lock the root account in the deployment unless the user defined root
 	// user options in the build configuration.
-	LockRootUser *bool
+	LockRootUser *bool `yaml:"lock_root_user,omitempty"`
 
-	IgnitionPlatform *string
+	IgnitionPlatform *string `yaml:"ignition_platform,omitempty"`
 
 	// InstallWeakDeps enables installation of weak dependencies for packages
 	// that are statically defined for the pipeline.
@@ -114,11 +114,11 @@ type ImageConfig struct {
 
 	// MountUnits creates systemd .mount units to describe the filesystem
 	// instead of writing to /etc/fstab
-	MountUnits *bool
+	MountUnits *bool `yaml:"mount_units,omitempty"`
 }
 
 type WSLConfig struct {
-	BootSystemd bool
+	BootSystemd bool `yaml:"boot_systemd,omitempty"`
 }
 
 // InheritFrom inherits unset values from the provided parent configuration and

--- a/pkg/distro/rhel/rhel10/ami.go
+++ b/pkg/distro/rhel/rhel10/ami.go
@@ -1,11 +1,8 @@
 package rhel10
 
 import (
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/datasizes"
-	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
-	"github.com/osbuild/images/pkg/osbuild"
 )
 
 // TODO: move these to the EC2 environment
@@ -22,7 +19,7 @@ func amiSapKernelOptions() []string {
 	return append(amiKernelOptions(), []string{"processor.max_cstate=1", "intel_idle.max_cstate=1"}...)
 }
 
-func mkAMIImgTypeX86_64() *rhel.ImageType {
+func mkAMIImgTypeX86_64(d *rhel.Distribution) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"ami",
 		"image.raw",
@@ -39,13 +36,13 @@ func mkAMIImgTypeX86_64() *rhel.ImageType {
 	it.KernelOptions = amiKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
-	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
+	it.DefaultImageConfig = imageConfig(d, "x86_64", "ami")
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
 }
 
-func mkAMIImgTypeAarch64() *rhel.ImageType {
+func mkAMIImgTypeAarch64(rd *rhel.Distribution) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"ami",
 		"image.raw",
@@ -62,14 +59,14 @@ func mkAMIImgTypeAarch64() *rhel.ImageType {
 	it.KernelOptions = amiAarch64KernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
-	it.DefaultImageConfig = defaultEc2ImageConfig()
+	it.DefaultImageConfig = imageConfig(rd, "aarch64", "ami")
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
 }
 
 // RHEL internal-only x86_64 EC2 image type
-func mkEc2ImgTypeX86_64() *rhel.ImageType {
+func mkEc2ImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"ec2",
 		"image.raw.xz",
@@ -87,14 +84,14 @@ func mkEc2ImgTypeX86_64() *rhel.ImageType {
 	it.KernelOptions = amiKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
-	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
+	it.DefaultImageConfig = imageConfig(rd, "x86_64", "ec2")
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
 }
 
 // RHEL internal-only aarch64 EC2 image type
-func mkEC2ImgTypeAarch64() *rhel.ImageType {
+func mkEC2ImgTypeAarch64(rd *rhel.Distribution) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"ec2",
 		"image.raw.xz",
@@ -112,14 +109,14 @@ func mkEC2ImgTypeAarch64() *rhel.ImageType {
 	it.KernelOptions = amiAarch64KernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
-	it.DefaultImageConfig = defaultEc2ImageConfig()
+	it.DefaultImageConfig = imageConfig(rd, "aarch64", "ec2")
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
 }
 
 // RHEL internal-only x86_64 EC2 HA image type
-func mkEc2HaImgTypeX86_64() *rhel.ImageType {
+func mkEc2HaImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"ec2-ha",
 		"image.raw.xz",
@@ -137,13 +134,13 @@ func mkEc2HaImgTypeX86_64() *rhel.ImageType {
 	it.KernelOptions = amiKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
-	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
+	it.DefaultImageConfig = imageConfig(rd, "x86_64", "ec2-ha")
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
 }
 
-func mkEC2SapImgTypeX86_64(osVersion string) *rhel.ImageType {
+func mkEC2SapImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"ec2-sap",
 		"image.raw.xz",
@@ -161,136 +158,9 @@ func mkEC2SapImgTypeX86_64(osVersion string) *rhel.ImageType {
 	it.KernelOptions = amiSapKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
-	it.DefaultImageConfig = sapImageConfig(osVersion).InheritFrom(defaultEc2ImageConfigX86_64())
+	// XXX: inherit in YAML
+	it.DefaultImageConfig = sapImageConfig(rd.OsVersion()).InheritFrom(imageConfig(rd, "x86_64", "ec2-ha"))
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
-}
-
-// IMAGE CONFIG
-
-// default EC2 images config (common for all architectures)
-func defaultEc2ImageConfig() *distro.ImageConfig {
-	return &distro.ImageConfig{
-		TimeSynchronization: &osbuild.ChronyStageOptions{
-			Servers: []osbuild.ChronyConfigServer{
-				{
-					Hostname: "169.254.169.123",
-					Prefer:   common.ToPtr(true),
-					Iburst:   common.ToPtr(true),
-					Minpoll:  common.ToPtr(4),
-					Maxpoll:  common.ToPtr(4),
-				},
-			},
-			// empty string will remove any occurrences of the option from the configuration
-			LeapsecTz: common.ToPtr(""),
-		},
-		Keyboard: &osbuild.KeymapStageOptions{
-			Keymap: "us",
-			X11Keymap: &osbuild.X11KeymapOptions{
-				Layouts: []string{"us"},
-			},
-		},
-		EnabledServices: []string{
-			"sshd",
-			"NetworkManager",
-			"nm-cloud-setup.service",
-			"nm-cloud-setup.timer",
-			"cloud-init",
-			"cloud-init-local",
-			"cloud-config",
-			"cloud-final",
-			"reboot.target",
-			"tuned",
-		},
-		DefaultTarget:       common.ToPtr("multi-user.target"),
-		UpdateDefaultKernel: common.ToPtr(true),
-		DefaultKernel:       common.ToPtr("kernel"),
-		Sysconfig: &distro.Sysconfig{
-			Networking: true,
-			NoZeroConf: true,
-		},
-		SystemdLogind: []*osbuild.SystemdLogindStageOptions{
-			{
-				Filename: "00-getty-fixes.conf",
-				Config: osbuild.SystemdLogindConfigDropin{
-					Login: osbuild.SystemdLogindConfigLoginSection{
-						NAutoVTs: common.ToPtr(0),
-					},
-				},
-			},
-		},
-		CloudInit: []*osbuild.CloudInitStageOptions{
-			{
-				Filename: "00-rhel-default-user.cfg",
-				Config: osbuild.CloudInitConfigFile{
-					SystemInfo: &osbuild.CloudInitConfigSystemInfo{
-						DefaultUser: &osbuild.CloudInitConfigDefaultUser{
-							Name: "ec2-user",
-						},
-					},
-				},
-			},
-		},
-		Modprobe: []*osbuild.ModprobeStageOptions{
-			{
-				Filename: "blacklist-nouveau.conf",
-				Commands: osbuild.ModprobeConfigCmdList{
-					osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
-				},
-			},
-			{
-				Filename: "blacklist-amdgpu.conf",
-				Commands: osbuild.ModprobeConfigCmdList{
-					osbuild.NewModprobeConfigCmdBlacklist("amdgpu"),
-				},
-			},
-			// https://issues.redhat.com/browse/RHEL-71926
-			{
-				Filename: "blacklist-i2c_piix4.conf",
-				Commands: osbuild.ModprobeConfigCmdList{
-					osbuild.NewModprobeConfigCmdBlacklist("i2c_piix4"),
-				},
-			},
-		},
-		SystemdDropin: []*osbuild.SystemdUnitStageOptions{
-			// RHBZ#1822863
-			{
-				Unit:   "nm-cloud-setup.service",
-				Dropin: "10-rh-enable-for-ec2.conf",
-				Config: osbuild.SystemdServiceUnitDropin{
-					Service: &osbuild.SystemdUnitServiceSection{
-						Environment: []osbuild.EnvironmentVariable{{Key: "NM_CLOUD_SETUP_EC2", Value: "yes"}},
-					},
-				},
-			},
-		},
-		Authselect: &osbuild.AuthselectStageOptions{
-			Profile: "sssd",
-		},
-		SshdConfig: &osbuild.SshdConfigStageOptions{
-			Config: osbuild.SshdConfigConfig{
-				PasswordAuthentication: common.ToPtr(false),
-			},
-		},
-	}
-}
-
-func appendEC2DracutX86_64(ic *distro.ImageConfig) *distro.ImageConfig {
-	ic.DracutConf = append(ic.DracutConf,
-		&osbuild.DracutConfStageOptions{
-			Filename: "ec2.conf",
-			Config: osbuild.DracutConfigFile{
-				AddDrivers: []string{
-					"nvme",
-					"xen-blkfront",
-				},
-			},
-		})
-	return ic
-}
-
-func defaultEc2ImageConfigX86_64() *distro.ImageConfig {
-	ic := defaultEc2ImageConfig()
-	return appendEC2DracutX86_64(ic)
 }

--- a/pkg/distro/rhel/rhel10/distro.go
+++ b/pkg/distro/rhel/rhel10/distro.go
@@ -112,13 +112,13 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 	x86_64.AddImageTypes(
 		&platform.X86{},
 		mkTarImgType(),
-		mkWSLImgType(),
+		mkWSLImgType(rd),
 	)
 
 	aarch64.AddImageTypes(
 		&platform.Aarch64{},
 		mkTarImgType(),
-		mkWSLImgType(),
+		mkWSLImgType(rd),
 	)
 
 	aarch64.AddImageTypes(
@@ -171,7 +171,7 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 	}
 	x86_64.AddImageTypes(
 		ec2X86Platform,
-		mkAMIImgTypeX86_64(),
+		mkAMIImgTypeX86_64(rd),
 	)
 
 	ec2Aarch64Platform := &platform.Aarch64{
@@ -182,7 +182,7 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 	}
 	aarch64.AddImageTypes(
 		ec2Aarch64Platform,
-		mkAMIImgTypeAarch64(),
+		mkAMIImgTypeAarch64(rd),
 	)
 
 	azureX64Platform := &platform.X86{
@@ -211,7 +211,7 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 	}
 	x86_64.AddImageTypes(
 		gceX86Platform,
-		mkGCEImageType(),
+		mkGCEImageType(rd),
 	)
 
 	x86_64.AddImageTypes(
@@ -251,8 +251,8 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 
 		x86_64.AddImageTypes(azureX64Platform, mkAzureSapInternalImgType(rd))
 
-		x86_64.AddImageTypes(ec2X86Platform, mkEc2ImgTypeX86_64(), mkEc2HaImgTypeX86_64(), mkEC2SapImgTypeX86_64(rd.OsVersion()))
-		aarch64.AddImageTypes(ec2Aarch64Platform, mkEC2ImgTypeAarch64())
+		x86_64.AddImageTypes(ec2X86Platform, mkEc2ImgTypeX86_64(rd), mkEc2HaImgTypeX86_64(rd), mkEC2SapImgTypeX86_64(rd))
+		aarch64.AddImageTypes(ec2Aarch64Platform, mkEC2ImgTypeAarch64(rd))
 	}
 
 	rd.AddArches(x86_64, aarch64, ppc64le, s390x)

--- a/pkg/distro/rhel/rhel10/gce.go
+++ b/pkg/distro/rhel/rhel10/gce.go
@@ -1,18 +1,15 @@
 package rhel10
 
 import (
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/datasizes"
-	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
-	"github.com/osbuild/images/pkg/osbuild"
 )
 
 func gceKernelOptions() []string {
 	return []string{"biosdevname=0", "scsi_mod.use_blk_mq=Y", "console=ttyS0,38400n8d"}
 }
 
-func mkGCEImageType() *rhel.ImageType {
+func mkGCEImageType(rd *rhel.Distribution) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"gce",
 		"image.tar.gz",
@@ -26,7 +23,7 @@ func mkGCEImageType() *rhel.ImageType {
 		[]string{"archive"},
 	)
 
-	it.DefaultImageConfig = baseGCEImageConfig()
+	it.DefaultImageConfig = imageConfig(rd, "", "gce")
 	it.KernelOptions = gceKernelOptions()
 	it.DefaultSize = 20 * datasizes.GibiByte
 	it.Bootable = true
@@ -34,105 +31,4 @@ func mkGCEImageType() *rhel.ImageType {
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
-}
-
-func baseGCEImageConfig() *distro.ImageConfig {
-	ic := &distro.ImageConfig{
-		TimeSynchronization: &osbuild.ChronyStageOptions{
-			Servers: []osbuild.ChronyConfigServer{{Hostname: "metadata.google.internal"}},
-		},
-		Firewall: &osbuild.FirewallStageOptions{
-			DefaultZone: "trusted",
-		},
-		EnabledServices: []string{
-			"sshd",
-			"rngd",
-			"dnf-automatic.timer",
-			// TODO: remove cloud-init services once we switch back to GCP guest tools
-			"cloud-init",
-			"cloud-init-local",
-			"cloud-config",
-			"cloud-final",
-		},
-		DisabledServices: []string{
-			"sshd-keygen@",
-			"reboot.target",
-		},
-		DefaultTarget: common.ToPtr("multi-user.target"),
-		Keyboard: &osbuild.KeymapStageOptions{
-			Keymap: "us",
-		},
-		DNFConfig: []*osbuild.DNFConfigStageOptions{
-			{
-				Config: &osbuild.DNFConfig{
-					Main: &osbuild.DNFConfigMain{
-						IPResolve: "4",
-					},
-				},
-			},
-		},
-		DNFAutomaticConfig: &osbuild.DNFAutomaticConfigStageOptions{
-			Config: &osbuild.DNFAutomaticConfig{
-				Commands: &osbuild.DNFAutomaticConfigCommands{
-					ApplyUpdates: common.ToPtr(true),
-					UpgradeType:  osbuild.DNFAutomaticUpgradeTypeSecurity,
-				},
-			},
-		},
-		YUMRepos: []*osbuild.YumReposStageOptions{
-			{
-				Filename: "google-cloud.repo",
-				Repos: []osbuild.YumRepository{
-					{
-						Id:   "google-compute-engine",
-						Name: "Google Compute Engine",
-						// TODO: use el10 repo once it's available
-						BaseURLs: []string{"https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable"},
-						Enabled:  common.ToPtr(true),
-						// TODO: enable GPG check once Google stops using SHA-1 in their keys
-						// https://issuetracker.google.com/issues/360905189
-						GPGCheck:     common.ToPtr(false),
-						RepoGPGCheck: common.ToPtr(false),
-						GPGKey: []string{
-							"https://packages.cloud.google.com/yum/doc/yum-key.gpg",
-							"https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg",
-						},
-					},
-				},
-			},
-		},
-		SshdConfig: &osbuild.SshdConfigStageOptions{
-			Config: osbuild.SshdConfigConfig{
-				PasswordAuthentication: common.ToPtr(false),
-				ClientAliveInterval:    common.ToPtr(420),
-				PermitRootLogin:        osbuild.PermitRootLoginValueNo,
-			},
-		},
-		UpdateDefaultKernel: common.ToPtr(true),
-		DefaultKernel:       common.ToPtr("kernel-core"),
-		// XXX: ensure the "old" behavior is preserved (that is
-		// likely a bug) where for GCE the sysconfig network
-		// options are not set because the merge of imageConfig
-		// is shallow and the previous setup was changing the
-		// kernel without also changing the network options.
-		Sysconfig: &distro.Sysconfig{},
-		Modprobe: []*osbuild.ModprobeStageOptions{
-			{
-				Filename: "blacklist-floppy.conf",
-				Commands: osbuild.ModprobeConfigCmdList{
-					osbuild.NewModprobeConfigCmdBlacklist("floppy"),
-				},
-			},
-		},
-		GCPGuestAgentConfig: &osbuild.GcpGuestAgentConfigOptions{
-			ConfigScope: osbuild.GcpGuestAgentConfigScopeDistro,
-			Config: &osbuild.GcpGuestAgentConfig{
-				InstanceSetup: &osbuild.GcpGuestAgentConfigInstanceSetup{
-					SetBotoConfig: common.ToPtr(false),
-				},
-			},
-		},
-	}
-
-	return ic
 }

--- a/pkg/distro/rhel/rhel10/package_sets.go
+++ b/pkg/distro/rhel/rhel10/package_sets.go
@@ -3,6 +3,8 @@ package rhel10
 // This file defines package sets that are used by more than one image type.
 
 import (
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -10,4 +12,8 @@ import (
 
 func packageSetLoader(t *rhel.ImageType) (rpmmd.PackageSet, error) {
 	return defs.PackageSet(t, "", nil)
+}
+
+func imageConfig(d *rhel.Distribution, archName, imageType string) *distro.ImageConfig {
+	return common.Must(defs.ImageConfig(d.Name(), archName, imageType, nil))
 }

--- a/pkg/distro/rhel/rhel10/qcow2.go
+++ b/pkg/distro/rhel/rhel10/qcow2.go
@@ -1,10 +1,7 @@
 package rhel10
 
 import (
-	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/customizations/subscription"
 	"github.com/osbuild/images/pkg/datasizes"
-	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 )
 
@@ -22,7 +19,7 @@ func mkQcow2ImgType(d *rhel.Distribution) *rhel.ImageType {
 		[]string{"qcow2"},
 	)
 
-	it.DefaultImageConfig = qcowImageConfig(d)
+	it.DefaultImageConfig = imageConfig(d, "", "qcow2")
 	it.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check"}
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.Bootable = true
@@ -45,32 +42,11 @@ func mkOCIImgType(d *rhel.Distribution) *rhel.ImageType {
 		[]string{"qcow2"},
 	)
 
-	it.DefaultImageConfig = qcowImageConfig(d)
+	it.DefaultImageConfig = imageConfig(d, "", "oci")
 	it.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check"}
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
-}
-
-func qcowImageConfig(d *rhel.Distribution) *distro.ImageConfig {
-	ic := &distro.ImageConfig{
-		DefaultTarget: common.ToPtr("multi-user.target"),
-	}
-	if d.IsRHEL() {
-		ic.RHSMConfig = map[subscription.RHSMStatus]*subscription.RHSMConfig{
-			subscription.RHSMConfigNoSubscription: {
-				DnfPlugins: subscription.SubManDNFPluginsConfig{
-					ProductID: subscription.DNFPluginConfig{
-						Enabled: common.ToPtr(false),
-					},
-					SubscriptionManager: subscription.DNFPluginConfig{
-						Enabled: common.ToPtr(false),
-					},
-				},
-			},
-		}
-	}
-	return ic
 }

--- a/pkg/distro/rhel/rhel10/sap.go
+++ b/pkg/distro/rhel/rhel10/sap.go
@@ -103,6 +103,11 @@ func sapImageConfig(osVersion string) *distro.ImageConfig {
 			),
 		},
 		// E4S/EUS
+		//
+		// XXX: this must become a declrative option like
+		// ImageCconfig.AddDNFReleaseVerVar or something
+		// as we do not want to support variable substituion
+		// in our YAML
 		DNFConfig: []*osbuild.DNFConfigStageOptions{
 			osbuild.NewDNFConfigStageOptions(
 				[]osbuild.DNFVariable{

--- a/pkg/distro/rhel/rhel10/ubi.go
+++ b/pkg/distro/rhel/rhel10/ubi.go
@@ -1,13 +1,10 @@
 package rhel10
 
 import (
-	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
-	"github.com/osbuild/images/pkg/osbuild"
 )
 
-func mkWSLImgType() *rhel.ImageType {
+func mkWSLImgType(rd *rhel.Distribution) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"wsl",
 		"disk.tar.gz",
@@ -21,26 +18,6 @@ func mkWSLImgType() *rhel.ImageType {
 		[]string{"archive"},
 	)
 
-	it.DefaultImageConfig = &distro.ImageConfig{
-		CloudInit: []*osbuild.CloudInitStageOptions{
-			{
-				Filename: "99_wsl.cfg",
-				Config: osbuild.CloudInitConfigFile{
-					DatasourceList: []string{
-						"WSL",
-						"None",
-					},
-					Network: &osbuild.CloudInitConfigNetwork{
-						Config: "disabled",
-					},
-				},
-			},
-		},
-		NoSElinux: common.ToPtr(true),
-		WSLConfig: &distro.WSLConfig{
-			BootSystemd: true,
-		},
-	}
-
+	it.DefaultImageConfig = imageConfig(rd, "", "wsl")
 	return it
 }

--- a/pkg/image/disk.go
+++ b/pkg/image/disk.go
@@ -108,7 +108,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 		tarPipeline.SetFilename(img.Filename) // filename extension will determine compression
 		imagePipeline = tarPipeline
 	default:
-		panic(fmt.Sprintf("invalid image format %v for image kind %v", img.Platform.GetImageFormat(), img.Name()))
+		panic(fmt.Sprintf("invalid image format %v for image kind %v (%T %+v)", img.Platform.GetImageFormat(), img.Name(), img.Platform, img.Platform))
 	}
 
 	switch img.Compression {

--- a/pkg/image/disk.go
+++ b/pkg/image/disk.go
@@ -108,7 +108,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 		tarPipeline.SetFilename(img.Filename) // filename extension will determine compression
 		imagePipeline = tarPipeline
 	default:
-		panic("invalid image format for image kind")
+		panic(fmt.Sprintf("invalid image format %v for image kind %v", img.Platform.GetImageFormat(), img.Name()))
 	}
 
 	switch img.Compression {

--- a/pkg/osbuild/cloud_init_stage.go
+++ b/pkg/osbuild/cloud_init_stage.go
@@ -25,7 +25,7 @@ func NewCloudInitStage(options *CloudInitStageOptions) *Stage {
 
 // Represents a cloud-init configuration file
 type CloudInitConfigFile struct {
-	SystemInfo     *CloudInitConfigSystemInfo `json:"system_info,omitempty"`
+	SystemInfo     *CloudInitConfigSystemInfo `json:"system_info,omitempty" yaml:"system_info,omitempty"`
 	Reporting      *CloudInitConfigReporting  `json:"reporting,omitempty"`
 	Datasource     *CloudInitConfigDatasource `json:"datasource,omitempty"`
 	DatasourceList []string                   `json:"datasource_list,omitempty" yaml:"datasource_list,omitempty"`
@@ -35,7 +35,7 @@ type CloudInitConfigFile struct {
 
 // Represents the 'system_info' configuration section
 type CloudInitConfigSystemInfo struct {
-	DefaultUser *CloudInitConfigDefaultUser `json:"default_user,omitempty"`
+	DefaultUser *CloudInitConfigDefaultUser `json:"default_user,omitempty" yaml:"default_user,omitempty"`
 }
 
 // Represents the 'reporting' configuration section
@@ -54,7 +54,7 @@ type CloudInitConfigDatasource struct {
 }
 
 type CloudInitConfigDatasourceAzure struct {
-	ApplyNetworkConfig bool `json:"apply_network_config"`
+	ApplyNetworkConfig bool `json:"apply_network_config" yaml:"apply_network_config"`
 }
 
 // Represents the 'output' configuration section

--- a/pkg/osbuild/cloud_init_stage.go
+++ b/pkg/osbuild/cloud_init_stage.go
@@ -28,7 +28,7 @@ type CloudInitConfigFile struct {
 	SystemInfo     *CloudInitConfigSystemInfo `json:"system_info,omitempty"`
 	Reporting      *CloudInitConfigReporting  `json:"reporting,omitempty"`
 	Datasource     *CloudInitConfigDatasource `json:"datasource,omitempty"`
-	DatasourceList []string                   `json:"datasource_list,omitempty"`
+	DatasourceList []string                   `json:"datasource_list,omitempty" yaml:"datasource_list,omitempty"`
 	Output         *CloudInitConfigOutput     `json:"output,omitempty"`
 	Network        *CloudInitConfigNetwork    `json:"network,omitempty"`
 }

--- a/pkg/osbuild/dnf_automatic_config_stage.go
+++ b/pkg/osbuild/dnf_automatic_config_stage.go
@@ -13,9 +13,9 @@ const (
 // DNFAutomaticConfigCommands represents the 'commands' configuration section.
 type DNFAutomaticConfigCommands struct {
 	// Whether packages comprising the available updates should be installed
-	ApplyUpdates *bool `json:"apply_updates,omitempty"`
+	ApplyUpdates *bool `json:"apply_updates,omitempty" yaml:"apply_updates,omitempty"`
 	// What kind of upgrades to look at
-	UpgradeType DNFAutomaticUpgradeTypeValue `json:"upgrade_type,omitempty"`
+	UpgradeType DNFAutomaticUpgradeTypeValue `json:"upgrade_type,omitempty" yaml:"upgrade_type,omitempty"`
 }
 
 // DNFAutomaticConfig represents DNF Automatic configuration.

--- a/pkg/osbuild/dracut_conf_stage.go
+++ b/pkg/osbuild/dracut_conf_stage.go
@@ -28,7 +28,7 @@ type DracutConfigFile struct {
 	Modules []string `json:"dracutmodules,omitempty"`
 
 	// Additional dracut modules to include
-	AddModules []string `json:"add_dracutmodules,omitempty"`
+	AddModules []string `json:"add_dracutmodules,omitempty" yaml:"add_dracutmodules,omitempty"`
 
 	// Dracut modules to not include
 	OmitModules []string `json:"omit_dracutmodules,omitempty"`

--- a/pkg/osbuild/dracut_conf_stage.go
+++ b/pkg/osbuild/dracut_conf_stage.go
@@ -37,7 +37,7 @@ type DracutConfigFile struct {
 	Drivers []string `json:"drivers,omitempty"`
 
 	// Add a specific kernel module
-	AddDrivers []string `json:"add_drivers,omitempty"`
+	AddDrivers []string `json:"add_drivers,omitempty" yaml:"add_drivers,omitempty"`
 
 	// Add driver and ensure that they are tried to be loaded
 	ForceDrivers []string `json:"force_drivers,omitempty"`

--- a/pkg/osbuild/dracut_stage.go
+++ b/pkg/osbuild/dracut_stage.go
@@ -20,7 +20,7 @@ type DracutStageOptions struct {
 	Drivers []string `json:"drivers,omitempty"`
 
 	// Add a specific kernel module
-	AddDrivers []string `json:"add_drivers,omitempty"`
+	AddDrivers []string `json:"add_drivers,omitempty" yaml:"add_drivers,omitempty"`
 
 	// Add driver and ensure that they are tried to be loaded
 	ForceDrivers []string `json:"force_drivers,omitempty"`

--- a/pkg/osbuild/firewall_stage.go
+++ b/pkg/osbuild/firewall_stage.go
@@ -6,7 +6,7 @@ type FirewallStageOptions struct {
 	Ports            []string       `json:"ports,omitempty"`
 	EnabledServices  []string       `json:"enabled_services,omitempty"`
 	DisabledServices []string       `json:"disabled_services,omitempty"`
-	DefaultZone      string         `json:"default_zone,omitempty"`
+	DefaultZone      string         `json:"default_zone,omitempty" yaml:"default_zone,omitempty"`
 	Zones            []FirewallZone `json:"zones,omitempty"`
 }
 

--- a/pkg/osbuild/gcp_guest_agent_conf_stage.go
+++ b/pkg/osbuild/gcp_guest_agent_conf_stage.go
@@ -32,7 +32,7 @@ type GcpGuestAgentConfigInstanceSetup struct {
 	HostKeyTypes     []string `json:"host_key_types,omitempty"`
 	OptimizeLocalSsd *bool    `json:"optimize_local_ssd,omitempty"`
 	NetworkEnabled   *bool    `json:"network_enabled,omitempty"`
-	SetBotoConfig    *bool    `json:"set_boto_config,omitempty"`
+	SetBotoConfig    *bool    `json:"set_boto_config,omitempty" yaml:"set_boto_config,omitempty"`
 	SetHostKeys      *bool    `json:"set_host_keys,omitempty"`
 	SetMultiqueue    *bool    `json:"set_multiqueue,omitempty"`
 }
@@ -57,16 +57,17 @@ type GcpGuestAgentConfigNetworkInterfaces struct {
 }
 
 type GcpGuestAgentConfig struct {
-	Accounts          *GcpGuestAgentConfigAccounts          `json:"Accounts,omitempty"`
-	Daemons           *GcpGuestAgentConfigDaemons           `json:"Daemons,omitempty"`
-	InstanceSetup     *GcpGuestAgentConfigInstanceSetup     `json:"InstanceSetup,omitempty"`
+	Accounts *GcpGuestAgentConfigAccounts `json:"Accounts,omitempty"`
+	Daemons  *GcpGuestAgentConfigDaemons  `json:"Daemons,omitempty"`
+	// XXX: json/yaml inconcistent
+	InstanceSetup     *GcpGuestAgentConfigInstanceSetup     `json:"InstanceSetup,omitempty" yaml:"instance_setup,omitempty"`
 	IpForwarding      *GcpGuestAgentConfigIpForwarding      `json:"IpForwarding,omitempty"`
 	MetadataScripts   *GcpGuestAgentConfigMetadataScripts   `json:"MetadataScripts,omitempty"`
 	NetworkInterfaces *GcpGuestAgentConfigNetworkInterfaces `json:"NetworkInterfaces,omitempty"`
 }
 
 type GcpGuestAgentConfigOptions struct {
-	ConfigScope GcpGuestAgentConfigScopeValue `json:"config_scope,omitempty"`
+	ConfigScope GcpGuestAgentConfigScopeValue `json:"config_scope,omitempty" yaml:"config_scope,omitempty"`
 	Config      *GcpGuestAgentConfig          `json:"config"`
 }
 

--- a/pkg/osbuild/grub2_stage.go
+++ b/pkg/osbuild/grub2_stage.go
@@ -44,14 +44,14 @@ const (
 
 type GRUB2Config struct {
 	Default         string                  `json:"default,omitempty"`
-	DisableRecovery *bool                   `json:"disable_recovery,omitempty"`
-	DisableSubmenu  *bool                   `json:"disable_submenu,omitempty"`
+	DisableRecovery *bool                   `json:"disable_recovery,omitempty" yaml:"disable_recovery,omitempty"`
+	DisableSubmenu  *bool                   `json:"disable_submenu,omitempty" yaml:"disable_submenu,omitempty"`
 	Distributor     string                  `json:"distributor,omitempty"`
 	Terminal        []string                `json:"terminal,omitempty"`
 	TerminalInput   []string                `json:"terminal_input,omitempty"`
 	TerminalOutput  []string                `json:"terminal_output,omitempty"`
 	Timeout         int                     `json:"timeout,omitempty"`
-	TimeoutStyle    GRUB2ConfigTimeoutStyle `json:"timeout_style,omitempty"`
+	TimeoutStyle    GRUB2ConfigTimeoutStyle `json:"timeout_style,omitempty" yaml:"timeout_style,omitempty"`
 	Serial          string                  `json:"serial,omitempty"`
 }
 

--- a/pkg/osbuild/keymap_stage.go
+++ b/pkg/osbuild/keymap_stage.go
@@ -6,8 +6,9 @@ import (
 )
 
 type KeymapStageOptions struct {
-	Keymap    string            `json:"keymap"`
-	X11Keymap *X11KeymapOptions `json:"x11-keymap,omitempty"`
+	Keymap string `json:"keymap"`
+	// XXX: yaml/json inconsistent
+	X11Keymap *X11KeymapOptions `json:"x11-keymap,omitempty" yaml:"x11_keymap,omitempty"`
 }
 
 func (KeymapStageOptions) isStageOptions() {}

--- a/pkg/osbuild/modprobe_stage.go
+++ b/pkg/osbuild/modprobe_stage.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+
+	"github.com/osbuild/images/internal/common"
 )
 
 const modprobeCfgFilenameRegex = "^[\\w.-]{1,250}\\.conf$"
@@ -93,6 +95,10 @@ func (configFile *ModprobeConfigCmdList) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+func (configFile *ModprobeConfigCmdList) UnmarshalYAML(unmarshal func(any) error) error {
+	return common.UnmarshalYAMLviaJSON(configFile, unmarshal)
 }
 
 // ModprobeConfigCmdBlacklist represents the 'blacklist' command in the

--- a/pkg/osbuild/sshd_config_stage_test.go
+++ b/pkg/osbuild/sshd_config_stage_test.go
@@ -2,10 +2,10 @@ package osbuild
 
 import (
 	"encoding/json"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 
 	"github.com/osbuild/images/internal/common"
 )
@@ -40,7 +40,18 @@ func TestJsonSshdConfigStage(t *testing.T) {
 	var inputOptions SshdConfigStageOptions
 	err := json.Unmarshal([]byte(inputString), &inputOptions)
 	assert.NoError(t, err, "failed to parse JSON into sshd config")
-	assert.True(t, reflect.DeepEqual(expectedOptions, inputOptions))
+	assert.Equal(t, expectedOptions, inputOptions)
+
+	inputStringYAML := `
+config:
+  password_authentication: false
+  challenge_response_authentication: false
+  client_alive_interval: 180
+  permit_root_login: "prohibit-password"
+`
+	err = yaml.Unmarshal([]byte(inputStringYAML), &inputOptions)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOptions, inputOptions)
 
 	// Second try the other way around with stress on missing values
 	// for those parameters that the user didn't specify.

--- a/pkg/osbuild/waagent_conf.go
+++ b/pkg/osbuild/waagent_conf.go
@@ -3,8 +3,10 @@ package osbuild
 type WAAgentConfig struct {
 	ProvisioningUseCloudInit *bool `json:"Provisioning.UseCloudInit,omitempty"`
 	ProvisioningEnabled      *bool `json:"Provisioning.Enabled,omitempty"`
-	RDFormat                 *bool `json:"ResourceDisk.Format,omitempty"`
-	RDEnableSwap             *bool `json:"ResourceDisk.EnableSwap,omitempty"`
+	// XXX: yaml/json inconsistent :(
+	RDFormat *bool `json:"ResourceDisk.Format,omitempty" yaml:"rd_format"`
+	// XXX: yaml/json inconsistent :(
+	RDEnableSwap *bool `json:"ResourceDisk.EnableSwap,omitempty" yaml:"rd_enable_swap"`
 }
 
 type WAAgentConfStageOptions struct {

--- a/pkg/osbuild/yum_repos_stage.go
+++ b/pkg/osbuild/yum_repos_stage.go
@@ -13,18 +13,20 @@ const repoIDRegex = "^[\\w.\\-:]+$"
 
 // YumRepository represents a single DNF / YUM repository.
 type YumRepository struct {
-	Id             string   `json:"id"`
-	BaseURLs       []string `json:"baseurl,omitempty"`
-	Cost           *int     `json:"cost,omitempty"`
-	Enabled        *bool    `json:"enabled,omitempty"`
-	Priority       *int     `json:"priority,omitempty"`
-	GPGKey         []string `json:"gpgkey,omitempty"`
+	Id string `json:"id"`
+	// XXX: yaml/json inconsistent
+	BaseURLs []string `json:"baseurl,omitempty" yaml:"baseurls,omitempty"`
+	Cost     *int     `json:"cost,omitempty"`
+	Enabled  *bool    `json:"enabled,omitempty"`
+	Priority *int     `json:"priority,omitempty"`
+	// XXX: yaml/json inconsistent
+	GPGKey         []string `json:"gpgkey,omitempty" yaml:"gpgkeys,omitempty" `
 	Metalink       string   `json:"metalink,omitempty"`
 	Mirrorlist     string   `json:"mirrorlist,omitempty"`
 	ModuleHotfixes *bool    `json:"module_hotfixes,omitempty"`
 	Name           string   `json:"name,omitempty"`
-	GPGCheck       *bool    `json:"gpgcheck,omitempty"`
-	RepoGPGCheck   *bool    `json:"repo_gpgcheck,omitempty"`
+	GPGCheck       *bool    `json:"gpgcheck,omitempty" yaml:"gpgcheck,omitempty"`
+	RepoGPGCheck   *bool    `json:"repo_gpgcheck,omitempty" yaml:"repo_gpgcheck,omitempty"`
 	SSLVerify      *bool    `json:"sslverify,omitempty"`
 }
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -42,6 +42,23 @@ func (f ImageFormat) String() string {
 	}
 }
 
+func (f ImageFormat) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	switch s {
+	case "unset":
+		f = FORMAT_UNSET
+		// XXX add the rest
+	case "qcow2":
+		f = FORMAT_QCOW2
+	default:
+		panic(fmt.Errorf("unknown image format %q", s))
+	}
+	return nil
+}
+
 type Platform interface {
 	GetArch() arch.Arch
 	GetImageFormat() ImageFormat

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -42,17 +42,28 @@ func (f ImageFormat) String() string {
 	}
 }
 
-func (f ImageFormat) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (f *ImageFormat) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return err
 	}
 	switch s {
 	case "unset":
-		f = FORMAT_UNSET
-		// XXX add the rest
+		*f = FORMAT_UNSET
+	case "raw":
+		*f = FORMAT_RAW
+	case "iso":
+		*f = FORMAT_ISO
 	case "qcow2":
-		f = FORMAT_QCOW2
+		*f = FORMAT_QCOW2
+	case "vmdk":
+		*f = FORMAT_VMDK
+	case "vhd":
+		*f = FORMAT_VHD
+	case "gce":
+		*f = FORMAT_GCE
+	case "ova":
+		*f = FORMAT_OVA
 	default:
 		panic(fmt.Errorf("unknown image format %q", s))
 	}

--- a/tools/gen-manifests-diff
+++ b/tools/gen-manifests-diff
@@ -43,13 +43,17 @@ def top_srcdir() -> pathlib.Path:
 def run_gen_manifests(cmd, output_dir):
     env = os.environ.copy()
     env["OSBUILD_TESTING_RNG_SEED"] = "0"
-    subprocess.run(cmd + [
+    p = subprocess.run(cmd + [
         "-packages=false",
         "-metadata=false",
         "-containers=false",
         "-arches", ",".join(arches),
         "-output", output_dir,
-    ], env=env, text=True, capture_output=True, check=True)
+    ], env=env, text=True, capture_output=True, check=False)
+    if p.returncode != 0:
+        print(p.stdout)
+        print(p.stderr)
+        raise RuntimeError(f"{cmd} failed")
 
 
 def manifests_diff(tmp_path, rev):


### PR DESCRIPTION
This is a preview for moving ImageConfig into YAML  - this code moves fedora and rhel10 to get a feel for what issue there are.

Some of the challenges we need to resolve:
1. a bunch of missing custom unmarshallers custom types in YAML (smop)
2. inconsistency in our osbuild options, most common is "snake_case", but we use many different other styles, including: `ResourceDisk.Format`, `x11-keyboard` and singular/plural is often a problem.
3. in one case we put a variable "osVersion" into the imageConfig (sap.go). this is not directly mappable in yaml so we need a indirection here

But overall it is pretty straightforward.

JIRA: HMS-5284