### PR TITLE
fsnode: add JSON/YAML support for File/Directory

### DIFF
--- a/pkg/customizations/fsnode/dir.go
+++ b/pkg/customizations/fsnode/dir.go
@@ -11,6 +11,15 @@ import (
 
 type Directory struct {
 	baseFsNode
+	// We cannot use a "json" tag here because "go vet" complains
+	// that it is used on an unexported field and "go vet" cannot
+	// ignore lines.
+	//
+	// Longer term it is probably worthwhile to refactor this
+	// code so that custom unmarshaling is not needed, i.e.
+	// just have an unexpored "type directoryJSON" with
+	// exported fields and a public method only type (like
+	// we have now).
 	ensureParentDirs bool `rename:"ensure_parent_dirs"`
 }
 

--- a/pkg/customizations/fsnode/dir.go
+++ b/pkg/customizations/fsnode/dir.go
@@ -11,7 +11,7 @@ import (
 
 type Directory struct {
 	baseFsNode
-	ensureParentDirs bool
+	ensureParentDirs bool `rename:"ensure_parent_dirs"`
 }
 
 func (d *Directory) EnsureParentDirs() bool {
@@ -26,6 +26,8 @@ func (d *Directory) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// XXX: ideally we would also check here that we do not
+	// get extra/mistyped fields
 	var m map[string]interface{}
 	dec := json.NewDecoder(bytes.NewBuffer(data))
 	if err := dec.Decode(&m); err != nil {
@@ -37,6 +39,15 @@ func (d *Directory) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("unexpected type %T for ensure_parent_dirs (want bool)", ensureParents)
 		}
 	}
+
+	// validate only known names are used
+	fieldNames := fieldNames(d)
+	for k := range m {
+		if !fieldNames[k] {
+			return fmt.Errorf("unknown key %q in dir", k)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/customizations/fsnode/file.go
+++ b/pkg/customizations/fsnode/file.go
@@ -38,6 +38,15 @@ func (f *File) UnmarshalJSON(data []byte) error {
 		}
 		f.data = []byte(dataStr)
 	}
+
+	// validate only known names are used
+	fieldNames := fieldNames(f)
+	for k := range m {
+		if !fieldNames[k] {
+			return fmt.Errorf("unknown key %q in file", k)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/customizations/fsnode/fsnode.go
+++ b/pkg/customizations/fsnode/fsnode.go
@@ -3,7 +3,7 @@ package fsnode
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 )
 
@@ -73,7 +73,7 @@ func (f *baseFsNode) validate() error {
 	if f.path[len(f.path)-1] == '/' {
 		return fmt.Errorf("path must not end with a slash")
 	}
-	if f.path != path.Clean(f.path) {
+	if f.path != filepath.Clean(f.path) {
 		return fmt.Errorf("path must be canonical")
 	}
 

--- a/pkg/customizations/fsnode/fsnode_test.go
+++ b/pkg/customizations/fsnode/fsnode_test.go
@@ -210,6 +210,7 @@ func TestFsNodeUnmarshalBadFile(t *testing.T) {
 		{"path: /foo\nuser: -1", `user ID must be non-negative`},
 		{"path: /foo\ngroup: a!b", `group name "a!b" doesn't conform to validating regex`},
 		{"path: /foo\ndata: 1.61", `unexpected type float64 for data (want string)`},
+		{"path: /foo\nextra: field", `unknown key "extra" in file`},
 	} {
 		var fsn File
 		err := yaml.Unmarshal([]byte(tc.inputYAML), &fsn)
@@ -223,6 +224,7 @@ func TestFsNodeUnmarshalBadDir(t *testing.T) {
 		expectedErr string
 	}{
 		{"path: /foo\nensure_parent_dirs: maybe", `unexpected type string for ensure_parent_dirs (want bool)`},
+		{"path: /foo\nextra: field", `unknown key "extra" in dir`},
 	} {
 		var fsn Directory
 		err := yaml.Unmarshal([]byte(tc.inputYAML), &fsn)


### PR DESCRIPTION
More unmarshal support in preparation for the  ImageConfig work in https://github.com/osbuild/images/pull/1462 - split to make reviews easier, the fsnode ones are a bit more tricky.

--- 

fsnode: validate unknown keys in fsnode.{Dir,File}

When unmarshaling fsnode.{Dir,File}, also validate that no
extra keys are used.

---

fsnode: add JSON/YAML support for File/Directory

When we move `ImageConfig` into YAML we will need support for
`fsnode.File` as it is used as part of the ImageConfig.

This commit adds support for JSON/YAML unmarshaling.

---

fsnode: use `path/filepath` instead of `path`

When validating paths in the fsnode module, use the `filepath`
module instead of the (more generic) `path`.
