### PR TITLE
fsnode: add JSON/YAML support for File/Directory

### DIFF
--- a/pkg/customizations/fsnode/dir_test.go
+++ b/pkg/customizations/fsnode/dir_test.go
@@ -25,7 +25,7 @@ func TestNewDirectory(t *testing.T) {
 			user:             nil,
 			group:            nil,
 			ensureParentDirs: false,
-			expected:         &Directory{baseFsNode: baseFsNode{path: "/etc/dir", mode: nil, user: nil, group: nil}, ensureParentDirs: false},
+			expected:         &Directory{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/dir", Mode: nil, User: nil, Group: nil}}, ensureParentDirs: false},
 		},
 		{
 			name:             "directory-with-mode",
@@ -34,7 +34,7 @@ func TestNewDirectory(t *testing.T) {
 			user:             nil,
 			group:            nil,
 			ensureParentDirs: false,
-			expected:         &Directory{baseFsNode: baseFsNode{path: "/etc/dir", mode: common.ToPtr(os.FileMode(0644)), user: nil, group: nil}, ensureParentDirs: false},
+			expected:         &Directory{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/dir", Mode: common.ToPtr(os.FileMode(0644)), User: nil, Group: nil}}, ensureParentDirs: false},
 		},
 		{
 			name:             "directory-with-user-and-group-string",
@@ -43,7 +43,7 @@ func TestNewDirectory(t *testing.T) {
 			user:             "user",
 			group:            "group",
 			ensureParentDirs: false,
-			expected:         &Directory{baseFsNode: baseFsNode{path: "/etc/dir", mode: nil, user: "user", group: "group"}, ensureParentDirs: false},
+			expected:         &Directory{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/dir", Mode: nil, User: "user", Group: "group"}}, ensureParentDirs: false},
 		},
 		{
 			name:             "directory-with-user-and-group-int64",
@@ -52,7 +52,7 @@ func TestNewDirectory(t *testing.T) {
 			user:             int64(1000),
 			group:            int64(1000),
 			ensureParentDirs: false,
-			expected:         &Directory{baseFsNode: baseFsNode{path: "/etc/dir", mode: nil, user: int64(1000), group: int64(1000)}, ensureParentDirs: false},
+			expected:         &Directory{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/dir", Mode: nil, User: int64(1000), Group: int64(1000)}}, ensureParentDirs: false},
 		},
 		{
 			name:             "directory-with-ensure-parent-dirs",
@@ -61,7 +61,7 @@ func TestNewDirectory(t *testing.T) {
 			user:             nil,
 			group:            nil,
 			ensureParentDirs: true,
-			expected:         &Directory{baseFsNode: baseFsNode{path: "/etc/dir", mode: nil, user: nil, group: nil}, ensureParentDirs: true},
+			expected:         &Directory{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/dir", Mode: nil, User: nil, Group: nil}}, ensureParentDirs: true},
 		},
 	}
 

--- a/pkg/customizations/fsnode/file_test.go
+++ b/pkg/customizations/fsnode/file_test.go
@@ -25,7 +25,7 @@ func TestNewFile(t *testing.T) {
 			mode:     nil,
 			user:     nil,
 			group:    nil,
-			expected: &File{baseFsNode: baseFsNode{path: "/etc/file", mode: nil, user: nil, group: nil}, data: nil},
+			expected: &File{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/file", Mode: nil, User: nil, Group: nil}}, data: nil},
 		},
 		{
 			name:     "file-with-data",
@@ -34,7 +34,7 @@ func TestNewFile(t *testing.T) {
 			mode:     nil,
 			user:     nil,
 			group:    nil,
-			expected: &File{baseFsNode: baseFsNode{path: "/etc/file", mode: nil, user: nil, group: nil}, data: []byte("data")},
+			expected: &File{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/file", Mode: nil, User: nil, Group: nil}}, data: []byte("data")},
 		},
 		{
 			name:     "file-with-mode",
@@ -43,7 +43,7 @@ func TestNewFile(t *testing.T) {
 			mode:     common.ToPtr(os.FileMode(0644)),
 			user:     nil,
 			group:    nil,
-			expected: &File{baseFsNode: baseFsNode{path: "/etc/file", mode: common.ToPtr(os.FileMode(0644)), user: nil, group: nil}, data: nil},
+			expected: &File{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/file", Mode: common.ToPtr(os.FileMode(0644)), User: nil, Group: nil}}, data: nil},
 		},
 		{
 			name:     "file-with-user-and-group-string",
@@ -52,7 +52,7 @@ func TestNewFile(t *testing.T) {
 			mode:     nil,
 			user:     "user",
 			group:    "group",
-			expected: &File{baseFsNode: baseFsNode{path: "/etc/file", mode: nil, user: "user", group: "group"}, data: nil},
+			expected: &File{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/file", Mode: nil, User: "user", Group: "group"}}, data: nil},
 		},
 		{
 			name:     "file-with-user-and-group-int64",
@@ -61,7 +61,7 @@ func TestNewFile(t *testing.T) {
 			mode:     nil,
 			user:     int64(1000),
 			group:    int64(1000),
-			expected: &File{baseFsNode: baseFsNode{path: "/etc/file", mode: nil, user: int64(1000), group: int64(1000)}, data: nil},
+			expected: &File{baseFsNode: baseFsNode{baseFsNodeJSON{Path: "/etc/file", Mode: nil, User: int64(1000), Group: int64(1000)}}, data: nil},
 		},
 	}
 

--- a/pkg/customizations/fsnode/fsnode.go
+++ b/pkg/customizations/fsnode/fsnode.go
@@ -1,34 +1,42 @@
 package fsnode
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+
+	"github.com/osbuild/images/internal/common"
 )
 
 const usernameRegex = `^[A-Za-z0-9_.][A-Za-z0-9_.-]{0,31}$`
 const groupnameRegex = `^[A-Za-z0-9_][A-Za-z0-9_-]{0,31}$`
 
+type baseFsNodeJSON struct {
+	Path  string
+	Mode  *os.FileMode
+	User  interface{}
+	Group interface{}
+}
+
 type baseFsNode struct {
-	path  string
-	mode  *os.FileMode
-	user  interface{}
-	group interface{}
+	baseFsNodeJSON
 }
 
 func (f *baseFsNode) Path() string {
 	if f == nil {
 		return ""
 	}
-	return f.path
+	return f.baseFsNodeJSON.Path
 }
 
 func (f *baseFsNode) Mode() *os.FileMode {
 	if f == nil {
 		return nil
 	}
-	return f.mode
+	return f.baseFsNodeJSON.Mode
 }
 
 // User can return either a string (user name) or an int64 (UID)
@@ -36,7 +44,7 @@ func (f *baseFsNode) User() interface{} {
 	if f == nil {
 		return nil
 	}
-	return f.user
+	return f.baseFsNodeJSON.User
 }
 
 // Group can return either a string (group name) or an int64 (GID)
@@ -44,15 +52,17 @@ func (f *baseFsNode) Group() interface{} {
 	if f == nil {
 		return nil
 	}
-	return f.group
+	return f.baseFsNodeJSON.Group
 }
 
 func newBaseFsNode(path string, mode *os.FileMode, user interface{}, group interface{}) (*baseFsNode, error) {
 	node := &baseFsNode{
-		path:  path,
-		mode:  mode,
-		user:  user,
-		group: group,
+		baseFsNodeJSON: baseFsNodeJSON{
+			Path:  path,
+			Mode:  mode,
+			User:  user,
+			Group: group,
+		},
 	}
 
 	err := node.validate()
@@ -63,31 +73,42 @@ func newBaseFsNode(path string, mode *os.FileMode, user interface{}, group inter
 }
 
 func (f *baseFsNode) validate() error {
+	return f.baseFsNodeJSON.validate()
+}
+
+func (f *baseFsNodeJSON) validate() error {
 	// Check that the path is valid
-	if f.path == "" {
+	if f.Path == "" {
 		return fmt.Errorf("path must not be empty")
 	}
-	if f.path[0] != '/' {
+	if f.Path[0] != '/' {
 		return fmt.Errorf("path must be absolute")
 	}
-	if f.path[len(f.path)-1] == '/' {
+	if f.Path[len(f.Path)-1] == '/' {
 		return fmt.Errorf("path must not end with a slash")
 	}
-	if f.path != filepath.Clean(f.path) {
+	if f.Path != filepath.Clean(f.Path) {
 		return fmt.Errorf("path must be canonical")
 	}
 
 	// Check that the mode is valid
-	if f.mode != nil && *f.mode&os.ModeType != 0 {
+	if f.Mode != nil && *f.Mode&os.ModeType != 0 {
 		return fmt.Errorf("mode must not contain file type bits")
 	}
 
 	// Check that the user and group are valid
-	switch user := f.user.(type) {
+	switch user := f.User.(type) {
 	case string:
 		nameRegex := regexp.MustCompile(usernameRegex)
 		if !nameRegex.MatchString(user) {
 			return fmt.Errorf("user name %q doesn't conform to validating regex (%s)", user, nameRegex.String())
+		}
+	case float64:
+		if user != float64(int64(user)) {
+			return fmt.Errorf("user ID must be int")
+		}
+		if user < 0 {
+			return fmt.Errorf("user ID must be non-negative")
 		}
 	case int64:
 		if user < 0 {
@@ -99,11 +120,18 @@ func (f *baseFsNode) validate() error {
 		return fmt.Errorf("user must be either a string or an int64, got %T", user)
 	}
 
-	switch group := f.group.(type) {
+	switch group := f.Group.(type) {
 	case string:
 		nameRegex := regexp.MustCompile(groupnameRegex)
 		if !nameRegex.MatchString(group) {
 			return fmt.Errorf("group name %q doesn't conform to validating regex (%s)", group, nameRegex.String())
+		}
+	case float64:
+		if group != float64(int64(group)) {
+			return fmt.Errorf("group ID must be int")
+		}
+		if group < 0 {
+			return fmt.Errorf("group ID must be non-negative")
 		}
 	case int64:
 		if group < 0 {
@@ -116,4 +144,23 @@ func (f *baseFsNode) validate() error {
 	}
 
 	return nil
+}
+
+func (f *baseFsNode) UnmarshalJSON(data []byte) error {
+	var fv baseFsNodeJSON
+	dec := json.NewDecoder(bytes.NewBuffer(data))
+	if err := dec.Decode(&fv); err != nil {
+		return err
+	}
+	if err := fv.validate(); err != nil {
+		return err
+	}
+	f.baseFsNodeJSON = fv
+
+	return nil
+
+}
+
+func (f *baseFsNode) UnmarshalYAML(unmarshal func(any) error) error {
+	return common.UnmarshalYAMLviaJSON(f, unmarshal)
 }

--- a/pkg/customizations/fsnode/fsnode.go
+++ b/pkg/customizations/fsnode/fsnode.go
@@ -3,7 +3,7 @@ package fsnode
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 )
 
@@ -73,7 +73,7 @@ func (f *baseFsNode) validate() error {
 	if f.path[len(f.path)-1] == '/' {
 		return fmt.Errorf("path must not end with a slash")
 	}
-	if f.path != path.Clean(f.path) {
+	if f.path != filepath.Clean(f.path) {
 		return fmt.Errorf("path must be canonical")
 	}
 

--- a/pkg/customizations/fsnode/fsnode_test.go
+++ b/pkg/customizations/fsnode/fsnode_test.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+
+	"github.com/osbuild/images/internal/common"
 )
 
 func TestBaseFsNodeValidate(t *testing.T) {
@@ -18,134 +20,172 @@ func TestBaseFsNodeValidate(t *testing.T) {
 		// relative path is not allowed
 		{
 			Node: baseFsNode{
-				path: "relative/path/file",
+				baseFsNodeJSON{
+					Path: "relative/path/file",
+				},
 			},
 			Error: true,
 		},
 		// path ending with slash is not allowed
 		{
 			Node: baseFsNode{
-				path: "/dir/with/trailing/slash/",
+				baseFsNodeJSON{
+					Path: "/dir/with/trailing/slash/",
+				},
 			},
 			Error: true,
 		},
 		// empty path is not allowed
 		{
 			Node: baseFsNode{
-				path: "",
+				baseFsNodeJSON{
+					Path: "",
+				},
 			},
 			Error: true,
 		},
 		// path must be canonical
 		{
 			Node: baseFsNode{
-				path: "/dir/../file",
+				baseFsNodeJSON{
+					Path: "/dir/../file",
+				},
 			},
 			Error: true,
 		},
 		{
 			Node: baseFsNode{
-				path: "/dir/./file",
+				baseFsNodeJSON{
+					Path: "/dir/./file",
+				},
 			},
 			Error: true,
 		},
 		// valid paths
 		{
 			Node: baseFsNode{
-				path: "/etc/file",
+				baseFsNodeJSON{
+					Path: "/etc/file",
+				},
 			},
 		},
 		{
 			Node: baseFsNode{
-				path: "/etc/dir",
+				baseFsNodeJSON{
+					Path: "/etc/dir",
+				},
 			},
 		},
 		// MODE
 		// invalid mode
 		{
 			Node: baseFsNode{
-				path: "/etc/file",
-				mode: common.ToPtr(os.FileMode(os.ModeDir)),
+				baseFsNodeJSON{
+					Path: "/etc/file",
+					Mode: common.ToPtr(os.FileMode(os.ModeDir)),
+				},
 			},
 			Error: true,
 		},
 		// valid mode
 		{
 			Node: baseFsNode{
-				path: "/etc/file",
-				mode: common.ToPtr(os.FileMode(0o644)),
+				baseFsNodeJSON{
+					Path: "/etc/file",
+					Mode: common.ToPtr(os.FileMode(0o644)),
+				},
 			},
 		},
 		// USER
 		// invalid user
 		{
 			Node: baseFsNode{
-				path: "/etc/file",
-				user: "",
+				baseFsNodeJSON{
+					Path: "/etc/file",
+					User: "",
+				},
 			},
 			Error: true,
 		},
 		{
 			Node: baseFsNode{
-				path: "/etc/file",
-				user: "invalid@@@user",
+				baseFsNodeJSON{
+					Path: "/etc/file",
+					User: "invalid@@@user",
+				},
 			},
 			Error: true,
 		},
 		{
 			Node: baseFsNode{
-				path: "/etc/file",
-				user: int64(-1),
+				baseFsNodeJSON{
+					Path: "/etc/file",
+					User: int64(-1),
+				},
 			},
 			Error: true,
 		},
 		// valid user
 		{
 			Node: baseFsNode{
-				path: "/etc/file",
-				user: "osbuild",
+				baseFsNodeJSON{
+					Path: "/etc/file",
+					User: "osbuild",
+				},
 			},
 		},
 		{
 			Node: baseFsNode{
-				path: "/etc/file",
-				user: int64(0),
+				baseFsNodeJSON{
+					Path: "/etc/file",
+					User: int64(0),
+				},
 			},
 		},
 		// GROUP
 		// invalid group
 		{
 			Node: baseFsNode{
-				path:  "/etc/file",
-				group: "",
+				baseFsNodeJSON{
+					Path:  "/etc/file",
+					Group: "",
+				},
 			},
 			Error: true,
 		},
 		{
 			Node: baseFsNode{
-				path:  "/etc/file",
-				group: "invalid@@@group",
+				baseFsNodeJSON{
+					Path:  "/etc/file",
+					Group: "invalid@@@group",
+				},
 			},
 			Error: true,
 		},
 		{
 			Node: baseFsNode{
-				path:  "/etc/file",
-				group: int64(-1),
+				baseFsNodeJSON{
+					Path:  "/etc/file",
+					Group: int64(-1),
+				},
 			},
 			Error: true,
 		},
 		// valid group
 		{
 			Node: baseFsNode{
-				path:  "/etc/file",
-				group: "osbuild",
+				baseFsNodeJSON{
+					Path:  "/etc/file",
+					Group: "osbuild",
+				},
 			},
 		},
 		{
 			Node: baseFsNode{
-				path:  "/etc/file",
-				group: int64(0),
+				baseFsNodeJSON{
+					Path:  "/etc/file",
+					Group: int64(0),
+				},
 			},
 		},
 	}
@@ -159,5 +199,73 @@ func TestBaseFsNodeValidate(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
+	}
+}
+
+func TestFsNodeUnmarshalDir(t *testing.T) {
+	inputYAML := `
+path: /some/path
+mode: 0644
+user: 1000
+group: group
+ensure_parent_dirs: true
+`
+	var fsn Directory
+	err := yaml.Unmarshal([]byte(inputYAML), &fsn)
+	assert.NoError(t, err)
+	expected, err := NewDirectory("/some/path", common.ToPtr(os.FileMode(0644)), float64(1000), "group", true)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, &fsn)
+}
+
+func TestFsNodeUnmarshalFile(t *testing.T) {
+	inputYAML := `
+path: /some/path
+mode: 0644
+user: 1000
+group: group
+data: some-data
+`
+	var fsn File
+	err := yaml.Unmarshal([]byte(inputYAML), &fsn)
+	assert.NoError(t, err)
+	expected, err := NewFile("/some/path", common.ToPtr(os.FileMode(0644)), float64(1000), "group", []byte("some-data"))
+	assert.NoError(t, err)
+	assert.Equal(t, expected, &fsn)
+}
+
+func TestFsNodeUnmarshalBadFile(t *testing.T) {
+	for _, tc := range []struct {
+		inputYAML   string
+		expectedErr string
+	}{
+		{`path: 123`, `json: cannot unmarshal number into Go struct field .Path of type string`},
+		{`mode: -rw-rw-r--`, ` json: cannot unmarshal string into Go struct field .Mode of type fs.FileMode`},
+		{`mode: -1`, `cannot unmarshal number -1 into Go struct field .Mode of type fs.FileMode`},
+		{`mode: 5_000_000_000`, `json: cannot unmarshal number 5000000000 into Go struct field .Mode of type fs.FileMode`},
+		{"path: /foo\nuser: 3.14", `user ID must be int`},
+		{"path: /foo\ngroup: 2.71", `group ID must be int`},
+		{"path: /foo\nuser: -1", `user ID must be non-negative`},
+		{"path: /foo\ngroup: a!b", `group name "a!b" doesn't conform to validating regex`},
+		{"path: /foo\ndata: 1.61", `cannot unmarshal number into Go struct field .data of type string`},
+		{"path: /foo\nextra: field", `unknown field "extra"`},
+	} {
+		var fsn File
+		err := yaml.Unmarshal([]byte(tc.inputYAML), &fsn)
+		assert.ErrorContains(t, err, tc.expectedErr)
+	}
+}
+
+func TestFsNodeUnmarshalBadDir(t *testing.T) {
+	for _, tc := range []struct {
+		inputYAML   string
+		expectedErr string
+	}{
+		{"path: /foo\nensure_parent_dirs: maybe", `json: cannot unmarshal string into Go struct field .ensure_parent_dirs of type bool`},
+		{"path: /foo\nextra: field", `unknown field "extra"`},
+	} {
+		var fsn Directory
+		err := yaml.Unmarshal([]byte(tc.inputYAML), &fsn)
+		assert.ErrorContains(t, err, tc.expectedErr)
 	}
 }


### PR DESCRIPTION
Another alternative version of https://github.com/osbuild/images/pull/1479 - I think I like this one best so far

---

When we move `ImageConfig` into YAML we will need support for
`fsnode.File` as it is used as part of the ImageConfig.

This commit adds support for JSON/YAML unmarshaling.

---

fsnode: use `path/filepath` instead of `path`

When validating paths in the fsnode module, use the `filepath`
module instead of the (more generic) `path`.
