### PR TITLE
manifest/os: immediately create directories (HMS-6043)

### DIFF
--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -669,7 +669,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 			panic(err)
 		}
 		pipeline.AddStage(subStage)
-		p.OSCustomizations.Directories = append(p.OSCustomizations.Directories, subDirs...)
+		pipeline.AddStages(osbuild.GenDirectoryNodesStages(subDirs)...)
 		p.addInlineDataAndStages(&pipeline, subFiles)
 		p.OSCustomizations.EnabledServices = append(p.OSCustomizations.EnabledServices, subServices...)
 	}


### PR DESCRIPTION
Instead of appending the directories that are necessary to the OS customizations we create them immediately.

Punting the directories into the customizations means that the `mkdir` stage for these is inserted later in the process. Since the copy stages for the files are created immediately and the directories are deferred it's possible for image types that don't have the directory pre-created to fail to build as the copy fails.

---

`p.addInlineDataAndStages` creates the `copy` stages immediately. The directories are created much later in the manifest. This can fail.