### PR TITLE
distro: add DNFSetReleaseVerVar to ImageConfig

### DIFF
--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -227,7 +227,7 @@ func osCustomizations(
 	osc.Tmpfilesd = imageConfig.Tmpfilesd
 	osc.PamLimitsConf = imageConfig.PamLimitsConf
 	osc.Sysctld = imageConfig.Sysctld
-	osc.DNFConfig = imageConfig.DNFConfig
+	osc.DNFConfig = imageConfig.DNFConfigOptions(t.arch.distro.osVersion)
 	osc.SshdConfig = imageConfig.SshdConfig
 	osc.AuthConfig = imageConfig.Authconfig
 	osc.PwQuality = imageConfig.PwQuality

--- a/pkg/distro/image_config_test.go
+++ b/pkg/distro/image_config_test.go
@@ -166,3 +166,32 @@ func TestImageConfigInheritFrom(t *testing.T) {
 		})
 	}
 }
+
+func TestImageConfigDNFSetReleaseVerNotSet(t *testing.T) {
+	var expected []*osbuild.DNFConfigStageOptions
+	cnf := &ImageConfig{}
+	assert.Equal(t, expected, cnf.DNFConfigOptions("9-stream"))
+
+	cnf.DNFSetReleaseVerVar = common.ToPtr(false)
+	assert.Equal(t, expected, cnf.DNFConfigOptions("9-stream"))
+}
+
+func TestImageConfigDNFConfigOptionsPreExisting(t *testing.T) {
+	cnf := &ImageConfig{
+		DNFConfig: []*osbuild.DNFConfigStageOptions{
+			{
+				Config: &osbuild.DNFConfig{
+					Main: &osbuild.DNFConfigMain{
+						IPResolve: "4",
+					},
+				},
+			},
+		},
+	}
+	assert.Equal(t, cnf.DNFConfig, cnf.DNFConfigOptions("9-stream"))
+
+	cnf.DNFSetReleaseVerVar = common.ToPtr(true)
+	assert.PanicsWithError(t, "internal error: currently DNFConfig and DNFSetReleaseVerVar cannot be used together, please reporting this as a feature request", func() {
+		cnf.DNFConfigOptions("9-stream")
+	})
+}

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -260,7 +260,7 @@ func osCustomizations(
 	osc.Tmpfilesd = imageConfig.Tmpfilesd
 	osc.PamLimitsConf = imageConfig.PamLimitsConf
 	osc.Sysctld = imageConfig.Sysctld
-	osc.DNFConfig = imageConfig.DNFConfig
+	osc.DNFConfig = imageConfig.DNFConfigOptions(t.arch.distro.osVersion)
 	osc.DNFAutomaticConfig = imageConfig.DNFAutomaticConfig
 	osc.YUMConfig = imageConfig.YumConfig
 	osc.SshdConfig = imageConfig.SshdConfig

--- a/pkg/distro/rhel/rhel10/sap.go
+++ b/pkg/distro/rhel/rhel10/sap.go
@@ -1,6 +1,7 @@
 package rhel10
 
 import (
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/osbuild"
 )
@@ -103,16 +104,6 @@ func sapImageConfig(osVersion string) *distro.ImageConfig {
 			),
 		},
 		// E4S/EUS
-		DNFConfig: []*osbuild.DNFConfigStageOptions{
-			osbuild.NewDNFConfigStageOptions(
-				[]osbuild.DNFVariable{
-					{
-						Name:  "releasever",
-						Value: osVersion,
-					},
-				},
-				nil,
-			),
-		},
+		DNFSetReleaseVerVar: common.ToPtr(true),
 	}
 }

--- a/pkg/distro/rhel/rhel8/sap.go
+++ b/pkg/distro/rhel/rhel8/sap.go
@@ -107,17 +107,7 @@ func sapImageConfig(rd distro.Distro) *distro.ImageConfig {
 
 	if common.VersionLessThan(rd.OsVersion(), "8.10") {
 		// E4S/EUS
-		ic.DNFConfig = []*osbuild.DNFConfigStageOptions{
-			osbuild.NewDNFConfigStageOptions(
-				[]osbuild.DNFVariable{
-					{
-						Name:  "releasever",
-						Value: rd.OsVersion(),
-					},
-				},
-				nil,
-			),
-		}
+		ic.DNFSetReleaseVerVar = common.ToPtr(true)
 	}
 
 	return ic

--- a/pkg/distro/rhel/rhel9/sap.go
+++ b/pkg/distro/rhel/rhel9/sap.go
@@ -1,6 +1,7 @@
 package rhel9
 
 import (
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/osbuild"
 )
@@ -103,16 +104,6 @@ func sapImageConfig(osVersion string) *distro.ImageConfig {
 			),
 		},
 		// E4S/EUS
-		DNFConfig: []*osbuild.DNFConfigStageOptions{
-			osbuild.NewDNFConfigStageOptions(
-				[]osbuild.DNFVariable{
-					{
-						Name:  "releasever",
-						Value: osVersion,
-					},
-				},
-				nil,
-			),
-		},
+		DNFSetReleaseVerVar: common.ToPtr(true),
 	}
 }


### PR DESCRIPTION
This commit adds a new `DNFSetReleaseVerVar` to
`ImageConfig` and a new `DNFConfigOptions() helper.

The rational is that `DNFConfigStageOptions` current gets the `osVersion` passed in directly. When we move to a YAML based ImageConfig this will be problematic as we do not have access to variables like this. By making this new declarative option we sidestep the problem.

This option is used in the rhel sap images.

Its slightly unfortunate that we need to change two places (images.go in rhel/fedora) to use the new
helper (pr#1387 would fix this) but with more YAML work eventually this should converge.

Thanks to thozza for suggesting this simplified approach.

JIRA: HMS-5284