### PR TITLE
fsnode: add custom unmarshalers for File/Dir

### DIFF
--- a/pkg/customizations/fsnode/dir.go
+++ b/pkg/customizations/fsnode/dir.go
@@ -1,21 +1,25 @@
 package fsnode
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
+
+	"github.com/osbuild/images/internal/common"
 )
 
 type Directory struct {
-	Path  string
-	Mode  *os.FileMode
-	User  any
-	Group any
+	Path  string       `json:"path,omitempty"`
+	Mode  *os.FileMode `json:"mode,omitempty"`
+	User  any          `json:"user,omitempty"`
+	Group any          `json:"group,omitempty"`
 
-	EnsureParentDirs bool
+	EnsureParentDirs bool `json:"ensure_parent_dirs,omitempty"`
 }
 
 // NewDirectory creates a new directory with the given path, mode, user and group.
 // user and group can be either a string (user name/group name), an int64 (UID/GID) or nil.
-func NewDirectory(path string, mode *os.FileMode, user interface{}, group interface{}, ensureParentDirs bool) (*Directory, error) {
+func NewDirectory(path string, mode *os.FileMode, user any, group any, ensureParentDirs bool) (*Directory, error) {
 	if err := validate(path, mode, user, group); err != nil {
 		return nil, err
 	}
@@ -27,4 +31,22 @@ func NewDirectory(path string, mode *os.FileMode, user interface{}, group interf
 		Group:            group,
 		EnsureParentDirs: ensureParentDirs,
 	}, nil
+}
+
+func (d *Directory) UnmarshalJSON(data []byte) error {
+	type dir Directory
+
+	var v dir
+	dec := json.NewDecoder(bytes.NewBuffer(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&v); err != nil {
+		return err
+	}
+	*d = Directory(v)
+
+	return validate(d.Path, d.Mode, d.User, d.Group)
+}
+
+func (d *Directory) UnmarshalYAML(unmarshal func(any) error) error {
+	return common.UnmarshalYAMLviaJSON(d, unmarshal)
 }

--- a/pkg/customizations/fsnode/dir.go
+++ b/pkg/customizations/fsnode/dir.go
@@ -1,30 +1,30 @@
 package fsnode
 
-import "os"
+import (
+	"os"
+)
 
 type Directory struct {
-	baseFsNode
-	ensureParentDirs bool
-}
+	Path  string
+	Mode  *os.FileMode
+	User  any
+	Group any
 
-func (d *Directory) EnsureParentDirs() bool {
-	if d == nil {
-		return false
-	}
-	return d.ensureParentDirs
+	EnsureParentDirs bool
 }
 
 // NewDirectory creates a new directory with the given path, mode, user and group.
 // user and group can be either a string (user name/group name), an int64 (UID/GID) or nil.
 func NewDirectory(path string, mode *os.FileMode, user interface{}, group interface{}, ensureParentDirs bool) (*Directory, error) {
-	baseNode, err := newBaseFsNode(path, mode, user, group)
-
-	if err != nil {
+	if err := validate(path, mode, user, group); err != nil {
 		return nil, err
 	}
 
 	return &Directory{
-		baseFsNode:       *baseNode,
-		ensureParentDirs: ensureParentDirs,
+		Path:             path,
+		Mode:             mode,
+		User:             user,
+		Group:            group,
+		EnsureParentDirs: ensureParentDirs,
 	}, nil
 }

--- a/pkg/customizations/fsnode/dir_test.go
+++ b/pkg/customizations/fsnode/dir_test.go
@@ -25,7 +25,7 @@ func TestNewDirectory(t *testing.T) {
 			user:             nil,
 			group:            nil,
 			ensureParentDirs: false,
-			expected:         &Directory{baseFsNode: baseFsNode{path: "/etc/dir", mode: nil, user: nil, group: nil}, ensureParentDirs: false},
+			expected:         &Directory{Path: "/etc/dir", Mode: nil, User: nil, Group: nil, EnsureParentDirs: false},
 		},
 		{
 			name:             "directory-with-mode",
@@ -34,7 +34,7 @@ func TestNewDirectory(t *testing.T) {
 			user:             nil,
 			group:            nil,
 			ensureParentDirs: false,
-			expected:         &Directory{baseFsNode: baseFsNode{path: "/etc/dir", mode: common.ToPtr(os.FileMode(0644)), user: nil, group: nil}, ensureParentDirs: false},
+			expected:         &Directory{Path: "/etc/dir", Mode: common.ToPtr(os.FileMode(0644)), User: nil, Group: nil, EnsureParentDirs: false},
 		},
 		{
 			name:             "directory-with-user-and-group-string",
@@ -43,7 +43,7 @@ func TestNewDirectory(t *testing.T) {
 			user:             "user",
 			group:            "group",
 			ensureParentDirs: false,
-			expected:         &Directory{baseFsNode: baseFsNode{path: "/etc/dir", mode: nil, user: "user", group: "group"}, ensureParentDirs: false},
+			expected:         &Directory{Path: "/etc/dir", Mode: nil, User: "user", Group: "group", EnsureParentDirs: false},
 		},
 		{
 			name:             "directory-with-user-and-group-int64",
@@ -52,7 +52,7 @@ func TestNewDirectory(t *testing.T) {
 			user:             int64(1000),
 			group:            int64(1000),
 			ensureParentDirs: false,
-			expected:         &Directory{baseFsNode: baseFsNode{path: "/etc/dir", mode: nil, user: int64(1000), group: int64(1000)}, ensureParentDirs: false},
+			expected:         &Directory{Path: "/etc/dir", Mode: nil, User: int64(1000), Group: int64(1000), EnsureParentDirs: false},
 		},
 		{
 			name:             "directory-with-ensure-parent-dirs",
@@ -61,7 +61,7 @@ func TestNewDirectory(t *testing.T) {
 			user:             nil,
 			group:            nil,
 			ensureParentDirs: true,
-			expected:         &Directory{baseFsNode: baseFsNode{path: "/etc/dir", mode: nil, user: nil, group: nil}, ensureParentDirs: true},
+			expected:         &Directory{Path: "/etc/dir", Mode: nil, User: nil, Group: nil, EnsureParentDirs: true},
 		},
 	}
 

--- a/pkg/customizations/fsnode/dir_test.go
+++ b/pkg/customizations/fsnode/dir_test.go
@@ -13,8 +13,8 @@ func TestNewDirectory(t *testing.T) {
 		name             string
 		path             string
 		mode             *os.FileMode
-		user             interface{}
-		group            interface{}
+		user             any
+		group            any
 		ensureParentDirs bool
 		expected         *Directory
 	}{

--- a/pkg/customizations/fsnode/file.go
+++ b/pkg/customizations/fsnode/file.go
@@ -5,28 +5,26 @@ import (
 )
 
 type File struct {
-	baseFsNode
-	data []byte
-}
+	Path  string
+	Mode  *os.FileMode
+	User  any
+	Group any
 
-func (f *File) Data() []byte {
-	if f == nil {
-		return nil
-	}
-	return f.data
+	Data []byte
 }
 
 // NewFile creates a new file with the given path, data, mode, user and group.
 // user and group can be either a string (user name/group name), an int64 (UID/GID) or nil.
 func NewFile(path string, mode *os.FileMode, user interface{}, group interface{}, data []byte) (*File, error) {
-	baseNode, err := newBaseFsNode(path, mode, user, group)
-
-	if err != nil {
+	if err := validate(path, mode, user, group); err != nil {
 		return nil, err
 	}
 
 	return &File{
-		baseFsNode: *baseNode,
-		data:       data,
+		Path:  path,
+		Mode:  mode,
+		User:  user,
+		Group: group,
+		Data:  data,
 	}, nil
 }

--- a/pkg/customizations/fsnode/file.go
+++ b/pkg/customizations/fsnode/file.go
@@ -1,21 +1,26 @@
 package fsnode
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
 	"os"
+
+	"github.com/osbuild/images/internal/common"
 )
 
 type File struct {
-	Path  string
-	Mode  *os.FileMode
-	User  any
-	Group any
+	Path  string       `json:"path,omitempty"`
+	Mode  *os.FileMode `json:"mode,omitempty"`
+	User  any          `json:"user,omitempty"`
+	Group any          `json:"group,omitempty"`
 
-	Data []byte
+	Data []byte `json:"data,omitempty"`
 }
 
 // NewFile creates a new file with the given path, data, mode, user and group.
 // user and group can be either a string (user name/group name), an int64 (UID/GID) or nil.
-func NewFile(path string, mode *os.FileMode, user interface{}, group interface{}, data []byte) (*File, error) {
+func NewFile(path string, mode *os.FileMode, user any, group any, data []byte) (*File, error) {
 	if err := validate(path, mode, user, group); err != nil {
 		return nil, err
 	}
@@ -27,4 +32,38 @@ func NewFile(path string, mode *os.FileMode, user interface{}, group interface{}
 		Group: group,
 		Data:  data,
 	}, nil
+}
+
+func (f *File) UnmarshalJSON(data []byte) error {
+	// create an alias so that we can custom unmarshal without
+	// infinite loop
+	type file File
+	var v struct {
+		file
+		// when unmarshaling, support a "text" field for
+		// convenience that is converted into "Data []byte"
+		// so that we can write nice ImageConfigs without
+		// having to "base64" encode the content
+		Text string `json:"text,omitempty"`
+	}
+	dec := json.NewDecoder(bytes.NewBuffer(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&v); err != nil {
+		return err
+	}
+
+	if err := validate(v.Path, v.Mode, v.User, v.Group); err != nil {
+		return err
+	}
+	if v.Data != nil && v.Text != "" {
+		return fmt.Errorf("fsnode file only allows data or text but not both")
+	}
+	*f = File(v.file)
+	f.Data = []byte(v.Text)
+
+	return nil
+}
+
+func (f *File) UnmarshalYAML(unmarshal func(any) error) error {
+	return common.UnmarshalYAMLviaJSON(f, unmarshal)
 }

--- a/pkg/customizations/fsnode/file_test.go
+++ b/pkg/customizations/fsnode/file_test.go
@@ -25,7 +25,7 @@ func TestNewFile(t *testing.T) {
 			mode:     nil,
 			user:     nil,
 			group:    nil,
-			expected: &File{baseFsNode: baseFsNode{path: "/etc/file", mode: nil, user: nil, group: nil}, data: nil},
+			expected: &File{Path: "/etc/file", Mode: nil, User: nil, Group: nil, Data: nil},
 		},
 		{
 			name:     "file-with-data",
@@ -34,7 +34,7 @@ func TestNewFile(t *testing.T) {
 			mode:     nil,
 			user:     nil,
 			group:    nil,
-			expected: &File{baseFsNode: baseFsNode{path: "/etc/file", mode: nil, user: nil, group: nil}, data: []byte("data")},
+			expected: &File{Path: "/etc/file", Mode: nil, User: nil, Group: nil, Data: []byte("data")},
 		},
 		{
 			name:     "file-with-mode",
@@ -43,7 +43,7 @@ func TestNewFile(t *testing.T) {
 			mode:     common.ToPtr(os.FileMode(0644)),
 			user:     nil,
 			group:    nil,
-			expected: &File{baseFsNode: baseFsNode{path: "/etc/file", mode: common.ToPtr(os.FileMode(0644)), user: nil, group: nil}, data: nil},
+			expected: &File{Path: "/etc/file", Mode: common.ToPtr(os.FileMode(0644)), User: nil, Group: nil, Data: nil},
 		},
 		{
 			name:     "file-with-user-and-group-string",
@@ -52,7 +52,7 @@ func TestNewFile(t *testing.T) {
 			mode:     nil,
 			user:     "user",
 			group:    "group",
-			expected: &File{baseFsNode: baseFsNode{path: "/etc/file", mode: nil, user: "user", group: "group"}, data: nil},
+			expected: &File{Path: "/etc/file", Mode: nil, User: "user", Group: "group", Data: nil},
 		},
 		{
 			name:     "file-with-user-and-group-int64",
@@ -61,7 +61,7 @@ func TestNewFile(t *testing.T) {
 			mode:     nil,
 			user:     int64(1000),
 			group:    int64(1000),
-			expected: &File{baseFsNode: baseFsNode{path: "/etc/file", mode: nil, user: int64(1000), group: int64(1000)}, data: nil},
+			expected: &File{Path: "/etc/file", Mode: nil, User: int64(1000), Group: int64(1000), Data: nil},
 		},
 	}
 

--- a/pkg/customizations/fsnode/file_test.go
+++ b/pkg/customizations/fsnode/file_test.go
@@ -14,8 +14,8 @@ func TestNewFile(t *testing.T) {
 		path     string
 		data     []byte
 		mode     *os.FileMode
-		user     interface{}
-		group    interface{}
+		user     any
+		group    any
 		expected *File
 	}{
 		{

--- a/pkg/customizations/fsnode/fsnode.go
+++ b/pkg/customizations/fsnode/fsnode.go
@@ -37,6 +37,17 @@ func validate(path string, mode *os.FileMode, user any, group any) error {
 		if !nameRegex.MatchString(user) {
 			return fmt.Errorf("user name %q doesn't conform to validating regex (%s)", user, nameRegex.String())
 		}
+	case float64:
+		if user != float64(int64(user)) {
+			return fmt.Errorf("user ID must be int")
+		}
+		if user < 0 {
+			return fmt.Errorf("user ID must be non-negative")
+		}
+	case int:
+		if user < 0 {
+			return fmt.Errorf("user ID must be non-negative")
+		}
 	case int64:
 		if user < 0 {
 			return fmt.Errorf("user ID must be non-negative")
@@ -52,6 +63,17 @@ func validate(path string, mode *os.FileMode, user any, group any) error {
 		nameRegex := regexp.MustCompile(groupnameRegex)
 		if !nameRegex.MatchString(group) {
 			return fmt.Errorf("group name %q doesn't conform to validating regex (%s)", group, nameRegex.String())
+		}
+	case float64:
+		if group != float64(int64(group)) {
+			return fmt.Errorf("group ID must be int")
+		}
+		if group < 0 {
+			return fmt.Errorf("group ID must be non-negative")
+		}
+	case int:
+		if group < 0 {
+			return fmt.Errorf("group ID must be non-negative")
 		}
 	case int64:
 		if group < 0 {

--- a/pkg/customizations/fsnode/fsnode.go
+++ b/pkg/customizations/fsnode/fsnode.go
@@ -3,7 +3,7 @@ package fsnode
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 )
 
@@ -73,7 +73,7 @@ func (f *baseFsNode) validate() error {
 	if f.path[len(f.path)-1] == '/' {
 		return fmt.Errorf("path must not end with a slash")
 	}
-	if f.path != path.Clean(f.path) {
+	if f.path != filepath.Clean(f.path) {
 		return fmt.Errorf("path must be canonical")
 	}
 

--- a/pkg/customizations/fsnode/fsnode_test.go
+++ b/pkg/customizations/fsnode/fsnode_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/osbuild/images/internal/common"
 	"github.com/stretchr/testify/assert"
 )
@@ -124,5 +126,43 @@ func TestValidate(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
+	}
+}
+
+func TestFsNodeUnmarshalFile(t *testing.T) {
+	inputYAML := `
+path: /some/path
+mode: 0644
+user: 1000
+group: group
+text: some-data
+`
+	var fsn File
+	err := yaml.Unmarshal([]byte(inputYAML), &fsn)
+	assert.NoError(t, err)
+	expected, err := NewFile("/some/path", common.ToPtr(os.FileMode(0644)), float64(1000), "group", []byte("some-data"))
+	assert.NoError(t, err)
+	assert.Equal(t, expected, &fsn)
+}
+
+func TestFsNodeUnmarshalBadFile(t *testing.T) {
+	for _, tc := range []struct {
+		inputYAML   string
+		expectedErr string
+	}{
+		{`path: 123`, `json: cannot unmarshal number into Go struct field .file.path of type string`},
+		{`mode: -rw-rw-r--`, ` json: cannot unmarshal string into Go struct field .file.mode of type fs.FileMode`},
+		{`mode: -1`, `cannot unmarshal number -1 into Go struct field .file.mode of type fs.FileMode`},
+		{`mode: 5_000_000_000`, `json: cannot unmarshal number 5000000000 into Go struct field .file.mode of type fs.FileMode`},
+		{"path: /foo\nuser: 3.14", `user ID must be int`},
+		{"path: /foo\ngroup: 2.71", `group ID must be int`},
+		{"path: /foo\nuser: -1", `user ID must be non-negative`},
+		{"path: /foo\ngroup: a!b", `group name "a!b" doesn't conform to validating regex`},
+		{"path: /foo\ntext: 1.61", `cannot unmarshal number into Go struct field .text of type string`},
+		{"path: /foo\nextra: field", `unknown field "extra"`},
+	} {
+		var fsn File
+		err := yaml.Unmarshal([]byte(tc.inputYAML), &fsn)
+		assert.ErrorContains(t, err, tc.expectedErr)
 	}
 }

--- a/pkg/customizations/fsnode/fsnode_test.go
+++ b/pkg/customizations/fsnode/fsnode_test.go
@@ -9,151 +9,116 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBaseFsNodeValidate(t *testing.T) {
+func TestValidate(t *testing.T) {
 	testCases := []struct {
-		Node  baseFsNode
+		path  string
+		mode  *os.FileMode
+		user  any
+		group any
 		Error bool
 	}{
 		// PATH
 		// relative path is not allowed
 		{
-			Node: baseFsNode{
-				path: "relative/path/file",
-			},
+			path:  "relative/path/file",
 			Error: true,
 		},
 		// path ending with slash is not allowed
 		{
-			Node: baseFsNode{
-				path: "/dir/with/trailing/slash/",
-			},
+			path:  "/dir/with/trailing/slash/",
 			Error: true,
 		},
 		// empty path is not allowed
 		{
-			Node: baseFsNode{
-				path: "",
-			},
+			path:  "",
 			Error: true,
 		},
 		// path must be canonical
 		{
-			Node: baseFsNode{
-				path: "/dir/../file",
-			},
+			path:  "/dir/../file",
 			Error: true,
 		},
 		{
-			Node: baseFsNode{
-				path: "/dir/./file",
-			},
+			path:  "/dir/./file",
 			Error: true,
 		},
 		// valid paths
 		{
-			Node: baseFsNode{
-				path: "/etc/file",
-			},
+			path: "/etc/file",
 		},
 		{
-			Node: baseFsNode{
-				path: "/etc/dir",
-			},
+			path: "/etc/dir",
 		},
 		// MODE
 		// invalid mode
 		{
-			Node: baseFsNode{
-				path: "/etc/file",
-				mode: common.ToPtr(os.FileMode(os.ModeDir)),
-			},
+			path:  "/etc/file",
+			mode:  common.ToPtr(os.FileMode(os.ModeDir)),
 			Error: true,
 		},
 		// valid mode
 		{
-			Node: baseFsNode{
-				path: "/etc/file",
-				mode: common.ToPtr(os.FileMode(0o644)),
-			},
+			path: "/etc/file",
+			mode: common.ToPtr(os.FileMode(0o644)),
 		},
 		// USER
 		// invalid user
 		{
-			Node: baseFsNode{
-				path: "/etc/file",
-				user: "",
-			},
+			path:  "/etc/file",
+			user:  "",
 			Error: true,
 		},
 		{
-			Node: baseFsNode{
-				path: "/etc/file",
-				user: "invalid@@@user",
-			},
+			path:  "/etc/file",
+			user:  "invalid@@@user",
 			Error: true,
 		},
 		{
-			Node: baseFsNode{
-				path: "/etc/file",
-				user: int64(-1),
-			},
+			path:  "/etc/file",
+			user:  int64(-1),
 			Error: true,
 		},
 		// valid user
 		{
-			Node: baseFsNode{
-				path: "/etc/file",
-				user: "osbuild",
-			},
+			path: "/etc/file",
+			user: "osbuild",
 		},
 		{
-			Node: baseFsNode{
-				path: "/etc/file",
-				user: int64(0),
-			},
+			path: "/etc/file",
+			user: int64(0),
 		},
 		// GROUP
 		// invalid group
 		{
-			Node: baseFsNode{
-				path:  "/etc/file",
-				group: "",
-			},
+			path:  "/etc/file",
+			group: "",
 			Error: true,
 		},
 		{
-			Node: baseFsNode{
-				path:  "/etc/file",
-				group: "invalid@@@group",
-			},
+			path:  "/etc/file",
+			group: "invalid@@@group",
 			Error: true,
 		},
 		{
-			Node: baseFsNode{
-				path:  "/etc/file",
-				group: int64(-1),
-			},
+			path:  "/etc/file",
+			group: int64(-1),
 			Error: true,
 		},
 		// valid group
 		{
-			Node: baseFsNode{
-				path:  "/etc/file",
-				group: "osbuild",
-			},
+			path:  "/etc/file",
+			group: "osbuild",
 		},
 		{
-			Node: baseFsNode{
-				path:  "/etc/file",
-				group: int64(0),
-			},
+			path:  "/etc/file",
+			group: int64(0),
 		},
 	}
 
-	for idx, testCase := range testCases {
+	for idx, tc := range testCases {
 		t.Run(fmt.Sprintf("case #%d", idx), func(t *testing.T) {
-			err := testCase.Node.validate()
-			if testCase.Error {
+			err := validate(tc.path, tc.mode, tc.user, tc.group)
+			if tc.Error {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -481,7 +481,7 @@ func (p *AnacondaInstaller) getInline() []string {
 
 	// inline data for custom files
 	for _, file := range p.Files {
-		inlineData = append(inlineData, string(file.Data()))
+		inlineData = append(inlineData, string(file.Data))
 	}
 
 	return inlineData

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -139,7 +139,7 @@ func (p *AnacondaInstallerISOTree) getInline() []string {
 
 	// inline data for custom files
 	for _, file := range p.Files {
-		inlineData = append(inlineData, string(file.Data()))
+		inlineData = append(inlineData, string(file.Data))
 	}
 
 	return inlineData

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -1001,6 +1001,6 @@ func (p *OS) addInlineDataAndStages(pipeline *osbuild.Pipeline, files []*fsnode.
 	pipeline.AddStages(osbuild.GenFileNodesStages(files)...)
 
 	for _, file := range files {
-		p.inlineData = append(p.inlineData, string(file.Data()))
+		p.inlineData = append(p.inlineData, string(file.Data))
 	}
 }

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -516,7 +516,7 @@ func (p *OSTreeDeployment) addInlineDataAndStages(pipeline *osbuild.Pipeline, fi
 	}
 
 	for _, file := range files {
-		p.inlineData = append(p.inlineData, string(file.Data()))
+		p.inlineData = append(p.inlineData, string(file.Data))
 	}
 }
 

--- a/pkg/manifest/raw_bootc.go
+++ b/pkg/manifest/raw_bootc.go
@@ -253,7 +253,7 @@ func (p *RawBootcImage) getInline() []string {
 
 	// inline data for custom files
 	for _, file := range p.Files {
-		inlineData = append(inlineData, string(file.Data()))
+		inlineData = append(inlineData, string(file.Data))
 	}
 
 	return inlineData

--- a/pkg/manifest/subscription.go
+++ b/pkg/manifest/subscription.go
@@ -63,7 +63,7 @@ func (p *Subscription) getInline() []string {
 
 	// inline data for custom files
 	for _, file := range p.Files {
-		inlineData = append(inlineData, string(file.Data()))
+		inlineData = append(inlineData, string(file.Data))
 	}
 
 	return inlineData

--- a/pkg/manifest/subscription_test.go
+++ b/pkg/manifest/subscription_test.go
@@ -544,13 +544,13 @@ func TestSubscriptionService(t *testing.T) {
 
 			// ensure no directories or files have non-nil ownership
 			for _, file := range files {
-				assert.Nil(file.User())
-				assert.Nil(file.Group())
+				assert.Nil(file.User)
+				assert.Nil(file.Group)
 			}
 
 			for _, dir := range dirs {
-				assert.Nil(dir.User())
-				assert.Nil(dir.Group())
+				assert.Nil(dir.User)
+				assert.Nil(dir.Group)
 			}
 		})
 	}

--- a/pkg/osbuild/fsnode.go
+++ b/pkg/osbuild/fsnode.go
@@ -22,11 +22,11 @@ func GenFileNodesStages(files []*fsnode.File) []*Stage {
 	chownPaths := make(map[string]ChownStagePathOptions)
 
 	for _, file := range files {
-		fileDataChecksum := fmt.Sprintf("%x", sha256.Sum256(file.Data()))
+		fileDataChecksum := fmt.Sprintf("%x", sha256.Sum256(file.Data))
 		copyStageInputKey := fmt.Sprintf("file-%s", fileDataChecksum)
 		copyStagePaths = append(copyStagePaths, CopyStagePath{
 			From: fmt.Sprintf("input://%s/sha256:%s", copyStageInputKey, fileDataChecksum),
-			To:   fmt.Sprintf("tree://%s", file.Path()),
+			To:   fmt.Sprintf("tree://%s", file.Path),
 			// Default to removing the destination if it exists to ensure that symlinks are not followed.
 			RemoveDestination: true,
 		})
@@ -34,14 +34,14 @@ func GenFileNodesStages(files []*fsnode.File) []*Stage {
 			NewFilesInputSourceArrayRefEntry(fmt.Sprintf("sha256:%s", fileDataChecksum), nil),
 		}))
 
-		if file.Mode() != nil {
-			chmodPaths[file.Path()] = ChmodStagePathOptions{Mode: fmt.Sprintf("%#o", *file.Mode())}
+		if file.Mode != nil {
+			chmodPaths[file.Path] = ChmodStagePathOptions{Mode: fmt.Sprintf("%#o", *file.Mode)}
 		}
 
-		if file.User() != nil || file.Group() != nil {
-			chownPaths[file.Path()] = ChownStagePathOptions{
-				User:  file.User(),
-				Group: file.Group(),
+		if file.User != nil || file.Group != nil {
+			chownPaths[file.Path] = ChownStagePathOptions{
+				User:  file.User,
+				Group: file.Group,
 			}
 		}
 	}
@@ -79,23 +79,23 @@ func GenDirectoryNodesStages(dirs []*fsnode.Directory) []*Stage {
 		// This prevents the generated stages from changing the ownership and permissions of existing directories.
 		// TODO: We may want to make this configurable if we end up internally using `fsnode.Directory` for other
 		//       purposes than BP customizations.
-		dirExistOk := dir.Mode() == nil && dir.User() == nil && dir.Group() == nil
+		dirExistOk := dir.Mode == nil && dir.User == nil && dir.Group == nil
 
 		// Mode is intentionally not set, because it will be set by the chmod stage anyway.
 		mkdirPaths = append(mkdirPaths, MkdirStagePath{
-			Path:    dir.Path(),
-			Parents: dir.EnsureParentDirs(),
+			Path:    dir.Path,
+			Parents: dir.EnsureParentDirs,
 			ExistOk: dirExistOk,
 		})
 
-		if dir.Mode() != nil {
-			chmodPaths[dir.Path()] = ChmodStagePathOptions{Mode: fmt.Sprintf("%#o", *dir.Mode())}
+		if dir.Mode != nil {
+			chmodPaths[dir.Path] = ChmodStagePathOptions{Mode: fmt.Sprintf("%#o", *dir.Mode)}
 		}
 
-		if dir.User() != nil || dir.Group() != nil {
-			chownPaths[dir.Path()] = ChownStagePathOptions{
-				User:  dir.User(),
-				Group: dir.Group(),
+		if dir.User != nil || dir.Group != nil {
+			chownPaths[dir.Path] = ChownStagePathOptions{
+				User:  dir.User,
+				Group: dir.Group,
 			}
 		}
 	}

--- a/pkg/osbuild/pki_update_ca_trust_stage_test.go
+++ b/pkg/osbuild/pki_update_ca_trust_stage_test.go
@@ -66,7 +66,7 @@ func TestNewCAFileNodes(t *testing.T) {
 		"/etc/pki/ca-trust/source/anchors/4550f533dccaa359ad1b20d2ddbd27cd0d0de24.pem",
 	}
 	for i, c := range certs {
-		assert.Equal(t, expectedPaths[i], files[i].Path())
-		assert.Equal(t, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: c.Raw}), files[i].Data())
+		assert.Equal(t, expectedPaths[i], files[i].Path)
+		assert.Equal(t, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: c.Raw}), files[i].Data)
 	}
 }


### PR DESCRIPTION
Alternative implementation for https://github.com/osbuild/images/pull/1479 that changes the structure of the fsnode as suggested by @achilleas-k and @lzap 

I have no super strong opinion. One nice property of the original code with the getters/setters is that after NewFile() it would always be valid. This approach with the exported fields does not protect against changes to invalid data after the creation (or by creation from hand). It also adds a bunch of (extra) churn. 

---

fsnode: add custom unmarshalers for File/Dir

This commit adds custom unmarshalers for fsnode.{File,Directory}
that also do validation. For convenience when unmarshaling a
`fsnode.File` we support an extra `text: foo` field so that
in an ImageConfig YAML we can write:
```yaml
minimal_raw: &minimal_raw:
   image_config:
     files:
       - path: "/root/anaconda-ks.cfg"
         user: "root"
         group: "root"
         text: |
           # Run initial-setup on first boot
           # Created by osbuild
           firstboot --reconfig
```
The user can also use `data:` to put a base64 encoded string
in for binary files.


---

fsnode: remove Getters, export field to make JSON friendly

When we move `ImageConfig` into YAML we will need support for
`fsnode.File` as it is used as part of the ImageConfig.

This can be done in multiple ways, one is to add a custom
unmarshaller. This is done in PR#1479 but because of the
way the code was written the custom unmarshaling is rather
ugly.

This commit is an alternative version. As a starting point
the struct fields are simply exported and the getters of
the same name removed. Then we can add a custom unmarshal
that just validates.
