### PR TITLE
distro: move `kernelOptions` into `ImageConfig`

### DIFF
--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -232,6 +232,7 @@ func mkIotSimplifiedInstallerImgType(d distribution) imageType {
 			OSTreeConfSysrootReadOnly: common.ToPtr(true),
 			LockRootUser:              common.ToPtr(true),
 			IgnitionPlatform:          common.ToPtr("metal"),
+			KernelOptions:             ostreeDeploymentKernelOptions(),
 		},
 		defaultSize:            10 * datasizes.GibiByte,
 		rpmOstree:              true,
@@ -242,7 +243,6 @@ func mkIotSimplifiedInstallerImgType(d distribution) imageType {
 		buildPipelines:         []string{"build"},
 		payloadPipelines:       []string{"ostree-deployment", "image", "xz", "coi-tree", "efiboot-tree", "bootiso-tree", "bootiso"},
 		exports:                []string{"bootiso"},
-		kernelOptions:          ostreeDeploymentKernelOptions(),
 		requiredPartitionSizes: requiredDirectorySizes,
 	}
 }
@@ -263,6 +263,7 @@ func mkIotRawImgType(d distribution) imageType {
 			OSTreeConfSysrootReadOnly: common.ToPtr(true),
 			LockRootUser:              common.ToPtr(true),
 			IgnitionPlatform:          common.ToPtr("metal"),
+			KernelOptions:             ostreeDeploymentKernelOptions(),
 		},
 		defaultSize:      4 * datasizes.GibiByte,
 		rpmOstree:        true,
@@ -271,7 +272,6 @@ func mkIotRawImgType(d distribution) imageType {
 		buildPipelines:   []string{"build"},
 		payloadPipelines: []string{"ostree-deployment", "image", "xz"},
 		exports:          []string{"xz"},
-		kernelOptions:    ostreeDeploymentKernelOptions(),
 
 		// Passing an empty map into the required partition sizes disables the
 		// default partition sizes normally set so our `basePartitionTables` can
@@ -295,6 +295,7 @@ func mkIotQcow2ImgType(d distribution) imageType {
 			OSTreeConfSysrootReadOnly: common.ToPtr(true),
 			LockRootUser:              common.ToPtr(true),
 			IgnitionPlatform:          common.ToPtr("qemu"),
+			KernelOptions:             ostreeDeploymentKernelOptions(),
 		},
 		defaultSize:            10 * datasizes.GibiByte,
 		rpmOstree:              true,
@@ -303,7 +304,6 @@ func mkIotQcow2ImgType(d distribution) imageType {
 		buildPipelines:         []string{"build"},
 		payloadPipelines:       []string{"ostree-deployment", "image", "qcow2"},
 		exports:                []string{"qcow2"},
-		kernelOptions:          ostreeDeploymentKernelOptions(),
 		requiredPartitionSizes: requiredDirectorySizes,
 	}
 }
@@ -320,8 +320,8 @@ func mkQcow2ImgType(d distribution) imageType {
 		},
 		defaultImageConfig: &distro.ImageConfig{
 			DefaultTarget: common.ToPtr("multi-user.target"),
+			KernelOptions: cloudKernelOptions(),
 		},
-		kernelOptions:          cloudKernelOptions(),
 		bootable:               true,
 		defaultSize:            5 * datasizes.GibiByte,
 		image:                  diskImage,
@@ -341,6 +341,7 @@ var (
 			"cloud-final.service",
 			"cloud-init-local.service",
 		},
+		KernelOptions: cloudKernelOptions(),
 	}
 )
 
@@ -354,7 +355,6 @@ func mkVmdkImgType(d distribution) imageType {
 			osPkgsKey: packageSetLoader,
 		},
 		defaultImageConfig:     vmdkDefaultImageConfig,
-		kernelOptions:          cloudKernelOptions(),
 		bootable:               true,
 		defaultSize:            2 * datasizes.GibiByte,
 		image:                  diskImage,
@@ -375,7 +375,6 @@ func mkOvaImgType(d distribution) imageType {
 			osPkgsKey: packageSetLoader,
 		},
 		defaultImageConfig:     vmdkDefaultImageConfig,
-		kernelOptions:          cloudKernelOptions(),
 		bootable:               true,
 		defaultSize:            2 * datasizes.GibiByte,
 		image:                  diskImage,
@@ -470,9 +469,9 @@ func mkMinimalRawImgType(d distribution) imageType {
 				Timeout: 5,
 			},
 			InstallWeakDeps: common.ToPtr(common.VersionLessThan(d.osVersion, VERSION_MINIMAL_WEAKDEPS)),
+			KernelOptions:   defaultKernelOptions(),
 		},
 		rpmOstree:              false,
-		kernelOptions:          defaultKernelOptions(),
 		bootable:               true,
 		defaultSize:            2 * datasizes.GibiByte,
 		image:                  diskImage,
@@ -488,7 +487,7 @@ func mkMinimalRawImgType(d distribution) imageType {
 
 		// when using systemd mount units we also want them to be mounted rw
 		// while the default options are not
-		it.kernelOptions = []string{"rw"}
+		it.defaultImageConfig.KernelOptions = []string{"rw"}
 	}
 	return it
 }

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -41,8 +41,9 @@ func osCustomizations(
 		osc.KernelName = c.GetKernel().Name
 
 		var kernelOptions []string
-		if len(t.kernelOptions) > 0 {
-			kernelOptions = append(kernelOptions, t.kernelOptions...)
+		// XXX: keep in sync with the identical copy in rhel/images.go
+		if t.defaultImageConfig != nil && len(t.defaultImageConfig.KernelOptions) > 0 {
+			kernelOptions = append(kernelOptions, t.defaultImageConfig.KernelOptions...)
 		}
 		if bpKernel := c.GetKernel(); bpKernel.Append != "" {
 			kernelOptions = append(kernelOptions, bpKernel.Append)
@@ -268,8 +269,8 @@ func ostreeDeploymentCustomizations(
 	deploymentConf := manifest.OSTreeDeploymentCustomizations{}
 
 	var kernelOptions []string
-	if len(t.kernelOptions) > 0 {
-		kernelOptions = append(kernelOptions, t.kernelOptions...)
+	if len(t.defaultImageConfig.KernelOptions) > 0 {
+		kernelOptions = append(kernelOptions, t.defaultImageConfig.KernelOptions...)
 	}
 	if bpKernel := c.GetKernel(); bpKernel != nil && bpKernel.Append != "" {
 		kernelOptions = append(kernelOptions, bpKernel.Append)

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -45,7 +45,6 @@ type imageType struct {
 	packageSets            map[string]packageSetFunc
 	defaultImageConfig     *distro.ImageConfig
 	defaultInstallerConfig *distro.InstallerConfig
-	kernelOptions          []string
 	defaultSize            uint64
 	buildPipelines         []string
 	payloadPipelines       []string

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -26,6 +26,7 @@ type ImageConfig struct {
 	Sysconfig           *Sysconfig `yaml:"sysconfig,omitempty"`
 	DefaultKernel       *string    `yaml:"default_kernel,omitempty"`
 	UpdateDefaultKernel *bool      `yaml:"update_default_kernel,omitempty"`
+	KernelOptions       []string   `yaml:"kernel_options,omitempty"`
 
 	// List of files from which to import GPG keys into the RPM database
 	GPGKeyFiles []string `yaml:"gpgkey_files,omitempty"`

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -40,8 +40,9 @@ func osCustomizations(
 		osc.KernelName = c.GetKernel().Name
 
 		var kernelOptions []string
-		if len(t.KernelOptions) > 0 {
-			kernelOptions = append(kernelOptions, t.KernelOptions...)
+		// XXX: keep in sync with the identical copy in fedora/images.go
+		if t.DefaultImageConfig != nil && len(t.DefaultImageConfig.KernelOptions) > 0 {
+			kernelOptions = append(kernelOptions, t.DefaultImageConfig.KernelOptions...)
 		}
 		if bpKernel := c.GetKernel(); bpKernel.Append != "" {
 			kernelOptions = append(kernelOptions, bpKernel.Append)
@@ -311,8 +312,8 @@ func ostreeDeploymentCustomizations(
 	deploymentConf := manifest.OSTreeDeploymentCustomizations{}
 
 	var kernelOptions []string
-	if len(t.KernelOptions) > 0 {
-		kernelOptions = append(kernelOptions, t.KernelOptions...)
+	if len(t.DefaultImageConfig.KernelOptions) > 0 {
+		kernelOptions = append(kernelOptions, t.DefaultImageConfig.KernelOptions...)
 	}
 	if bpKernel := c.GetKernel(); bpKernel != nil && bpKernel.Append != "" {
 		kernelOptions = append(kernelOptions, bpKernel.Append)

--- a/pkg/distro/rhel/imagetype.go
+++ b/pkg/distro/rhel/imagetype.go
@@ -78,7 +78,6 @@ type ImageType struct {
 	Compression            string // TODO: remove from image definition and make it a transport option
 	DefaultImageConfig     *distro.ImageConfig
 	DefaultInstallerConfig *distro.InstallerConfig
-	KernelOptions          []string
 	DefaultSize            uint64
 
 	// bootISO: installable ISO

--- a/pkg/distro/rhel/rhel10/ami.go
+++ b/pkg/distro/rhel/rhel10/ami.go
@@ -36,10 +36,10 @@ func mkAMIImgTypeX86_64() *rhel.ImageType {
 		[]string{"image"},
 	)
 
-	it.KernelOptions = amiKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
+	it.DefaultImageConfig.KernelOptions = amiKernelOptions()
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -59,10 +59,10 @@ func mkAMIImgTypeAarch64() *rhel.ImageType {
 		[]string{"image"},
 	)
 
-	it.KernelOptions = amiAarch64KernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfig()
+	it.DefaultImageConfig.KernelOptions = amiAarch64KernelOptions()
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -84,10 +84,10 @@ func mkEc2ImgTypeX86_64() *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = amiKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
+	it.DefaultImageConfig.KernelOptions = amiKernelOptions()
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -109,10 +109,10 @@ func mkEC2ImgTypeAarch64() *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = amiAarch64KernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfig()
+	it.DefaultImageConfig.KernelOptions = amiAarch64KernelOptions()
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -134,10 +134,10 @@ func mkEc2HaImgTypeX86_64() *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = amiKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
+	it.DefaultImageConfig.KernelOptions = amiKernelOptions()
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -158,10 +158,10 @@ func mkEC2SapImgTypeX86_64(osVersion string) *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = amiSapKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = sapImageConfig(osVersion).InheritFrom(defaultEc2ImageConfigX86_64())
+	it.DefaultImageConfig.KernelOptions = amiSapKernelOptions()
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it

--- a/pkg/distro/rhel/rhel10/azure.go
+++ b/pkg/distro/rhel/rhel10/azure.go
@@ -26,10 +26,10 @@ func mkAzureImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 		[]string{"vpc"},
 	)
 
-	it.KernelOptions = defaultAzureKernelOptions(a)
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultAzureImageConfig(rd)
+	it.DefaultImageConfig.KernelOptions = defaultAzureKernelOptions(a)
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -51,10 +51,10 @@ func mkAzureInternalImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType 
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = defaultAzureKernelOptions(a)
 	it.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultAzureImageConfig(rd)
+	it.DefaultImageConfig.KernelOptions = defaultAzureKernelOptions(a)
 	it.BasePartitionTables = azureInternalBasePartitionTables
 
 	return it
@@ -75,10 +75,10 @@ func mkAzureSapInternalImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageTy
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = defaultAzureKernelOptions(a)
 	it.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.DefaultImageConfig = sapAzureImageConfig(rd)
+	it.DefaultImageConfig.KernelOptions = defaultAzureKernelOptions(a)
 	it.BasePartitionTables = azureInternalBasePartitionTables
 
 	return it

--- a/pkg/distro/rhel/rhel10/distro_test.go
+++ b/pkg/distro/rhel/rhel10/distro_test.go
@@ -405,7 +405,10 @@ func TestRhel10_KernelOption_NoIfnames(t *testing.T) {
 			for _, imgTypeName := range arch.ListImageTypes() {
 				imgType, err := arch.GetImageType(imgTypeName)
 				assert.NoError(t, err)
-				assert.NotContains(t, imgType.(*rhel.ImageType).KernelOptions, "net.ifnames=0", "type %s contains unwanted net.ifnames=0", imgType.Name())
+				imgCfg := imgType.(*rhel.ImageType).DefaultImageConfig
+				if imgCfg != nil {
+					assert.NotContains(t, imgCfg.KernelOptions, "net.ifnames=0", "type %s contains unwanted net.ifnames=0", imgType.Name())
+				}
 			}
 		}
 	}

--- a/pkg/distro/rhel/rhel10/gce.go
+++ b/pkg/distro/rhel/rhel10/gce.go
@@ -27,7 +27,7 @@ func mkGCEImageType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = baseGCEImageConfig()
-	it.KernelOptions = gceKernelOptions()
+	it.DefaultImageConfig.KernelOptions = gceKernelOptions()
 	it.DefaultSize = 20 * datasizes.GibiByte
 	it.Bootable = true
 	// TODO: the base partition table still contains the BIOS boot partition, but the image is UEFI-only

--- a/pkg/distro/rhel/rhel10/qcow2.go
+++ b/pkg/distro/rhel/rhel10/qcow2.go
@@ -23,7 +23,7 @@ func mkQcow2ImgType(d *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = qcowImageConfig(d)
-	it.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check"}
+	it.DefaultImageConfig.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check"}
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -46,7 +46,7 @@ func mkOCIImgType(d *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = qcowImageConfig(d)
-	it.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check"}
+	it.DefaultImageConfig.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check"}
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables

--- a/pkg/distro/rhel/rhel10/vmdk.go
+++ b/pkg/distro/rhel/rhel10/vmdk.go
@@ -2,6 +2,7 @@ package rhel10
 
 import (
 	"github.com/osbuild/images/pkg/datasizes"
+	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 )
 
@@ -23,7 +24,9 @@ func mkVMDKImgType() *rhel.ImageType {
 		[]string{"vmdk"},
 	)
 
-	it.KernelOptions = vmdkKernelOptions()
+	it.DefaultImageConfig = &distro.ImageConfig{
+		KernelOptions: vmdkKernelOptions(),
+	}
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -45,7 +48,9 @@ func mkOVAImgType() *rhel.ImageType {
 		[]string{"archive"},
 	)
 
-	it.KernelOptions = vmdkKernelOptions()
+	it.DefaultImageConfig = &distro.ImageConfig{
+		KernelOptions: vmdkKernelOptions(),
+	}
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables

--- a/pkg/distro/rhel/rhel7/ami.go
+++ b/pkg/distro/rhel/rhel7/ami.go
@@ -13,10 +13,6 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
-func ec2KernelOptions() []string {
-	return []string{"ro", "console=tty0", "console=ttyS0,115200n8", "net.ifnames=0", "rd.blacklist=nouveau", "nvme_core.io_timeout=4294967295", "crashkernel=auto", "LANG=en_US.UTF-8"}
-}
-
 func mkEc2ImgTypeX86_64() *rhel.ImageType {
 	it := rhel.NewImageType(
 		"ec2",
@@ -36,7 +32,6 @@ func mkEc2ImgTypeX86_64() *rhel.ImageType {
 
 	it.Compression = "xz"
 	it.DefaultImageConfig = ec2ImageConfig()
-	it.KernelOptions = ec2KernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = ec2PartitionTables
@@ -175,6 +170,7 @@ func ec2ImageConfig() *distro.ImageConfig {
 			hostnameFile,
 		},
 		SELinuxForceRelabel: common.ToPtr(true),
+		KernelOptions:       []string{"ro", "console=tty0", "console=ttyS0,115200n8", "net.ifnames=0", "rd.blacklist=nouveau", "nvme_core.io_timeout=4294967295", "crashkernel=auto", "LANG=en_US.UTF-8"},
 	}
 }
 

--- a/pkg/distro/rhel/rhel7/azure.go
+++ b/pkg/distro/rhel/rhel7/azure.go
@@ -31,7 +31,6 @@ func mkAzureRhuiImgType() *rhel.ImageType {
 	it.DiskImageVPCForceSize = common.ToPtr(false)
 
 	it.Compression = "xz"
-	it.KernelOptions = []string{"ro", "crashkernel=auto", "console=tty1", "console=ttyS0", "earlyprintk=ttyS0", "rootdelay=300", "scsi_mod.use_blk_mq=y"}
 	it.DefaultImageConfig = azureDefaultImgConfig
 	it.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
@@ -219,6 +218,7 @@ var azureDefaultImgConfig = &distro.ImageConfig{
 		},
 	},
 	DefaultTarget: common.ToPtr("multi-user.target"),
+	KernelOptions: []string{"ro", "crashkernel=auto", "console=tty1", "console=ttyS0", "earlyprintk=ttyS0", "rootdelay=300", "scsi_mod.use_blk_mq=y"},
 }
 
 func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {

--- a/pkg/distro/rhel/rhel7/qcow2.go
+++ b/pkg/distro/rhel/rhel7/qcow2.go
@@ -26,7 +26,6 @@ func mkQcow2ImgType() *rhel.ImageType {
 	// all RHEL 7 images should use sgdisk
 	it.DiskImagePartTool = common.ToPtr(osbuild.PTSgdisk)
 
-	it.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0", "crashkernel=auto"}
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = qcow2DefaultImgConfig
@@ -57,4 +56,5 @@ var qcow2DefaultImgConfig = &distro.ImageConfig{
 			},
 		},
 	},
+	KernelOptions: []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0", "crashkernel=auto"},
 }

--- a/pkg/distro/rhel/rhel8/ami.go
+++ b/pkg/distro/rhel/rhel8/ami.go
@@ -36,7 +36,7 @@ func mkAmiImgTypeX86_64() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = defaultAMIImageConfigX86_64()
-	it.KernelOptions = amiX86KernelOptions()
+	it.DefaultImageConfig.KernelOptions = amiX86KernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -60,7 +60,7 @@ func mkEc2ImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 
 	it.Compression = "xz"
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64(rd)
-	it.KernelOptions = amiX86KernelOptions()
+	it.DefaultImageConfig.KernelOptions = amiX86KernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -84,7 +84,7 @@ func mkEc2HaImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 
 	it.Compression = "xz"
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64(rd)
-	it.KernelOptions = amiX86KernelOptions()
+	it.DefaultImageConfig.KernelOptions = amiX86KernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -107,7 +107,7 @@ func mkAmiImgTypeAarch64() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = defaultAMIImageConfig()
-	it.KernelOptions = amiAarch64KernelOptions()
+	it.DefaultImageConfig.KernelOptions = amiAarch64KernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -131,7 +131,7 @@ func mkEc2ImgTypeAarch64(rd *rhel.Distribution) *rhel.ImageType {
 
 	it.Compression = "xz"
 	it.DefaultImageConfig = defaultEc2ImageConfig(rd)
-	it.KernelOptions = amiAarch64KernelOptions()
+	it.DefaultImageConfig.KernelOptions = amiAarch64KernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -155,7 +155,7 @@ func mkEc2SapImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 
 	it.Compression = "xz"
 	it.DefaultImageConfig = defaultEc2SapImageConfigX86_64(rd)
-	it.KernelOptions = amiSapKernelOptions()
+	it.DefaultImageConfig.KernelOptions = amiSapKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables

--- a/pkg/distro/rhel/rhel8/azure.go
+++ b/pkg/distro/rhel/rhel8/azure.go
@@ -33,7 +33,7 @@ func mkAzureRhuiImgType() *rhel.ImageType {
 
 	it.Compression = "xz"
 	it.DefaultImageConfig = defaultAzureRhuiImageConfig.InheritFrom(defaultVhdImageConfig())
-	it.KernelOptions = defaultAzureKernelOptions()
+	it.DefaultImageConfig.KernelOptions = defaultAzureKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.BasePartitionTables = azureRhuiBasePartitionTables
@@ -57,7 +57,7 @@ func mkAzureSapRhuiImgType(rd *rhel.Distribution) *rhel.ImageType {
 
 	it.Compression = "xz"
 	it.DefaultImageConfig = defaultAzureRhuiImageConfig.InheritFrom(sapAzureImageConfig(rd))
-	it.KernelOptions = defaultAzureKernelOptions()
+	it.DefaultImageConfig.KernelOptions = defaultAzureKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.BasePartitionTables = azureRhuiBasePartitionTables
@@ -80,7 +80,7 @@ func mkAzureByosImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = defaultAzureByosImageConfig.InheritFrom(defaultVhdImageConfig())
-	it.KernelOptions = defaultAzureKernelOptions()
+	it.DefaultImageConfig.KernelOptions = defaultAzureKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -104,7 +104,7 @@ func mkAzureImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = defaultVhdImageConfig()
-	it.KernelOptions = defaultAzureKernelOptions()
+	it.DefaultImageConfig.KernelOptions = defaultAzureKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -128,7 +128,7 @@ func mkAzureEap7RhuiImgType() *rhel.ImageType {
 
 	it.Compression = "xz"
 	it.DefaultImageConfig = defaultAzureEapImageConfig.InheritFrom(defaultAzureRhuiImageConfig.InheritFrom(defaultAzureImageConfig))
-	it.KernelOptions = defaultAzureKernelOptions()
+	it.DefaultImageConfig.KernelOptions = defaultAzureKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.BasePartitionTables = azureRhuiBasePartitionTables

--- a/pkg/distro/rhel/rhel8/edge.go
+++ b/pkg/distro/rhel/rhel8/edge.go
@@ -77,13 +77,13 @@ func mkEdgeRawImgType() *rhel.ImageType {
 
 	it.NameAliases = []string{"rhel-edge-raw-image"}
 	it.Compression = "xz"
-	it.KernelOptions = []string{"modprobe.blacklist=vc4"}
 	it.DefaultImageConfig = &distro.ImageConfig{
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",
 		},
-		Locale:       common.ToPtr("C.UTF-8"),
-		LockRootUser: common.ToPtr(true),
+		Locale:        common.ToPtr("C.UTF-8"),
+		LockRootUser:  common.ToPtr(true),
+		KernelOptions: []string{"modprobe.blacklist=vc4"},
 	}
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.RPMOSTree = true
@@ -142,14 +142,14 @@ func mkEdgeSimplifiedInstallerImgType(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.NameAliases = []string{"rhel-edge-simplified-installer"}
-	it.KernelOptions = []string{"modprobe.blacklist=vc4"}
 	it.DefaultImageConfig = &distro.ImageConfig{
 		EnabledServices: edgeServices(rd),
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",
 		},
-		Locale:       common.ToPtr("C.UTF-8"),
-		LockRootUser: common.ToPtr(true),
+		Locale:        common.ToPtr("C.UTF-8"),
+		LockRootUser:  common.ToPtr(true),
+		KernelOptions: []string{"modprobe.blacklist=vc4"},
 	}
 	it.DefaultInstallerConfig = &distro.InstallerConfig{
 		AdditionalDracutModules: []string{
@@ -190,9 +190,9 @@ func mkMinimalRawImgType() *rhel.ImageType {
 		EnabledServices: minimalrawServices,
 		// NOTE: temporary workaround for a bug in initial-setup that
 		// requires a kickstart file in the root directory.
-		Files: []*fsnode.File{initialSetupKickstart()},
+		Files:         []*fsnode.File{initialSetupKickstart()},
+		KernelOptions: []string{"ro"},
 	}
-	it.KernelOptions = []string{"ro"}
 	it.Bootable = true
 	it.DefaultSize = 2 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables

--- a/pkg/distro/rhel/rhel8/gce.go
+++ b/pkg/distro/rhel/rhel8/gce.go
@@ -9,10 +9,6 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
-func gceKernelOptions() []string {
-	return []string{"net.ifnames=0", "biosdevname=0", "scsi_mod.use_blk_mq=Y", "crashkernel=auto", "console=ttyS0,38400n8d"}
-}
-
 func mkGceImgType(rd distro.Distro) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"gce",
@@ -28,7 +24,6 @@ func mkGceImgType(rd distro.Distro) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = defaultGceByosImageConfig(rd)
-	it.KernelOptions = gceKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 20 * datasizes.GibiByte
 	// TODO: the base partition table still contains the BIOS boot partition, but the image is UEFI-only
@@ -52,7 +47,6 @@ func mkGceRhuiImgType(rd distro.Distro) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = defaultGceRhuiImageConfig(rd)
-	it.KernelOptions = gceKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 20 * datasizes.GibiByte
 	// TODO: the base partition table still contains the BIOS boot partition, but the image is UEFI-only
@@ -153,6 +147,7 @@ func defaultGceByosImageConfig(rd distro.Distro) *distro.ImageConfig {
 				},
 			},
 		},
+		KernelOptions: []string{"net.ifnames=0", "biosdevname=0", "scsi_mod.use_blk_mq=Y", "crashkernel=auto", "console=ttyS0,38400n8d"},
 	}
 	if rd.OsVersion() == "8.4" {
 		// NOTE(akoutsou): these are enabled in the package preset, but for

--- a/pkg/distro/rhel/rhel8/qcow2.go
+++ b/pkg/distro/rhel/rhel8/qcow2.go
@@ -23,7 +23,6 @@ func mkQcow2ImgType(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = qcowImageConfig(rd)
-	it.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0", "crashkernel=auto"}
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -46,7 +45,6 @@ func mkOCIImgType(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = qcowImageConfig(rd)
-	it.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0", "crashkernel=auto"}
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -67,8 +65,9 @@ func mkOpenstackImgType() *rhel.ImageType {
 		[]string{"os", "image", "qcow2"},
 		[]string{"qcow2"},
 	)
-
-	it.KernelOptions = []string{"ro", "net.ifnames=0"}
+	it.DefaultImageConfig = &distro.ImageConfig{
+		KernelOptions: []string{"ro", "net.ifnames=0"},
+	}
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = partitionTables
@@ -79,6 +78,7 @@ func mkOpenstackImgType() *rhel.ImageType {
 func qcowImageConfig(d *rhel.Distribution) *distro.ImageConfig {
 	ic := &distro.ImageConfig{
 		DefaultTarget: common.ToPtr("multi-user.target"),
+		KernelOptions: []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0", "crashkernel=auto"},
 	}
 	if d.IsRHEL() {
 		ic.RHSMConfig = map[subscription.RHSMStatus]*subscription.RHSMConfig{

--- a/pkg/distro/rhel/rhel8/vmdk.go
+++ b/pkg/distro/rhel/rhel8/vmdk.go
@@ -2,6 +2,7 @@ package rhel8
 
 import (
 	"github.com/osbuild/images/pkg/datasizes"
+	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 )
 
@@ -22,8 +23,9 @@ func mkVmdkImgType() *rhel.ImageType {
 		[]string{"os", "image", "vmdk"},
 		[]string{"vmdk"},
 	)
-
-	it.KernelOptions = vmdkKernelOptions()
+	it.DefaultImageConfig = &distro.ImageConfig{
+		KernelOptions: vmdkKernelOptions(),
+	}
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -44,8 +46,9 @@ func mkOvaImgType() *rhel.ImageType {
 		[]string{"os", "image", "vmdk", "ovf", "archive"},
 		[]string{"archive"},
 	)
-
-	it.KernelOptions = vmdkKernelOptions()
+	it.DefaultImageConfig = &distro.ImageConfig{
+		KernelOptions: vmdkKernelOptions(),
+	}
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables

--- a/pkg/distro/rhel/rhel9/ami.go
+++ b/pkg/distro/rhel/rhel9/ami.go
@@ -161,10 +161,10 @@ func mkEc2ImgTypeX86_64() *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = amiKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
+	it.DefaultImageConfig.KernelOptions = amiKernelOptions()
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -184,10 +184,10 @@ func mkAMIImgTypeX86_64() *rhel.ImageType {
 		[]string{"image"},
 	)
 
-	it.KernelOptions = amiKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
+	it.DefaultImageConfig.KernelOptions = amiKernelOptions()
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -208,10 +208,10 @@ func mkEC2SapImgTypeX86_64(osVersion string) *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = []string{"console=ttyS0,115200n8", "console=tty0", "net.ifnames=0", "nvme_core.io_timeout=4294967295", "processor.max_cstate=1", "intel_idle.max_cstate=1"}
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = sapImageConfig(osVersion).InheritFrom(defaultEc2ImageConfigX86_64())
+	it.DefaultImageConfig.KernelOptions = []string{"console=ttyS0,115200n8", "console=tty0", "net.ifnames=0", "nvme_core.io_timeout=4294967295", "processor.max_cstate=1", "intel_idle.max_cstate=1"}
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -232,10 +232,10 @@ func mkEc2HaImgTypeX86_64() *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = amiKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfigX86_64()
+	it.DefaultImageConfig.KernelOptions = amiKernelOptions()
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -255,10 +255,10 @@ func mkAMIImgTypeAarch64() *rhel.ImageType {
 		[]string{"image"},
 	)
 
-	it.KernelOptions = []string{"console=ttyS0,115200n8", "console=tty0", "net.ifnames=0", "nvme_core.io_timeout=4294967295", "iommu.strict=0"}
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfig()
+	it.DefaultImageConfig.KernelOptions = []string{"console=ttyS0,115200n8", "console=tty0", "net.ifnames=0", "nvme_core.io_timeout=4294967295", "iommu.strict=0"}
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -279,10 +279,10 @@ func mkEC2ImgTypeAarch64() *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = []string{"console=ttyS0,115200n8", "console=tty0", "net.ifnames=0", "nvme_core.io_timeout=4294967295", "iommu.strict=0"}
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultEc2ImageConfig()
+	it.DefaultImageConfig.KernelOptions = []string{"console=ttyS0,115200n8", "console=tty0", "net.ifnames=0", "nvme_core.io_timeout=4294967295", "iommu.strict=0"}
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it

--- a/pkg/distro/rhel/rhel9/azure.go
+++ b/pkg/distro/rhel/rhel9/azure.go
@@ -25,10 +25,10 @@ func mkAzureImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 		[]string{"vpc"},
 	)
 
-	it.KernelOptions = defaultAzureKernelOptions(rd, a)
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultAzureImageConfig(rd)
+	it.DefaultImageConfig.KernelOptions = defaultAzureKernelOptions(rd, a)
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
@@ -50,10 +50,10 @@ func mkAzureInternalImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType 
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = defaultAzureKernelOptions(rd, a)
 	it.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.DefaultImageConfig = defaultAzureImageConfig(rd)
+	it.DefaultImageConfig.KernelOptions = defaultAzureKernelOptions(rd, a)
 	it.BasePartitionTables = azureInternalBasePartitionTables
 
 	return it
@@ -74,10 +74,10 @@ func mkAzureSapInternalImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageTy
 	)
 
 	it.Compression = "xz"
-	it.KernelOptions = defaultAzureKernelOptions(rd, a)
 	it.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.DefaultImageConfig = sapAzureImageConfig(rd)
+	it.DefaultImageConfig.KernelOptions = defaultAzureKernelOptions(rd, a)
 	it.BasePartitionTables = azureInternalBasePartitionTables
 
 	return it

--- a/pkg/distro/rhel/rhel9/edge.go
+++ b/pkg/distro/rhel/rhel9/edge.go
@@ -99,17 +99,17 @@ func mkEdgeRawImgType(d *rhel.Distribution) *rhel.ImageType {
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",
 		},
-		Locale:       common.ToPtr("C.UTF-8"),
-		LockRootUser: common.ToPtr(true),
+		Locale:        common.ToPtr("C.UTF-8"),
+		LockRootUser:  common.ToPtr(true),
+		KernelOptions: []string{"modprobe.blacklist=vc4"},
 	}
 	if common.VersionGreaterThanOrEqual(d.OsVersion(), "9.2") || !d.IsRHEL() {
 		it.DefaultImageConfig.OSTreeConfSysrootReadOnly = common.ToPtr(true)
 		it.DefaultImageConfig.IgnitionPlatform = common.ToPtr("metal")
 	}
 
-	it.KernelOptions = []string{"modprobe.blacklist=vc4"}
 	if common.VersionGreaterThanOrEqual(d.OsVersion(), "9.2") || !d.IsRHEL() {
-		it.KernelOptions = append(it.KernelOptions, "rw", "coreos.no_persist_ip")
+		it.DefaultImageConfig.KernelOptions = append(it.DefaultImageConfig.KernelOptions, "rw", "coreos.no_persist_ip")
 	}
 
 	it.DefaultSize = 10 * datasizes.GibiByte
@@ -185,8 +185,9 @@ func mkEdgeSimplifiedInstallerImgType(d *rhel.Distribution) *rhel.ImageType {
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",
 		},
-		Locale:       common.ToPtr("C.UTF-8"),
-		LockRootUser: common.ToPtr(true),
+		Locale:        common.ToPtr("C.UTF-8"),
+		LockRootUser:  common.ToPtr(true),
+		KernelOptions: []string{"modprobe.blacklist=vc4"},
 	}
 	if common.VersionGreaterThanOrEqual(d.OsVersion(), "9.2") || !d.IsRHEL() {
 		it.DefaultImageConfig.OSTreeConfSysrootReadOnly = common.ToPtr(true)
@@ -208,9 +209,8 @@ func mkEdgeSimplifiedInstallerImgType(d *rhel.Distribution) *rhel.ImageType {
 	it.BasePartitionTables = edgeBasePartitionTables
 	it.UnsupportedPartitioningModes = []disk.PartitioningMode{disk.RawPartitioningMode}
 
-	it.KernelOptions = []string{"modprobe.blacklist=vc4"}
 	if common.VersionGreaterThanOrEqual(d.OsVersion(), "9.2") || !d.IsRHEL() {
-		it.KernelOptions = append(it.KernelOptions, "rw", "coreos.no_persist_ip")
+		it.DefaultImageConfig.KernelOptions = append(it.DefaultImageConfig.KernelOptions, "rw", "coreos.no_persist_ip")
 	}
 
 	return it
@@ -240,9 +240,9 @@ func mkEdgeAMIImgType(d *rhel.Distribution) *rhel.ImageType {
 		it.DefaultImageConfig.IgnitionPlatform = common.ToPtr("metal")
 	}
 
-	it.KernelOptions = append(amiKernelOptions(), "modprobe.blacklist=vc4")
+	it.DefaultImageConfig.KernelOptions = append(amiKernelOptions(), "modprobe.blacklist=vc4")
 	if common.VersionGreaterThanOrEqual(d.OsVersion(), "9.2") || !d.IsRHEL() {
-		it.KernelOptions = append(it.KernelOptions, "rw", "coreos.no_persist_ip")
+		it.DefaultImageConfig.KernelOptions = append(it.DefaultImageConfig.KernelOptions, "rw", "coreos.no_persist_ip")
 	}
 
 	it.DefaultSize = 10 * datasizes.GibiByte
@@ -279,9 +279,9 @@ func mkEdgeVsphereImgType(d *rhel.Distribution) *rhel.ImageType {
 		it.DefaultImageConfig.IgnitionPlatform = common.ToPtr("metal")
 	}
 
-	it.KernelOptions = []string{"modprobe.blacklist=vc4"}
+	it.DefaultImageConfig.KernelOptions = []string{"modprobe.blacklist=vc4"}
 	if common.VersionGreaterThanOrEqual(d.OsVersion(), "9.2") || !d.IsRHEL() {
-		it.KernelOptions = append(it.KernelOptions, "rw", "coreos.no_persist_ip")
+		it.DefaultImageConfig.KernelOptions = append(it.DefaultImageConfig.KernelOptions, "rw", "coreos.no_persist_ip")
 	}
 
 	it.DefaultSize = 10 * datasizes.GibiByte
@@ -315,7 +315,7 @@ func mkMinimalrawImgType() *rhel.ImageType {
 		// requires a kickstart file in the root directory.
 		Files: []*fsnode.File{initialSetupKickstart()},
 	}
-	it.KernelOptions = []string{"ro"}
+	it.DefaultImageConfig.KernelOptions = []string{"ro"}
 	it.DefaultSize = 2 * datasizes.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = minimalrawPartitionTables

--- a/pkg/distro/rhel/rhel9/gce.go
+++ b/pkg/distro/rhel/rhel9/gce.go
@@ -30,7 +30,7 @@ func mkGCEImageType() *rhel.ImageType {
 	// The configuration for non-RHUI images does not touch the RHSM configuration at all.
 	// https://issues.redhat.com/browse/COMPOSER-2157
 	it.DefaultImageConfig = baseGCEImageConfig()
-	it.KernelOptions = gceKernelOptions()
+	it.DefaultImageConfig.KernelOptions = gceKernelOptions()
 	it.DefaultSize = 20 * datasizes.GibiByte
 	it.Bootable = true
 	// TODO: the base partition table still contains the BIOS boot partition, but the image is UEFI-only

--- a/pkg/distro/rhel/rhel9/qcow2.go
+++ b/pkg/distro/rhel/rhel9/qcow2.go
@@ -23,7 +23,7 @@ func mkQcow2ImgType(d *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = qcowImageConfig(d)
-	it.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0"}
+	it.DefaultImageConfig.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0"}
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -46,7 +46,7 @@ func mkOCIImgType(d *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = qcowImageConfig(d)
-	it.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0"}
+	it.DefaultImageConfig.KernelOptions = []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0"}
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -71,7 +71,7 @@ func mkOpenstackImgType() *rhel.ImageType {
 	it.DefaultImageConfig = &distro.ImageConfig{
 		Locale: common.ToPtr("en_US.UTF-8"),
 	}
-	it.KernelOptions = []string{"ro", "net.ifnames=0"}
+	it.DefaultImageConfig.KernelOptions = []string{"ro", "net.ifnames=0"}
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = defaultBasePartitionTables

--- a/pkg/distro/rhel/rhel9/vmdk.go
+++ b/pkg/distro/rhel/rhel9/vmdk.go
@@ -26,9 +26,9 @@ func mkVMDKImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = &distro.ImageConfig{
-		Locale: common.ToPtr("en_US.UTF-8"),
+		Locale:        common.ToPtr("en_US.UTF-8"),
+		KernelOptions: vmdkKernelOptions(),
 	}
-	it.KernelOptions = vmdkKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables
@@ -51,9 +51,9 @@ func mkOVAImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = &distro.ImageConfig{
-		Locale: common.ToPtr("en_US.UTF-8"),
+		Locale:        common.ToPtr("en_US.UTF-8"),
+		KernelOptions: vmdkKernelOptions(),
 	}
-	it.KernelOptions = vmdkKernelOptions()
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = defaultBasePartitionTables


### PR DESCRIPTION
[draft until https://github.com/osbuild/images/pull/1472 is merged to not cause conflicts there]

This commit moves the `imageType.kernelOptions` option into `distro.ImageConfig`. The rational is that when we move to YAML we will need to be able to override the kernel options based on various conditions.

Here is an example from mkMinimalRawImgType():
```go
if common.VersionGreaterThanOrEqual(d.osVersion, "43") {
	it.kernelOptions = []string{"rw"}
}
```
The conditions will be implemented on the imageConfig but having conditions when defining image types would be a bit stange. The easiest fix is to move kernelOptions into ImageConfig. Fwiw, I think conceptually it also makes sense there so this is probably a worthwhile chage on its own but it will make the YAML work in
https://github.com/osbuild/images/pull/1462
easier.