### PR TITLE
Makefile: add vet command to check for consistent struct tags

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,18 +128,11 @@ jobs:
       - name: Mark the working directory as safe for git
         run: git config --global --add safe.directory "$(pwd)"
 
-      - name: Run unit tests
-        run: go test -timeout 20m -race  ./...
-
       - name: Install openssl for cgo test below
         run: dnf -y install openssl
 
-      - name: Run unit tests without CGO
-        # keep tags in sync with BUILDTAGS_CROSS in https://github.com/containers/podman/blob/2981262215f563461d449b9841741339f4d9a894/Makefile#L85
-        run: CGO_ENABLED=0 go test -tags "containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_overlay" ./...
-
-      - name: Run depsolver tests with force-dnf to make sure it's not skipped for any reason
-        run: go test -race ./pkg/dnfjson/... -force-dnf
+      - name: Run unit tests
+        run: make test
 
   lint:
     name: "⌨ Lint"

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,11 @@ gh-action-test: container_built_$(CONTAINER_IMAGE).info ## run all tests in a co
 
 .PHONY: test
 test: ## run all tests locally
-	go test -race  ./...
+	# Run unit tests
+	go test -timeout 20m -race  ./...
+	# Run unit tests without CGO
+        # keep tags in sync with BUILDTAGS_CROSS in https://github.com/containers/podman/blob/2981262215f563461d449b9841741339f4d9a894/Makefile#L85
+	CGO_ENABLED=0 go test -tags "containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_overlay" ./...
 	# Run depsolver tests with force-dnf to make sure it's not skipped for any reason
 	go test -race ./pkg/dnfjson/... -force-dnf
 	# ensure our tags are consistent

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ test: ## run all tests locally
 	go test -race  ./...
 	# Run depsolver tests with force-dnf to make sure it's not skipped for any reason
 	go test -race ./pkg/dnfjson/... -force-dnf
+	# ensure our tags are consistent
+	go run github.com/mvo5/vet-tagseq/cmd/tagseq@latest ./...
 
 clean: ## remove all build files
 	rm -f container_built*.info

--- a/pkg/blueprint/blueprint.go
+++ b/pkg/blueprint/blueprint.go
@@ -15,7 +15,7 @@ type Blueprint struct {
 
 	Groups         []Group         `json:"groups" toml:"groups"`
 	Containers     []Container     `json:"containers,omitempty" toml:"containers,omitempty"`
-	Customizations *Customizations `json:"customizations,omitempty" toml:"customizations"`
+	Customizations *Customizations `json:"customizations,omitempty" toml:"customizations,omitempty"`
 	Distro         string          `json:"distro" toml:"distro"`
 
 	// EXPERIMENTAL

--- a/pkg/osbuild/sysconfig_stage.go
+++ b/pkg/osbuild/sysconfig_stage.go
@@ -5,7 +5,7 @@ type SysconfigStageOptions struct {
 	Network        *SysconfigNetworkOptions `json:"network,omitempty" yaml:"network,omitempty"`
 	NetworkScripts *NetworkScriptsOptions   `json:"network-scripts,omitempty" yaml:"network-scripts,omitempty"`
 	Desktop        *SysconfigDesktopOptions `json:"desktop,omitempty" yaml:"desktop,omitempty"`
-	LiveSys        *SysconfigLivesysOptions `json:"livesys,omitempty" yaml:"libesys,omitempty"`
+	LiveSys        *SysconfigLivesysOptions `json:"livesys,omitempty" yaml:"livesys,omitempty"`
 }
 
 func (SysconfigStageOptions) isStageOptions() {}

--- a/pkg/osbuild/yum_repos_stage.go
+++ b/pkg/osbuild/yum_repos_stage.go
@@ -18,7 +18,7 @@ type YumRepository struct {
 	Cost           *int     `json:"cost,omitempty"`
 	Enabled        *bool    `json:"enabled,omitempty"`
 	Priority       *int     `json:"priority,omitempty"`
-	GPGKey         []string `json:"gpgkey,omitempty" yaml:"gpgkey,omitempty" `
+	GPGKey         []string `json:"gpgkey,omitempty" yaml:"gpgkey,omitempty"`
 	Metalink       string   `json:"metalink,omitempty"`
 	Mirrorlist     string   `json:"mirrorlist,omitempty"`
 	ModuleHotfixes *bool    `json:"module_hotfixes,omitempty"`


### PR DESCRIPTION
This commit adds a new tags-equal vet checker that ensures our json/yaml/toml tags are consistent. This is a followup for https://github.com/osbuild/blueprint/pull/18 where this caused problems.