### PR TITLE
github: don't run manifest checksum validation on the merge queue

### DIFF
--- a/.github/workflows/validate-checksums.yml
+++ b/.github/workflows/validate-checksums.yml
@@ -4,8 +4,6 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches:
       - "*"
-  # for merge queue
-  merge_group:
 
 jobs:
   manifest-checksums:


### PR DESCRIPTION
On the merge queue, the validate checksum fails because we use the base branch to start checking.  We could check if the checksums changed from the rebase, but that wouldn't be useful since the check isn't required anyway.

For now, let's make the check run only on PRs.  This might result in inconsistencies in main, but we're still experimenting with this test anyway, so it'll be interesting to see how often that happens and how confusing it might be.