### PR TITLE
github: run dependabot gomod action weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "04:00"
     groups:
       go-deps:


### PR DESCRIPTION
We recently added a new action for Go dependency updates called gobump. The new action handles dependency updates but only if they don't require go version bumps, which dependabot seems to struggle with, creating broken PRs daily.
I'm inclined to disable dependabot's gomod action completely, but we instead decided to let it run weekly to review what it's proposing, on a lower frequency, while we also evaluate the new gobump action.