### PR TITLE
distro: create new ImageConfig.DNFConfig

### DIFF
--- a/pkg/distro/defs/rhel-10/distro.yaml
+++ b/pkg/distro/defs/rhel-10/distro.yaml
@@ -86,7 +86,8 @@
             value: "4194304"
           - key: "vm.max_map_count"
             value: "2147483647"
-    dnf_set_release_ver_var: true
+    dnf_config:
+      set_release_ver_var: true
 
   sap_pkgset: &sap_pkgset
     include:
@@ -1287,9 +1288,10 @@ image_types:
       keyboard:
         keymap: "us"
       dnf_config:
-        - config:
-            main:
-              ipresolve: "4"
+        options:
+          - config:
+              main:
+                ipresolve: "4"
       dnf_automatic_config:
         config:
           commands:

--- a/pkg/distro/image_config_test.go
+++ b/pkg/distro/image_config_test.go
@@ -172,25 +172,29 @@ func TestImageConfigDNFSetReleaseVerNotSet(t *testing.T) {
 	cnf := &ImageConfig{}
 	assert.Equal(t, expected, cnf.DNFConfigOptions("9-stream"))
 
-	cnf.DNFSetReleaseVerVar = common.ToPtr(false)
+	cnf.DNFConfig = &DNFConfig{
+		SetReleaseVerVar: common.ToPtr(false),
+	}
 	assert.Equal(t, expected, cnf.DNFConfigOptions("9-stream"))
 }
 
 func TestImageConfigDNFConfigOptionsPreExisting(t *testing.T) {
 	cnf := &ImageConfig{
-		DNFConfig: []*osbuild.DNFConfigStageOptions{
-			{
-				Config: &osbuild.DNFConfig{
-					Main: &osbuild.DNFConfigMain{
-						IPResolve: "4",
+		DNFConfig: &DNFConfig{
+			Options: []*osbuild.DNFConfigStageOptions{
+				{
+					Config: &osbuild.DNFConfig{
+						Main: &osbuild.DNFConfigMain{
+							IPResolve: "4",
+						},
 					},
 				},
 			},
 		},
 	}
-	assert.Equal(t, cnf.DNFConfig, cnf.DNFConfigOptions("9-stream"))
+	assert.Equal(t, cnf.DNFConfig.Options, cnf.DNFConfigOptions("9-stream"))
 
-	cnf.DNFSetReleaseVerVar = common.ToPtr(true)
+	cnf.DNFConfig.SetReleaseVerVar = common.ToPtr(true)
 	assert.PanicsWithError(t, "internal error: currently DNFConfig and DNFSetReleaseVerVar cannot be used together, please reporting this as a feature request", func() {
 		cnf.DNFConfigOptions("9-stream")
 	})

--- a/pkg/distro/rhel/rhel8/gce.go
+++ b/pkg/distro/rhel/rhel8/gce.go
@@ -76,11 +76,13 @@ func defaultGceByosImageConfig(rd distro.Distro) *distro.ImageConfig {
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",
 		},
-		DNFConfig: []*osbuild.DNFConfigStageOptions{
-			{
-				Config: &osbuild.DNFConfig{
-					Main: &osbuild.DNFConfigMain{
-						IPResolve: "4",
+		DNFConfig: &distro.DNFConfig{
+			Options: []*osbuild.DNFConfigStageOptions{
+				{
+					Config: &osbuild.DNFConfig{
+						Main: &osbuild.DNFConfigMain{
+							IPResolve: "4",
+						},
 					},
 				},
 			},

--- a/pkg/distro/rhel/rhel8/sap.go
+++ b/pkg/distro/rhel/rhel8/sap.go
@@ -107,7 +107,10 @@ func sapImageConfig(rd distro.Distro) *distro.ImageConfig {
 
 	if common.VersionLessThan(rd.OsVersion(), "8.10") {
 		// E4S/EUS
-		ic.DNFSetReleaseVerVar = common.ToPtr(true)
+		if ic.DNFConfig == nil {
+			ic.DNFConfig = &distro.DNFConfig{}
+		}
+		ic.DNFConfig.SetReleaseVerVar = common.ToPtr(true)
 	}
 
 	return ic

--- a/pkg/distro/rhel/rhel9/gce.go
+++ b/pkg/distro/rhel/rhel9/gce.go
@@ -60,11 +60,13 @@ func baseGCEImageConfig() *distro.ImageConfig {
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",
 		},
-		DNFConfig: []*osbuild.DNFConfigStageOptions{
-			{
-				Config: &osbuild.DNFConfig{
-					Main: &osbuild.DNFConfigMain{
-						IPResolve: "4",
+		DNFConfig: &distro.DNFConfig{
+			Options: []*osbuild.DNFConfigStageOptions{
+				{
+					Config: &osbuild.DNFConfig{
+						Main: &osbuild.DNFConfigMain{
+							IPResolve: "4",
+						},
 					},
 				},
 			},

--- a/pkg/distro/rhel/rhel9/sap.go
+++ b/pkg/distro/rhel/rhel9/sap.go
@@ -104,6 +104,8 @@ func sapImageConfig(osVersion string) *distro.ImageConfig {
 			),
 		},
 		// E4S/EUS
-		DNFSetReleaseVerVar: common.ToPtr(true),
+		DNFConfig: &distro.DNFConfig{
+			SetReleaseVerVar: common.ToPtr(true),
+		},
 	}
 }


### PR DESCRIPTION
This commit creates a new 'ImageConfig.DNFConfig` struct that contains the `Options` and the `SetReleaseVerVar` options in a single struct.

This is a followup for
https://github.com/osbuild/images/pull/1465#discussion_r2063811785

Thanks to Tomáš for the suggestion.