### PR TITLE
BootcDiskImage: Support using a custom container for the build pipeline

### DIFF
--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -53,7 +53,11 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 	runner runner.Runner,
 	rng *rand.Rand) error {
 
-	buildPipeline := manifest.NewBuildFromContainer(m, runner, containers, &manifest.BuildOptions{ContainerBuildable: true})
+	buildPipeline := manifest.NewBuildFromContainer(m, runner, containers,
+		&manifest.BuildOptions{
+			ContainerBuildable: true,
+			SELinuxPolicy:      img.SELinux,
+		})
 	buildPipeline.Checkpoint()
 
 	// In the bootc flow, we reuse the host container context for tools;

--- a/pkg/image/bootc_disk_test.go
+++ b/pkg/image/bootc_disk_test.go
@@ -25,7 +25,7 @@ func TestBootcDiskImageNew(t *testing.T) {
 		Name:   "name",
 	}
 
-	img := image.NewBootcDiskImage(containerSource)
+	img := image.NewBootcDiskImage(containerSource, containerSource)
 	require.NotNil(t, img)
 	assert.Equal(t, img.Base.Name(), "bootc-raw-image")
 }
@@ -71,7 +71,7 @@ func makeBootcDiskImageOsbuildManifest(t *testing.T, opts *bootcDiskImageTestOpt
 	}
 	containers := []container.SourceSpec{containerSource}
 
-	img := image.NewBootcDiskImage(containerSource)
+	img := image.NewBootcDiskImage(containerSource, containerSource)
 	img.Filename = "fake-disk"
 	require.NotNil(t, img)
 	img.Platform = makeFakePlatform(opts)
@@ -85,7 +85,7 @@ func makeBootcDiskImageOsbuildManifest(t *testing.T, opts *bootcDiskImageTestOpt
 
 	m := &manifest.Manifest{}
 	runi := &runner.Fedora{}
-	err := img.InstantiateManifestFromContainers(m, containers, runi, nil)
+	err := img.InstantiateManifestFromContainers(m, containers, containers, runi, nil)
 	require.Nil(t, err)
 
 	fakeSourceSpecs := map[string][]container.Spec{

--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -43,6 +43,8 @@ type BuildrootFromPackages struct {
 	// buildroot itself when running setfiles. Once osbuild has
 	// this then this option would become "useChrootSetfiles"
 	disableSelinux bool
+
+	selinuxPolicy string
 }
 
 type BuildOptions struct {
@@ -53,6 +55,9 @@ type BuildOptions struct {
 	// DisableSELinux disables SELinux, this is not advised, but is
 	// currently needed when using (experimental) cross-arch building.
 	DisableSELinux bool
+
+	// The SELinux policy to use in the buildroot, defaults to 'targeted' if not specified
+	SELinuxPolicy string
 
 	// BootstrapPipeline add the given bootstrap pipeline to the
 	// build pipeline. This is only needed when doing cross-arch
@@ -75,6 +80,7 @@ func NewBuild(m *Manifest, runner runner.Runner, repos []rpmmd.RepoConfig, opts 
 		repos:              filterRepos(repos, name),
 		containerBuildable: opts.ContainerBuildable,
 		disableSelinux:     opts.DisableSELinux,
+		selinuxPolicy:      opts.SELinuxPolicy,
 	}
 
 	m.addPipeline(pipeline)
@@ -93,10 +99,11 @@ func (p *BuildrootFromPackages) addDependent(dep Pipeline) {
 func (p *BuildrootFromPackages) getPackageSetChain(distro Distro) []rpmmd.PackageSet {
 	// TODO: make the /usr/bin/cp dependency conditional
 	// TODO: make the /usr/bin/xz dependency conditional
+	policy_package := fmt.Sprintf("selinux-policy-%s", p.getSELinuxPolicy())
 	packages := []string{
-		"selinux-policy-targeted", // needed to build the build pipeline
-		"coreutils",               // /usr/bin/cp - used all over
-		"xz",                      // usage unclear
+		policy_package, // needed to build the build pipeline
+		"coreutils",    // /usr/bin/cp - used all over
+		"xz",           // usage unclear
 	}
 
 	packages = append(packages, p.runner.GetBuildPackages()...)
@@ -143,13 +150,20 @@ func (p *BuildrootFromPackages) serialize() osbuild.Pipeline {
 	pipeline.AddStage(osbuild.NewRPMStage(osbuild.NewRPMStageOptions(p.repos), osbuild.NewRpmStageSourceFilesInputs(p.packageSpecs)))
 	if !p.disableSelinux {
 		pipeline.AddStage(osbuild.NewSELinuxStage(&osbuild.SELinuxStageOptions{
-			FileContexts: "etc/selinux/targeted/contexts/files/file_contexts",
+			FileContexts: fmt.Sprintf("etc/selinux/%s/contexts/files/file_contexts", p.getSELinuxPolicy()),
 			Labels:       p.getSELinuxLabels(),
 		},
 		))
 	}
 
 	return pipeline
+}
+
+func (p *BuildrootFromPackages) getSELinuxPolicy() string {
+	if p.selinuxPolicy != "" {
+		return p.selinuxPolicy
+	}
+	return "targeted"
 }
 
 // Returns a map of paths to labels for the SELinux stage based on specific
@@ -182,6 +196,7 @@ type BuildrootFromContainer struct {
 
 	containerBuildable bool
 	disableSelinux     bool
+	selinuxPolicy      string
 }
 
 // NewBuildFromContainer creates a new build pipeline from the given
@@ -200,6 +215,7 @@ func NewBuildFromContainer(m *Manifest, runner runner.Runner, containerSources [
 
 		containerBuildable: opts.ContainerBuildable,
 		disableSelinux:     opts.DisableSELinux,
+		selinuxPolicy:      opts.SELinuxPolicy,
 	}
 	m.addPipeline(pipeline)
 	return pipeline
@@ -234,6 +250,13 @@ func (p *BuildrootFromContainer) serializeEnd() {
 		panic("serializeEnd() call when serialization not in progress")
 	}
 	p.containerSpecs = nil
+}
+
+func (p *BuildrootFromContainer) getSELinuxPolicy() string {
+	if p.selinuxPolicy != "" {
+		return p.selinuxPolicy
+	}
+	return "targeted"
 }
 
 func (p *BuildrootFromContainer) getSELinuxLabels() map[string]string {
@@ -273,7 +296,7 @@ func (p *BuildrootFromContainer) serialize() osbuild.Pipeline {
 	if !p.disableSelinux {
 		pipeline.AddStage(osbuild.NewSELinuxStage(
 			&osbuild.SELinuxStageOptions{
-				FileContexts: "etc/selinux/targeted/contexts/files/file_contexts",
+				FileContexts: fmt.Sprintf("etc/selinux/%s/contexts/files/file_contexts", p.getSELinuxPolicy()),
 				ExcludePaths: []string{"/sysroot"},
 				Labels:       p.getSELinuxLabels(),
 			},


### PR DESCRIPTION
The automotive project wants to build minimal bootc images which will not contain tools like dnf, mkfs.ext, etc. We support this by allowing the container used in the build pipeline to come from another (but related) container image.

Note: This depends on, and includes the commits from, https://github.com/osbuild/images/pull/1506

Question: This just changes the API, what are the policy here? Is this fine, or should I duplicate NewBootcDiskImage() to NewBootcDiskImageWithBuild() so the old calls keep working?