### PR TITLE
many: add custom unmarshalers for osbuild, platform

### DIFF
--- a/internal/common/unmarshal.go
+++ b/internal/common/unmarshal.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// UnmarshalYAMLviaJSON unmarshals via the JSON interface, this avoids code
+// duplication on the expense of slightly uglier errors
+func UnmarshalYAMLviaJSON(u json.Unmarshaler, unmarshal func(any) error) error {
+	var data any
+	if err := unmarshal(&data); err != nil {
+		return fmt.Errorf("cannot unmarshal to any: %w", err)
+	}
+
+	dataJSON, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("unmarshal yaml via json failed: %w", err)
+	}
+	if err := u.UnmarshalJSON(dataJSON); err != nil {
+		return fmt.Errorf("unmarshal yaml via json for %s failed: %w", dataJSON, err)
+	}
+	return nil
+}

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 )
 
@@ -267,7 +268,7 @@ func (t *PartitionTableType) UnmarshalJSON(data []byte) error {
 }
 
 func (t *PartitionTableType) UnmarshalYAML(unmarshal func(any) error) error {
-	return unmarshalYAMLviaJSON(t, unmarshal)
+	return common.UnmarshalYAMLviaJSON(t, unmarshal)
 }
 
 func NewPartitionTableType(s string) (PartitionTableType, error) {

--- a/pkg/disk/luks.go
+++ b/pkg/disk/luks.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/datasizes"
 )
 
@@ -151,5 +152,5 @@ func (lc *LUKSContainer) UnmarshalJSON(data []byte) (err error) {
 }
 
 func (lc *LUKSContainer) UnmarshalYAML(unmarshal func(any) error) error {
-	return unmarshalYAMLviaJSON(lc, unmarshal)
+	return common.UnmarshalYAMLviaJSON(lc, unmarshal)
 }

--- a/pkg/disk/lvm.go
+++ b/pkg/disk/lvm.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/datasizes"
 )
 
@@ -262,5 +263,5 @@ func (lv *LVMLogicalVolume) UnmarshalJSON(data []byte) (err error) {
 }
 
 func (lv *LVMLogicalVolume) UnmarshalYAML(unmarshal func(any) error) error {
-	return unmarshalYAMLviaJSON(lv, unmarshal)
+	return common.UnmarshalYAMLviaJSON(lv, unmarshal)
 }

--- a/pkg/disk/partition.go
+++ b/pkg/disk/partition.go
@@ -3,6 +3,8 @@ package disk
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/osbuild/images/internal/common"
 )
 
 type Partition struct {
@@ -137,5 +139,5 @@ func (p *Partition) UnmarshalJSON(data []byte) (err error) {
 }
 
 func (t *Partition) UnmarshalYAML(unmarshal func(any) error) error {
-	return unmarshalYAMLviaJSON(t, unmarshal)
+	return common.UnmarshalYAMLviaJSON(t, unmarshal)
 }

--- a/pkg/disk/unmarshal.go
+++ b/pkg/disk/unmarshal.go
@@ -7,24 +7,6 @@ import (
 	"reflect"
 )
 
-// unmarshalYAMLviaJSON unmarshals via the JSON interface, this avoids code
-// duplication on the expense of slightly uglier errors
-func unmarshalYAMLviaJSON(u json.Unmarshaler, unmarshal func(any) error) error {
-	var data any
-	if err := unmarshal(&data); err != nil {
-		return fmt.Errorf("cannot unmarshal to any: %w", err)
-	}
-
-	dataJSON, err := json.Marshal(data)
-	if err != nil {
-		return fmt.Errorf("unmarshal yaml via json failed: %w", err)
-	}
-	if err := u.UnmarshalJSON(dataJSON); err != nil {
-		return fmt.Errorf("unmarshal yaml via json for %s failed: %w", dataJSON, err)
-	}
-	return nil
-}
-
 func unmarshalJSONPayload(data []byte) (PayloadEntity, error) {
 	var payload struct {
 		Payload     json.RawMessage `json:"payload"`

--- a/pkg/osbuild/modprobe_stage.go
+++ b/pkg/osbuild/modprobe_stage.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+
+	"github.com/osbuild/images/internal/common"
 )
 
 const modprobeCfgFilenameRegex = "^[\\w.-]{1,250}\\.conf$"
@@ -93,6 +95,10 @@ func (configFile *ModprobeConfigCmdList) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+func (configFile *ModprobeConfigCmdList) UnmarshalYAML(unmarshal func(any) error) error {
+	return common.UnmarshalYAMLviaJSON(configFile, unmarshal)
 }
 
 // ModprobeConfigCmdBlacklist represents the 'blacklist' command in the

--- a/pkg/osbuild/modprobe_stage_test.go
+++ b/pkg/osbuild/modprobe_stage_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 func TestNewModprobeStage(t *testing.T) {
@@ -145,4 +146,27 @@ func TestNewModprobeConfigCmdInstall(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestModprobeConfigCmdListUnmarshal(t *testing.T) {
+	inputYAML := []byte(`
+filename: "blacklist-amdgpu.conf"
+commands:
+  - command: blacklist
+    modulename: "amdgpu"
+  - command: install
+    modulename: "install-mod"
+    cmdline: "mod-cmdline"
+`)
+	var modprobeOpts ModprobeStageOptions
+	err := yaml.Unmarshal(inputYAML, &modprobeOpts)
+	assert.NoError(t, err)
+	expected := ModprobeStageOptions{
+		Filename: "blacklist-amdgpu.conf",
+		Commands: []ModprobeConfigCmd{
+			NewModprobeConfigCmdBlacklist("amdgpu"),
+			NewModprobeConfigCmdInstall("install-mod", "mod-cmdline"),
+		},
+	}
+	assert.Equal(t, expected, modprobeOpts)
 }

--- a/pkg/osbuild/sshd_config_stage.go
+++ b/pkg/osbuild/sshd_config_stage.go
@@ -3,6 +3,8 @@ package osbuild
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/osbuild/images/internal/common"
 )
 
 type SshdConfigConfig struct {
@@ -73,6 +75,10 @@ func (c *SshdConfigConfig) UnmarshalJSON(data []byte) error {
 	c.PermitRootLogin = permitRootLogin
 
 	return nil
+}
+
+func (c *SshdConfigConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	return common.UnmarshalYAMLviaJSON(c, unmarshal)
 }
 
 type SshdConfigStageOptions struct {

--- a/pkg/osbuild/sshd_config_stage_test.go
+++ b/pkg/osbuild/sshd_config_stage_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 
 	"github.com/osbuild/images/internal/common"
 )
@@ -19,7 +20,7 @@ func TestNewSshdConfigStage(t *testing.T) {
 	assert.Equal(t, expectedStage, actualStage)
 }
 
-func TestJsonSshdConfigStage(t *testing.T) {
+func TestJsonYamlSshdConfigStage(t *testing.T) {
 	// First test that the JSON can be parsed into the expected structure.
 	expectedOptions := SshdConfigStageOptions{
 		Config: SshdConfigConfig{
@@ -29,7 +30,7 @@ func TestJsonSshdConfigStage(t *testing.T) {
 			PermitRootLogin:                 PermitRootLoginValueProhibitPassword,
 		},
 	}
-	inputString := `{
+	inputStringJSON := `{
 		"config": {
 		  "PasswordAuthentication": false,
 		  "ChallengeResponseAuthentication": false,
@@ -37,10 +38,21 @@ func TestJsonSshdConfigStage(t *testing.T) {
 		  "PermitRootLogin": "prohibit-password"
 		}
 	  }`
+	inputStringYAML := `
+config:
+  PasswordAuthentication: false
+  ChallengeResponseAuthentication: false
+  ClientAliveInterval: 180
+  PermitRootLogin: "prohibit-password"
+`
 	var inputOptions SshdConfigStageOptions
-	err := json.Unmarshal([]byte(inputString), &inputOptions)
+	err := json.Unmarshal([]byte(inputStringJSON), &inputOptions)
 	assert.NoError(t, err, "failed to parse JSON into sshd config")
 	assert.True(t, reflect.DeepEqual(expectedOptions, inputOptions))
+	// ensure YAML is decoded the same way
+	err = yaml.Unmarshal([]byte(inputStringYAML), &inputOptions)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOptions, inputOptions)
 
 	// Second try the other way around with stress on missing values
 	// for those parameters that the user didn't specify.

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1,8 +1,10 @@
 package platform
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 )
 
@@ -40,6 +42,38 @@ func (f ImageFormat) String() string {
 	default:
 		panic(fmt.Errorf("unknown image format %d", f))
 	}
+}
+
+func (f *ImageFormat) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "unset":
+		*f = FORMAT_UNSET
+	case "raw":
+		*f = FORMAT_RAW
+	case "iso":
+		*f = FORMAT_ISO
+	case "qcow2":
+		*f = FORMAT_QCOW2
+	case "vmdk":
+		*f = FORMAT_VMDK
+	case "vhd":
+		*f = FORMAT_VHD
+	case "gce":
+		*f = FORMAT_GCE
+	case "ova":
+		*f = FORMAT_OVA
+	default:
+		panic(fmt.Errorf("unknown image format %q", s))
+	}
+	return nil
+}
+
+func (f *ImageFormat) UnmarshalYAML(unmarshal func(any) error) error {
+	return common.UnmarshalYAMLviaJSON(f, unmarshal)
 }
 
 type Platform interface {

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -1,9 +1,12 @@
 package platform_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 
 	"github.com/osbuild/images/pkg/platform"
 )
@@ -17,4 +20,30 @@ func TestImageFormatStringUnknown(t *testing.T) {
 	assert.PanicsWithError(t, "unknown image format 999", func() {
 		_ = platform.ImageFormat(999).String()
 	})
+}
+
+func TestImageFormatUnmarshal(t *testing.T) {
+	ifmts := []platform.ImageFormat{
+		platform.FORMAT_UNSET,
+		platform.FORMAT_RAW,
+		platform.FORMAT_ISO,
+		platform.FORMAT_QCOW2,
+		platform.FORMAT_VMDK,
+		platform.FORMAT_VHD,
+		platform.FORMAT_GCE,
+		platform.FORMAT_OVA,
+	}
+	for _, ifmt := range ifmts {
+		inpJSON := fmt.Sprintf("%q", ifmt.String())
+		inpYAML := ifmt.String()
+		// json
+		var f platform.ImageFormat
+		err := json.Unmarshal([]byte(inpJSON), &f)
+		assert.NoError(t, err)
+		assert.Equal(t, ifmt, f)
+		// now YAML
+		err = yaml.Unmarshal([]byte(inpYAML), &f)
+		assert.NoError(t, err)
+		assert.Equal(t, ifmt, f)
+	}
 }


### PR DESCRIPTION
This PR adds custom unmarshalers to various parts of osbuild and platform. We will need to be able to unmarshal osbuild options that are used in the ImageConfig. And we will need to be able to set platform information for image types in YAML too so the platform.ImageFormat also needs to be handed.

Split out from https://github.com/osbuild/images/pull/1462