### PR TITLE
arch: add unmarshal support for arch.Arch

### DIFF
--- a/cmd/otk/osbuild-gen-partition-table/main.go
+++ b/cmd/otk/osbuild-gen-partition-table/main.go
@@ -245,7 +245,10 @@ func genPartitionTable(genPartInput *Input, rng *rand.Rand) (*Output, error) {
 	architecture := arch.ARCH_UNSET
 	if genPartInput.Properties.Type == otkdisk.PartTypeGPT {
 		// GPT partition table generation requires an architecture
-		architecture = arch.FromString(genPartInput.Properties.Architecture) // NOTE: this panics on invalid input - arch parsing should return error
+		architecture, err = arch.FromString(genPartInput.Properties.Architecture)
+		if err != nil {
+			return nil, err
+		}
 	}
 	pt, err := disk.NewPartitionTable(basePt, genPartInput.Modifications.Filesystems, diskSize, genPartInput.Modifications.PartitionMode, architecture, nil, rng)
 	if err != nil {

--- a/cmd/otk/osbuild-resolve-containers/main_test.go
+++ b/cmd/otk/osbuild-resolve-containers/main_test.go
@@ -90,7 +90,7 @@ func TestResolver(t *testing.T) {
 			for idx, ref := range refs {
 				// resolve directly with the registry and convert to ContainerInfo to
 				// compare with output.
-				spec, err := registry.Resolve(ref, arch.FromString(containerArch))
+				spec, err := registry.Resolve(ref, common.Must(arch.FromString(containerArch)))
 				assert.NoError(err)
 				expectedOutput[idx] = resolver.ContainerInfo{
 					Source:  spec.Source,
@@ -224,7 +224,7 @@ func TestResolverRawJSON(t *testing.T) {
 
 			// resolve directly with the registry and convert to a raw JSON
 			// string to compare with output
-			spec, err := registry.Resolve(refs[0], arch.FromString(containerArch))
+			spec, err := registry.Resolve(refs[0], common.Must(arch.FromString(containerArch)))
 			require.NoError(err)
 
 			expected := fmt.Sprintf(`{

--- a/internal/testregistry/testregistry.go
+++ b/internal/testregistry/testregistry.go
@@ -365,7 +365,7 @@ func (reg *Registry) Resolve(target string, imgArch arch.Arch) (container.Spec, 
 		checksum = ""
 
 		for _, m := range lst.Manifests {
-			if arch.FromString(m.Platform.Architecture) == imgArch {
+			if common.Must(arch.FromString(m.Platform.Architecture)) == imgArch {
 				checksum = m.Digest.String()
 				break
 			}

--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -50,7 +50,7 @@ func FromString(a string) (Arch, error) {
 	case "riscv64":
 		return ARCH_RISCV64, nil
 	default:
-		return ARCH_UNSET, fmt.Errorf("unsupported architecture")
+		return ARCH_UNSET, fmt.Errorf("unsupported architecture %q", a)
 	}
 }
 

--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -1,6 +1,7 @@
 package arch
 
 import (
+	"encoding/json"
 	"fmt"
 	"runtime"
 
@@ -35,6 +36,19 @@ func (a Arch) String() string {
 	default:
 		panic("invalid architecture")
 	}
+}
+
+func (a *Arch) UnmarshalJSON(data []byte) (err error) {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	*a, err = FromString(s)
+	return err
+}
+
+func (a *Arch) UnmarshalYAML(unmarshal func(any) error) error {
+	return common.UnmarshalYAMLviaJSON(a, unmarshal)
 }
 
 func FromString(a string) (Arch, error) {

--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -1,7 +1,10 @@
 package arch
 
 import (
+	"fmt"
 	"runtime"
+
+	"github.com/osbuild/images/internal/common"
 )
 
 type Arch uint64
@@ -34,27 +37,27 @@ func (a Arch) String() string {
 	}
 }
 
-func FromString(a string) Arch {
+func FromString(a string) (Arch, error) {
 	switch a {
 	case "amd64", "x86_64":
-		return ARCH_X86_64
+		return ARCH_X86_64, nil
 	case "arm64", "aarch64":
-		return ARCH_AARCH64
+		return ARCH_AARCH64, nil
 	case "s390x":
-		return ARCH_S390X
+		return ARCH_S390X, nil
 	case "ppc64le":
-		return ARCH_PPC64LE
+		return ARCH_PPC64LE, nil
 	case "riscv64":
-		return ARCH_RISCV64
+		return ARCH_RISCV64, nil
 	default:
-		panic("unsupported architecture")
+		return ARCH_UNSET, fmt.Errorf("unsupported architecture")
 	}
 }
 
 var runtimeGOARCH = runtime.GOARCH
 
 func Current() Arch {
-	return FromString(runtimeGOARCH)
+	return common.Must(FromString(runtimeGOARCH))
 }
 
 func IsX86_64() bool {

--- a/pkg/arch/arch_test.go
+++ b/pkg/arch/arch_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 
 	"github.com/osbuild/images/internal/common"
 )
@@ -68,4 +69,24 @@ func TestFromString(t *testing.T) {
 	assert.Equal(t, ARCH_S390X, common.Must(FromString("s390x")))
 	assert.Equal(t, ARCH_PPC64LE, common.Must(FromString("ppc64le")))
 	assert.Equal(t, ARCH_RISCV64, common.Must(FromString("riscv64")))
+}
+
+func TestUnmarshal(t *testing.T) {
+	for _, tc := range []struct {
+		inp      string
+		expected Arch
+	}{
+		{"arch: arm64", ARCH_AARCH64},
+		{"arch: amd64", ARCH_X86_64},
+		{"arch: s390x", ARCH_S390X},
+		{"arch: ppc64le", ARCH_PPC64LE},
+		{"arch: riscv64", ARCH_RISCV64},
+	} {
+		var v struct {
+			Arch Arch
+		}
+		err := yaml.Unmarshal([]byte(tc.inp), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, tc.expected, v.Arch)
+	}
 }

--- a/pkg/arch/arch_test.go
+++ b/pkg/arch/arch_test.go
@@ -51,13 +51,13 @@ func TestCurrentArchRiscv64(t *testing.T) {
 func TestCurrentArchUnsupported(t *testing.T) {
 	origRuntimeGOARCH := runtimeGOARCH
 	defer func() { runtimeGOARCH = origRuntimeGOARCH }()
-	runtimeGOARCH = "UKNOWN"
-	assert.PanicsWithError(t, "unsupported architecture", func() { Current() })
+	runtimeGOARCH = "UNKNOWN"
+	assert.PanicsWithError(t, `unsupported architecture "UNKNOWN"`, func() { Current() })
 }
 
 func TestFromStringUnsupported(t *testing.T) {
 	_, err := FromString("UNKNOWN")
-	assert.EqualError(t, err, "unsupported architecture")
+	assert.EqualError(t, err, `unsupported architecture "UNKNOWN"`)
 }
 
 func TestFromString(t *testing.T) {

--- a/pkg/arch/arch_test.go
+++ b/pkg/arch/arch_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/internal/common"
 )
 
 func TestCurrentArchAMD64(t *testing.T) {
@@ -50,19 +52,20 @@ func TestCurrentArchUnsupported(t *testing.T) {
 	origRuntimeGOARCH := runtimeGOARCH
 	defer func() { runtimeGOARCH = origRuntimeGOARCH }()
 	runtimeGOARCH = "UKNOWN"
-	assert.PanicsWithValue(t, "unsupported architecture", func() { Current() })
+	assert.PanicsWithError(t, "unsupported architecture", func() { Current() })
 }
 
 func TestFromStringUnsupported(t *testing.T) {
-	assert.PanicsWithValue(t, "unsupported architecture", func() { FromString("UNKNOWN") })
+	_, err := FromString("UNKNOWN")
+	assert.EqualError(t, err, "unsupported architecture")
 }
 
 func TestFromString(t *testing.T) {
-	assert.Equal(t, ARCH_AARCH64, FromString("arm64"))
-	assert.Equal(t, ARCH_AARCH64, FromString("aarch64"))
-	assert.Equal(t, ARCH_X86_64, FromString("amd64"))
-	assert.Equal(t, ARCH_X86_64, FromString("x86_64"))
-	assert.Equal(t, ARCH_S390X, FromString("s390x"))
-	assert.Equal(t, ARCH_PPC64LE, FromString("ppc64le"))
-	assert.Equal(t, ARCH_RISCV64, FromString("riscv64"))
+	assert.Equal(t, ARCH_AARCH64, common.Must(FromString("arm64")))
+	assert.Equal(t, ARCH_AARCH64, common.Must(FromString("aarch64")))
+	assert.Equal(t, ARCH_X86_64, common.Must(FromString("amd64")))
+	assert.Equal(t, ARCH_X86_64, common.Must(FromString("x86_64")))
+	assert.Equal(t, ARCH_S390X, common.Must(FromString("s390x")))
+	assert.Equal(t, ARCH_PPC64LE, common.Must(FromString("ppc64le")))
+	assert.Equal(t, ARCH_RISCV64, common.Must(FromString("riscv64")))
 }

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -370,8 +370,8 @@ func (cl *Client) resolveContainerImageArch(ctx context.Context, ref types.Image
 	if err != nil {
 		return nil, err
 	}
-	a := arch.FromString(info.Architecture)
-	return &a, nil
+	a, err := arch.FromString(info.Architecture)
+	return &a, err
 }
 
 func (cl *Client) getLocalImageIDFromDigest(instance digest.Digest) (string, error) {


### PR DESCRIPTION
This is another split out from #1462 - we will want to define the platforms for the image types in YAML too. Because the architecture(s) are part of that platform definition we need it to be unmarshal-able. 


This is part of https://github.com/osbuild/images/compare/main...mvo5:platform_yaml?expand=1 which I will open after (and all part of the larger 1462 effort).

---

arch: add unmarshal support for arch.Arch

We will define the platform in YAML so we need a way to
unmarshal the architecture (that is part of the platform).

---

arch: add architecture to "unsupported architecture" errors

The error so far could be more helpful, so far we do:
```
unsupported architecture
```
instead we now error with the unsupported architecture as
part of the error message.
```
unsupported architecture <unsupported-arch>
```

---

arch: make arch.FromString() return an error on invalid input

The previous code was panic()ing on invalid input. This is no
longer an option as we will define platforms in YAML and here
we need to be able to handle incorrect input more gracefully
than a panic. The callers are also updated.
