### PR TITLE
fedora: implement setting of the RootfsType via YAML

### DIFF
--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -1175,6 +1175,10 @@ image_types:
     installer_config: *default_installer_config
     image_config:
       locale: "en_US.UTF-8"
+      # ideally we would centralize the iso_rootfs_type here - but
+      # some installers (like coreos_installer) do things differently
+      # than the anaconda iso so we do not want to disturb whatever
+      # special things they expect in their images.
     package_sets:
       os:
         - *minimal_raw_pkgset
@@ -1337,6 +1341,11 @@ image_types:
     image_config:
       <<: *image_config_iot_enabled_services
       locale: "en_US.UTF-8"
+      iso_rootfs_type: "squashfs"
+      condition:
+        version_less_than:
+          41:
+            iso_rootfs_type: "squashfs-ext4"
     package_sets:
       installer:
         - *anaconda_pkgset
@@ -1365,6 +1374,12 @@ image_types:
     installer_config: *default_installer_config
     image_config:
       locale: "en_US.UTF-8"
+      iso_rootfs_type: "squashfs"
+      condition:
+        version_less_than:
+          41:
+            iso_rootfs_type: "squashfs-ext4"
+
     package_sets:
       installer:
         - include:
@@ -1419,6 +1434,13 @@ image_types:
       - "bootiso"
     exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
+    image_config:
+      locale: "en_US.UTF-8"
+      iso_rootfs_type: "squashfs"
+      condition:
+        version_less_than:
+          41:
+            iso_rootfs_type: "squashfs-ext4"
     platforms:
       - *x86_64_installer_platform
       - *aarch64_installer_platform

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -423,10 +423,6 @@ func liveInstallerImage(workload workload.Workload,
 
 	img.Filename = t.Filename()
 
-	if common.VersionGreaterThanOrEqual(img.OSVersion, VERSION_ROOTFS_SQUASHFS) {
-		img.RootfsType = manifest.SquashfsRootfs
-	}
-
 	// Enable grub2 BIOS iso on x86_64 only
 	if img.Platform.GetArch() == arch.ARCH_X86_64 {
 		img.ISOBoot = manifest.Grub2ISOBoot
@@ -444,6 +440,11 @@ func liveInstallerImage(workload workload.Workload,
 	if installerConfig != nil {
 		img.AdditionalDracutModules = append(img.AdditionalDracutModules, installerConfig.AdditionalDracutModules...)
 		img.AdditionalDrivers = append(img.AdditionalDrivers, installerConfig.AdditionalDrivers...)
+	}
+
+	imgConfig := t.getDefaultImageConfig()
+	if imgConfig != nil && imgConfig.IsoRootfsType != nil {
+		img.RootfsType = *imgConfig.IsoRootfsType
 	}
 
 	return img, nil
@@ -532,8 +533,9 @@ func imageInstallerImage(workload workload.Workload,
 	img.Filename = t.Filename()
 
 	img.RootfsCompression = "xz" // This also triggers using the bcj filter
-	if common.VersionGreaterThanOrEqual(img.OSVersion, VERSION_ROOTFS_SQUASHFS) {
-		img.RootfsType = manifest.SquashfsRootfs
+	imgConfig := t.getDefaultImageConfig()
+	if imgConfig != nil && imgConfig.IsoRootfsType != nil {
+		img.RootfsType = *imgConfig.IsoRootfsType
 	}
 
 	// Enable grub2 BIOS iso on x86_64 only
@@ -751,8 +753,9 @@ func iotInstallerImage(workload workload.Workload,
 	img.Filename = t.Filename()
 
 	img.RootfsCompression = "xz" // This also triggers using the bcj filter
-	if common.VersionGreaterThanOrEqual(img.OSVersion, VERSION_ROOTFS_SQUASHFS) {
-		img.RootfsType = manifest.SquashfsRootfs
+	imgConfig := t.getDefaultImageConfig()
+	if imgConfig != nil && imgConfig.IsoRootfsType != nil {
+		img.RootfsType = *imgConfig.IsoRootfsType
 	}
 
 	// Enable grub2 BIOS iso on x86_64 only

--- a/pkg/distro/fedora/version.go
+++ b/pkg/distro/fedora/version.go
@@ -3,18 +3,13 @@ package fedora
 const VERSION_BRANCHED = "43"
 const VERSION_RAWHIDE = "43"
 
-// Fedora version 41 and later use a plain squashfs rootfs on the iso instead of
-// compressing an ext4 filesystem.
-const VERSION_ROOTFS_SQUASHFS = "41"
-
 // Fedora 43 and later we reset the machine-id file to align ourselves with the
 // other Fedora variants.
 const VERSION_FIRSTBOOT = "43"
 
 func VersionReplacements() map[string]string {
 	return map[string]string{
-		"VERSION_BRANCHED":        VERSION_BRANCHED,
-		"VERSION_RAWHIDE":         VERSION_RAWHIDE,
-		"VERSION_ROOTFS_SQUASHFS": VERSION_ROOTFS_SQUASHFS,
+		"VERSION_BRANCHED": VERSION_BRANCHED,
+		"VERSION_RAWHIDE":  VERSION_RAWHIDE,
 	}
 }

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/shell"
 	"github.com/osbuild/images/pkg/customizations/subscription"
+	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
@@ -118,6 +119,10 @@ type ImageConfig struct {
 	// MountUnits creates systemd .mount units to describe the filesystem
 	// instead of writing to /etc/fstab
 	MountUnits *bool `yaml:"mount_units,omitempty"`
+
+	// IsoRootfsType defines what rootfs (squashfs, erofs,ext4)
+	// is used
+	IsoRootfsType *manifest.RootfsType `yaml:"iso_rootfs_type,omitempty"`
 }
 
 type WSLConfig struct {

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"encoding/json"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -24,6 +25,29 @@ const ( // Rootfs type enum
 	SquashfsRootfs                       // Create a plain squashfs rootfs
 	ErofsRootfs                          // Create a plain erofs rootfs
 )
+
+func (r *RootfsType) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "squashfs-ext4", "":
+		*r = SquashfsExt4Rootfs
+	case "squashfs":
+		*r = SquashfsRootfs
+	case "erofs":
+		*r = ErofsRootfs
+	default:
+		return fmt.Errorf("unknown RootfsType: %q", s)
+	}
+
+	return nil
+}
+
+func (r *RootfsType) UnmarshalYAML(unmarshal func(any) error) error {
+	return common.UnmarshalYAMLviaJSON(r, unmarshal)
+}
 
 type ISOBootType uint64
 


### PR DESCRIPTION
fedora: implement setting of the RootfsType via YAML

This commit moves the setting of the rootfs type into the
ImageConfig and by implication into pure YAML.

The relevant image defintions are now also updated. This
also means that one can define `iso_rootfs_type: "erofs"`
trivially now per image type.

Note that this also shows an inconsistency with the old
code, some of the iso images have been moved to the new
SquashfsRootfs but other have not. We should probably
look into this too but for now this PR opts to not change
the behavior just moves the place how the RootfsType for
the iso is set.

---

manifest: make `RootfsType` marshallable via JSON/YAML

This commit makes the `manifest.RootfsType` marshallable via
JSON/YAML so that we can use it in the image defintions.

This will be useful for:
https://github.com/osbuild/images/pull/1239
https://github.com/osbuild/images/pull/1537
