### PR TITLE
osbuild: Add config to InsightsClientConfigStageOptions

### DIFF
--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -233,7 +233,7 @@ func osCustomizations(
 	if options.Subscription != nil {
 		subscriptionStatus = subscription.RHSMConfigWithSubscription
 		if options.Subscription.Proxy != "" {
-			osc.InsightsClientConfig = &osbuild.InsightsClientConfigStageOptions{Proxy: options.Subscription.Proxy}
+			osc.InsightsClientConfig = &osbuild.InsightsClientConfigStageOptions{Config: osbuild.InsightsClientConfig{Proxy: options.Subscription.Proxy}}
 		}
 	} else {
 		subscriptionStatus = subscription.RHSMConfigNoSubscription

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -170,8 +170,10 @@ func TestBootupdStage(t *testing.T) {
 func TestInsightsClientConfigStage(t *testing.T) {
 	os := manifest.NewTestOS()
 	os.OSCustomizations.InsightsClientConfig = &osbuild.InsightsClientConfigStageOptions{
-		Proxy: "some-proxy",
-		Path:  "some/path",
+		Config: osbuild.InsightsClientConfig{
+			Proxy: "some-proxy",
+			Path:  "some/path",
+		},
 	}
 	pipeline := os.Serialize()
 	st := manifest.FindStage("org.osbuild.insights-client.config", pipeline.Stages)

--- a/pkg/osbuild/insights_client_config_stage.go
+++ b/pkg/osbuild/insights_client_config_stage.go
@@ -1,8 +1,12 @@
 package osbuild
 
-type InsightsClientConfigStageOptions struct {
+type InsightsClientConfig struct {
 	Proxy string `json:"proxy,omitempty"`
 	Path  string `json:"path,omitempty"`
+}
+
+type InsightsClientConfigStageOptions struct {
+	Config InsightsClientConfig `json:"config"`
 }
 
 func (InsightsClientConfigStageOptions) isStageOptions() {}

--- a/pkg/osbuild/insights_client_config_stage_test.go
+++ b/pkg/osbuild/insights_client_config_stage_test.go
@@ -1,15 +1,31 @@
 package osbuild
 
 import (
+	"encoding/json"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestNewInsightsClientConfigStage(t *testing.T) {
+	stageOptions := &InsightsClientConfigStageOptions{
+		Config: InsightsClientConfig{Path: "foo/bar", Proxy: "proxy"},
+	}
 	expectedStage := &Stage{
 		Type:    "org.osbuild.insights-client.config",
-		Options: &InsightsClientConfigStageOptions{},
+		Options: stageOptions,
 	}
-	actualStage := NewInsightsClientConfigStage(&InsightsClientConfigStageOptions{})
+	actualStage := NewInsightsClientConfigStage(stageOptions)
 	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestInsightsClientConfigOptionsJSON(t *testing.T) {
+	stageOptions := &InsightsClientConfigStageOptions{
+		Config: InsightsClientConfig{
+			Proxy: "some-proxy",
+			Path:  "some-path",
+		},
+	}
+	b, err := json.Marshal(stageOptions)
+	assert.NoError(t, err)
+	assert.Equal(t, string(b), `{"config":{"proxy":"some-proxy","path":"some-path"}}`)
 }


### PR DESCRIPTION
Fixes a bug because the insights_client_config stage expects the options to be nested under a config object.