### PR TITLE
disk: tiny tweaks for the new MkfsOptions support

### DIFF
--- a/pkg/disk/filesystem.go
+++ b/pkg/disk/filesystem.go
@@ -19,8 +19,8 @@ func getMkfsOptionMapping() []string {
 	return []string{"verity"}
 }
 
-// ToString converts MkfsOption into a human readable string
-func (option MkfsOption) ToString() string {
+// String converts MkfsOption into a human readable string
+func (option MkfsOption) String() string {
 	return getMkfsOptionMapping()[int(option)]
 }
 

--- a/pkg/disk/filesystem_test.go
+++ b/pkg/disk/filesystem_test.go
@@ -1,7 +1,10 @@
 package disk_test
 
 import (
+	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/images/pkg/disk"
 )
@@ -10,4 +13,29 @@ func TestImplementsInterfacesCompileTimeCheckFilesystem(t *testing.T) {
 	var _ = disk.Mountable(&disk.Filesystem{})
 	var _ = disk.UniqueEntity(&disk.Filesystem{})
 	var _ = disk.FSTabEntity(&disk.Filesystem{})
+}
+
+func TestMkfsOptionUnmarshalHappy(t *testing.T) {
+	for _, tc := range []struct {
+		inp      string
+		expected disk.MkfsOption
+	}{
+		{`"verity"`, disk.MkfsVerity},
+	} {
+		var opt disk.MkfsOption
+		err := json.Unmarshal([]byte(tc.inp), &opt)
+		assert.NoError(t, err)
+		assert.Equal(t, tc.expected, opt)
+
+		// encoding again yields the same result
+		encoded, err := json.Marshal(opt)
+		assert.NoError(t, err)
+		assert.Equal(t, tc.inp, string(encoded))
+	}
+}
+
+func TestMkfsOptionUnmarshalSad(t *testing.T) {
+	var opt disk.MkfsOption
+	err := json.Unmarshal([]byte(`"invalid-mkfs-option"`), &opt)
+	assert.EqualError(t, err, `invalid mkfsoption: invalid-mkfs-option`)
 }

--- a/pkg/disk/filesystem_test.go
+++ b/pkg/disk/filesystem_test.go
@@ -2,6 +2,7 @@ package disk_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,7 @@ func TestMkfsOptionUnmarshalHappy(t *testing.T) {
 		{`"verity"`, disk.MkfsVerity},
 	} {
 		var opt disk.MkfsOption
+		// unmarshaling works
 		err := json.Unmarshal([]byte(tc.inp), &opt)
 		assert.NoError(t, err)
 		assert.Equal(t, tc.expected, opt)
@@ -31,6 +33,10 @@ func TestMkfsOptionUnmarshalHappy(t *testing.T) {
 		encoded, err := json.Marshal(opt)
 		assert.NoError(t, err)
 		assert.Equal(t, tc.inp, string(encoded))
+
+		// and converting to a string gives us the mkfs option
+		// again
+		assert.Equal(t, tc.inp, fmt.Sprintf("%q", opt))
 	}
 }
 


### PR DESCRIPTION
This is a small followup for https://github.com/osbuild/images/pull/1526 - I was too late with my review (but also don't want to burden Alex with chores like the marshal/unmarshal tests). 

The first commit just add tests, the second has a tiny change that should be useful (unless I miss something and the ToString() was deliberately chosen to avoid the automatic convertion via `%s` - if so I'm happy to just change it to an explicit test that tests that this does not work and a commit message with the rational why we selected it this way).


---

disk: rename `MkfsOption.ToString` to `MkfsOption.String`

This commit renames `MkfsOption.ToString` to `MkfsOption.String`
and expands the test to cover that too.

In go its much more common to just have `String()` methods
to convert a type to a string. The `ToString` is very rare,
another advantage of the rename is that `%s` will automatically
work if there is a `String()`.

---

disk: add unit test for new MkfsOption marshal/unmarshal

Tiny PR that adds unit tests around the new marshal/unmarshal
feature of `MkfsOption`.

