### PR TITLE
disk: move disk.PartitioningMode into its own package

### DIFF
--- a/cmd/osbuild-playground/my-image.go
+++ b/cmd/osbuild-playground/my-image.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/osbuild/images/pkg/artifact"
 	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/disk/partition"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -39,7 +40,7 @@ func (img *MyImage) InstantiateManifest(m *manifest.Manifest,
 	}
 
 	// TODO: add helper
-	pt, err := disk.NewPartitionTable(&basePT, nil, 0, disk.RawPartitioningMode, platform.GetArch(), nil, rng)
+	pt, err := disk.NewPartitionTable(&basePT, nil, 0, partition.RawPartitioningMode, platform.GetArch(), nil, rng)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/otk/osbuild-gen-partition-table/main.go
+++ b/cmd/otk/osbuild-gen-partition-table/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/disk/partition"
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
@@ -71,7 +72,7 @@ type InputPartition struct {
 // InputModifications allow modifiying the partition generation to e.g.
 // increase the default disk size
 type InputModifications struct {
-	PartitionMode disk.PartitioningMode               `json:"partition_mode"`
+	PartitionMode partition.PartitioningMode          `json:"partition_mode"`
 	Filesystems   []blueprint.FilesystemCustomization `json:"filesystems"`
 	MinDiskSize   string                              `json:"min_disk_size"`
 	Filename      string                              `json:"filename"`

--- a/cmd/otk/osbuild-gen-partition-table/main_test.go
+++ b/cmd/otk/osbuild-gen-partition-table/main_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/disk/partition"
 )
 
 // see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
@@ -88,7 +89,7 @@ var expectedInput = &genpart.Input{
 	},
 	Modifications: genpart.InputModifications{
 		MinDiskSize:   "20 GiB",
-		PartitionMode: disk.AutoLVMPartitioningMode,
+		PartitionMode: partition.AutoLVMPartitioningMode,
 		Filesystems: []blueprint.FilesystemCustomization{
 			{
 				Mountpoint: "/var/log",
@@ -523,7 +524,7 @@ func TestGenPartitionTableCustomizationExtraMpPlusModificationPartitionMode(t *t
 		},
 		Modifications: genpart.InputModifications{
 			// note that the extra partitin mode is used here
-			PartitionMode: disk.RawPartitioningMode,
+			PartitionMode: partition.RawPartitioningMode,
 			Filesystems: []blueprint.FilesystemCustomization{
 				{
 					Mountpoint: "/var/log",

--- a/pkg/disk/disk_test.go
+++ b/pkg/disk/disk_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/disk/partition"
 )
 
 const (
@@ -80,7 +81,7 @@ func TestDynamicallyResizePartitionTable(t *testing.T) {
 	// math/rand is good enough in this case
 	/* #nosec G404 */
 	rng := rand.New(rand.NewSource(0))
-	newpt, err := disk.NewPartitionTable(&pt, mountpoints, 1024, disk.RawPartitioningMode, arch.ARCH_AARCH64, nil, rng)
+	newpt, err := disk.NewPartitionTable(&pt, mountpoints, 1024, partition.RawPartitioningMode, arch.ARCH_AARCH64, nil, rng)
 	assert.NoError(t, err)
 	assert.GreaterOrEqual(t, newpt.Size, expectedSize)
 }
@@ -189,9 +190,9 @@ func TestCreatePartitionTable(t *testing.T) {
 	rng := rand.New(rand.NewSource(13))
 	for ptName, pt := range testdisk.TestPartitionTables() {
 		for bpName, bp := range testBlueprints {
-			ptMode := disk.RawPartitioningMode
+			ptMode := partition.RawPartitioningMode
 			if ptName == "luks+lvm" {
-				ptMode = disk.AutoLVMPartitioningMode
+				ptMode = partition.AutoLVMPartitioningMode
 			}
 			mpt, err := disk.NewPartitionTable(&pt, bp, uint64(13*MiB), ptMode, arch.ARCH_PPC64LE, nil, rng)
 			require.NoError(t, err, "Partition table generation failed: PT %q BP %q (%s)", ptName, bpName, err)
@@ -217,12 +218,12 @@ func TestCreatePartitionTableLVMify(t *testing.T) {
 	for bpName, tbp := range testBlueprints {
 		for ptName, pt := range testdisk.TestPartitionTables() {
 			if tbp != nil && (ptName == "btrfs" || ptName == "luks") {
-				_, err := disk.NewPartitionTable(&pt, tbp, uint64(13*MiB), disk.AutoLVMPartitioningMode, arch.ARCH_X86_64, nil, rng)
+				_, err := disk.NewPartitionTable(&pt, tbp, uint64(13*MiB), partition.AutoLVMPartitioningMode, arch.ARCH_X86_64, nil, rng)
 				assert.Error(err, "PT %q BP %q: should return an error with LVMPartitioningMode", ptName, bpName)
 				continue
 			}
 
-			mpt, err := disk.NewPartitionTable(&pt, tbp, uint64(13*MiB), disk.AutoLVMPartitioningMode, arch.ARCH_X86_64, nil, rng)
+			mpt, err := disk.NewPartitionTable(&pt, tbp, uint64(13*MiB), partition.AutoLVMPartitioningMode, arch.ARCH_X86_64, nil, rng)
 			assert.NoError(err, "PT %q BP %q: Partition table generation failed: (%s)", ptName, bpName, err)
 
 			rootPath := disk.EntityPath(mpt, "/")
@@ -253,12 +254,12 @@ func TestCreatePartitionTableBtrfsify(t *testing.T) {
 	for bpName, tbp := range testBlueprints {
 		for ptName, pt := range testdisk.TestPartitionTables() {
 			if ptName == "auto-lvm" || ptName == "luks" || ptName == "luks+lvm" {
-				_, err := disk.NewPartitionTable(&pt, tbp, uint64(13*MiB), disk.BtrfsPartitioningMode, arch.ARCH_X86_64, nil, rng)
+				_, err := disk.NewPartitionTable(&pt, tbp, uint64(13*MiB), partition.BtrfsPartitioningMode, arch.ARCH_X86_64, nil, rng)
 				assert.Error(err, "PT %q BP %q: should return an error with BtrfsPartitioningMode", ptName, bpName)
 				continue
 			}
 
-			mpt, err := disk.NewPartitionTable(&pt, tbp, uint64(13*MiB), disk.BtrfsPartitioningMode, arch.ARCH_X86_64, nil, rng)
+			mpt, err := disk.NewPartitionTable(&pt, tbp, uint64(13*MiB), partition.BtrfsPartitioningMode, arch.ARCH_X86_64, nil, rng)
 			assert.NoError(err, "PT %q BP %q: Partition table generation failed: (%s)", ptName, bpName, err)
 
 			rootPath := disk.EntityPath(mpt, "/")
@@ -289,12 +290,12 @@ func TestCreatePartitionTableLVMOnly(t *testing.T) {
 	for bpName, tbp := range testBlueprints {
 		for ptName, pt := range testdisk.TestPartitionTables() {
 			if ptName == "btrfs" || ptName == "luks" {
-				_, err := disk.NewPartitionTable(&pt, tbp, uint64(13*MiB), disk.LVMPartitioningMode, arch.ARCH_S390X, nil, rng)
+				_, err := disk.NewPartitionTable(&pt, tbp, uint64(13*MiB), partition.LVMPartitioningMode, arch.ARCH_S390X, nil, rng)
 				assert.Error(err, "PT %q BP %q: should return an error with LVMPartitioningMode", ptName, bpName)
 				continue
 			}
 
-			mpt, err := disk.NewPartitionTable(&pt, tbp, uint64(13*MiB), disk.LVMPartitioningMode, arch.ARCH_S390X, nil, rng)
+			mpt, err := disk.NewPartitionTable(&pt, tbp, uint64(13*MiB), partition.LVMPartitioningMode, arch.ARCH_S390X, nil, rng)
 			require.NoError(t, err, "PT %q BP %q: Partition table generation failed: (%s)", ptName, bpName, err)
 
 			rootPath := disk.EntityPath(mpt, "/")
@@ -446,7 +447,7 @@ func TestMinimumSizes(t *testing.T) {
 
 	for idx, tc := range testCases {
 		{ // without LVM
-			mpt, err := disk.NewPartitionTable(&pt, tc.Blueprint, uint64(3*GiB), disk.RawPartitioningMode, arch.ARCH_X86_64, nil, rng)
+			mpt, err := disk.NewPartitionTable(&pt, tc.Blueprint, uint64(3*GiB), partition.RawPartitioningMode, arch.ARCH_X86_64, nil, rng)
 			assert.NoError(err)
 			for mnt, minSize := range tc.ExpectedMinSizes {
 				path := disk.EntityPath(mpt, mnt)
@@ -460,7 +461,7 @@ func TestMinimumSizes(t *testing.T) {
 		}
 
 		{ // with LVM
-			mpt, err := disk.NewPartitionTable(&pt, tc.Blueprint, uint64(3*GiB), disk.AutoLVMPartitioningMode, arch.ARCH_X86_64, nil, rng)
+			mpt, err := disk.NewPartitionTable(&pt, tc.Blueprint, uint64(3*GiB), partition.AutoLVMPartitioningMode, arch.ARCH_X86_64, nil, rng)
 			assert.NoError(err)
 			for mnt, minSize := range tc.ExpectedMinSizes {
 				path := disk.EntityPath(mpt, mnt)
@@ -547,7 +548,7 @@ func TestLVMExtentAlignment(t *testing.T) {
 	}
 
 	for idx, tc := range testCases {
-		mpt, err := disk.NewPartitionTable(&pt, tc.Blueprint, uint64(3*GiB), disk.AutoLVMPartitioningMode, arch.ARCH_X86_64, nil, rng)
+		mpt, err := disk.NewPartitionTable(&pt, tc.Blueprint, uint64(3*GiB), partition.AutoLVMPartitioningMode, arch.ARCH_X86_64, nil, rng)
 		assert.NoError(err)
 		for mnt, expSize := range tc.ExpectedSizes {
 			path := disk.EntityPath(mpt, mnt)
@@ -576,7 +577,7 @@ func TestNewBootWithSizeLVMify(t *testing.T) {
 		},
 	}
 
-	mpt, err := disk.NewPartitionTable(&pt, custom, uint64(3*GiB), disk.AutoLVMPartitioningMode, arch.ARCH_AARCH64, nil, rng)
+	mpt, err := disk.NewPartitionTable(&pt, custom, uint64(3*GiB), partition.AutoLVMPartitioningMode, arch.ARCH_AARCH64, nil, rng)
 	assert.NoError(err)
 
 	for idx, c := range custom {
@@ -919,7 +920,7 @@ func TestMinimumSizesWithRequiredSizes(t *testing.T) {
 
 	for idx, tc := range testCases {
 		{ // without LVM
-			mpt, err := disk.NewPartitionTable(&pt, tc.Blueprint, uint64(3*GiB), disk.RawPartitioningMode, arch.ARCH_AARCH64, map[string]uint64{"/": 1 * GiB, "/usr": 3 * GiB}, rng)
+			mpt, err := disk.NewPartitionTable(&pt, tc.Blueprint, uint64(3*GiB), partition.RawPartitioningMode, arch.ARCH_AARCH64, map[string]uint64{"/": 1 * GiB, "/usr": 3 * GiB}, rng)
 			assert.NoError(err)
 			for mnt, minSize := range tc.ExpectedMinSizes {
 				path := disk.EntityPath(mpt, mnt)
@@ -933,7 +934,7 @@ func TestMinimumSizesWithRequiredSizes(t *testing.T) {
 		}
 
 		{ // with LVM
-			mpt, err := disk.NewPartitionTable(&pt, tc.Blueprint, uint64(3*GiB), disk.AutoLVMPartitioningMode, arch.ARCH_AARCH64, map[string]uint64{"/": 1 * GiB, "/usr": 3 * GiB}, rng)
+			mpt, err := disk.NewPartitionTable(&pt, tc.Blueprint, uint64(3*GiB), partition.AutoLVMPartitioningMode, arch.ARCH_AARCH64, map[string]uint64{"/": 1 * GiB, "/usr": 3 * GiB}, rng)
 			assert.NoError(err)
 			for mnt, minSize := range tc.ExpectedMinSizes {
 				path := disk.EntityPath(mpt, mnt)

--- a/pkg/disk/partition/partition_mode.go
+++ b/pkg/disk/partition/partition_mode.go
@@ -1,0 +1,22 @@
+package partition
+
+type PartitioningMode string
+
+const (
+	// AutoLVMPartitioningMode creates a LVM layout if the filesystem
+	// contains a mountpoint that's not defined in the base partition table
+	// of the specified image type. In the other case, a raw layout is used.
+	AutoLVMPartitioningMode PartitioningMode = "auto-lvm"
+
+	// LVMPartitioningMode always creates an LVM layout.
+	LVMPartitioningMode PartitioningMode = "lvm"
+
+	// RawPartitioningMode always creates a raw layout.
+	RawPartitioningMode PartitioningMode = "raw"
+
+	// BtrfsPartitioningMode creates a btrfs layout.
+	BtrfsPartitioningMode PartitioningMode = "btrfs"
+
+	// DefaultPartitioningMode is AutoLVMPartitioningMode and is the empty state
+	DefaultPartitioningMode PartitioningMode = ""
+)

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/datasizes"
+	"github.com/osbuild/images/pkg/disk/partition"
 	"github.com/osbuild/images/pkg/platform"
 )
 
@@ -29,27 +30,6 @@ type PartitionTable struct {
 	// Starting offset of the first partition in the table (Mb)
 	StartOffset uint64 `json:"start_offset,omitempty" yaml:"start_offset,omitempty"`
 }
-
-type PartitioningMode string
-
-const (
-	// AutoLVMPartitioningMode creates a LVM layout if the filesystem
-	// contains a mountpoint that's not defined in the base partition table
-	// of the specified image type. In the other case, a raw layout is used.
-	AutoLVMPartitioningMode PartitioningMode = "auto-lvm"
-
-	// LVMPartitioningMode always creates an LVM layout.
-	LVMPartitioningMode PartitioningMode = "lvm"
-
-	// RawPartitioningMode always creates a raw layout.
-	RawPartitioningMode PartitioningMode = "raw"
-
-	// BtrfsPartitioningMode creates a btrfs layout.
-	BtrfsPartitioningMode PartitioningMode = "btrfs"
-
-	// DefaultPartitioningMode is AutoLVMPartitioningMode and is the empty state
-	DefaultPartitioningMode PartitioningMode = ""
-)
 
 // DefaultBootPartitionSize is the default size of the /boot partition if it
 // needs to be auto-created. This happens if the custom partitioning don't
@@ -109,10 +89,10 @@ const DefaultBootPartitionSize = 1 * datasizes.GiB
 // containing the root filesystem is grown to fill any left over space on the
 // partition table. Logical Volumes are not grown to fill the space in the
 // Volume Group since they are trivial to grow on a live system.
-func NewPartitionTable(basePT *PartitionTable, mountpoints []blueprint.FilesystemCustomization, imageSize uint64, mode PartitioningMode, architecture arch.Arch, requiredSizes map[string]uint64, rng *rand.Rand) (*PartitionTable, error) {
+func NewPartitionTable(basePT *PartitionTable, mountpoints []blueprint.FilesystemCustomization, imageSize uint64, mode partition.PartitioningMode, architecture arch.Arch, requiredSizes map[string]uint64, rng *rand.Rand) (*PartitionTable, error) {
 	newPT := basePT.Clone().(*PartitionTable)
 
-	if basePT.features().LVM && (mode == RawPartitioningMode || mode == BtrfsPartitioningMode) {
+	if basePT.features().LVM && (mode == partition.RawPartitioningMode || mode == partition.BtrfsPartitioningMode) {
 		return nil, fmt.Errorf("%s partitioning mode set for a base partition table with LVM, this is unsupported", mode)
 	}
 
@@ -121,13 +101,13 @@ func NewPartitionTable(basePT *PartitionTable, mountpoints []blueprint.Filesyste
 
 	var ensureLVM, ensureBtrfs bool
 	switch mode {
-	case LVMPartitioningMode:
+	case partition.LVMPartitioningMode:
 		ensureLVM = true
-	case RawPartitioningMode:
+	case partition.RawPartitioningMode:
 		ensureLVM = false
-	case DefaultPartitioningMode, AutoLVMPartitioningMode:
+	case partition.DefaultPartitioningMode, partition.AutoLVMPartitioningMode:
 		ensureLVM = len(newMountpoints) > 0
-	case BtrfsPartitioningMode:
+	case partition.BtrfsPartitioningMode:
 		ensureBtrfs = true
 	default:
 		return nil, fmt.Errorf("unsupported partitioning mode %q", mode)

--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -6,11 +6,13 @@ import (
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/customizations/subscription"
 	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/disk/partition"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rhsm/facts"
 	"github.com/osbuild/images/pkg/rpmmd"
+
 )
 
 const (
@@ -137,7 +139,7 @@ type ImageOptions struct {
 	OSTree           *ostree.ImageOptions       `json:"ostree,omitempty"`
 	Subscription     *subscription.ImageOptions `json:"subscription,omitempty"`
 	Facts            *facts.ImageOptions        `json:"facts,omitempty"`
-	PartitioningMode disk.PartitioningMode      `json:"partitioning-mode,omitempty"`
+	PartitioningMode partition.PartitioningMode `json:"partitioning-mode,omitempty"`
 
 	UseBootstrapContainer bool `json:"use_bootstrap_container,omitempty"`
 }

--- a/pkg/distro/fedora/imagetype.go
+++ b/pkg/distro/fedora/imagetype.go
@@ -16,6 +16,7 @@ import (
 	"github.com/osbuild/images/pkg/customizations/oscap"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/disk/partition"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/experimentalflags"
@@ -181,10 +182,10 @@ func (t *imageType) getPartitionTable(
 		// IoT supports only LVM, force it.
 		// Raw is not supported, return an error if it is requested
 		// TODO Need a central location for logic like this
-		if partitioningMode == disk.RawPartitioningMode {
+		if partitioningMode == partition.RawPartitioningMode {
 			return nil, fmt.Errorf("partitioning mode raw not supported for %s on %s", t.Name(), t.arch.Name())
 		}
-		partitioningMode = disk.AutoLVMPartitioningMode
+		partitioningMode = partition.AutoLVMPartitioningMode
 	}
 
 	mountpoints := customizations.GetFilesystems()

--- a/pkg/distro/rhel/imagetype.go
+++ b/pkg/distro/rhel/imagetype.go
@@ -13,6 +13,7 @@ import (
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/disk/partition"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/experimentalflags"
 	"github.com/osbuild/images/pkg/image"
@@ -89,7 +90,7 @@ type ImageType struct {
 	// List of valid arches for the image type
 	BasePartitionTables BasePartitionTableFunc
 	// Optional list of unsupported partitioning modes
-	UnsupportedPartitioningModes []disk.PartitioningMode
+	UnsupportedPartitioningModes []partition.PartitioningMode
 
 	ISOLabelFn ISOLabelFunc
 

--- a/pkg/distro/rhel/rhel8/edge.go
+++ b/pkg/distro/rhel/rhel8/edge.go
@@ -4,7 +4,7 @@ import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/datasizes"
-	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/disk/partition"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -80,9 +80,9 @@ func mkEdgeRawImgType() *rhel.ImageType {
 	it.RPMOSTree = true
 	it.Bootable = true
 	it.BasePartitionTables = partitionTables
-	it.UnsupportedPartitioningModes = []disk.PartitioningMode{
-		disk.AutoLVMPartitioningMode,
-		disk.LVMPartitioningMode,
+	it.UnsupportedPartitioningModes = []partition.PartitioningMode{
+		partition.AutoLVMPartitioningMode,
+		partition.LVMPartitioningMode,
 	}
 
 	return it
@@ -150,9 +150,9 @@ func mkEdgeSimplifiedInstallerImgType(rd *rhel.Distribution) *rhel.ImageType {
 	it.BootISO = true
 	it.ISOLabelFn = distroISOLabelFunc
 	it.BasePartitionTables = partitionTables
-	it.UnsupportedPartitioningModes = []disk.PartitioningMode{
-		disk.AutoLVMPartitioningMode,
-		disk.LVMPartitioningMode,
+	it.UnsupportedPartitioningModes = []partition.PartitioningMode{
+		partition.AutoLVMPartitioningMode,
+		partition.LVMPartitioningMode,
 	}
 
 	return it

--- a/pkg/distro/rhel/rhel9/edge.go
+++ b/pkg/distro/rhel/rhel9/edge.go
@@ -7,6 +7,7 @@ import (
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/disk/partition"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -107,7 +108,7 @@ func mkEdgeRawImgType(d *rhel.Distribution) *rhel.ImageType {
 	it.RPMOSTree = true
 	it.Bootable = true
 	it.BasePartitionTables = edgeBasePartitionTables
-	it.UnsupportedPartitioningModes = []disk.PartitioningMode{disk.RawPartitioningMode}
+	it.UnsupportedPartitioningModes = []partition.PartitioningMode{partition.RawPartitioningMode}
 
 	return it
 }
@@ -194,7 +195,7 @@ func mkEdgeSimplifiedInstallerImgType(d *rhel.Distribution) *rhel.ImageType {
 	it.Bootable = true
 	it.ISOLabelFn = distroISOLabelFunc
 	it.BasePartitionTables = edgeBasePartitionTables
-	it.UnsupportedPartitioningModes = []disk.PartitioningMode{disk.RawPartitioningMode}
+	it.UnsupportedPartitioningModes = []partition.PartitioningMode{partition.RawPartitioningMode}
 
 	if common.VersionGreaterThanOrEqual(d.OsVersion(), "9.2") || !d.IsRHEL() {
 		it.DefaultImageConfig.KernelOptions = append(it.DefaultImageConfig.KernelOptions, "rw", "coreos.no_persist_ip")
@@ -236,7 +237,7 @@ func mkEdgeAMIImgType(d *rhel.Distribution) *rhel.ImageType {
 	it.RPMOSTree = true
 	it.Bootable = true
 	it.BasePartitionTables = edgeBasePartitionTables
-	it.UnsupportedPartitioningModes = []disk.PartitioningMode{disk.RawPartitioningMode}
+	it.UnsupportedPartitioningModes = []partition.PartitioningMode{partition.RawPartitioningMode}
 	it.Environment = &environment.EC2{}
 
 	return it
@@ -275,7 +276,7 @@ func mkEdgeVsphereImgType(d *rhel.Distribution) *rhel.ImageType {
 	it.RPMOSTree = true
 	it.Bootable = true
 	it.BasePartitionTables = edgeBasePartitionTables
-	it.UnsupportedPartitioningModes = []disk.PartitioningMode{disk.RawPartitioningMode}
+	it.UnsupportedPartitioningModes = []partition.PartitioningMode{partition.RawPartitioningMode}
 
 	return it
 }

--- a/pkg/osbuild/device_test.go
+++ b/pkg/osbuild/device_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/disk/partition"
 )
 
 func TestGenDeviceCreationStages(t *testing.T) {
@@ -23,7 +24,7 @@ func TestGenDeviceCreationStages(t *testing.T) {
 
 	luks_lvm := testPartitionTables["luks+lvm"]
 
-	pt, err := disk.NewPartitionTable(&luks_lvm, []blueprint.FilesystemCustomization{}, 0, disk.AutoLVMPartitioningMode, arch.ARCH_AARCH64, make(map[string]uint64), rng)
+	pt, err := disk.NewPartitionTable(&luks_lvm, []blueprint.FilesystemCustomization{}, 0, partition.AutoLVMPartitioningMode, arch.ARCH_AARCH64, make(map[string]uint64), rng)
 	assert.NoError(err)
 
 	stages := GenDeviceCreationStages(pt, "image.raw")
@@ -86,7 +87,7 @@ func TestGenDeviceFinishStages(t *testing.T) {
 
 	luks_lvm := testPartitionTables["luks+lvm"]
 
-	pt, err := disk.NewPartitionTable(&luks_lvm, []blueprint.FilesystemCustomization{}, 0, disk.AutoLVMPartitioningMode, arch.ARCH_PPC64LE, make(map[string]uint64), rng)
+	pt, err := disk.NewPartitionTable(&luks_lvm, []blueprint.FilesystemCustomization{}, 0, partition.AutoLVMPartitioningMode, arch.ARCH_PPC64LE, make(map[string]uint64), rng)
 	assert.NoError(err)
 
 	stages := GenDeviceFinishStages(pt, "image.raw")
@@ -129,7 +130,7 @@ func TestGenDeviceFinishStagesOrderWithLVMClevisBind(t *testing.T) {
 
 	luks_lvm := testPartitionTables["luks+lvm+clevisBind"]
 
-	pt, err := disk.NewPartitionTable(&luks_lvm, []blueprint.FilesystemCustomization{}, 0, disk.AutoLVMPartitioningMode, arch.ARCH_S390X, make(map[string]uint64), rng)
+	pt, err := disk.NewPartitionTable(&luks_lvm, []blueprint.FilesystemCustomization{}, 0, partition.AutoLVMPartitioningMode, arch.ARCH_S390X, make(map[string]uint64), rng)
 	assert.NoError(err)
 
 	stages := GenDeviceFinishStages(pt, "image.raw")

--- a/pkg/osbuild/disk_test.go
+++ b/pkg/osbuild/disk_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/disk/partition"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -43,7 +44,7 @@ func TestGenImageKernelOptions(t *testing.T) {
 
 	luks_lvm := testPartitionTables["luks+lvm"]
 
-	pt, err := disk.NewPartitionTable(&luks_lvm, []blueprint.FilesystemCustomization{}, 0, disk.AutoLVMPartitioningMode, arch.ARCH_X86_64, make(map[string]uint64), rng)
+	pt, err := disk.NewPartitionTable(&luks_lvm, []blueprint.FilesystemCustomization{}, 0, partition.AutoLVMPartitioningMode, arch.ARCH_X86_64, make(map[string]uint64), rng)
 	assert.NoError(err)
 
 	uuids := collectUUIDs(pt)


### PR DESCRIPTION
[edit: moved to draft as their is concern about the whole approach in https://github.com/osbuild/images/pull/1552]

This change is needed so that we can import the partitioning mode from the `osbuild/blueprint` library. Otherwise we get a circular import in blueprint/images as
github.com/osbuild/images/pkg/disk
github.com/osbuild/blueprint/pkg/blueprint
have a circular import.github.com/osbuild/images/pkg/disk