### PR TITLE
test: install yamllint for tests

### DIFF
--- a/test/scripts/install-dependencies
+++ b/test/scripts/install-dependencies
@@ -16,4 +16,5 @@ dnf -y install \
     osbuild-selinux \
     podman \
     python3 \
+    yamllint \
     xz


### PR DESCRIPTION
Install yamllint so that it's run by the unit test in the GH actions.

The test is skipped when the tool is not found.

https://github.com/osbuild/images/blob/2651be020a53db7f44d39ef028934fe55bc66d5d/pkg/distro/defs/loader_test.go#L48-L64