### PR TITLE
[RFC] customizations: drop `FsNode` interface as it is not used

### DIFF
--- a/pkg/customizations/fsnode/fsnode.go
+++ b/pkg/customizations/fsnode/fsnode.go
@@ -10,16 +10,6 @@ import (
 const usernameRegex = `^[A-Za-z0-9_.][A-Za-z0-9_.-]{0,31}$`
 const groupnameRegex = `^[A-Za-z0-9_][A-Za-z0-9_-]{0,31}$`
 
-type FsNode interface {
-	Path() string
-	Mode() *os.FileMode
-	// User can return either a string (user name/group name), an int64 (UID/GID) or nil
-	User() interface{}
-	// Group can return either a string (user name/group name), an int64 (UID/GID) or nil
-	Group() interface{}
-	IsDir() bool
-}
-
 type baseFsNode struct {
 	path  string
 	mode  *os.FileMode


### PR DESCRIPTION
This commit removes the unused `customizations.FsNode` interface.

AFAICT this is unused and composer is also not using it (it does have an identical copy though). Opening to see if really all tests pass wihtout it.