### PR TITLE
Many: support using string with unit for byte-sized partitioning fields in YAML distro definitions

### DIFF
--- a/pkg/datasizes/parse.go
+++ b/pkg/datasizes/parse.go
@@ -1,6 +1,7 @@
 package datasizes
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -53,4 +54,27 @@ func Parse(size string) (uint64, error) {
 	// even if a number was found. This is to prevent users from submitting
 	// unknown units.
 	return 0, fmt.Errorf("unknown data size units in string: %s", size)
+}
+
+// ParseSizeInJSONMapping will process the given JSON data, assuming it
+// contains a mapping. It will convert the value of the given field to a size
+// in bytes using the Parse function if the field exists and is a string.
+func ParseSizeInJSONMapping(field string, data []byte) ([]byte, error) {
+	var mapping map[string]any
+	if err := json.Unmarshal(data, &mapping); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON data: %w", err)
+	}
+
+	if rawSize, ok := mapping[field]; ok {
+		// If the size is a string, parse it and replace the value in the map
+		if sizeStr, ok := rawSize.(string); ok {
+			size, err := Parse(sizeStr)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse size field named %q to bytes: %w", field, err)
+			}
+			mapping[field] = size
+		}
+	}
+
+	return json.Marshal(mapping)
 }

--- a/pkg/datasizes/parse.go
+++ b/pkg/datasizes/parse.go
@@ -49,7 +49,7 @@ func Parse(size string) (uint64, error) {
 		}
 	}
 
-	// In case the strign didn't match any of the above regexes, return nil
+	// In case the string didn't match any of the above regexes, return nil
 	// even if a number was found. This is to prevent users from submitting
 	// unknown units.
 	return 0, fmt.Errorf("unknown data size units in string: %s", size)

--- a/pkg/disk/btrfs_test.go
+++ b/pkg/disk/btrfs_test.go
@@ -1,8 +1,11 @@
 package disk
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,4 +38,51 @@ func TestImplementsInterfacesCompileTimeCheckBtrfs(t *testing.T) {
 	var _ = Mountable(&BtrfsSubvolume{})
 	var _ = Sizeable(&BtrfsSubvolume{})
 	var _ = FSTabEntity(&BtrfsSubvolume{})
+}
+
+func TestUnmarshalSizeUnitStringBtrfsSubvolume(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected uint64
+		err      error
+	}{
+		{
+			name:     "valid size with unit",
+			input:    `{"size": "1 GiB"}`,
+			expected: 1 * datasizes.GiB,
+			err:      nil,
+		},
+		{
+			name:     "valid size without unit",
+			input:    `{"size": 1073741824}`,
+			expected: 1 * datasizes.GiB,
+			err:      nil,
+		},
+		{
+			name:     "valid size without unit as string",
+			input:    `{"size": "123"}`,
+			expected: 123,
+			err:      nil,
+		},
+		{
+			name:     "invalid size with unit",
+			input:    `{"size": "1 GGB"}`,
+			expected: 0,
+			err:      fmt.Errorf("error parsing size in btrfs subvolume: failed to parse size field named \"size\" to bytes: unknown data size units in string: 1 GGB"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var bs BtrfsSubvolume
+			err := json.Unmarshal([]byte(tc.input), &bs)
+			if tc.err != nil {
+				assert.ErrorContains(t, err, tc.err.Error())
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, bs.Size)
+		})
+	}
 }

--- a/pkg/disk/lvm.go
+++ b/pkg/disk/lvm.go
@@ -246,6 +246,11 @@ func lvname(path string) string {
 }
 
 func (lv *LVMLogicalVolume) UnmarshalJSON(data []byte) (err error) {
+	data, err = datasizes.ParseSizeInJSONMapping("size", data)
+	if err != nil {
+		return fmt.Errorf("error parsing size in LVM LV: %w", err)
+	}
+
 	// keep in sync with lvm.go,partition.go,luks.go
 	type alias LVMLogicalVolume
 	var withoutPayload struct {

--- a/pkg/disk/lvm_test.go
+++ b/pkg/disk/lvm_test.go
@@ -1,6 +1,8 @@
 package disk
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -76,4 +78,51 @@ func TestLVMLogicalVolumeEnsureSize(t *testing.T) {
 	resized := lv.EnsureSize(1024*1024 + 17)
 	assert.True(t, resized)
 	assert.Equal(t, uint64(4*datasizes.MiB), lv.Size)
+}
+
+func TestUnmarshalSizeUnitString(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected uint64
+		err      error
+	}{
+		{
+			name:     "valid size with unit",
+			input:    `{"size": "1 GiB"}`,
+			expected: 1 * datasizes.GiB,
+			err:      nil,
+		},
+		{
+			name:     "valid size without unit",
+			input:    `{"size": 1073741824}`,
+			expected: 1 * datasizes.GiB,
+			err:      nil,
+		},
+		{
+			name:     "valid size without unit as string",
+			input:    `{"size": "123"}`,
+			expected: 123,
+			err:      nil,
+		},
+		{
+			name:     "invalid size with unit",
+			input:    `{"size": "1 GGB"}`,
+			expected: 0,
+			err:      fmt.Errorf("error parsing size in LVM LV: failed to parse size field named \"size\" to bytes: unknown data size units in string: 1 GGB"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var lv LVMLogicalVolume
+			err := json.Unmarshal([]byte(tc.input), &lv)
+			if tc.err != nil {
+				assert.ErrorContains(t, err, tc.err.Error())
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, lv.Size)
+		})
+	}
 }

--- a/pkg/disk/partition.go
+++ b/pkg/disk/partition.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/datasizes"
 )
 
 type Partition struct {
@@ -126,6 +127,11 @@ func (p *Partition) MarshalJSON() ([]byte, error) {
 }
 
 func (p *Partition) UnmarshalJSON(data []byte) (err error) {
+	data, err = datasizes.ParseSizeInJSONMapping("size", data)
+	if err != nil {
+		return fmt.Errorf("error parsing size in partition: %w", err)
+	}
+
 	// keep in sync with lvm.go,partition.go,luks.go
 	type alias Partition
 	var withoutPayload struct {

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/datasizes"
@@ -26,7 +27,7 @@ type PartitionTable struct {
 	SectorSize uint64 `json:"sector_size,omitempty" yaml:"sector_size,omitempty"`
 	// Extra space at the end of the partition table (sectors)
 	ExtraPadding uint64 `json:"extra_padding,omitempty" yaml:"extra_padding,omitempty"`
-	// Starting offset of the first partition in the table (Mb)
+	// Starting offset of the first partition in the table (in bytes)
 	StartOffset uint64 `json:"start_offset,omitempty" yaml:"start_offset,omitempty"`
 }
 
@@ -170,6 +171,25 @@ func NewPartitionTable(basePT *PartitionTable, mountpoints []blueprint.Filesyste
 	newPT.GenerateUUIDs(rng)
 
 	return newPT, nil
+}
+
+func (pt *PartitionTable) UnmarshalJSON(data []byte) (err error) {
+	data, err = datasizes.ParseSizeInJSONMapping("start_offset", data)
+	if err != nil {
+		return fmt.Errorf("error parsing start_offset in partition table: %w", err)
+	}
+
+	type aliasStruct PartitionTable
+	var alias aliasStruct
+	if err := jsonUnmarshalStrict(data, &alias); err != nil {
+		return fmt.Errorf("cannot unmarshal %q: %w", data, err)
+	}
+	*pt = PartitionTable(alias)
+	return err
+}
+
+func (pt *PartitionTable) UnmarshalYAML(unmarshal func(any) error) error {
+	return common.UnmarshalYAMLviaJSON(pt, unmarshal)
 }
 
 func (pt *PartitionTable) Clone() Entity {

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -174,9 +174,11 @@ func NewPartitionTable(basePT *PartitionTable, mountpoints []blueprint.Filesyste
 }
 
 func (pt *PartitionTable) UnmarshalJSON(data []byte) (err error) {
-	data, err = datasizes.ParseSizeInJSONMapping("start_offset", data)
-	if err != nil {
-		return fmt.Errorf("error parsing start_offset in partition table: %w", err)
+	for _, field := range []string{"size", "start_offset"} {
+		data, err = datasizes.ParseSizeInJSONMapping(field, data)
+		if err != nil {
+			return fmt.Errorf("error parsing %q in partition table: %w", field, err)
+		}
 	}
 
 	type aliasStruct PartitionTable

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -2808,19 +2808,19 @@ func TestUnmarshalSizeUnitStringPartitionTable(t *testing.T) {
 	}{
 		{
 			name:     "valid size with unit",
-			input:    `{"start_offset": "1 GiB"}`,
+			input:    `{"start_offset": "1 GiB", "size": "1 GiB"}`,
 			expected: 1 * datasizes.GiB,
 			err:      nil,
 		},
 		{
 			name:     "valid size without unit",
-			input:    `{"start_offset": 1073741824}`,
+			input:    `{"start_offset": 1073741824, "size": 1073741824}`,
 			expected: 1 * datasizes.GiB,
 			err:      nil,
 		},
 		{
 			name:     "valid size without unit as string",
-			input:    `{"start_offset": "123"}`,
+			input:    `{"start_offset": "123", "size": "123"}`,
 			expected: 123,
 			err:      nil,
 		},
@@ -2828,7 +2828,13 @@ func TestUnmarshalSizeUnitStringPartitionTable(t *testing.T) {
 			name:     "invalid size with unit",
 			input:    `{"start_offset": "1 GGB"}`,
 			expected: 0,
-			err:      fmt.Errorf("error parsing start_offset in partition table: failed to parse size field named \"start_offset\" to bytes: unknown data size units in string: 1 GGB"),
+			err:      fmt.Errorf("error parsing \"start_offset\" in partition table: failed to parse size field named \"start_offset\" to bytes: unknown data size units in string: 1 GGB"),
+		},
+		{
+			name:     "invalid size with unit",
+			input:    `{"size": "1 GGB"}`,
+			expected: 0,
+			err:      fmt.Errorf("error parsing \"size\" in partition table: failed to parse size field named \"size\" to bytes: unknown data size units in string: 1 GGB"),
 		},
 	}
 
@@ -2842,6 +2848,7 @@ func TestUnmarshalSizeUnitStringPartitionTable(t *testing.T) {
 			}
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, pt.StartOffset)
+			assert.Equal(t, tc.expected, pt.Size)
 		})
 	}
 }

--- a/pkg/disk/partition_table_yaml_test.go
+++ b/pkg/disk/partition_table_yaml_test.go
@@ -53,7 +53,7 @@ partition_table:
         fstab_freq: 0
         fstab_passno: 2
     - &default_partition_table_part_root
-      size: 2_147_483_648  # 2 * datasizes.GibiByte,
+      size: "2 GiB"
       type: *filesystem_data_guid
       uuid: *root_partition_uuid
       payload_type: "filesystem"

--- a/pkg/disk/partition_table_yaml_test.go
+++ b/pkg/disk/partition_table_yaml_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 )
 
@@ -34,6 +35,7 @@ uuids:
 partition_table:
   uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
   type: "gpt"
+  start_offset: "8 MiB"
   partitions:
     - size: 1_048_576  # 1 MiB
       bootable: true
@@ -72,8 +74,9 @@ partition_table:
 	err := yaml.Unmarshal([]byte(inputYAML), &ptWrapper)
 	require.NoError(t, err)
 	expected := disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: disk.PT_GPT,
+		UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type:        disk.PT_GPT,
+		StartOffset: 8 * datasizes.MiB,
 		Partitions: []disk.Partition{
 			{
 				Start:    0,

--- a/pkg/disk/partition_test.go
+++ b/pkg/disk/partition_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/images/internal/testdisk"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 
 	"golang.org/x/tools/go/packages"
@@ -24,6 +25,53 @@ func TestMarshalUnmarshalSimple(t *testing.T) {
 	err = json.Unmarshal(js, &ptFromJS)
 	assert.NoError(t, err)
 	assert.Equal(t, fakePt, &ptFromJS)
+}
+
+func TestUnmarshalSizeUnitStringPartition(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected uint64
+		err      error
+	}{
+		{
+			name:     "valid size with unit",
+			input:    `{"size": "1 GiB"}`,
+			expected: 1 * datasizes.GiB,
+			err:      nil,
+		},
+		{
+			name:     "valid size without unit",
+			input:    `{"size": 1073741824}`,
+			expected: 1 * datasizes.GiB,
+			err:      nil,
+		},
+		{
+			name:     "valid size without unit as string",
+			input:    `{"size": "123"}`,
+			expected: 123,
+			err:      nil,
+		},
+		{
+			name:     "invalid size with unit",
+			input:    `{"size": "1 GGB"}`,
+			expected: 0,
+			err:      fmt.Errorf("error parsing size in partition: failed to parse size field named \"size\" to bytes: unknown data size units in string: 1 GGB"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var part disk.Partition
+			err := json.Unmarshal([]byte(tc.input), &part)
+			if tc.err != nil {
+				assert.ErrorContains(t, err, tc.err.Error())
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, part.Size)
+		})
+	}
 }
 
 func TestMarshalUnmarshalSad(t *testing.T) {

--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -246,12 +246,12 @@
     # the invidual partitions for easier composibility
     partitions:
       - &default_partition_table_part_bios
-        size: 1_048_576  # 1 MiB
+        size: "1 MiB"
         bootable: true
         type: *bios_boot_partition_guid
         uuid: *bios_boot_partition_uuid
       - &default_partition_table_part_efi
-        size: 209_715_200  # 200 MiB
+        size: "200 MiB"
         type: *efi_system_partition_guid
         uuid: *efi_system_partition_uuid
         payload_type: "filesystem"
@@ -264,7 +264,7 @@
           fstab_freq: 0
           fstab_passno: 2
       - &default_partition_table_part_boot
-        size: 1_073_741_824  # 1 * datasizes.GibiByte,
+        size: "1 GiB"
         type: *filesystem_data_guid
         uuid: *data_partition_uuid
         payload_type: "filesystem"
@@ -276,7 +276,7 @@
           fstab_freq: 0
           fstab_passno: 0
       - &default_partition_table_part_root
-        size: 2_147_483_648  # 2 * datasizes.GibiByte,
+        size: "2 GiB"
         type: *filesystem_data_guid
         uuid: *root_partition_uuid
         payload_type: "filesystem"
@@ -289,7 +289,7 @@
           fstab_passno: 0
       # iot partitions
       - &iot_base_partition_table_part_efi
-        size: 525_336_576  # 501 * datasizes.MebiByte
+        size: "501 MiB"
         type: *efi_system_partition_guid
         uuid: *efi_system_partition_uuid
         payload_type: "filesystem"
@@ -302,7 +302,7 @@
           fstab_freq: 0
           fstab_passno: 2
       - &iot_base_partition_table_part_boot
-        size: 1_073_741_824  # 1 * datasizes.GibiByte,
+        size: "1 GiB"
         type: *filesystem_data_guid
         uuid: *data_partition_uuid
         payload_type: "filesystem"
@@ -314,7 +314,7 @@
           fstab_freq: 1
           fstab_passno: 2
       - &iot_base_partition_table_part_root
-        size: 2_693_791_744  # 2569 * datasizes.MebiByte,
+        size: "2569 MiB"
         type: *filesystem_data_guid
         uuid: *root_partition_uuid
         payload_type: "filesystem"
@@ -371,11 +371,11 @@
         uuid: "0x14fc63d2"
         type: "dos"
         partitions:
-          - size: 4_194_304  # 4 MiB
+          - size: "4 MiB"
             bootable: true
             type: *prep_partition_dosid
           - &default_partition_table_part_boot_ppc64le
-            size: 1_073_741_824  # 1 * datasizes.GibiByte,
+            size: "1 GiB"
             payload_type: "filesystem"
             payload:
               type: "ext4"
@@ -385,7 +385,7 @@
               fstab_freq: 0
               fstab_passno: 0
           - &default_partition_table_part_root_ppc64le
-            size: 2_147_483_648  # 2 * datasizes.GibiByte,
+            size: "2 GiB"
             payload_type: "filesystem"
             payload:
               type: "ext4"
@@ -406,7 +406,7 @@
       x86_64:
         uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
         type: "gpt"
-        start_offset: 8_388_608  # 8 * datasizes.MebiByte
+        start_offset: "8 MiB"
         partitions:
           - *default_partition_table_part_efi
           - &minimal_raw_partition_table_part_boot
@@ -417,7 +417,7 @@
       aarch64: &minimal_raw_partition_table_aarch64
         uuid: "0xc1748067"
         type: "dos"
-        start_offset: 8_388_608  # 8 * datasizes.MebiByte
+        start_offset: "8 MiB"
         partitions:
           - <<: *default_partition_table_part_efi
             bootable: true
@@ -435,7 +435,7 @@
       x86_64: &iot_base_partition_table_x86_64
         uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
         type: "gpt"
-        start_offset: 8_388_608  # 8 * datasizes.MebiByte
+        start_offset: "8 MiB"
         partitions:
           - *iot_base_partition_table_part_efi
           - *iot_base_partition_table_part_boot
@@ -443,7 +443,7 @@
       aarch64: &iot_base_partition_table_aarch64
         uuid: "0xc1748067"
         type: "dos"
-        start_offset: 8_388_608  # 8 * datasizes.MebiByte
+        start_offset: "8 MiB"
         partitions:
           - *iot_base_partition_table_part_efi_aarch64
           - *iot_base_partition_table_part_boot_aarch64
@@ -455,7 +455,7 @@
         type: "gpt"
         partitions:
           - *iot_base_partition_table_part_efi
-          - size: 1_073_741_824  # 1 * datasizes.GibiByte,
+          - size: "1 GiB"
             type: *xboot_ldr_partition_guid
             uuid: *data_partition_uuid
             payload_type: "filesystem"
@@ -486,7 +486,7 @@
                 name: "rootvg"
                 description: "built with lvm2 and osbuild"
                 logical_volumes:
-                  - size: 8_589_934_592  # 8 * datasizes.GibiByte,
+                  - size: "8 GiB"
                     name: "rootlv"
                     payload_type: "filesystem"
                     payload:

--- a/pkg/distro/defs/rhel-10/distro.yaml
+++ b/pkg/distro/defs/rhel-10/distro.yaml
@@ -242,12 +242,12 @@
         uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
         type: "gpt"
         partitions:
-          - size: 1_048_576  # 1 MiB
+          - size: "1 MiB"
             bootable: true
             type: *bios_boot_partition_guid
             uuid: *bios_boot_partition_uuid
           - &default_partition_table_part_efi
-            size: 209_715_200  # 200 MiB
+            size: "200 MiB"
             type: *efi_system_partition_guid
             uuid: *efi_system_partition_uuid
             payload_type: "filesystem"
@@ -260,7 +260,7 @@
               fstab_freq: 0
               fstab_passno: 2
           - &default_partition_table_part_root
-            size: 2_147_483_648  # 2 * datasizes.GibiByte,
+            size: "2 GiB"
             type: *filesystem_data_guid
             uuid: *root_partition_uuid
             payload_type: "filesystem"
@@ -281,11 +281,11 @@
         uuid: "0x14fc63d2"
         type: "dos"
         partitions:
-          - size: 4_194_304  # 4 MiB
+          - size: "4 MiB"
             bootable: true
             type: *prep_partition_dosid
           - &default_partition_table_part_root_ppc64le
-            size: 2_147_483_648  # 2 * datasizes.GibiByte,
+            size: "2 GiB"
             payload_type: "filesystem"
             payload:
               <<: *default_partition_table_part_root_payload
@@ -746,10 +746,10 @@ image_types:
       x86_64:
         uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
         type: "gpt"
-        size: 68_719_476_736  # 64 * datasizes.GibiByte
+        size: "64 GiB"
         partitions:
           - &azure_rhui_part_boot_efi
-            size: 524_288_000   # 500 * datasizes.MebiByte
+            size: "500 MiB"
             type: *efi_system_partition_guid
             UUID: *efi_system_partition_uuid
             payload_type: "filesystem"
@@ -762,7 +762,7 @@ image_types:
               fstab_passno: 2
           # NB: we currently don't support /boot on LVM
           - &azure_rhui_part_boot
-            size: 1_073_741_824   # 1 * datasizes.GibiByte
+            size: "1 GiB"
             type: *filesystem_data_guid
             uuid: *data_partition_uuid
             payload_type: "filesystem"
@@ -772,7 +772,7 @@ image_types:
               fstab_options: "defaults"
               fstab_freq: 0
               fstab_passno: 0
-          - size: 2_097_152  # 2 * datasizes.MebiByte
+          - size: "2 MiB"
             bootable: true
             type: *bios_boot_partition_guid
             uuid: *bios_boot_partition_uuid
@@ -784,7 +784,7 @@ image_types:
               name: "rootvg"
               description: "built with lvm2 and osbuild"
               logical_volumes:
-                - size: 1_073_741_824  # 1 * datasizes.GibiByte
+                - size: "1 GiB"
                   name: "homelv"
                   payload_type: "filesystem"
                   payload:
@@ -792,7 +792,7 @@ image_types:
                     label: "home"
                     mountpoint: "/home"
                     fstab_options: "defaults"
-                - size: 2_147_483_648  # 2 * datasizes.GibiByte
+                - size: "2 GiB"
                   name: "rootlv"
                   payload_type: "filesystem"
                   payload:
@@ -800,7 +800,7 @@ image_types:
                     label: "root"
                     mountpoint: "/"
                     fstab_options: "defaults"
-                - size: 2_147_483_648  # 2 * datasizes.GibiByte
+                - size: "2 GiB"
                   name: "tmplv"
                   payload_type: "filesystem"
                   payload:
@@ -808,7 +808,7 @@ image_types:
                     label: "tmp"
                     mountpoint: "/tmp"
                     fstab_options: "defaults"
-                - size: 10_737_418_240  # 10 * datasizes.GibiByte
+                - size: "10 GiB"
                   name: "usrlv"
                   payload_type: "filesystem"
                   payload:
@@ -816,7 +816,7 @@ image_types:
                     label: "usr"
                     mountpoint: "/usr"
                     fstab_options: "defaults"
-                - size: 10_737_418_240  # 10 * datasizes.GibiByte
+                - size: "10 GiB"
                   name: "varlv"
                   payload_type: "filesystem"
                   payload:
@@ -827,7 +827,7 @@ image_types:
       aarch64:
         uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
         type: "gpt"
-        size: 68_719_476_736  # 64 * datasizes.GibiByte
+        size: "64 GiB"
         partitions:
           - *azure_rhui_part_boot_efi
           # NB: we currently don't support /boot on LVM

--- a/pkg/distro/defs/rhel-7/distro.yaml
+++ b/pkg/distro/defs/rhel-7/distro.yaml
@@ -72,12 +72,12 @@
         uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
         type: "gpt"
         partitions:
-          - size: 1_048_576  # 1 MiB
+          - size: "1 MiB"
             bootable: true
             type: *bios_boot_partition_guid
             uuid: *bios_boot_partition_uuid
           - &default_partition_table_part_efi
-            size: 209_715_200  # 200 MiB
+            size: "200 MiB"
             type: *efi_system_partition_guid
             uuid: *efi_system_partition_uuid
             payload_type: "filesystem"
@@ -90,7 +90,7 @@
               fstab_freq: 0
               fstab_passno: 2
           - &default_partition_table_part_boot
-            size: 524_288_000  # 500 * MiB
+            size: "500 MiB"
             type: *filesystem_data_guid
             uuid: *data_partition_uuid
             payload_type: "filesystem"
@@ -102,7 +102,7 @@
               fstab_freq: 0
               fstab_passno: 0
           - &default_partition_table_part_root
-            size: 2_147_483_648  # 2 * datasizes.GibiByte,
+            size: "2 GiB"
             type: *filesystem_data_guid
             uuid: *root_partition_uuid
             payload_type: "filesystem"

--- a/pkg/distro/defs/rhel-8/distro.yaml
+++ b/pkg/distro/defs/rhel-8/distro.yaml
@@ -555,12 +555,12 @@
 
     partitions:
       - &default_partition_table_part_bios
-        size: 1_048_576  # 1 MiB
+        size: "1 MiB"
         bootable: true
         type: *bios_boot_partition_guid
         uuid: *bios_boot_partition_uuid
       - &default_partition_table_part_efi
-        size: 104_857_600  # 100 MiB
+        size: "100 MiB"
         type: *efi_system_partition_guid
         uuid: *efi_system_partition_uuid
         payload_type: "filesystem"
@@ -573,7 +573,7 @@
           fstab_freq: 0
           fstab_passno: 2
       - &default_partition_table_part_root
-        size: 2_147_483_648  # 2 * datasizes.GibiByte,
+        size: "2 GiB"
         type: *filesystem_data_guid
         uuid: *root_partition_uuid
         payload_type: "filesystem"
@@ -586,7 +586,7 @@
           fstab_passno: 0
       # ec2
       - &ec2_partition_table_part_boot
-        size: 1_073_741_824  # 1 GiB
+        size: "1 GiB"
         type: *filesystem_data_guid
         uuid: *data_partition_uuid
         payload_type: "filesystem"
@@ -598,7 +598,7 @@
           fstab_passno: 0
       - &ec2_partition_table_part_boot512
         <<: *ec2_partition_table_part_boot
-        size: 536_870_912  # 512MiB
+        size: "512 MiB"
 
     default_partition_tables: &default_partition_tables
       x86_64:
@@ -618,11 +618,11 @@
         uuid: "0x14fc63d2"
         type: "dos"
         partitions:
-          - size: 4_194_304  # 4 MiB
+          - size: "4 MiB"
             bootable: true
             type: *prep_partition_dosid
           - &default_partition_table_part_root_ppc64le
-            size: 2_147_483_648  # 2 * datasizes.GibiByte,
+            size: "2 GiB"
             payload_type: "filesystem"
             payload:
               <<: *default_partition_table_part_root_payload
@@ -641,7 +641,7 @@
         partitions:
           - *default_partition_table_part_bios
           - &edge_base_partition_table_part_efi
-            size: 133_169_152  # 127 MiB
+            size: "127 MiB"
             type: *efi_system_partition_guid
             uuid: *efi_system_partition_uuid
             payload_type: "filesystem"
@@ -654,7 +654,7 @@
               fstab_freq: 0
               fstab_passno: 2
           - &edge_base_partition_table_part_boot
-            size: 402_653_184  # 384 * MiB
+            size: "384 MiB"
             type: *filesystem_data_guid
             uuid: *data_partition_uuid
             payload_type: "filesystem"
@@ -666,7 +666,7 @@
               fstab_freq: 1
               fstab_passno: 1
           - &edge_base_partition_table_part_root
-            size: 2_147_483_648  # 2 * datasizes.GibiByte,
+            size: "2 GiB"
             type: *filesystem_data_guid
             uuid: *root_partition_uuid
             payload_type: "luks"
@@ -707,7 +707,7 @@
         partitions:
           - *default_partition_table_part_bios
           - &ec2_partition_table_part_efi
-            size: 209_715_200  # 200 MiB
+            size: "200 MiB"
             type: *efi_system_partition_guid
             uuid: *efi_system_partition_uuid
             payload_type: "filesystem"
@@ -720,7 +720,7 @@
               fstab_freq: 0
               fstab_passno: 2
           - &ec2_partition_table_part_root
-            size: 2_147_483_648  # 2 * datasizes.GibiByte,
+            size: "2 GiB"
             type: *filesystem_data_guid
             uuid: *root_partition_uuid
             payload_type: "filesystem"

--- a/pkg/distro/defs/rhel-9/distro.yaml
+++ b/pkg/distro/defs/rhel-9/distro.yaml
@@ -391,12 +391,12 @@
 
     partitions:
       - &default_partition_table_part_bios
-        size: 1_048_576  # 1 MiB
+        size: "1 MiB"
         bootable: true
         type: *bios_boot_partition_guid
         uuid: *bios_boot_partition_uuid
       - &default_partition_table_part_efi
-        size: 209_715_200  # 200 MiB
+        size: "200 MiB"
         type: *efi_system_partition_guid
         uuid: *efi_system_partition_uuid
         payload_type: "filesystem"
@@ -409,7 +409,7 @@
           fstab_freq: 0
           fstab_passno: 2
       - &default_partition_table_part_boot
-        size: 1_073_741_824  # 1 GiB
+        size: "1 GiB"
         type: *xboot_ldr_partition_guid
         uuid: *data_partition_uuid
         payload_type: "filesystem"
@@ -421,7 +421,7 @@
           fstab_freq: 0
           fstab_passno: 0
       - &default_partition_table_part_root
-        size: 2_147_483_648  # 2 * datasizes.GibiByte,
+        size: "2 GiB"
         type: *filesystem_data_guid
         uuid: *root_partition_uuid
         payload_type: "filesystem"
@@ -434,22 +434,22 @@
           fstab_passno: 0
       # ppc64
       - &default_partition_table_part_bios_ppc64le
-        size: 4_194_304  # 4 MiB
+        size: "4 MiB"
         bootable: true
         type: *prep_partition_dosid
       - &default_partition_table_part_boot_ppc64le
-        size: 1_073_741_824  # 1 GiB
+        size: "1 GiB"
         payload_type: "filesystem"
         payload:
           <<: *default_partition_table_part_boot_payload
       - &default_partition_table_part_boot512_ppc64le
         <<: *default_partition_table_part_boot_ppc64le
-        size: 524_288_000  # 500 MiB
+        size: "500 MiB"
       - &default_partition_table_part_boot600_ppc64le
         <<: *default_partition_table_part_boot_ppc64le
-        size: 629_145_600  # 600 MiB
+        size: "600 MiB"
       - &default_partition_table_part_root_ppc64le
-        size: 2_147_483_648  # 2 * datasizes.GibiByte,
+        size: "2 GiB"
         payload_type: "filesystem"
         payload:
           <<: *default_partition_table_part_root_payload


### PR DESCRIPTION
With the move of image definitions to YAML, we lost the ability to use units to define various byte-sized properties of partitioning. This PR adds a helper function `datasizes.ParseSizeInJSONMapping()` for parsing strings with units and converting them to bytes in JSON objects. The helper function is then used in a struct-specific custom unmarshaler.

I've also adjusted the existing distro definitions in YAML to use strings with units, instead of integers.

Notes:

- I acknowledge that the `ParseSizeInJSONMapping()` function can be extended to process multiple byte-sized fields in the same JSON object, instead of calling it multiple times. I'd address this in a follow-up that should happen after the YAMLification converges (see other points).
- There are additional byte-sized fields in the image definitions, specifically in the "image type". I deliberately left them out of this PR to avoid creating conflicts with @mvo5 PRs such as https://github.com/osbuild/images/pull/1563. The reason is that the data structures defined for distro defs do not have JSON tags defined and do not use strict unmarshalling for YAML via JSON.