### PR TITLE
Initial automotive work: custom selinux policy, separate build container for bootc, and ext4 verity

### DIFF
--- a/pkg/disk/filesystem.go
+++ b/pkg/disk/filesystem.go
@@ -22,6 +22,8 @@ type Filesystem struct {
 	FSTabFreq uint64 `json:"fstab_freq,omitempty" yaml:"fstab_freq,omitempty"`
 	// The sixth field of fstab(5); fs_passno
 	FSTabPassNo uint64 `json:"fstab_passno,omitempty" yaml:"fstab_passno,omitempty"`
+	// Custom mkfs options
+	MkfsOptions []string `json:"mkfs_options,omitempty" yaml:"mkfs_options,omitempty"`
 }
 
 func init() {
@@ -46,6 +48,7 @@ func (fs *Filesystem) Clone() Entity {
 		FSTabOptions: fs.FSTabOptions,
 		FSTabFreq:    fs.FSTabFreq,
 		FSTabPassNo:  fs.FSTabPassNo,
+		MkfsOptions:  fs.MkfsOptions,
 	}
 }
 

--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -53,7 +53,11 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 	runner runner.Runner,
 	rng *rand.Rand) error {
 
-	buildPipeline := manifest.NewBuildFromContainer(m, runner, containers, &manifest.BuildOptions{ContainerBuildable: true})
+	buildPipeline := manifest.NewBuildFromContainer(m, runner, containers,
+		&manifest.BuildOptions{
+			ContainerBuildable: true,
+			SELinuxPolicy:      img.SELinux,
+		})
 	buildPipeline.Checkpoint()
 
 	// In the bootc flow, we reuse the host container context for tools;

--- a/pkg/image/bootc_disk_test.go
+++ b/pkg/image/bootc_disk_test.go
@@ -308,3 +308,18 @@ func TestBootcDiskImageInstantiateDirs(t *testing.T) {
 		}
 	}
 }
+
+func TestBootcDiskImageBuildpipelineHonorsSELinuxPolicy(t *testing.T) {
+	opts := &bootcDiskImageTestOpts{
+		SELinux: "custom",
+	}
+	osbuildManifest := makeBootcDiskImageOsbuildManifest(t, opts)
+	buildPipeline := findPipelineFromOsbuildManifest(t, osbuildManifest, "build")
+	require.NotNil(t, buildPipeline)
+	selinuxStage := findStageFromOsbuildPipeline(t, buildPipeline, "org.osbuild.selinux")
+	require.NotNil(t, selinuxStage)
+
+	// ensure selinux policy is set
+	selinuxOptions := selinuxStage["options"].(map[string]interface{})
+	assert.Equal(t, "etc/selinux/custom/contexts/files/file_contexts", selinuxOptions["file_contexts"])
+}

--- a/pkg/image/bootc_disk_test.go
+++ b/pkg/image/bootc_disk_test.go
@@ -25,7 +25,7 @@ func TestBootcDiskImageNew(t *testing.T) {
 		Name:   "name",
 	}
 
-	img := image.NewBootcDiskImage(containerSource)
+	img := image.NewBootcDiskImage(containerSource, containerSource)
 	require.NotNil(t, img)
 	assert.Equal(t, img.Base.Name(), "bootc-raw-image")
 }
@@ -71,7 +71,7 @@ func makeBootcDiskImageOsbuildManifest(t *testing.T, opts *bootcDiskImageTestOpt
 	}
 	containers := []container.SourceSpec{containerSource}
 
-	img := image.NewBootcDiskImage(containerSource)
+	img := image.NewBootcDiskImage(containerSource, containerSource)
 	img.Filename = "fake-disk"
 	require.NotNil(t, img)
 	img.Platform = makeFakePlatform(opts)
@@ -85,7 +85,7 @@ func makeBootcDiskImageOsbuildManifest(t *testing.T, opts *bootcDiskImageTestOpt
 
 	m := &manifest.Manifest{}
 	runi := &runner.Fedora{}
-	err := img.InstantiateManifestFromContainers(m, containers, runi, nil)
+	err := img.InstantiateManifestFromContainers(m, containers, containers, runi, nil)
 	require.Nil(t, err)
 
 	fakeSourceSpecs := map[string][]container.Spec{

--- a/pkg/osbuild/mkfs_ext4_stage.go
+++ b/pkg/osbuild/mkfs_ext4_stage.go
@@ -1,8 +1,9 @@
 package osbuild
 
 type MkfsExt4StageOptions struct {
-	UUID  string `json:"uuid"`
-	Label string `json:"label,omitempty"`
+	UUID   string `json:"uuid"`
+	Label  string `json:"label,omitempty"`
+	Verity *bool  `json:"verity,omitempty"`
 }
 
 func (MkfsExt4StageOptions) isStageOptions() {}

--- a/pkg/osbuild/mkfs_stage.go
+++ b/pkg/osbuild/mkfs_stage.go
@@ -2,8 +2,10 @@ package osbuild
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/disk"
 )
 
@@ -45,6 +47,10 @@ func GenFsStages(pt *disk.PartitionTable, filename string) []*Stage {
 					UUID:  e.UUID,
 					Label: e.Label,
 				}
+				if slices.Contains(e.MkfsOptions, "verity") {
+					options.Verity = common.ToPtr(true)
+				}
+
 				stages = append(stages, NewMkfsExt4Stage(options, stageDevices))
 			default:
 				panic(fmt.Sprintf("unknown fs type: %s", e.GetFSType()))

--- a/pkg/osbuild/mkfs_stages_test.go
+++ b/pkg/osbuild/mkfs_stages_test.go
@@ -39,8 +39,9 @@ func TestNewMkfsStage(t *testing.T) {
 	assert.Equal(t, mkbtrfsExpected, mkbtrfs)
 
 	ext4Options := &MkfsExt4StageOptions{
-		UUID:  uuid.New().String(),
-		Label: "test",
+		UUID:   uuid.New().String(),
+		Label:  "test",
+		Verity: common.ToPtr(true),
 	}
 	mkext4 := NewMkfsExt4Stage(ext4Options, devices)
 	mkext4Expected := &Stage{


### PR DESCRIPTION
This is some initial work for supporting bootc in the automotive projects. It includes the following:
 * Support for selinux policies other than "targeted"
 * Support for using a different container for the "build" pipeline (because we want a minimal target image without e.g. mkfs.ext4)
 * Always enable the "verity" ext4 filesystem in mkfs.ext4, which allows us to use validated composefs support