### PR TITLE
image_config: allow specifying users

### DIFF
--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -15,12 +15,14 @@ import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/datasizes"
+	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/distro/test_distro"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
+
 )
 
 func makeTestImageType(t *testing.T) distro.ImageType {
@@ -457,6 +459,8 @@ image_config:
   default:
     locale: "C.UTF-8"
     timezone: "DefaultTZ"
+    users:
+      - name: testuser
   condition:
     distro_name:
       "test-distro":
@@ -474,6 +478,7 @@ image_config:
 	assert.Equal(t, &distro.ImageConfig{
 		Locale:   common.ToPtr("C.UTF-8"),
 		Timezone: common.ToPtr("OverrideTZ"),
+		Users: []users.User{users.User{Name: "testuser"},},
 	}, imgConfig)
 }
 

--- a/pkg/distro/fedora/images.go
+++ b/pkg/distro/fedora/images.go
@@ -72,7 +72,9 @@ func osCustomizations(
 		// don't put users and groups in the payload of an installer
 		// add them via kickstart instead
 		osc.Groups = users.GroupsFromBP(c.GetGroups())
+
 		osc.Users = users.UsersFromBP(c.GetUsers())
+		osc.Users = append(osc.Users, imageConfig.Users...)
 	}
 
 	osc.EnabledServices = imageConfig.EnabledServices

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/shell"
 	"github.com/osbuild/images/pkg/customizations/subscription"
+	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/osbuild"
 )
@@ -77,6 +78,8 @@ type ImageConfig struct {
 
 	WSLConfig *WSLConfig `yaml:"wsl_config,omitempty"`
 
+	Users []users.User
+
 	Files       []*fsnode.File
 	Directories []*fsnode.Directory
 
@@ -123,6 +126,7 @@ type ImageConfig struct {
 	// IsoRootfsType defines what rootfs (squashfs, erofs,ext4)
 	// is used
 	IsoRootfsType *manifest.RootfsType `yaml:"iso_rootfs_type,omitempty"`
+
 }
 
 type WSLConfig struct {

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -74,7 +74,9 @@ func osCustomizations(
 		// don't put users and groups in the payload of an installer
 		// add them via kickstart instead
 		osc.Groups = users.GroupsFromBP(c.GetGroups())
+
 		osc.Users = users.UsersFromBP(c.GetUsers())
+		osc.Users = append(osc.Users, imageConfig.Users...)
 	}
 
 	osc.EnabledServices = imageConfig.EnabledServices


### PR DESCRIPTION
Allow to specify users directly in `ImageConfig`, for some image types such as Vagrant it might be nice to be able to do this.

---

This PR would allow #1562 to be implemented in a less abstract way. This PR is mostly for discussion though it does work.