### PR TITLE
distro/rhel: remove the user/group warnings for edge-commits

### DIFF
--- a/pkg/distro/rhel/rhel8/options.go
+++ b/pkg/distro/rhel/rhel8/options.go
@@ -87,17 +87,6 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 		// TODO: consider additional checks, such as those in "edge-simplified-installer"
 	}
 
-	// warn that user & group customizations on edge-commit, edge-container are deprecated
-	// TODO(edge): directly error if these options are provided when rhel-9.5's time arrives
-	if t.Name() == "edge-commit" || t.Name() == "edge-container" {
-		if customizations.GetUsers() != nil {
-			warnings = append(warnings, fmt.Sprintf("Please note that user customizations on %q image type are deprecated and will be removed in the near future\n", t.Name()))
-		}
-		if customizations.GetGroups() != nil {
-			warnings = append(warnings, fmt.Sprintf("Please note that group customizations on %q image type are deprecated and will be removed in the near future\n", t.Name()))
-		}
-	}
-
 	if kernelOpts := customizations.GetKernel(); kernelOpts.Append != "" && t.RPMOSTree && t.Name() != "edge-raw-image" && t.Name() != "edge-simplified-installer" {
 		return warnings, fmt.Errorf("kernel boot parameter customizations are not supported for ostree types")
 	}

--- a/pkg/distro/rhel/rhel9/options.go
+++ b/pkg/distro/rhel/rhel9/options.go
@@ -99,17 +99,6 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 		// TODO: consider additional checks, such as those in "edge-simplified-installer"
 	}
 
-	// warn that user & group customizations on edge-commit, edge-container are deprecated
-	// TODO(edge): directly error if these options are provided when rhel-9.5's time arrives
-	if t.Name() == "edge-commit" || t.Name() == "edge-container" {
-		if customizations.GetUsers() != nil {
-			warnings = append(warnings, fmt.Sprintf("Please note that user customizations on %q image type are deprecated and will be removed in the near future\n", t.Name()))
-		}
-		if customizations.GetGroups() != nil {
-			warnings = append(warnings, fmt.Sprintf("Please note that group customizations on %q image type are deprecated and will be removed in the near future\n", t.Name()))
-		}
-	}
-
 	if kernelOpts := customizations.GetKernel(); kernelOpts.Append != "" && t.RPMOSTree && t.Name() != "edge-raw-image" && t.Name() != "edge-simplified-installer" {
 		return warnings, fmt.Errorf("kernel boot parameter customizations are not supported for ostree types")
 	}


### PR DESCRIPTION
A long time ago, we decided that user and group creation for ostree-based images should happen in the deployment (disk image creation or via an installer).  The plan was to deprecate the feature of user and group creation in ostree commits (the base, immutable part of the system) for a few minor versions and then remove the feature completely.

Normally, this kind of thing would make sense to change in a major release (RHEL 10), but with the move to bootc and image mode in RHEL 10, we're not deprecating any features but the whole thing is changing.

The decision has changed now: There will be no removal of the feature in edge for the lifetime of RHEL 9.

See comment on [THEEDGE-4235](https://issues.redhat.com/browse/THEEDGE-4235)

See also https://github.com/osbuild/osbuild-composer/issues/3106 for some more historical context.