### PR TITLE
fedora/wsl: include `wsl-setup` (HMS-8573)

### DIFF
--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -1518,10 +1518,10 @@ image_types:
     name_aliases: ["server-wsl"]
     filename: "wsl.tar"
     mime_type: "application/x-tar"
-    image_func: "container"
+    image_func: "tar"
     build_pipelines: ["build"]
-    payload_pipelines: ["os", "container"]
-    exports: ["container"]
+    payload_pipelines: ["os", "archive"]
+    exports: ["archive"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - arch: "x86_64"

--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -1527,25 +1527,24 @@ image_types:
       - arch: "x86_64"
     image_config:
       <<: *image_config_container
-      cloud_init:
-        - filename: "99_wsl.cfg"
-          config:
-            datasource_list:
-              - "WSL"
-              - "None"
-            network:
-              config: "disabled"
       condition:
         version_less_than:
           "42":
             wsl_config:
               boot_systemd: true
+            cloud_init:
+              - filename: "99_wsl.cfg"
+                config:
+                  datasource_list:
+                    - "WSL"
+                    - "None"
+                  network:
+                    config: "disabled"
     package_sets:
       os:
         - include:
             - "bash"
             - "coreutils"
-            - "cloud-init"
             - "yum"
             - "dnf"
             - "fedora-release-container"
@@ -1590,6 +1589,10 @@ image_types:
               "42":
                 include:
                   - "wsl-setup"
+            version_less_than:
+              "42":
+                include:
+                  - "cloud-init"
 
   "iot-simplified-installer":
     filename: "simplified-installer.iso"

--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -1535,8 +1535,11 @@ image_types:
               - "None"
             network:
               config: "disabled"
-      wsl_config:
-        boot_systemd: true
+      condition:
+        version_less_than:
+          "42":
+            wsl_config:
+              boot_systemd: true
     package_sets:
       os:
         - include:

--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -1516,7 +1516,7 @@ image_types:
     # this is the eventual name, and `wsl` the alias but we've been
     # having issues with CI renaming it
     name_aliases: ["server-wsl"]
-    filename: "wsl.tar"
+    filename: "image.wsl"
     mime_type: "application/x-tar"
     image_func: "tar"
     build_pipelines: ["build"]

--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -1584,6 +1584,9 @@ image_types:
               "41":
                 exclude:
                   - "fuse-libs"
+              "42":
+                include:
+                  - "wsl-setup"
 
   "iot-simplified-installer":
     filename: "simplified-installer.iso"

--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -1516,6 +1516,9 @@ image_types:
     # this is the eventual name, and `wsl` the alias but we've been
     # having issues with CI renaming it
     name_aliases: ["server-wsl"]
+    # note that other distributions in images differ and use a .tar suffix, however .wsl is the
+    # correct suffix, see:
+    # https://learn.microsoft.com/en-us/windows/wsl/build-custom-distro#what-are-wsl-root-filesystem-tar-files
     filename: "image.wsl"
     mime_type: "application/x-tar"
     image_func: "tar"

--- a/pkg/distro/fedora/distro_test.go
+++ b/pkg/distro/fedora/distro_test.go
@@ -106,7 +106,7 @@ func TestFilenameFromType(t *testing.T) {
 			name: "wsl",
 			args: args{"wsl"},
 			want: wantResult{
-				filename: "wsl.tar",
+				filename: "image.wsl",
 				mimeType: "application/x-tar",
 			},
 		},

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -368,6 +368,31 @@ func diskImage(workload workload.Workload,
 	return img, nil
 }
 
+func tarImage(workload workload.Workload,
+	t *imageType,
+	bp *blueprint.Blueprint,
+	options distro.ImageOptions,
+	packageSets map[string]rpmmd.PackageSet,
+	containers []container.SourceSpec,
+	rng *rand.Rand) (image.ImageKind, error) {
+	img := image.NewArchive()
+
+	img.Platform = t.platform
+
+	var err error
+	img.OSCustomizations, err = osCustomizations(t, packageSets[osPkgsKey], containers, bp.Customizations)
+	if err != nil {
+		return nil, err
+	}
+
+	img.Environment = t.environment
+	img.Workload = workload
+
+	img.Filename = t.Filename()
+
+	return img, nil
+}
+
 func containerImage(workload workload.Workload,
 	t *imageType,
 	bp *blueprint.Blueprint,

--- a/pkg/distro/fedora/package_sets.go
+++ b/pkg/distro/fedora/package_sets.go
@@ -69,6 +69,8 @@ func newImageTypeFrom(d distribution, imgYAML defs.ImageTypeYAML) imageType {
 		it.image = iotInstallerImage
 	case "iot_simplified_installer":
 		it.image = iotSimplifiedInstallerImage
+	case "tar":
+		it.image = tarImage
 	default:
 		err := fmt.Errorf("unknown image func: %v for %v", imgYAML.Image, imgYAML.Name())
 		panic(err)

--- a/test/data/manifest-checksums.txt
+++ b/test/data/manifest-checksums.txt
@@ -181,7 +181,7 @@ b422e5cc726ef6bc561aac6da7a1f27c95aa1f30  fedora_40-x86_64-server_qcow2-import_r
 05e3c036e55e26daa3080b3c0fd1d1eca8096e86  fedora_40-x86_64-server_vhd-empty_fedora.json
 1170dd9c5f8efdbe151cdb730f9fad8fe537248a  fedora_40-x86_64-server_vmdk-empty_fedora.json
 e659ba056e767a08eca153dffba7acba56024bd4  fedora_40-x86_64-workstation_live_installer-empty_fedora.json
-9c28e38e2bbf20b902e3853dbe063715a2acff98  fedora_40-x86_64-wsl-empty_fedora.json
+5b6eace6e801afc291cb5f71aec7b7441b8ea07d  fedora_40-x86_64-wsl-empty_fedora.json
 6d6ec2e972758aae24d0448dd3a6068c1e364293  fedora_41-aarch64-container-empty_fedora.json
 ae8513196c06484c39c2cd7dd8fc1966ed0c62cd  fedora_41-aarch64-iot_bootable_container-empty_fedora.json
 a138faeeade6b04a1329f22d8573e974f5a4439a  fedora_41-aarch64-iot_commit-kernel_debug.json
@@ -259,7 +259,7 @@ b92b4aabffde754c5c3b0d6b8fbbae84f801634f  fedora_41-x86_64-server_qcow2-import_r
 cf1299d2886f181be638ddd9f85c7d0e368c36e6  fedora_41-x86_64-server_vhd-empty_fedora.json
 ecc9b81e8e5edd842a9c90be8fd2e0e40bec7a91  fedora_41-x86_64-server_vmdk-empty_fedora.json
 fcd7eedd5c2aa739d2e5815d7c3a726a08a52a5f  fedora_41-x86_64-workstation_live_installer-empty_fedora.json
-24becaadad8f09a784780da4c47047ed22a26946  fedora_41-x86_64-wsl-empty_fedora.json
+be61d7d593817ac61ec37272530cc13797c1bf95  fedora_41-x86_64-wsl-empty_fedora.json
 7989b997b2aff346184fe0c510b0fc2a6519f7b0  fedora_42-aarch64-container-empty_fedora.json
 66d31c84304733b6afacad0ba7476ae48aa65029  fedora_42-aarch64-iot_bootable_container-empty_fedora.json
 fcedd521c11d5dc8bf9338cc7a327ee2b59cc08b  fedora_42-aarch64-iot_commit-kernel_debug.json
@@ -337,7 +337,7 @@ c5c8752dd936e5adef524cf007e0e9ad01b1bb97  fedora_42-x86_64-server_qcow2-import_r
 fabcfdb54b06199c4dc7509a1814a824e3e21b26  fedora_42-x86_64-server_vhd-empty_fedora.json
 59b3f34ea32cb0163dc14f4d76244f79d3927da4  fedora_42-x86_64-server_vmdk-empty_fedora.json
 6bb0b7dc876301869a3464b7fb1aa2d5e1f1422e  fedora_42-x86_64-workstation_live_installer-empty_fedora.json
-3164692238b6820ea436309c21b3fa82a2b1cd06  fedora_42-x86_64-wsl-empty_fedora.json
+9edc0b042585f6cb5134ad98369dbb93fc4f1eba  fedora_42-x86_64-wsl-empty_fedora.json
 af30ebb99bf61e93cc4dfb8dcf37990f51c2fa7d  fedora_43-aarch64-container-empty_fedora.json
 2d8af3f90d2982e203ddaea3431b2c334b8c603e  fedora_43-aarch64-iot_bootable_container-empty_fedora.json
 6413e3602c072200535533b7a7a41e1eb5051302  fedora_43-aarch64-iot_commit-kernel_debug.json
@@ -415,7 +415,7 @@ a20408ea841e0525de5dcb6b68e4d54924524153  fedora_43-x86_64-server_qcow2-oscap_ge
 dc50763132eef380fa19d197b028e8aab3fe676c  fedora_43-x86_64-server_vhd-empty_fedora.json
 ffdac90cb2a28ae406a3f8188c3504298e44c0ce  fedora_43-x86_64-server_vmdk-empty_fedora.json
 e5ed780c83bda5bec514b5a0ee75e726933f8fbb  fedora_43-x86_64-workstation_live_installer-empty_fedora.json
-5b3c2926137ecad986c0cc3f0b9fd9f28d580778  fedora_43-x86_64-wsl-empty_fedora.json
+f2583abaad7db9ff1aaf6472c58f2897ad6431f9  fedora_43-x86_64-wsl-empty_fedora.json
 eb7ea57b8a701e607721dcf025b4a48ee50908f8  rhel_10.0-aarch64-ami-all_customizations.json
 5a408896d306f4752f4a6c1812e52fc1407fb406  rhel_10.0-aarch64-ami-empty_rhel.json
 f63172040b0783190e09e4f653ee200f053c22fe  rhel_10.0-aarch64-ami-oscap_rhel10.json

--- a/test/data/manifest-checksums.txt
+++ b/test/data/manifest-checksums.txt
@@ -181,7 +181,7 @@ b422e5cc726ef6bc561aac6da7a1f27c95aa1f30  fedora_40-x86_64-server_qcow2-import_r
 05e3c036e55e26daa3080b3c0fd1d1eca8096e86  fedora_40-x86_64-server_vhd-empty_fedora.json
 1170dd9c5f8efdbe151cdb730f9fad8fe537248a  fedora_40-x86_64-server_vmdk-empty_fedora.json
 e659ba056e767a08eca153dffba7acba56024bd4  fedora_40-x86_64-workstation_live_installer-empty_fedora.json
-5b6eace6e801afc291cb5f71aec7b7441b8ea07d  fedora_40-x86_64-wsl-empty_fedora.json
+42bfa13b31abfe56d7e5840d770d916d19dd0845  fedora_40-x86_64-wsl-empty_fedora.json
 6d6ec2e972758aae24d0448dd3a6068c1e364293  fedora_41-aarch64-container-empty_fedora.json
 ae8513196c06484c39c2cd7dd8fc1966ed0c62cd  fedora_41-aarch64-iot_bootable_container-empty_fedora.json
 a138faeeade6b04a1329f22d8573e974f5a4439a  fedora_41-aarch64-iot_commit-kernel_debug.json
@@ -259,7 +259,7 @@ b92b4aabffde754c5c3b0d6b8fbbae84f801634f  fedora_41-x86_64-server_qcow2-import_r
 cf1299d2886f181be638ddd9f85c7d0e368c36e6  fedora_41-x86_64-server_vhd-empty_fedora.json
 ecc9b81e8e5edd842a9c90be8fd2e0e40bec7a91  fedora_41-x86_64-server_vmdk-empty_fedora.json
 fcd7eedd5c2aa739d2e5815d7c3a726a08a52a5f  fedora_41-x86_64-workstation_live_installer-empty_fedora.json
-be61d7d593817ac61ec37272530cc13797c1bf95  fedora_41-x86_64-wsl-empty_fedora.json
+6885fe31683978ac08919e5a20db8b0833d8a7dd  fedora_41-x86_64-wsl-empty_fedora.json
 7989b997b2aff346184fe0c510b0fc2a6519f7b0  fedora_42-aarch64-container-empty_fedora.json
 66d31c84304733b6afacad0ba7476ae48aa65029  fedora_42-aarch64-iot_bootable_container-empty_fedora.json
 fcedd521c11d5dc8bf9338cc7a327ee2b59cc08b  fedora_42-aarch64-iot_commit-kernel_debug.json
@@ -337,7 +337,7 @@ c5c8752dd936e5adef524cf007e0e9ad01b1bb97  fedora_42-x86_64-server_qcow2-import_r
 fabcfdb54b06199c4dc7509a1814a824e3e21b26  fedora_42-x86_64-server_vhd-empty_fedora.json
 59b3f34ea32cb0163dc14f4d76244f79d3927da4  fedora_42-x86_64-server_vmdk-empty_fedora.json
 6bb0b7dc876301869a3464b7fb1aa2d5e1f1422e  fedora_42-x86_64-workstation_live_installer-empty_fedora.json
-9edc0b042585f6cb5134ad98369dbb93fc4f1eba  fedora_42-x86_64-wsl-empty_fedora.json
+c4df7d8cc46ac2fefad95d22bb38aed2bb9af65c  fedora_42-x86_64-wsl-empty_fedora.json
 af30ebb99bf61e93cc4dfb8dcf37990f51c2fa7d  fedora_43-aarch64-container-empty_fedora.json
 2d8af3f90d2982e203ddaea3431b2c334b8c603e  fedora_43-aarch64-iot_bootable_container-empty_fedora.json
 6413e3602c072200535533b7a7a41e1eb5051302  fedora_43-aarch64-iot_commit-kernel_debug.json
@@ -415,7 +415,7 @@ a20408ea841e0525de5dcb6b68e4d54924524153  fedora_43-x86_64-server_qcow2-oscap_ge
 dc50763132eef380fa19d197b028e8aab3fe676c  fedora_43-x86_64-server_vhd-empty_fedora.json
 ffdac90cb2a28ae406a3f8188c3504298e44c0ce  fedora_43-x86_64-server_vmdk-empty_fedora.json
 e5ed780c83bda5bec514b5a0ee75e726933f8fbb  fedora_43-x86_64-workstation_live_installer-empty_fedora.json
-f2583abaad7db9ff1aaf6472c58f2897ad6431f9  fedora_43-x86_64-wsl-empty_fedora.json
+80baaed5cf84ac4e222ac6cd2855a16220db64de  fedora_43-x86_64-wsl-empty_fedora.json
 eb7ea57b8a701e607721dcf025b4a48ee50908f8  rhel_10.0-aarch64-ami-all_customizations.json
 5a408896d306f4752f4a6c1812e52fc1407fb406  rhel_10.0-aarch64-ami-empty_rhel.json
 f63172040b0783190e09e4f653ee200f053c22fe  rhel_10.0-aarch64-ami-oscap_rhel10.json

--- a/test/data/manifest-checksums.txt
+++ b/test/data/manifest-checksums.txt
@@ -337,7 +337,7 @@ c5c8752dd936e5adef524cf007e0e9ad01b1bb97  fedora_42-x86_64-server_qcow2-import_r
 fabcfdb54b06199c4dc7509a1814a824e3e21b26  fedora_42-x86_64-server_vhd-empty_fedora.json
 59b3f34ea32cb0163dc14f4d76244f79d3927da4  fedora_42-x86_64-server_vmdk-empty_fedora.json
 6bb0b7dc876301869a3464b7fb1aa2d5e1f1422e  fedora_42-x86_64-workstation_live_installer-empty_fedora.json
-c4df7d8cc46ac2fefad95d22bb38aed2bb9af65c  fedora_42-x86_64-wsl-empty_fedora.json
+152004d6da5b4396bea5134038e2c8f756d9eb55  fedora_42-x86_64-wsl-empty_fedora.json
 af30ebb99bf61e93cc4dfb8dcf37990f51c2fa7d  fedora_43-aarch64-container-empty_fedora.json
 2d8af3f90d2982e203ddaea3431b2c334b8c603e  fedora_43-aarch64-iot_bootable_container-empty_fedora.json
 6413e3602c072200535533b7a7a41e1eb5051302  fedora_43-aarch64-iot_commit-kernel_debug.json
@@ -415,7 +415,7 @@ a20408ea841e0525de5dcb6b68e4d54924524153  fedora_43-x86_64-server_qcow2-oscap_ge
 dc50763132eef380fa19d197b028e8aab3fe676c  fedora_43-x86_64-server_vhd-empty_fedora.json
 ffdac90cb2a28ae406a3f8188c3504298e44c0ce  fedora_43-x86_64-server_vmdk-empty_fedora.json
 e5ed780c83bda5bec514b5a0ee75e726933f8fbb  fedora_43-x86_64-workstation_live_installer-empty_fedora.json
-80baaed5cf84ac4e222ac6cd2855a16220db64de  fedora_43-x86_64-wsl-empty_fedora.json
+e590084f9b8203e19c813d95971ecc18ae75ed92  fedora_43-x86_64-wsl-empty_fedora.json
 eb7ea57b8a701e607721dcf025b4a48ee50908f8  rhel_10.0-aarch64-ami-all_customizations.json
 5a408896d306f4752f4a6c1812e52fc1407fb406  rhel_10.0-aarch64-ami-empty_rhel.json
 f63172040b0783190e09e4f653ee200f053c22fe  rhel_10.0-aarch64-ami-oscap_rhel10.json

--- a/test/data/manifest-checksums.txt
+++ b/test/data/manifest-checksums.txt
@@ -337,7 +337,7 @@ c5c8752dd936e5adef524cf007e0e9ad01b1bb97  fedora_42-x86_64-server_qcow2-import_r
 fabcfdb54b06199c4dc7509a1814a824e3e21b26  fedora_42-x86_64-server_vhd-empty_fedora.json
 59b3f34ea32cb0163dc14f4d76244f79d3927da4  fedora_42-x86_64-server_vmdk-empty_fedora.json
 6bb0b7dc876301869a3464b7fb1aa2d5e1f1422e  fedora_42-x86_64-workstation_live_installer-empty_fedora.json
-ab7a7e960a454cbdbca3b64fae2fe98fd1783d7d  fedora_42-x86_64-wsl-empty_fedora.json
+3164692238b6820ea436309c21b3fa82a2b1cd06  fedora_42-x86_64-wsl-empty_fedora.json
 af30ebb99bf61e93cc4dfb8dcf37990f51c2fa7d  fedora_43-aarch64-container-empty_fedora.json
 2d8af3f90d2982e203ddaea3431b2c334b8c603e  fedora_43-aarch64-iot_bootable_container-empty_fedora.json
 6413e3602c072200535533b7a7a41e1eb5051302  fedora_43-aarch64-iot_commit-kernel_debug.json
@@ -415,7 +415,7 @@ a20408ea841e0525de5dcb6b68e4d54924524153  fedora_43-x86_64-server_qcow2-oscap_ge
 dc50763132eef380fa19d197b028e8aab3fe676c  fedora_43-x86_64-server_vhd-empty_fedora.json
 ffdac90cb2a28ae406a3f8188c3504298e44c0ce  fedora_43-x86_64-server_vmdk-empty_fedora.json
 e5ed780c83bda5bec514b5a0ee75e726933f8fbb  fedora_43-x86_64-workstation_live_installer-empty_fedora.json
-fd491e11e205dd73b89675426cc9f482c2a8bb91  fedora_43-x86_64-wsl-empty_fedora.json
+5b3c2926137ecad986c0cc3f0b9fd9f28d580778  fedora_43-x86_64-wsl-empty_fedora.json
 eb7ea57b8a701e607721dcf025b4a48ee50908f8  rhel_10.0-aarch64-ami-all_customizations.json
 5a408896d306f4752f4a6c1812e52fc1407fb406  rhel_10.0-aarch64-ami-empty_rhel.json
 f63172040b0783190e09e4f653ee200f053c22fe  rhel_10.0-aarch64-ami-oscap_rhel10.json

--- a/test/data/manifest-checksums.txt
+++ b/test/data/manifest-checksums.txt
@@ -337,7 +337,7 @@ c5c8752dd936e5adef524cf007e0e9ad01b1bb97  fedora_42-x86_64-server_qcow2-import_r
 fabcfdb54b06199c4dc7509a1814a824e3e21b26  fedora_42-x86_64-server_vhd-empty_fedora.json
 59b3f34ea32cb0163dc14f4d76244f79d3927da4  fedora_42-x86_64-server_vmdk-empty_fedora.json
 6bb0b7dc876301869a3464b7fb1aa2d5e1f1422e  fedora_42-x86_64-workstation_live_installer-empty_fedora.json
-f516f7786ea2a538666b2c10b8cbabc20842e25a  fedora_42-x86_64-wsl-empty_fedora.json
+ab7a7e960a454cbdbca3b64fae2fe98fd1783d7d  fedora_42-x86_64-wsl-empty_fedora.json
 af30ebb99bf61e93cc4dfb8dcf37990f51c2fa7d  fedora_43-aarch64-container-empty_fedora.json
 2d8af3f90d2982e203ddaea3431b2c334b8c603e  fedora_43-aarch64-iot_bootable_container-empty_fedora.json
 6413e3602c072200535533b7a7a41e1eb5051302  fedora_43-aarch64-iot_commit-kernel_debug.json
@@ -415,7 +415,7 @@ a20408ea841e0525de5dcb6b68e4d54924524153  fedora_43-x86_64-server_qcow2-oscap_ge
 dc50763132eef380fa19d197b028e8aab3fe676c  fedora_43-x86_64-server_vhd-empty_fedora.json
 ffdac90cb2a28ae406a3f8188c3504298e44c0ce  fedora_43-x86_64-server_vmdk-empty_fedora.json
 e5ed780c83bda5bec514b5a0ee75e726933f8fbb  fedora_43-x86_64-workstation_live_installer-empty_fedora.json
-0f655fbad0ef2a1f3e7b7b898135f9c1f326bb2c  fedora_43-x86_64-wsl-empty_fedora.json
+fd491e11e205dd73b89675426cc9f482c2a8bb91  fedora_43-x86_64-wsl-empty_fedora.json
 eb7ea57b8a701e607721dcf025b4a48ee50908f8  rhel_10.0-aarch64-ami-all_customizations.json
 5a408896d306f4752f4a6c1812e52fc1407fb406  rhel_10.0-aarch64-ami-empty_rhel.json
 f63172040b0783190e09e4f653ee200f053c22fe  rhel_10.0-aarch64-ami-oscap_rhel10.json


### PR DESCRIPTION
In newer versions of WSL there's a new out-of-the-box experience. This is packaged in Fedora under `wsl-setup`. Let's include the package.