### PR TITLE
fedora: move per image type image config into YAML (HMS-6019)

### DIFF
--- a/pkg/customizations/fsnode/dir_test.go
+++ b/pkg/customizations/fsnode/dir_test.go
@@ -25,7 +25,7 @@ func TestNewDirectory(t *testing.T) {
 			user:             nil,
 			group:            nil,
 			ensureParentDirs: false,
-			expected:         &Directory{baseFsNode: baseFsNode{path: "/etc/dir", mode: nil, user: nil, group: nil}, ensureParentDirs: false},
+			expected:         &Directory{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/dir", Mode: nil, User: nil, Group: nil}}, ensureParentDirs: false},
 		},
 		{
 			name:             "directory-with-mode",
@@ -34,7 +34,7 @@ func TestNewDirectory(t *testing.T) {
 			user:             nil,
 			group:            nil,
 			ensureParentDirs: false,
-			expected:         &Directory{baseFsNode: baseFsNode{path: "/etc/dir", mode: common.ToPtr(os.FileMode(0644)), user: nil, group: nil}, ensureParentDirs: false},
+			expected:         &Directory{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/dir", Mode: common.ToPtr(os.FileMode(0644)), User: nil, Group: nil}}, ensureParentDirs: false},
 		},
 		{
 			name:             "directory-with-user-and-group-string",
@@ -43,7 +43,7 @@ func TestNewDirectory(t *testing.T) {
 			user:             "user",
 			group:            "group",
 			ensureParentDirs: false,
-			expected:         &Directory{baseFsNode: baseFsNode{path: "/etc/dir", mode: nil, user: "user", group: "group"}, ensureParentDirs: false},
+			expected:         &Directory{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/dir", Mode: nil, User: "user", Group: "group"}}, ensureParentDirs: false},
 		},
 		{
 			name:             "directory-with-user-and-group-int64",
@@ -52,7 +52,7 @@ func TestNewDirectory(t *testing.T) {
 			user:             int64(1000),
 			group:            int64(1000),
 			ensureParentDirs: false,
-			expected:         &Directory{baseFsNode: baseFsNode{path: "/etc/dir", mode: nil, user: int64(1000), group: int64(1000)}, ensureParentDirs: false},
+			expected:         &Directory{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/dir", Mode: nil, User: int64(1000), Group: int64(1000)}}, ensureParentDirs: false},
 		},
 		{
 			name:             "directory-with-ensure-parent-dirs",
@@ -61,7 +61,7 @@ func TestNewDirectory(t *testing.T) {
 			user:             nil,
 			group:            nil,
 			ensureParentDirs: true,
-			expected:         &Directory{baseFsNode: baseFsNode{path: "/etc/dir", mode: nil, user: nil, group: nil}, ensureParentDirs: true},
+			expected:         &Directory{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/dir", Mode: nil, User: nil, Group: nil}}, ensureParentDirs: true},
 		},
 	}
 

--- a/pkg/customizations/fsnode/file_test.go
+++ b/pkg/customizations/fsnode/file_test.go
@@ -25,7 +25,7 @@ func TestNewFile(t *testing.T) {
 			mode:     nil,
 			user:     nil,
 			group:    nil,
-			expected: &File{baseFsNode: baseFsNode{path: "/etc/file", mode: nil, user: nil, group: nil}, data: nil},
+			expected: &File{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/file", Mode: nil, User: nil, Group: nil}}, data: nil},
 		},
 		{
 			name:     "file-with-data",
@@ -34,7 +34,7 @@ func TestNewFile(t *testing.T) {
 			mode:     nil,
 			user:     nil,
 			group:    nil,
-			expected: &File{baseFsNode: baseFsNode{path: "/etc/file", mode: nil, user: nil, group: nil}, data: []byte("data")},
+			expected: &File{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/file", Mode: nil, User: nil, Group: nil}}, data: []byte("data")},
 		},
 		{
 			name:     "file-with-mode",
@@ -43,7 +43,7 @@ func TestNewFile(t *testing.T) {
 			mode:     common.ToPtr(os.FileMode(0644)),
 			user:     nil,
 			group:    nil,
-			expected: &File{baseFsNode: baseFsNode{path: "/etc/file", mode: common.ToPtr(os.FileMode(0644)), user: nil, group: nil}, data: nil},
+			expected: &File{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/file", Mode: common.ToPtr(os.FileMode(0644)), User: nil, Group: nil}}, data: nil},
 		},
 		{
 			name:     "file-with-user-and-group-string",
@@ -52,7 +52,7 @@ func TestNewFile(t *testing.T) {
 			mode:     nil,
 			user:     "user",
 			group:    "group",
-			expected: &File{baseFsNode: baseFsNode{path: "/etc/file", mode: nil, user: "user", group: "group"}, data: nil},
+			expected: &File{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/file", Mode: nil, User: "user", Group: "group"}}, data: nil},
 		},
 		{
 			name:     "file-with-user-and-group-int64",
@@ -61,7 +61,7 @@ func TestNewFile(t *testing.T) {
 			mode:     nil,
 			user:     int64(1000),
 			group:    int64(1000),
-			expected: &File{baseFsNode: baseFsNode{path: "/etc/file", mode: nil, user: int64(1000), group: int64(1000)}, data: nil},
+			expected: &File{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/file", Mode: nil, User: int64(1000), Group: int64(1000)}}, data: nil},
 		},
 	}
 

--- a/pkg/customizations/fsnode/fsnode.go
+++ b/pkg/customizations/fsnode/fsnode.go
@@ -1,34 +1,42 @@
 package fsnode
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+
+	"github.com/osbuild/images/internal/common"
 )
 
 const usernameRegex = `^[A-Za-z0-9_.][A-Za-z0-9_.-]{0,31}$`
 const groupnameRegex = `^[A-Za-z0-9_][A-Za-z0-9_-]{0,31}$`
 
+type baseFsNodeJSON struct {
+	Path  string
+	Mode  *os.FileMode
+	User  interface{}
+	Group interface{}
+}
+
 type baseFsNode struct {
-	path  string
-	mode  *os.FileMode
-	user  interface{}
-	group interface{}
+	baseFsNodeJSON
 }
 
 func (f *baseFsNode) Path() string {
 	if f == nil {
 		return ""
 	}
-	return f.path
+	return f.baseFsNodeJSON.Path
 }
 
 func (f *baseFsNode) Mode() *os.FileMode {
 	if f == nil {
 		return nil
 	}
-	return f.mode
+	return f.baseFsNodeJSON.Mode
 }
 
 // User can return either a string (user name) or an int64 (UID)
@@ -36,7 +44,7 @@ func (f *baseFsNode) User() interface{} {
 	if f == nil {
 		return nil
 	}
-	return f.user
+	return f.baseFsNodeJSON.User
 }
 
 // Group can return either a string (group name) or an int64 (GID)
@@ -44,15 +52,17 @@ func (f *baseFsNode) Group() interface{} {
 	if f == nil {
 		return nil
 	}
-	return f.group
+	return f.baseFsNodeJSON.Group
 }
 
 func newBaseFsNode(path string, mode *os.FileMode, user interface{}, group interface{}) (*baseFsNode, error) {
 	node := &baseFsNode{
-		path:  path,
-		mode:  mode,
-		user:  user,
-		group: group,
+		baseFsNodeJSON: baseFsNodeJSON{
+			Path:  path,
+			Mode:  mode,
+			User:  user,
+			Group: group,
+		},
 	}
 
 	err := node.validate()
@@ -63,31 +73,42 @@ func newBaseFsNode(path string, mode *os.FileMode, user interface{}, group inter
 }
 
 func (f *baseFsNode) validate() error {
+	return f.baseFsNodeJSON.validate()
+}
+
+func (f *baseFsNodeJSON) validate() error {
 	// Check that the path is valid
-	if f.path == "" {
+	if f.Path == "" {
 		return fmt.Errorf("path must not be empty")
 	}
-	if f.path[0] != '/' {
+	if f.Path[0] != '/' {
 		return fmt.Errorf("path must be absolute")
 	}
-	if f.path[len(f.path)-1] == '/' {
+	if f.Path[len(f.Path)-1] == '/' {
 		return fmt.Errorf("path must not end with a slash")
 	}
-	if f.path != filepath.Clean(f.path) {
+	if f.Path != filepath.Clean(f.Path) {
 		return fmt.Errorf("path must be canonical")
 	}
 
 	// Check that the mode is valid
-	if f.mode != nil && *f.mode&os.ModeType != 0 {
+	if f.Mode != nil && *f.Mode&os.ModeType != 0 {
 		return fmt.Errorf("mode must not contain file type bits")
 	}
 
 	// Check that the user and group are valid
-	switch user := f.user.(type) {
+	switch user := f.User.(type) {
 	case string:
 		nameRegex := regexp.MustCompile(usernameRegex)
 		if !nameRegex.MatchString(user) {
 			return fmt.Errorf("user name %q doesn't conform to validating regex (%s)", user, nameRegex.String())
+		}
+	case float64:
+		if user != float64(int64(user)) {
+			return fmt.Errorf("user ID must be int")
+		}
+		if user < 0 {
+			return fmt.Errorf("user ID must be non-negative")
 		}
 	case int64:
 		if user < 0 {
@@ -99,11 +120,18 @@ func (f *baseFsNode) validate() error {
 		return fmt.Errorf("user must be either a string or an int64, got %T", user)
 	}
 
-	switch group := f.group.(type) {
+	switch group := f.Group.(type) {
 	case string:
 		nameRegex := regexp.MustCompile(groupnameRegex)
 		if !nameRegex.MatchString(group) {
 			return fmt.Errorf("group name %q doesn't conform to validating regex (%s)", group, nameRegex.String())
+		}
+	case float64:
+		if group != float64(int64(group)) {
+			return fmt.Errorf("group ID must be int")
+		}
+		if group < 0 {
+			return fmt.Errorf("group ID must be non-negative")
 		}
 	case int64:
 		if group < 0 {
@@ -116,4 +144,23 @@ func (f *baseFsNode) validate() error {
 	}
 
 	return nil
+}
+
+func (f *baseFsNode) UnmarshalJSON(data []byte) error {
+	var fv baseFsNodeJSON
+	dec := json.NewDecoder(bytes.NewBuffer(data))
+	if err := dec.Decode(&fv); err != nil {
+		return err
+	}
+	if err := fv.validate(); err != nil {
+		return err
+	}
+	f.baseFsNodeJSON = fv
+
+	return nil
+
+}
+
+func (f *baseFsNode) UnmarshalYAML(unmarshal func(any) error) error {
+	return common.UnmarshalYAMLviaJSON(f, unmarshal)
 }

--- a/pkg/customizations/fsnode/fsnode.go
+++ b/pkg/customizations/fsnode/fsnode.go
@@ -3,7 +3,7 @@ package fsnode
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 )
 
@@ -73,7 +73,7 @@ func (f *baseFsNode) validate() error {
 	if f.path[len(f.path)-1] == '/' {
 		return fmt.Errorf("path must not end with a slash")
 	}
-	if f.path != path.Clean(f.path) {
+	if f.path != filepath.Clean(f.path) {
 		return fmt.Errorf("path must be canonical")
 	}
 

--- a/pkg/customizations/fsnode/fsnode_test.go
+++ b/pkg/customizations/fsnode/fsnode_test.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+
+	"github.com/osbuild/images/internal/common"
 )
 
 func TestBaseFsNodeValidate(t *testing.T) {
@@ -18,134 +20,172 @@ func TestBaseFsNodeValidate(t *testing.T) {
 		// relative path is not allowed
 		{
 			Node: baseFsNode{
-				path: "relative/path/file",
+				baseFsNodeJSON{
+					Path: "relative/path/file",
+				},
 			},
 			Error: true,
 		},
 		// path ending with slash is not allowed
 		{
 			Node: baseFsNode{
-				path: "/dir/with/trailing/slash/",
+				baseFsNodeJSON{
+					Path: "/dir/with/trailing/slash/",
+				},
 			},
 			Error: true,
 		},
 		// empty path is not allowed
 		{
 			Node: baseFsNode{
-				path: "",
+				baseFsNodeJSON{
+					Path: "",
+				},
 			},
 			Error: true,
 		},
 		// path must be canonical
 		{
 			Node: baseFsNode{
-				path: "/dir/../file",
+				baseFsNodeJSON{
+					Path: "/dir/../file",
+				},
 			},
 			Error: true,
 		},
 		{
 			Node: baseFsNode{
-				path: "/dir/./file",
+				baseFsNodeJSON{
+					Path: "/dir/./file",
+				},
 			},
 			Error: true,
 		},
 		// valid paths
 		{
 			Node: baseFsNode{
-				path: "/etc/file",
+				baseFsNodeJSON{
+					Path: "/etc/file",
+				},
 			},
 		},
 		{
 			Node: baseFsNode{
-				path: "/etc/dir",
+				baseFsNodeJSON{
+					Path: "/etc/dir",
+				},
 			},
 		},
 		// MODE
 		// invalid mode
 		{
 			Node: baseFsNode{
-				path: "/etc/file",
-				mode: common.ToPtr(os.FileMode(os.ModeDir)),
+				baseFsNodeJSON{
+					Path: "/etc/file",
+					Mode: common.ToPtr(os.FileMode(os.ModeDir)),
+				},
 			},
 			Error: true,
 		},
 		// valid mode
 		{
 			Node: baseFsNode{
-				path: "/etc/file",
-				mode: common.ToPtr(os.FileMode(0o644)),
+				baseFsNodeJSON{
+					Path: "/etc/file",
+					Mode: common.ToPtr(os.FileMode(0o644)),
+				},
 			},
 		},
 		// USER
 		// invalid user
 		{
 			Node: baseFsNode{
-				path: "/etc/file",
-				user: "",
+				baseFsNodeJSON{
+					Path: "/etc/file",
+					User: "",
+				},
 			},
 			Error: true,
 		},
 		{
 			Node: baseFsNode{
-				path: "/etc/file",
-				user: "invalid@@@user",
+				baseFsNodeJSON{
+					Path: "/etc/file",
+					User: "invalid@@@user",
+				},
 			},
 			Error: true,
 		},
 		{
 			Node: baseFsNode{
-				path: "/etc/file",
-				user: int64(-1),
+				baseFsNodeJSON{
+					Path: "/etc/file",
+					User: int64(-1),
+				},
 			},
 			Error: true,
 		},
 		// valid user
 		{
 			Node: baseFsNode{
-				path: "/etc/file",
-				user: "osbuild",
+				baseFsNodeJSON{
+					Path: "/etc/file",
+					User: "osbuild",
+				},
 			},
 		},
 		{
 			Node: baseFsNode{
-				path: "/etc/file",
-				user: int64(0),
+				baseFsNodeJSON{
+					Path: "/etc/file",
+					User: int64(0),
+				},
 			},
 		},
 		// GROUP
 		// invalid group
 		{
 			Node: baseFsNode{
-				path:  "/etc/file",
-				group: "",
+				baseFsNodeJSON{
+					Path:  "/etc/file",
+					Group: "",
+				},
 			},
 			Error: true,
 		},
 		{
 			Node: baseFsNode{
-				path:  "/etc/file",
-				group: "invalid@@@group",
+				baseFsNodeJSON{
+					Path:  "/etc/file",
+					Group: "invalid@@@group",
+				},
 			},
 			Error: true,
 		},
 		{
 			Node: baseFsNode{
-				path:  "/etc/file",
-				group: int64(-1),
+				baseFsNodeJSON{
+					Path:  "/etc/file",
+					Group: int64(-1),
+				},
 			},
 			Error: true,
 		},
 		// valid group
 		{
 			Node: baseFsNode{
-				path:  "/etc/file",
-				group: "osbuild",
+				baseFsNodeJSON{
+					Path:  "/etc/file",
+					Group: "osbuild",
+				},
 			},
 		},
 		{
 			Node: baseFsNode{
-				path:  "/etc/file",
-				group: int64(0),
+				baseFsNodeJSON{
+					Path:  "/etc/file",
+					Group: int64(0),
+				},
 			},
 		},
 	}
@@ -159,5 +199,73 @@ func TestBaseFsNodeValidate(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
+	}
+}
+
+func TestFsNodeUnmarshalDir(t *testing.T) {
+	inputYAML := `
+path: /some/path
+mode: 0644
+user: 1000
+group: group
+ensure_parent_dirs: true
+`
+	var fsn Directory
+	err := yaml.Unmarshal([]byte(inputYAML), &fsn)
+	assert.NoError(t, err)
+	expected, err := NewDirectory("/some/path", common.ToPtr(os.FileMode(0644)), float64(1000), "group", true)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, &fsn)
+}
+
+func TestFsNodeUnmarshalFile(t *testing.T) {
+	inputYAML := `
+path: /some/path
+mode: 0644
+user: 1000
+group: group
+data: some-data
+`
+	var fsn File
+	err := yaml.Unmarshal([]byte(inputYAML), &fsn)
+	assert.NoError(t, err)
+	expected, err := NewFile("/some/path", common.ToPtr(os.FileMode(0644)), float64(1000), "group", []byte("some-data"))
+	assert.NoError(t, err)
+	assert.Equal(t, expected, &fsn)
+}
+
+func TestFsNodeUnmarshalBadFile(t *testing.T) {
+	for _, tc := range []struct {
+		inputYAML   string
+		expectedErr string
+	}{
+		{`path: 123`, `json: cannot unmarshal number into Go struct field .Path of type string`},
+		{`mode: -rw-rw-r--`, ` json: cannot unmarshal string into Go struct field .Mode of type fs.FileMode`},
+		{`mode: -1`, `cannot unmarshal number -1 into Go struct field .Mode of type fs.FileMode`},
+		{`mode: 5_000_000_000`, `json: cannot unmarshal number 5000000000 into Go struct field .Mode of type fs.FileMode`},
+		{"path: /foo\nuser: 3.14", `user ID must be int`},
+		{"path: /foo\ngroup: 2.71", `group ID must be int`},
+		{"path: /foo\nuser: -1", `user ID must be non-negative`},
+		{"path: /foo\ngroup: a!b", `group name "a!b" doesn't conform to validating regex`},
+		{"path: /foo\ndata: 1.61", `cannot unmarshal number into Go struct field .data of type string`},
+		{"path: /foo\nextra: field", `unknown field "extra"`},
+	} {
+		var fsn File
+		err := yaml.Unmarshal([]byte(tc.inputYAML), &fsn)
+		assert.ErrorContains(t, err, tc.expectedErr)
+	}
+}
+
+func TestFsNodeUnmarshalBadDir(t *testing.T) {
+	for _, tc := range []struct {
+		inputYAML   string
+		expectedErr string
+	}{
+		{"path: /foo\nensure_parent_dirs: maybe", `json: cannot unmarshal string into Go struct field .ensure_parent_dirs of type bool`},
+		{"path: /foo\nextra: field", `unknown field "extra"`},
+	} {
+		var fsn Directory
+		err := yaml.Unmarshal([]byte(tc.inputYAML), &fsn)
+		assert.ErrorContains(t, err, tc.expectedErr)
 	}
 }

--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -12,6 +12,63 @@
       - "geolite2-country"
       - "plymouth"
 
+  kernel_options:
+    default_kernel_optons:
+      - "ro"
+    cloud_kernel_options: &cloud_kernel_options
+      - "ro"
+      - "no_timer_check"
+      - "console=ttyS0,115200n8"
+      - "biosdevname=0"
+      - "net.ifnames=0"
+    ostree_deployment_kernel_options: &ostree_deployment_kernel_options
+      - "modprobe.blacklist=vc4"
+      - "rw"
+      - "coreos.no_persist_ip"
+
+  image_config:
+    iot_enabled_services: &image_config_iot_enabled_services
+      enabled_services:
+        - "NetworkManager.service"
+        - "firewalld.service"
+        - "sshd.service"
+        - "greenboot-grub2-set-counter"
+        - "greenboot-grub2-set-success"
+        - "greenboot-healthcheck"
+        - "greenboot-rpm-ostree-grub2-check-fallback"
+        - "greenboot-status"
+        - "greenboot-task-runner"
+        - "redboot-auto-reboot"
+        - "redboot-task-runner"
+      kernel_options: *ostree_deployment_kernel_options
+      condition:
+        version_less_than:
+          "42":
+            enabled_services:
+              - "NetworkManager.service"
+              - "firewalld.service"
+              - "sshd.service"
+              - "greenboot-grub2-set-counter"
+              - "greenboot-grub2-set-success"
+              - "greenboot-healthcheck"
+              - "greenboot-rpm-ostree-grub2-check-fallback"
+              - "greenboot-status"
+              - "greenboot-task-runner"
+              - "redboot-auto-reboot"
+              - "redboot-task-runner"
+              # only in < 42
+              - "zezere_ignition.timer"
+              - "zezere_ignition_banner.service"
+              - "parsec"
+              - "dbus-parsec"
+    iot: &image_config_iot
+      <<: *image_config_iot_enabled_services
+      keyboard:
+        keymap: "us"
+      locale: "C.UTF-8"
+      ostree_conf_sysroot_readonly: true
+      lock_root_user: true
+
   partitioning:
     ids:
       - &prep_partition_dosid "41"
@@ -303,6 +360,9 @@ image_config:
 
 image_types:
   server_qcow2: &server_qcow2
+    image_config: &image_config_qcow2
+      default_target: "multi-user.target"
+      kernel_options: *cloud_kernel_options
     partition_table:
       <<: *default_partition_tables
     package_sets:
@@ -315,6 +375,12 @@ image_types:
   server_openstack: *server_qcow2
 
   server_vhd:
+    image_config:
+      <<: *image_config_qcow2
+      sshd_config:
+        # follows https://github.com/osbuild/osbuild/blob/main/stages/org.osbuild.sshd.config.meta.json
+        config:
+          ClientAliveInterval: 120
     partition_table:
       <<: *default_partition_tables
     package_sets:
@@ -323,6 +389,14 @@ image_types:
           - "WALinuxAgent"
 
   server_vmdk: &server_vmdk
+    image_config:
+      locale: "en_US.UTF-8"
+      enabled_services:
+        - "cloud-init.service"
+        - "cloud-config.service"
+        - "cloud-final.service"
+        - "cloud-init-local.service"
+      kernel_options: *cloud_kernel_options
     partition_table:
       <<: *default_partition_tables
     package_sets:
@@ -349,6 +423,14 @@ image_types:
   # NOTE: keep in sync with official fedora-iot definitions:
   # https://pagure.io/fedora-iot/ostree/blob/main/f/fedora-iot-base.yaml
   iot_commit: &iot_commit
+    image_config:
+      <<: *image_config_iot_enabled_services
+      dracut_conf:
+        - filename: "40-fips.conf"
+          config:
+            add_dracutmodules:
+              - "fips"
+      machine_id_uninitialized: false
     package_sets:
       - include:
           - "NetworkManager"
@@ -469,6 +551,9 @@ image_types:
   iot_container: *iot_commit
 
   iot_raw_xz:
+    image_config:
+      <<: *image_config_iot
+      ignition_platform: "metal"
     partition_table:
       <<: *iot_base_partition_tables
     partition_tables_override:
@@ -487,11 +572,17 @@ image_types:
                 - *iot_base_partition_table_part_efi_aarch64
                 - *iot_base_partition_table_part_boot_aarch64
                 - *iot_base_partition_table_part_root_fstab_ro_aarch64
+
   iot_qcow2:
+    image_config:
+      <<: *image_config_iot
+      ignition_platform: "qemu"
     partition_table:
       <<: *iot_base_partition_tables
 
   iot_bootable_container:
+    image_config:
+      machine_id_uninitialized: false
     package_sets:
       - include:
           - "acl"
@@ -618,6 +709,8 @@ image_types:
           - "xz"
 
   anaconda: &anaconda
+    image_config:
+      locale: "en_US.UTF-8"
     package_sets:
       - &anaconda_pkgset
         include:
@@ -758,12 +851,17 @@ image_types:
                 - "dmidecode"
 
   iot_installer:
+    image_config:
+      <<: *image_config_iot_enabled_services
+      locale: "en_US.UTF-8"
     package_sets:
       - *anaconda_pkgset
       - include:
           - "fedora-release-iot"
 
   workstation_live_installer:
+    image_config:
+      locale: "en_US.UTF-8"
     package_sets:
       - include:
           - "@workstation-product-environment"
@@ -798,6 +896,11 @@ image_types:
   minimal_installer: *anaconda
 
   container: &container
+    image_config: &image_config_container
+      no_selinux: true
+      exclude_docs: true
+      locale: "C.UTF-8"
+      timezone: "Etc/UTC"
     package_sets:
       - include:
           - "bash"
@@ -845,6 +948,18 @@ image_types:
           - "xkeyboard-config"
 
   wsl:
+    image_config:
+      <<: *image_config_container
+      cloud_init:
+        - filename: "99_wsl.cfg"
+          config:
+            datasource_list:
+              - "WSL"
+              - "None"
+            network:
+              config: "disabled"
+      wsl_config:
+        boot_systemd: true
     package_sets:
       - include:
           - "bash"
@@ -893,6 +1008,37 @@ image_types:
                 - "fuse-libs"
 
   minimal_raw: &minimal_raw
+    image_config:
+      # NOTE: temporary workaround for a bug in initial-setup that
+      # requires a kickstart file in the root directory.
+      files:
+        - path: "/root/anaconda-ks.cfg"
+          user: "root"
+          group: "root"
+          data: |
+            # Run initial-setup on first boot
+            # Created by osbuild
+            firstboot --reconfig
+      grub2_config:
+        timeout: 5
+      install_weak_deps: false
+      mount_units: true      
+      enabled_services:
+        - "NetworkManager.service"
+        - "initial-setup.service"
+        - "sshd.service"
+      kernel_options:
+        - "ro"
+      condition:
+        version_less_than:
+          "43":
+            install_weak_deps: true
+            mount_units: false
+            enabled_services:
+              - "NetworkManager.service"
+              - "initial-setup.service"
+              - "sshd.service"
+              - "firewalld.service"
     partition_table:
       <<: *minimal_raw_partition_tables
     package_sets:
@@ -922,6 +1068,9 @@ image_types:
   minimal_raw_xz: *minimal_raw
 
   iot_simplified_installer:
+    image_config:
+      <<: *image_config_iot
+      ignition_platform: "metal"
     partition_table:
       <<: *iot_simplified_installer_partition_tables
     package_sets:

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -437,7 +437,7 @@ image_types:
 	}, partTable)
 }
 
-func TestDefsImageConfig(t *testing.T) {
+func TestDefsDistroImageConfig(t *testing.T) {
 	fakeDistroYaml := `
 image_config:
   default:
@@ -503,4 +503,38 @@ image_types:
 		_, err := defs.PartitionTable(it, nil)
 		assert.ErrorIs(t, err, tc.expectedErr)
 	}
+}
+
+func TestImageTypeImageConfig(t *testing.T) {
+	fakeDistroYaml := `
+image_types:
+  test_type:
+    image_config:
+      hostname: "foo"
+      locale: "C.UTF-8"
+      timezone: "DefaultTZ"
+      condition:
+        version_less_than:
+          "2":
+            timezone: "OverrideTZ"
+        distro_name:
+          "test-distro":
+            locale: "en_US.UTF-8"
+        architecture:
+          "test_arch":
+            hostname: "test-arch-hn"
+`
+	fakeDistroName := "test-distro"
+	baseDir := makeFakeDefs(t, fakeDistroName, fakeDistroYaml)
+	restore := defs.MockDataFS(baseDir)
+	defer restore()
+
+	imgConfig, err := defs.ImageConfig("test-distro-1", "test_arch", "test_type", nil)
+	require.NoError(t, err)
+	assert.Equal(t, &distro.ImageConfig{
+		Hostname: common.ToPtr("test-arch-hn"),
+		Locale:   common.ToPtr("en_US.UTF-8"),
+		Timezone: common.ToPtr("OverrideTZ"),
+	}, imgConfig)
+
 }

--- a/pkg/distro/fedora/distro.go
+++ b/pkg/distro/fedora/distro.go
@@ -9,12 +9,10 @@ import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/environment"
 	"github.com/osbuild/images/pkg/arch"
-	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/oscap"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/defs"
-	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/runner"
@@ -50,23 +48,6 @@ var (
 	}
 )
 
-// kernel command line arguments
-// NOTE: we define them as functions to make sure they globals are never
-// modified
-
-// Default kernel command line
-func defaultKernelOptions() []string { return []string{"ro"} }
-
-// Added kernel command line options for ami, qcow2, openstack, vhd and vmdk types
-func cloudKernelOptions() []string {
-	return []string{"ro", "no_timer_check", "console=ttyS0,115200n8", "biosdevname=0", "net.ifnames=0"}
-}
-
-// Added kernel command line options for iot-raw-image and iot-qcow2-image types
-func ostreeDeploymentKernelOptions() []string {
-	return []string{"modprobe.blacklist=vc4", "rw", "coreos.no_persist_ip"}
-}
-
 // Image Definitions
 func mkImageInstallerImgType(d distribution) imageType {
 	return imageType{
@@ -81,13 +62,11 @@ func mkImageInstallerImgType(d distribution) imageType {
 			},
 			installerPkgsKey: packageSetLoader,
 		},
-		defaultImageConfig: &distro.ImageConfig{
-			Locale: common.ToPtr("en_US.UTF-8"),
-		},
-		bootable:  true,
-		bootISO:   true,
-		rpmOstree: false,
-		image:     imageInstallerImage,
+		defaultImageConfig: imageConfig(d, "minimal-installer"),
+		bootable:           true,
+		bootISO:            true,
+		rpmOstree:          false,
+		image:              imageInstallerImage,
 		// We don't know the variant of the OS pipeline being installed
 		isoLabel:               getISOLabelFunc("Unknown"),
 		buildPipelines:         []string{"build"},
@@ -106,9 +85,7 @@ func mkLiveInstallerImgType(d distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			installerPkgsKey: packageSetLoader,
 		},
-		defaultImageConfig: &distro.ImageConfig{
-			Locale: common.ToPtr("en_US.UTF-8"),
-		},
+		defaultImageConfig:     imageConfig(d, "workstation-live-installer"),
 		bootable:               true,
 		bootISO:                true,
 		rpmOstree:              false,
@@ -130,11 +107,7 @@ func mkIotCommitImgType(d distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: packageSetLoader,
 		},
-		defaultImageConfig: &distro.ImageConfig{
-			EnabledServices:        iotServicesForVersion(&d),
-			DracutConf:             []*osbuild.DracutConfStageOptions{osbuild.FIPSDracutConfStageOptions},
-			MachineIdUninitialized: common.ToPtr(false),
-		},
+		defaultImageConfig:     imageConfig(d, "iot-commit"),
 		rpmOstree:              true,
 		image:                  iotCommitImage,
 		buildPipelines:         []string{"build"},
@@ -152,9 +125,7 @@ func mkIotBootableContainer(d distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: packageSetLoader,
 		},
-		defaultImageConfig: &distro.ImageConfig{
-			MachineIdUninitialized: common.ToPtr(false),
-		},
+		defaultImageConfig:     imageConfig(d, "iot-bootable-container"),
 		rpmOstree:              true,
 		image:                  bootableContainerImage,
 		buildPipelines:         []string{"build"},
@@ -176,11 +147,7 @@ func mkIotOCIImgType(d distribution) imageType {
 				return rpmmd.PackageSet{}, nil
 			},
 		},
-		defaultImageConfig: &distro.ImageConfig{
-			EnabledServices:        iotServicesForVersion(&d),
-			DracutConf:             []*osbuild.DracutConfStageOptions{osbuild.FIPSDracutConfStageOptions},
-			MachineIdUninitialized: common.ToPtr(false),
-		},
+		defaultImageConfig:     imageConfig(d, "iot-container"),
 		rpmOstree:              true,
 		bootISO:                false,
 		image:                  iotContainerImage,
@@ -200,10 +167,7 @@ func mkIotInstallerImgType(d distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			installerPkgsKey: packageSetLoader,
 		},
-		defaultImageConfig: &distro.ImageConfig{
-			EnabledServices: iotServicesForVersion(&d),
-			Locale:          common.ToPtr("en_US.UTF-8"),
-		},
+		defaultImageConfig:     imageConfig(d, "iot-installer"),
 		rpmOstree:              true,
 		bootISO:                true,
 		image:                  iotInstallerImage,
@@ -223,17 +187,7 @@ func mkIotSimplifiedInstallerImgType(d distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			installerPkgsKey: packageSetLoader,
 		},
-		defaultImageConfig: &distro.ImageConfig{
-			EnabledServices: iotServicesForVersion(&d),
-			Keyboard: &osbuild.KeymapStageOptions{
-				Keymap: "us",
-			},
-			Locale:                    common.ToPtr("C.UTF-8"),
-			OSTreeConfSysrootReadOnly: common.ToPtr(true),
-			LockRootUser:              common.ToPtr(true),
-			IgnitionPlatform:          common.ToPtr("metal"),
-			KernelOptions:             ostreeDeploymentKernelOptions(),
-		},
+		defaultImageConfig:     imageConfig(d, "iot-simplified-installer"),
 		defaultSize:            10 * datasizes.GibiByte,
 		rpmOstree:              true,
 		bootable:               true,
@@ -249,29 +203,20 @@ func mkIotSimplifiedInstallerImgType(d distribution) imageType {
 
 func mkIotRawImgType(d distribution) imageType {
 	return imageType{
-		name:        "iot-raw-xz",
-		nameAliases: []string{"iot-raw-image", "fedora-iot-raw-image"},
-		filename:    "image.raw.xz",
-		compression: "xz",
-		mimeType:    "application/xz",
-		packageSets: map[string]packageSetFunc{},
-		defaultImageConfig: &distro.ImageConfig{
-			Keyboard: &osbuild.KeymapStageOptions{
-				Keymap: "us",
-			},
-			Locale:                    common.ToPtr("C.UTF-8"),
-			OSTreeConfSysrootReadOnly: common.ToPtr(true),
-			LockRootUser:              common.ToPtr(true),
-			IgnitionPlatform:          common.ToPtr("metal"),
-			KernelOptions:             ostreeDeploymentKernelOptions(),
-		},
-		defaultSize:      4 * datasizes.GibiByte,
-		rpmOstree:        true,
-		bootable:         true,
-		image:            iotImage,
-		buildPipelines:   []string{"build"},
-		payloadPipelines: []string{"ostree-deployment", "image", "xz"},
-		exports:          []string{"xz"},
+		name:               "iot-raw-xz",
+		nameAliases:        []string{"iot-raw-image", "fedora-iot-raw-image"},
+		filename:           "image.raw.xz",
+		compression:        "xz",
+		mimeType:           "application/xz",
+		packageSets:        map[string]packageSetFunc{},
+		defaultImageConfig: imageConfig(d, "iot-raw-xz"),
+		defaultSize:        4 * datasizes.GibiByte,
+		rpmOstree:          true,
+		bootable:           true,
+		image:              iotImage,
+		buildPipelines:     []string{"build"},
+		payloadPipelines:   []string{"ostree-deployment", "image", "xz"},
+		exports:            []string{"xz"},
 
 		// Passing an empty map into the required partition sizes disables the
 		// default partition sizes normally set so our `basePartitionTables` can
@@ -282,21 +227,12 @@ func mkIotRawImgType(d distribution) imageType {
 
 func mkIotQcow2ImgType(d distribution) imageType {
 	return imageType{
-		name:        "iot-qcow2",
-		nameAliases: []string{"iot-qcow2-image"}, // kept for backwards compatibility
-		filename:    "image.qcow2",
-		mimeType:    "application/x-qemu-disk",
-		packageSets: map[string]packageSetFunc{},
-		defaultImageConfig: &distro.ImageConfig{
-			Keyboard: &osbuild.KeymapStageOptions{
-				Keymap: "us",
-			},
-			Locale:                    common.ToPtr("C.UTF-8"),
-			OSTreeConfSysrootReadOnly: common.ToPtr(true),
-			LockRootUser:              common.ToPtr(true),
-			IgnitionPlatform:          common.ToPtr("qemu"),
-			KernelOptions:             ostreeDeploymentKernelOptions(),
-		},
+		name:                   "iot-qcow2",
+		nameAliases:            []string{"iot-qcow2-image"}, // kept for backwards compatibility
+		filename:               "image.qcow2",
+		mimeType:               "application/x-qemu-disk",
+		packageSets:            map[string]packageSetFunc{},
+		defaultImageConfig:     imageConfig(d, "iot-qcow2"),
 		defaultSize:            10 * datasizes.GibiByte,
 		rpmOstree:              true,
 		bootable:               true,
@@ -318,10 +254,7 @@ func mkQcow2ImgType(d distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: packageSetLoader,
 		},
-		defaultImageConfig: &distro.ImageConfig{
-			DefaultTarget: common.ToPtr("multi-user.target"),
-			KernelOptions: cloudKernelOptions(),
-		},
+		defaultImageConfig:     imageConfig(d, "server-qcow2"),
 		bootable:               true,
 		defaultSize:            5 * datasizes.GibiByte,
 		image:                  diskImage,
@@ -332,19 +265,6 @@ func mkQcow2ImgType(d distribution) imageType {
 	}
 }
 
-var (
-	vmdkDefaultImageConfig = &distro.ImageConfig{
-		Locale: common.ToPtr("en_US.UTF-8"),
-		EnabledServices: []string{
-			"cloud-init.service",
-			"cloud-config.service",
-			"cloud-final.service",
-			"cloud-init-local.service",
-		},
-		KernelOptions: cloudKernelOptions(),
-	}
-)
-
 func mkVmdkImgType(d distribution) imageType {
 	return imageType{
 		name:        "server-vmdk",
@@ -354,7 +274,7 @@ func mkVmdkImgType(d distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: packageSetLoader,
 		},
-		defaultImageConfig:     vmdkDefaultImageConfig,
+		defaultImageConfig:     imageConfig(d, "server-vmdk"),
 		bootable:               true,
 		defaultSize:            2 * datasizes.GibiByte,
 		image:                  diskImage,
@@ -374,7 +294,7 @@ func mkOvaImgType(d distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: packageSetLoader,
 		},
-		defaultImageConfig:     vmdkDefaultImageConfig,
+		defaultImageConfig:     imageConfig(d, "server-ova"),
 		bootable:               true,
 		defaultSize:            2 * datasizes.GibiByte,
 		image:                  diskImage,
@@ -393,12 +313,7 @@ func mkContainerImgType(d distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: packageSetLoader,
 		},
-		defaultImageConfig: &distro.ImageConfig{
-			NoSElinux:   common.ToPtr(true),
-			ExcludeDocs: common.ToPtr(true),
-			Locale:      common.ToPtr("C.UTF-8"),
-			Timezone:    common.ToPtr("Etc/UTC"),
-		},
+		defaultImageConfig:     imageConfig(d, "container"),
 		image:                  containerImage,
 		bootable:               false,
 		buildPipelines:         []string{"build"},
@@ -417,29 +332,7 @@ func mkWslImgType(d distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: packageSetLoader,
 		},
-		defaultImageConfig: &distro.ImageConfig{
-			CloudInit: []*osbuild.CloudInitStageOptions{
-				{
-					Filename: "99_wsl.cfg",
-					Config: osbuild.CloudInitConfigFile{
-						DatasourceList: []string{
-							"WSL",
-							"None",
-						},
-						Network: &osbuild.CloudInitConfigNetwork{
-							Config: "disabled",
-						},
-					},
-				},
-			},
-			NoSElinux:   common.ToPtr(true),
-			ExcludeDocs: common.ToPtr(true),
-			Locale:      common.ToPtr("C.UTF-8"),
-			Timezone:    common.ToPtr("Etc/UTC"),
-			WSLConfig: &distro.WSLConfig{
-				BootSystemd: true,
-			},
-		},
+		defaultImageConfig:     imageConfig(d, "wsl"),
 		image:                  containerImage,
 		bootable:               false,
 		buildPipelines:         []string{"build"},
@@ -459,18 +352,7 @@ func mkMinimalRawImgType(d distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: packageSetLoader,
 		},
-		defaultImageConfig: &distro.ImageConfig{
-			EnabledServices: minimalServicesForVersion(&d),
-			// NOTE: temporary workaround for a bug in initial-setup that
-			// requires a kickstart file in the root directory.
-			Files: []*fsnode.File{initialSetupKickstart()},
-			Grub2Config: &osbuild.GRUB2Config{
-				// Overwrite the default Grub2 timeout value.
-				Timeout: 5,
-			},
-			InstallWeakDeps: common.ToPtr(common.VersionLessThan(d.osVersion, VERSION_MINIMAL_WEAKDEPS)),
-			KernelOptions:   defaultKernelOptions(),
-		},
+		defaultImageConfig:     imageConfig(d, "minimal-raw-xz"),
 		rpmOstree:              false,
 		bootable:               true,
 		defaultSize:            2 * datasizes.GibiByte,
@@ -481,10 +363,6 @@ func mkMinimalRawImgType(d distribution) imageType {
 		requiredPartitionSizes: requiredDirectorySizes,
 	}
 	if common.VersionGreaterThanOrEqual(d.osVersion, "43") {
-		// from Fedora 43 onward, we stop writing /etc/fstab and start using
-		// mount units only
-		it.defaultImageConfig.MountUnits = common.ToPtr(true)
-
 		// when using systemd mount units we also want them to be mounted rw
 		// while the default options are not
 		it.defaultImageConfig.KernelOptions = []string{"rw"}
@@ -714,7 +592,7 @@ func newDistro(version int) distro.Distro {
 
 	vhdImgType := qcow2ImgType
 	vhdImgType.name = "server-vhd"
-	vhdImgType.nameAliases = []string{"vhd"} // kept for backwards compatibility
+	vhdImgType.nameAliases = []string{"server-vhd"} // kept for backwards compatibility
 	vhdImgType.filename = "disk.vhd"
 	vhdImgType.mimeType = "application/x-vhd"
 	vhdImgType.payloadPipelines = []string{"os", "image", "vpc"}
@@ -723,14 +601,7 @@ func newDistro(version int) distro.Distro {
 	vhdImgType.packageSets = map[string]packageSetFunc{
 		osPkgsKey: packageSetLoader,
 	}
-	vhdConfig := distro.ImageConfig{
-		SshdConfig: &osbuild.SshdConfigStageOptions{
-			Config: osbuild.SshdConfigConfig{
-				ClientAliveInterval: common.ToPtr(120),
-			},
-		},
-	}
-	vhdImgType.defaultImageConfig = vhdConfig.InheritFrom(qcow2ImgType.defaultImageConfig)
+	vhdImgType.defaultImageConfig = imageConfig(rd, "server-vhd")
 
 	minimalrawZstdImgType := mkMinimalRawImgType(rd)
 	minimalrawZstdImgType.name = "minimal-raw-zst"
@@ -1164,45 +1035,4 @@ func DistroFactory(idStr string) distro.Distro {
 	}
 
 	return newDistro(id.MajorVersion)
-}
-
-func iotServicesForVersion(d *distribution) []string {
-	services := []string{
-		"NetworkManager.service",
-		"firewalld.service",
-		"sshd.service",
-		"greenboot-grub2-set-counter",
-		"greenboot-grub2-set-success",
-		"greenboot-healthcheck",
-		"greenboot-rpm-ostree-grub2-check-fallback",
-		"greenboot-status",
-		"greenboot-task-runner",
-		"redboot-auto-reboot",
-		"redboot-task-runner",
-	}
-
-	if common.VersionLessThan(d.osVersion, "42") {
-		services = append(services, []string{
-			"zezere_ignition.timer",
-			"zezere_ignition_banner.service",
-			"parsec",
-			"dbus-parsec",
-		}...)
-	}
-
-	return services
-}
-
-func minimalServicesForVersion(d *distribution) []string {
-	services := []string{
-		"NetworkManager.service",
-		"initial-setup.service",
-		"sshd.service",
-	}
-
-	if common.VersionLessThan(d.osVersion, "43") {
-		services = append(services, []string{"firewalld.service"}...)
-	}
-
-	return services
 }

--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -1,10 +1,18 @@
 package fedora
 
 import (
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 func packageSetLoader(t *imageType) (rpmmd.PackageSet, error) {
 	return defs.PackageSet(t, "", VersionReplacements())
+}
+
+func imageConfig(d distribution, imageType string) *distro.ImageConfig {
+	// arch is currently not used in fedora
+	arch := ""
+	return common.Must(defs.ImageConfig(d.name, arch, imageType, VersionReplacements()))
 }

--- a/pkg/distro/fedora/version.go
+++ b/pkg/distro/fedora/version.go
@@ -11,9 +11,6 @@ const VERSION_ROOTFS_SQUASHFS = "41"
 // other Fedora variants.
 const VERSION_FIRSTBOOT = "43"
 
-// Version at which we stop installing weak dependencies for Fedora Minimal
-const VERSION_MINIMAL_WEAKDEPS = "43"
-
 func VersionReplacements() map[string]string {
 	return map[string]string{
 		"VERSION_BRANCHED":        VERSION_BRANCHED,

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -18,10 +18,10 @@ type ImageConfig struct {
 	TimeSynchronization *osbuild.ChronyStageOptions
 	Locale              *string `yaml:"locale,omitempty"`
 	Keyboard            *osbuild.KeymapStageOptions
-	EnabledServices     []string
+	EnabledServices     []string `yaml:"enabled_services,omitempty"`
 	DisabledServices    []string
 	MaskedServices      []string
-	DefaultTarget       *string
+	DefaultTarget       *string `yaml:"default_target,omitempty"`
 
 	Sysconfig           *Sysconfig `yaml:"sysconfig,omitempty"`
 	DefaultKernel       *string    `yaml:"default_kernel,omitempty"`
@@ -32,14 +32,14 @@ type ImageConfig struct {
 	GPGKeyFiles []string `yaml:"gpgkey_files,omitempty"`
 
 	// Disable SELinux labelling
-	NoSElinux *bool
+	NoSElinux *bool `yaml:"no_selinux,omitempty"`
 
 	// Do not use. Forces auto-relabelling on first boot.
 	// See https://github.com/osbuild/osbuild/commit/52cb27631b587c1df177cd17625c5b473e1e85d2
 	SELinuxForceRelabel *bool
 
 	// Disable documentation
-	ExcludeDocs *bool
+	ExcludeDocs *bool `yaml:"exclude_docs,omitempty"`
 
 	ShellInit []shell.InitFile
 
@@ -47,9 +47,9 @@ type ImageConfig struct {
 	// when the user want the image to be subscribed on first boot and when not
 	RHSMConfig    map[subscription.RHSMStatus]*subscription.RHSMConfig
 	SystemdLogind []*osbuild.SystemdLogindStageOptions
-	CloudInit     []*osbuild.CloudInitStageOptions
+	CloudInit     []*osbuild.CloudInitStageOptions `yaml:"cloud_init"`
 	Modprobe      []*osbuild.ModprobeStageOptions
-	DracutConf    []*osbuild.DracutConfStageOptions
+	DracutConf    []*osbuild.DracutConfStageOptions `yaml:"dracut_conf"`
 	SystemdDropin []*osbuild.SystemdUnitStageOptions
 	SystemdUnit   []*osbuild.SystemdUnitCreateStageOptions
 	Authselect    *osbuild.AuthselectStageOptions
@@ -61,11 +61,11 @@ type ImageConfig struct {
 	// Do not use DNFConfig directly, call "DNFConfigOptions()"
 	DNFConfig           []*osbuild.DNFConfigStageOptions
 	DNFSetReleaseVerVar *bool
-	SshdConfig          *osbuild.SshdConfigStageOptions
+	SshdConfig          *osbuild.SshdConfigStageOptions `yaml:"sshd_config"`
 	Authconfig          *osbuild.AuthconfigStageOptions
 	PwQuality           *osbuild.PwqualityConfStageOptions
 	WAAgentConfig       *osbuild.WAAgentConfStageOptions
-	Grub2Config         *osbuild.GRUB2Config
+	Grub2Config         *osbuild.GRUB2Config `yaml:"grub2_config,omitempty"`
 	DNFAutomaticConfig  *osbuild.DNFAutomaticConfigStageOptions
 	YumConfig           *osbuild.YumConfigStageOptions
 	YUMRepos            []*osbuild.YumReposStageOptions
@@ -74,7 +74,7 @@ type ImageConfig struct {
 	GCPGuestAgentConfig *osbuild.GcpGuestAgentConfigOptions
 	NetworkManager      *osbuild.NMConfStageOptions
 
-	WSLConfig *WSLConfig
+	WSLConfig *WSLConfig `yaml:"wsl_config,omitempty"`
 
 	Files       []*fsnode.File
 	Directories []*fsnode.Directory
@@ -98,13 +98,13 @@ type ImageConfig struct {
 	// OSTree specific configuration
 
 	// Read only sysroot and boot
-	OSTreeConfSysrootReadOnly *bool
+	OSTreeConfSysrootReadOnly *bool `yaml:"ostree_conf_sysroot_readonly,omitempty"`
 
 	// Lock the root account in the deployment unless the user defined root
 	// user options in the build configuration.
-	LockRootUser *bool
+	LockRootUser *bool `yaml:"lock_root_user,omitempty"`
 
-	IgnitionPlatform *string
+	IgnitionPlatform *string `yaml:"ignition_platform,omitempty"`
 
 	// InstallWeakDeps enables installation of weak dependencies for packages
 	// that are statically defined for the pipeline.
@@ -117,11 +117,11 @@ type ImageConfig struct {
 
 	// MountUnits creates systemd .mount units to describe the filesystem
 	// instead of writing to /etc/fstab
-	MountUnits *bool
+	MountUnits *bool `yaml:"mount_units,omitempty"`
 }
 
 type WSLConfig struct {
-	BootSystemd bool
+	BootSystemd bool `yaml:"boot_systemd,omitempty"`
 }
 
 // InheritFrom inherits unset values from the provided parent configuration and

--- a/pkg/osbuild/cloud_init_stage.go
+++ b/pkg/osbuild/cloud_init_stage.go
@@ -28,7 +28,7 @@ type CloudInitConfigFile struct {
 	SystemInfo     *CloudInitConfigSystemInfo `json:"system_info,omitempty"`
 	Reporting      *CloudInitConfigReporting  `json:"reporting,omitempty"`
 	Datasource     *CloudInitConfigDatasource `json:"datasource,omitempty"`
-	DatasourceList []string                   `json:"datasource_list,omitempty"`
+	DatasourceList []string                   `json:"datasource_list,omitempty" yaml:"datasource_list,omitempty"`
 	Output         *CloudInitConfigOutput     `json:"output,omitempty"`
 	Network        *CloudInitConfigNetwork    `json:"network,omitempty"`
 }

--- a/pkg/osbuild/dracut_conf_stage.go
+++ b/pkg/osbuild/dracut_conf_stage.go
@@ -28,7 +28,7 @@ type DracutConfigFile struct {
 	Modules []string `json:"dracutmodules,omitempty"`
 
 	// Additional dracut modules to include
-	AddModules []string `json:"add_dracutmodules,omitempty"`
+	AddModules []string `json:"add_dracutmodules,omitempty" yaml:"add_dracutmodules,omitempty"`
 
 	// Dracut modules to not include
 	OmitModules []string `json:"omit_dracutmodules,omitempty"`


### PR DESCRIPTION
[draft until https://github.com/osbuild/images/pull/1500 is merged]

This a cleaned up split-out of https://github.com/osbuild/images/pull/1462 - it moves the image configuration for fedora into YAML. It only needs #1500 as its prerequisite.

---

This commit moves the `ImageConfig` of each package into the
distro.yaml.

---

defs: implement `defs.ImageConfig()` for image config loading

This commit adds a new `defs.ImageConfig()` to load per image
type specific image config loading. This allows to write:
```yaml
image_types:
  test_type:
    image_config:
      locale: "C.UTF-8"
      timezone: "DefaultTZ"
      condition:
        version_less_than:
          "2":
            timezone: "OverrideTZ"

/jira-epic HMS-6019