### PR TITLE
distro: make `DNFConfig` more declarative

### DIFF
--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -227,7 +227,7 @@ func osCustomizations(
 	osc.Tmpfilesd = imageConfig.Tmpfilesd
 	osc.PamLimitsConf = imageConfig.PamLimitsConf
 	osc.Sysctld = imageConfig.Sysctld
-	osc.DNFConfig = imageConfig.DNFConfig
+	osc.DNFConfig = imageConfig.DNFConfigOptions(t.arch.distro.osVersion)
 	osc.SshdConfig = imageConfig.SshdConfig
 	osc.AuthConfig = imageConfig.Authconfig
 	osc.PwQuality = imageConfig.PwQuality

--- a/pkg/distro/image_config_test.go
+++ b/pkg/distro/image_config_test.go
@@ -166,3 +166,71 @@ func TestImageConfigInheritFrom(t *testing.T) {
 		})
 	}
 }
+
+func TestImageConfiDNCConfigNone(t *testing.T) {
+	var expected []*osbuild.DNFConfigStageOptions
+	cnf := &ImageConfig{}
+	assert.Equal(t, expected, cnf.DNFConfigOptions("centos-9"))
+}
+
+func TestImageConfiDNCConfigSetReleaseVer(t *testing.T) {
+	cnf := &ImageConfig{
+		DNFConfig: &DNFConfig{
+			SetReleaseVerVar: true,
+		},
+	}
+	assert.Equal(t, []*osbuild.DNFConfigStageOptions{
+		{
+			Variables: []osbuild.DNFVariable{
+				{
+					Name:  "releasever",
+					Value: "centos-9",
+				},
+			},
+		},
+	}, cnf.DNFConfigOptions("centos-9"))
+}
+
+func TestImageConfiDNCConfigForceIPv4(t *testing.T) {
+	cnf := &ImageConfig{
+		DNFConfig: &DNFConfig{
+			ForceIPv4: true,
+		},
+	}
+	assert.Equal(t, []*osbuild.DNFConfigStageOptions{
+		{
+			Config: &osbuild.DNFConfig{
+				Main: &osbuild.DNFConfigMain{
+					IPResolve: "4",
+				},
+			},
+		},
+	}, cnf.DNFConfigOptions("centos-9"))
+}
+
+func TestImageConfiDNCConfigAll(t *testing.T) {
+	cnf := &ImageConfig{
+		DNFConfig: &DNFConfig{
+			SetReleaseVerVar: true,
+			ForceIPv4:        true,
+		},
+	}
+	assert.Equal(t, []*osbuild.DNFConfigStageOptions{
+		{
+			Variables: []osbuild.DNFVariable{
+				{
+					Name:  "releasever",
+					Value: "centos-9",
+				},
+			},
+		},
+		{
+
+			Config: &osbuild.DNFConfig{
+				Main: &osbuild.DNFConfigMain{
+					IPResolve: "4",
+				},
+			},
+		},
+	}, cnf.DNFConfigOptions("centos-9"))
+}

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -260,7 +260,7 @@ func osCustomizations(
 	osc.Tmpfilesd = imageConfig.Tmpfilesd
 	osc.PamLimitsConf = imageConfig.PamLimitsConf
 	osc.Sysctld = imageConfig.Sysctld
-	osc.DNFConfig = imageConfig.DNFConfig
+	osc.DNFConfig = imageConfig.DNFConfigOptions(t.arch.distro.osVersion)
 	osc.DNFAutomaticConfig = imageConfig.DNFAutomaticConfig
 	osc.YUMConfig = imageConfig.YumConfig
 	osc.SshdConfig = imageConfig.SshdConfig

--- a/pkg/distro/rhel/rhel10/gce.go
+++ b/pkg/distro/rhel/rhel10/gce.go
@@ -62,14 +62,8 @@ func baseGCEImageConfig() *distro.ImageConfig {
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",
 		},
-		DNFConfig: []*osbuild.DNFConfigStageOptions{
-			{
-				Config: &osbuild.DNFConfig{
-					Main: &osbuild.DNFConfigMain{
-						IPResolve: "4",
-					},
-				},
-			},
+		DNFConfig: &distro.DNFConfig{
+			ForceIPv4: true,
 		},
 		DNFAutomaticConfig: &osbuild.DNFAutomaticConfigStageOptions{
 			Config: &osbuild.DNFAutomaticConfig{

--- a/pkg/distro/rhel/rhel10/sap.go
+++ b/pkg/distro/rhel/rhel10/sap.go
@@ -103,16 +103,8 @@ func sapImageConfig(osVersion string) *distro.ImageConfig {
 			),
 		},
 		// E4S/EUS
-		DNFConfig: []*osbuild.DNFConfigStageOptions{
-			osbuild.NewDNFConfigStageOptions(
-				[]osbuild.DNFVariable{
-					{
-						Name:  "releasever",
-						Value: osVersion,
-					},
-				},
-				nil,
-			),
+		DNFConfig: &distro.DNFConfig{
+			SetReleaseVerVar: true,
 		},
 	}
 }

--- a/pkg/distro/rhel/rhel8/gce.go
+++ b/pkg/distro/rhel/rhel8/gce.go
@@ -86,14 +86,8 @@ func defaultGceByosImageConfig(rd distro.Distro) *distro.ImageConfig {
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",
 		},
-		DNFConfig: []*osbuild.DNFConfigStageOptions{
-			{
-				Config: &osbuild.DNFConfig{
-					Main: &osbuild.DNFConfigMain{
-						IPResolve: "4",
-					},
-				},
-			},
+		DNFConfig: &distro.DNFConfig{
+			ForceIPv4: true,
 		},
 		DNFAutomaticConfig: &osbuild.DNFAutomaticConfigStageOptions{
 			Config: &osbuild.DNFAutomaticConfig{

--- a/pkg/distro/rhel/rhel8/sap.go
+++ b/pkg/distro/rhel/rhel8/sap.go
@@ -107,16 +107,8 @@ func sapImageConfig(rd distro.Distro) *distro.ImageConfig {
 
 	if common.VersionLessThan(rd.OsVersion(), "8.10") {
 		// E4S/EUS
-		ic.DNFConfig = []*osbuild.DNFConfigStageOptions{
-			osbuild.NewDNFConfigStageOptions(
-				[]osbuild.DNFVariable{
-					{
-						Name:  "releasever",
-						Value: rd.OsVersion(),
-					},
-				},
-				nil,
-			),
+		ic.DNFConfig = &distro.DNFConfig{
+			SetReleaseVerVar: true,
 		}
 	}
 

--- a/pkg/distro/rhel/rhel9/gce.go
+++ b/pkg/distro/rhel/rhel9/gce.go
@@ -62,14 +62,8 @@ func baseGCEImageConfig() *distro.ImageConfig {
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",
 		},
-		DNFConfig: []*osbuild.DNFConfigStageOptions{
-			{
-				Config: &osbuild.DNFConfig{
-					Main: &osbuild.DNFConfigMain{
-						IPResolve: "4",
-					},
-				},
-			},
+		DNFConfig: &distro.DNFConfig{
+			ForceIPv4: true,
 		},
 		DNFAutomaticConfig: &osbuild.DNFAutomaticConfigStageOptions{
 			Config: &osbuild.DNFAutomaticConfig{

--- a/pkg/distro/rhel/rhel9/sap.go
+++ b/pkg/distro/rhel/rhel9/sap.go
@@ -103,16 +103,8 @@ func sapImageConfig(osVersion string) *distro.ImageConfig {
 			),
 		},
 		// E4S/EUS
-		DNFConfig: []*osbuild.DNFConfigStageOptions{
-			osbuild.NewDNFConfigStageOptions(
-				[]osbuild.DNFVariable{
-					{
-						Name:  "releasever",
-						Value: osVersion,
-					},
-				},
-				nil,
-			),
+		DNFConfig: &distro.DNFConfig{
+			SetReleaseVerVar: true,
 		},
 	}
 }


### PR DESCRIPTION
This commit removes the `DNFConfigStageOptions` from `ImageConfig` in favor of a simpler `DNFConfig` struct.

The rational is that `DNFConfigStageOptions` current gets the `osVersion` passed in directly. When we move to a YAML based ImageConfig this will be problematic as we do not have access to variables like this. By making this a declarative option we sidestep the problem.

This  generates no manifest diff.

Needed for https://github.com/osbuild/images/pull/1462 