### PR TITLE
rhel8: move imageconfig into YAML

### DIFF
--- a/internal/common/distro.go
+++ b/internal/common/distro.go
@@ -30,3 +30,16 @@ func VersionLessThan(a, b string) bool {
 func VersionGreaterThanOrEqual(a, b string) bool {
 	return !VersionLessThan(a, b)
 }
+
+func VersionEqual(a, b string) bool {
+	aV, err := version.NewVersion(a)
+	if err != nil {
+		panic(err)
+	}
+	bV, err := version.NewVersion(b)
+	if err != nil {
+		panic(err)
+	}
+
+	return aV.Equal(bV)
+}

--- a/pkg/customizations/subscription/subscription.go
+++ b/pkg/customizations/subscription/subscription.go
@@ -30,13 +30,13 @@ const (
 
 // Subscription Manager [rhsm] configuration
 type SubManRHSMConfig struct {
-	ManageRepos          *bool
+	ManageRepos          *bool `yaml:"manage_repos"`
 	AutoEnableYumPlugins *bool
 }
 
 // Subscription Manager [rhsmcertd] configuration
 type SubManRHSMCertdConfig struct {
-	AutoRegistration *bool
+	AutoRegistration *bool `yaml:"auto_registration"`
 }
 
 // Subscription Manager 'rhsm.conf' configuration
@@ -56,7 +56,7 @@ type SubManDNFPluginsConfig struct {
 
 type RHSMConfig struct {
 	DnfPlugins SubManDNFPluginsConfig `yaml:"dnf_plugin,omitempty"`
-	YumPlugins SubManDNFPluginsConfig
+	YumPlugins SubManDNFPluginsConfig `yaml:"yum_plugin"`
 	SubMan     SubManConfig
 }
 

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -266,6 +266,7 @@ type conditionsImgConf struct {
 	Architecture    map[string]*distro.ImageConfig `yaml:"architecture,omitempty"`
 	DistroName      map[string]*distro.ImageConfig `yaml:"distro_name,omitempty"`
 	VersionLessThan map[string]*distro.ImageConfig `yaml:"version_less_than,omitempty"`
+	VersionEqual    map[string]*distro.ImageConfig `yaml:"version_equal,omitempty"`
 }
 
 type installerConfig struct {
@@ -629,6 +630,12 @@ func ImageConfig(distroNameVer, archName, typeName string) (*distro.ImageConfig,
 			ltOverrides := cond.VersionLessThan[ltVer]
 			if common.VersionLessThan(id.VersionString(), ltVer) {
 				imgConfig = ltOverrides.InheritFrom(imgConfig)
+			}
+		}
+		for _, eqVer := range versionLessThanSortedKeys(cond.VersionEqual) {
+			eqOverrides := cond.VersionEqual[eqVer]
+			if common.VersionEqual(id.VersionString(), eqVer) {
+				imgConfig = eqOverrides.InheritFrom(imgConfig)
 			}
 		}
 	}

--- a/pkg/distro/defs/rhel-8/distro.yaml
+++ b/pkg/distro/defs/rhel-8/distro.yaml
@@ -138,6 +138,218 @@
             # actually added so we don't add it here either
             # - "rhc"
 
+  # Default AMI (custom image built by users) images config.
+  # The configuration does not touch the RHSM configuration at all.
+  # https://issues.redhat.com/browse/COMPOSER-2157
+  ami_image_config: &ami_image_config
+    timezone: "UTC"
+    time_synchronization:
+      servers:
+        - hostname: "169.254.169.123"
+          prefer: true
+          iburst: true
+          minpoll: 4
+          maxpoll: 4
+      # empty string will remove any occurrences of the option
+      # from the configuration
+      leapsectz: ""
+    keyboard:
+      keymap: "us"
+      "x11-keymap":
+        layouts: ["us"]
+    enabled_services:
+      - "sshd"
+      - "NetworkManager"
+      - "nm-cloud-setup.service"
+      - "nm-cloud-setup.timer"
+      - "cloud-init"
+      - "cloud-init-local"
+      - "cloud-config"
+      - "cloud-final"
+      - "reboot.target"
+    default_target: "multi-user.target"
+    update_default_kernel: true
+    default_kernel: "kernel"
+    sysconfig:
+      networking: true
+      no_zero_conf: true
+      create_default_network_scripts: true
+    dracut_conf:
+      - &sgdisk_dracut_conf
+        filename: "sgdisk.conf"
+        config:
+          install: ["sgdisk"]
+    systemd_logind:
+      - filename: "00-getty-fixes.conf"
+        config:
+          login:
+            nautovts: 0
+    cloud_init:
+      - filename: "00-rhel-default-user.cfg"
+        config:
+          system_info:
+            default_user:
+              name: "ec2-user"
+    modprobe:
+      - filename: "blacklist-nouveau.conf"
+        commands:
+          - command: blacklist
+            modulename: "nouveau"
+      - filename: "blacklist-amdgpu.conf"
+        commands:
+          - command: blacklist
+            modulename: "amdgpu"
+    systemd_dropin:
+      # RHBZ#1822863
+      - unit: "nm-cloud-setup.service"
+        dropin: "10-rh-enable-for-ec2.conf"
+        config:
+          service:
+            environment:
+              - key: "NM_CLOUD_SETUP_EC2"
+                value: "yes"
+    authselect:
+      profile: "sssd"
+    sshd_config:
+      config:
+        PasswordAuthentication: false
+    condition: &ami_image_config_condition
+      architecture:
+        x86_64: &ami_image_config_cond_x86_64
+          dracut_conf:
+            - *sgdisk_dracut_conf
+            - filename: "ec2.conf"
+              config:
+                add_drivers:
+                  - "nvme"
+                  - "xen-blkfront"
+          # TODO: move these to the EC2 environment?
+          kernel_options:
+            - "console=tty0"
+            - "console=ttyS0,115200n8"
+            - "net.ifnames=0"
+            - "rd.blacklist=nouveau"
+            - "nvme_core.io_timeout=4294967295"
+            - "crashkernel=auto"
+        aarch64:
+          # TODO: move these to the EC2 environment?
+          kernel_options:
+            # XXX: duplicated with above x86_64 kernel defaults
+            - "console=tty0"
+            - "console=ttyS0,115200n8"
+            - "net.ifnames=0"
+            - "rd.blacklist=nouveau"
+            - "nvme_core.io_timeout=4294967295"
+            # this is the only difference
+            - "iommu.strict=0"
+            # same again
+            - "crashkernel=auto"
+
+  ec2_image_config: &ec2_image_config
+    <<: *ami_image_config
+    condition: &ec2_image_config_condition
+      <<: *ami_image_config_condition
+      version_less_than: &ec2_image_config_cond_version_lt
+        # The RHSM configuration should not be applied since 8.7, but it is instead done by installing the
+        # redhat-cloud-client-configuration package. See COMPOSER-1804 for more information.
+        "8.7":
+          rhsm_config:
+            "no-subscription":
+              # RHBZ#1932802
+              subman:
+                rhsmcertd:
+                  # RHBZ#1932802
+                  auto_registration: true
+                  # Don't disable RHSM redhat.repo management on the AMI
+                  # image, which is BYOS and does not use RHUI for content.
+                  # Otherwise subscribing the system manually after booting
+                  # it would result in empty redhat.repo. Without RHUI, such
+                  # system would have no way to get Red Hat content, but
+                  # enable the repo management manually, which would be very
+                  # confusing.
+                  #
+                  # XXX: the above is the orginal comment from the go code,
+                  # however at a different place it will do the setting below
+                  # which seem to contradict the previous comment.
+                rhsm:
+                  # Disable RHSM redhat.repo management
+                  manage_repos: false
+            "with-subscription":
+              # RHBZ#1932802
+              subman:
+                rhsmcertd:
+                  auto_registration: true
+                  # do not disable the redhat.repo management if the user
+                  # explicitly request the system to be subscribed
+
+  sap_image_config: &sap_image_config
+    selinux_config:
+      state: "permissive"
+    tuned:
+      profiles: ["sap-hana"]
+    # RHBZ#1959979
+    tmpfilesd:
+      - filename: "sap.conf"
+        config:
+          - type: "x"
+            path: "/tmp/.sap*"
+          - type: "x"
+            path: "/tmp/.hdb*lock"
+          - type: "x"
+            path: "/tmp/.trex*lock"
+    # RHBZ#1959963
+    pam_limits_conf:
+      - filename: "99-sap.conf"
+        config:
+          - domain: "@sapsys"
+            type: "hard"
+            item: "nofile"
+            value: 1048576
+          - domain: "@sapsys"
+            type: "soft"
+            item: "nofile"
+            value: 1048576
+          - domain: "@dba"
+            type: "hard"
+            item: "nofile"
+            value: 1048576
+          - domain: "@dba"
+            type: "soft"
+            item: "nofile"
+            value: 1048576
+          - domain: "@sapsys"
+            type: "hard"
+            item: "nproc"
+            value: "unlimited"
+          - domain: "@sapsys"
+            type: "soft"
+            item: "nproc"
+            value: "unlimited"
+          - domain: "@dba"
+            type: "hard"
+            item: "nproc"
+            value: "unlimited"
+          - domain: "@dba"
+            type: "soft"
+            item: "nproc"
+            value: "unlimited"
+    # RHBZ#1959962
+    sysctld:
+      - filename: "sap.conf"
+        config:
+          - key: "kernel.pid_max"
+            value: "4194304"
+          - key: "vm.max_map_count"
+            value: "2147483647"
+    dnf_config:
+      set_release_ver_var: false
+    condition: &sap_image_config_cond
+      version_less_than: &sap_image_config_cond_version_lt
+        "8.10":
+          dnf_config:
+            # E4S/EUS
+            set_release_ver_var: true
+
   sap_pkgset: &sap_pkgset
     include:
       # RHBZ#2074107
@@ -540,6 +752,7 @@
       - &efi_system_partition_guid "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
       - &filesystem_data_guid "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
       - &xboot_ldr_partition_guid "BC13C2FF-59E6-4262-A352-B275FD6F7172"
+      - &lvm_partition_guid "E6D6D379-F507-44C2-A23C-238F2A3DF928"
     # static UUIDs for partitions and filesystems
     # NOTE(akoutsou): These are unnecessary and have stuck around since the
     # beginning where (I believe) the goal was to have predictable,
@@ -764,6 +977,96 @@
             <<: *ec2_partition_table_x86_64
           aarch64:
             <<: *ec2_partition_table_aarch64
+  azure_rhui_partition_tables: &azure_rhui_partition_tables
+    x86_64:
+      uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
+      type: "gpt"
+      size: 68_719_476_736  # 64 * datasizes.GibiByte
+      partitions:
+        - &azure_rhui_part_boot_efi
+          size: 524_288_000   # 500 * datasizes.MebiByte
+          type: *efi_system_partition_guid
+          UUID: *efi_system_partition_uuid
+          payload_type: "filesystem"
+          payload:
+            type: "vfat"
+            uuid: *efi_filesystem_uuid
+            mountpoint: "/boot/efi"
+            fstab_options: "defaults,uid=0,gid=0,umask=077,shortname=winnt"
+            fstab_freq: 0
+            fstab_passno: 2
+        - &azure_rhui_part_boot
+          size: 524_288_000   # 500 * datasizes.MebiByte
+          type: *filesystem_data_guid
+          uuid: *data_partition_uuid
+          payload_type: "filesystem"
+          payload:
+            type: "xfs"
+            mountpoint: "/boot"
+            fstab_options: "defaults"
+            fstab_freq: 0
+            fstab_passno: 0
+        - size: 2_097_152  # 2 * datasizes.MebiByte
+          bootable: true
+          type: *bios_boot_partition_guid
+          uuid: *bios_boot_partition_uuid
+        - &azure_rhui_part_lvm
+          type: *lvm_partition_guid
+          uuid: *root_partition_uuid
+          payload_type: "lvm"
+          payload:
+            name: "rootvg"
+            description: "built with lvm2 and osbuild"
+            logical_volumes:
+              - size: 1_073_741_824  # 1 * datasizes.GibiByte
+                name: "homelv"
+                payload_type: "filesystem"
+                payload:
+                  type: "xfs"
+                  label: "home"
+                  mountpoint: "/home"
+                  fstab_options: "defaults"
+              - size: 2_147_483_648  # 2 * datasizes.GibiByte
+                name: "rootlv"
+                payload_type: "filesystem"
+                payload:
+                  type: "xfs"
+                  label: "root"
+                  mountpoint: "/"
+                  fstab_options: "defaults"
+              - size: 2_147_483_648  # 2 * datasizes.GibiByte
+                name: "tmplv"
+                payload_type: "filesystem"
+                payload:
+                  type: "xfs"
+                  label: "tmp"
+                  mountpoint: "/tmp"
+                  fstab_options: "defaults"
+              - size: 10_737_418_240  # 10 * datasizes.GibiByte
+                name: "usrlv"
+                payload_type: "filesystem"
+                payload:
+                  type: "xfs"
+                  label: "usr"
+                  mountpoint: "/usr"
+                  fstab_options: "defaults"
+              - size: 10_737_418_240  # 10 * datasizes.GibiByte
+                name: "varlv"
+                payload_type: "filesystem"
+                payload:
+                  type: "xfs"
+                  label: "var"
+                  mountpoint: "/var"
+                  fstab_options: "defaults"
+    aarch64:
+      uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
+      type: "gpt"
+      size: 68_719_476_736  # 64 * datasizes.GibiByte
+      partitions:
+        - *azure_rhui_part_boot_efi
+        # NB: we currently don't support /boot on LVM
+        - *azure_rhui_part_boot
+        - *azure_rhui_part_lvm
 
 image_config:
   default:
@@ -839,11 +1142,20 @@ image_types:
                   - "insights-client"
                   - "subscription-manager-cockpit"
 
-  ec2: &ec2
+  ami: &ami
+    package_sets:
+      os:
+        - *ec2_common_pkgset
     partition_table:
       <<: *ec2_partition_tables
     partition_tables_override:
       <<: *ec2_partition_tables_override
+    image_config: *ami_image_config
+
+  ec2: &ec2
+    <<: *ami
+    image_config:
+      <<: *ec2_image_config
     package_sets:
       os:
         - *ec2_common_pkgset
@@ -875,14 +1187,33 @@ image_types:
                 include:
                   - "redhat-cloud-client-configuration"
 
-  ami:
-    <<: *ec2
-    package_sets:
-      os:
-        - *ec2_common_pkgset
-
   "ec2-sap":
     <<: *ec2
+    # XXX: this is ugly, YAML only supports shallow merging of maps so
+    # we we want to merge e.g. the version conditions that sap and ec2
+    # have we need to manually "unroll" it. we need to think of a better
+    # way here.
+    image_config:
+      <<: [*ec2_image_config, *sap_image_config]
+      condition:
+        <<: [*ec2_image_config_condition, *sap_image_config_cond]
+        version_less_than:
+          <<: [*ec2_image_config_cond_version_lt, *sap_image_config_cond_version_lt]
+        architecture:
+          x86_64:
+            <<: *ami_image_config_cond_x86_64
+            kernel_options:
+              # amiSapKernelOptions()
+              # common AMI kernel options
+              - "console=tty0"
+              - "console=ttyS0,115200n8"
+              - "net.ifnames=0"
+              - "rd.blacklist=nouveau"
+              - "nvme_core.io_timeout=4294967295"
+              - "crashkernel=auto"
+              # SAP specific for ami
+              - "processor.max_cstate=1"
+              - "intel_idle.max_cstate=1"
     package_sets:
       os:
         - *ec2_common_pkgset
@@ -900,7 +1231,198 @@ image_types:
                 include:
                   - "redhat-cloud-client-configuration"
 
-  "azure-rhui":
+  qcow2: &qcow2
+    image_config:
+      default_target: "multi-user.target"
+      kernel_options:
+        - "console=tty0"
+        - "console=ttyS0,115200n8"
+        - "no_timer_check"
+        - "net.ifnames=0"
+        - "crashkernel=auto"
+      condition:
+        distro_name:
+          rhel:
+            rhsm_config:
+              "no-subscription":
+                dnf_plugin:
+                  product_id:
+                    enabled: false
+                  subscription_manager:
+                    enabled: false
+    partition_table:
+      <<: *default_partition_tables
+    package_sets: &qcow2_pkgset
+      os:
+        - *qcow2_common_pkgset
+
+  vhd:
+    # yamllint disable rule:line-length
+    # based on https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deploying_rhel_8_on_microsoft_azure/assembly_deploying-a-rhel-image-as-a-virtual-machine-on-microsoft-azure_cloud-content-azure#making-configuration-changes_configure-the-image-azure
+    # yamllint enable rule:line-length
+    image_config: &vhd_image_config
+      timezone: "Etc/UTC"
+      locale: "en_US.UTF-8"
+      keyboard:
+        keymap: "us"
+        "x11-keymap":
+          layouts: ["us"]
+      update_default_kernel: true
+      default_kernel: "kernel-core"
+      sysconfig:
+        networking: true
+        no_zero_conf: true
+      enabled_services:
+        - "nm-cloud-setup.service"
+        - "nm-cloud-setup.timer"
+        - "sshd"
+        - "waagent"
+        - "firewalld"
+      sshd_config:
+        config:
+          ClientAliveInterval: 180
+      modprobe:
+        - filename: "blacklist-amdgpu.conf"
+          commands:
+            - command: blacklist
+              modulename: "amdgpu"
+        - filename: "blacklist-intel-cstate.conf"
+          commands:
+            - command: blacklist
+              modulename: "intel_cstate"
+        - filename: "blacklist-floppy.conf"
+          commands:
+            - command: blacklist
+              modulename: "floppy"
+        - filename: "blacklist-nouveau.conf"
+          commands:
+            - command: blacklist
+              modulename: "nouveau"
+            - command: blacklist
+              modulename: "lbm-nouveau"
+        - filename: "blacklist-skylake-edac.conf"
+          commands:
+            - command: blacklist
+              modulename: "skx_edac"
+      cloud_init:
+        - filename: "10-azure-kvp.cfg"
+          config:
+            reporting:
+              logging:
+                type: "log"
+              telemetry:
+                type: "hyperv"
+        - filename: "91-azure_datasource.cfg"
+          config:
+            datasource:
+              azure:
+                apply_network_config: false
+            datasource_list:
+              - "Azure"
+      pwquality:
+        config:
+          minlen: 6
+          minclass: 3
+          dcredit: 0
+          ucredit: 0
+          lcredit: 0
+          ocredit: 0
+      waagent_config:
+        config:
+          "ResourceDisk.Format": false
+          "ResourceDisk.EnableSwap": false
+      grub2_config:
+        disable_recovery: true
+        disable_submenu: true
+        distributor: "$(sed 's, release .*$,,g' /etc/system-release)"
+        terminal: ["serial", "console"]
+        serial: "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
+        timeout: 10
+        timeout_style: "countdown"
+      udev_rules:
+        filename: "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules"
+        rules:
+          - comment:
+              - "Accelerated Networking on Azure exposes a new SRIOV interface to the VM."
+              - "This interface is transparently bonded to the synthetic interface,"
+              - "so NetworkManager should just ignore any SRIOV interfaces."
+          - rule:
+              - K: "SUBSYSTEM"
+                O: "=="
+                V: "net"
+              - K: "DRIVERS"
+                O: "=="
+                V: "hv_pci"
+              - K: "ACTION"
+                O: "=="
+                V: "add"
+              - K: "ENV"
+                A: "NM_UNMANAGED"
+                O: "="
+                V: "1"
+      systemd_dropin:
+        # RHBZ#1822863
+        - unit: "nm-cloud-setup.service"
+          dropin: "10-rh-enable-for-azure.conf"
+          config:
+            service:
+              environment:
+                - key: "NM_CLOUD_SETUP_AZURE"
+                  value: "yes"
+      default_target: "multi-user.target"
+      kernel_options: &vhd_image_config_kernel_options
+        - "ro"
+        # use loglevel=3 as described in the RHEL documentation and used in existing RHEL images built by MSFT
+        - "loglevel=3"
+        - "crashkernel=auto"
+        - "console=tty1"
+        - "console=ttyS0"
+        - "earlyprintk=ttyS0"
+        - "rootdelay=300"
+      condition:
+        architecture:
+          x86_64: &vhd_image_config_cond_x86_64
+            kernel_options: *vhd_image_config_kernel_options
+        distro_name:
+          rhel:
+            gpgkey_files:
+              - "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+    partition_table:
+      <<: *default_partition_tables
+    package_sets:
+      os:
+        - *azure_common_pkgset
+        - &azure_pkgset
+          include:
+            - "firewalld"
+          exclude:
+            - "alsa-lib"
+
+  "azure-rhui": &azure_rhui
+    image_config: &azure_rhui_image_config
+      <<: *vhd_image_config
+      rhsm_config:
+        "no-subscription":
+          dnf_plugin:
+            subscription_manager:
+              enabled: false
+          subman:
+            rhsmcertd:
+              auto_registration: true
+            rhsm:
+              manage_repos: false
+        "with-subscription":
+          subman:
+            rhsmcertd:
+              auto_registration: true
+              # do not disable the redhat.repo management if the user
+              # explicitly request the system to be subscribed
+      condition: &azure_rhui_image_config_cond
+        distro_name: &azure_rhui_image_config_distro_name
+          rhel:
+            gpgkey_files:
+              - "/etc/pki/rpm-gpg/RPM-GPG-KEY-microsoft-azure-release"
+              - "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
     package_sets:
       os:
         - *azure_common_pkgset
@@ -909,8 +1431,15 @@ image_types:
             - "rhui-azure-rhel8"
           exclude:
             - "alsa-lib"
+    partition_table:
+      <<: *azure_rhui_partition_tables
 
   "azure-sap-rhui":
+    <<: *azure_rhui
+    image_config:
+      <<: [*azure_rhui_image_config, *sap_image_config]
+      condition:
+        <<: [*azure_rhui_image_config_cond, *sap_image_config_cond]
     package_sets:
       os:
         - *azure_common_pkgset
@@ -928,6 +1457,22 @@ image_types:
                   - "rhui-azure-rhel8-sap-ha"
 
   "azure-eap7-rhui":
+    <<: *azure_rhui
+    image_config:
+      <<: *azure_rhui_image_config
+      enabled_services:
+        # XXX: same as RHUI but no firewalld
+        - "nm-cloud-setup.service"
+        - "nm-cloud-setup.timer"
+        - "sshd"
+        - "waagent"
+      shell_init:
+        - filename: "eap_env.sh"
+          variables:
+            - key: "EAP_HOME"
+              value: "/opt/rh/eap7/root/usr/share/wildfly"
+            - key: "JBOSS_HOME"
+              value: "/opt/rh/eap7/root/usr/share/wildfly"
     package_sets:
       os:
         - *azure_common_pkgset
@@ -935,18 +1480,6 @@ image_types:
             - "rhui-azure-rhel8"
           exclude:
             - "firewalld"
-
-  vhd:
-    partition_table:
-      <<: *default_partition_tables
-    package_sets:
-      os:
-        - *azure_common_pkgset
-        - &azure_pkgset
-          include:
-            - "firewalld"
-          exclude:
-            - "alsa-lib"
 
   "image-installer":
     package_sets:
@@ -957,6 +1490,17 @@ image_types:
         - *anaconda_boot_pkgset
 
   tar:
+    filename: "root.tar.xz"
+    mime_type: "application/x-tar"
+    image_func: "tar"
+    build_pipelines: ["build"]
+    payload_pipelines: ["os", "archive"]
+    exports: ["archive"]
+    platforms:
+      - arch: "x86_64"
+      - arch: "aarch64"
+      - arch: "ppc64le"
+      - arch: "s390x"
     package_sets:
       os:
         - include:
@@ -965,7 +1509,40 @@ image_types:
           exclude:
             - "rng-tools"
 
-  "edge-commit":
+  "edge-commit": &edge_commit
+    image_config: &edge_commit_image_config
+      enabled_services: &enabled_services_edge
+        - "NetworkManager.service"
+        - "firewalld.service"
+        - "sshd.service"
+        # only on rhel-8.6+ and centos
+        - "fdo-client-linuxapp.service"
+      dracut_conf:
+        - filename: "40-fips.conf"
+          config:
+            add_dracutmodules: ["fips"]
+      condition:
+        version_less_than: &edge_commit_image_config_cond_lt
+          "8.6":
+            enabled_services:
+              - "NetworkManager.service"
+              - "firewalld.service"
+              - "sshd.service"
+          "8.5":
+            enabled_services:
+              # same as 8.6
+              - "NetworkManager.service"
+              - "firewalld.service"
+              - "sshd.service"
+              # greenboot services aren't enabled by default in 8.4
+              - "greenboot-grub2-set-counter"
+              - "greenboot-grub2-set-success"
+              - "greenboot-healthcheck"
+              - "greenboot-rpm-ostree-grub2-check-fallback"
+              - "greenboot-status"
+              - "greenboot-task-runner"
+              - "redboot-auto-reboot"
+              - "redboot-task-runner"
     package_sets:
       os:
         - &edge_commit_pkgset
@@ -1089,6 +1666,8 @@ image_types:
                 *edge_commit_new_rhel
 
   "edge-installer":
+    image_config:
+      iso_rootfs_type: "squashfs-ext4"
     package_sets:
       installer:
         # TODO: non-arch-specific package set handling for installers
@@ -1102,13 +1681,27 @@ image_types:
         - *anaconda_pkgset
         - *anaconda_boot_pkgset
 
+  # XXX: only available for rhel-8.6+, this is not possible to limit right now
   "edge-raw-image":
+    image_config:
+      keyboard:
+        keymap: "us"
+      locale: "C.UTF-8"
+      lock_root_user: true
+      kernel_options: ["modprobe.blacklist=vc4"]
     partition_table:
       <<: *edge_base_partition_tables
 
   "edge-simplified-installer":
     partition_table:
       <<: *edge_base_partition_tables
+    image_config:
+      enabled_services: *enabled_services_edge
+      keyboard:
+        keymap: "us"
+      locale: "C.UTF-8"
+      lock_root_user: true
+      kernel_options: ["modprobe.blacklist=vc4"]
     package_sets:
       # TODO: non-arch-specific package set handling for installers
       # This image type requires build packages for installers and
@@ -1164,18 +1757,17 @@ image_types:
                 *edge_commit_aarch64_pkgset
 
   "edge-container":
+    image_config:
+      <<: *edge_commit_image_config
     package_sets:
       os:
         - *edge_commit_pkgset
 
-  # XXX: not a real pkgset but the "containerPkgsKey"
-  "edge-container-pipeline-pkgset":
-    package_sets:
-      os:
-        - include:
-            - "nginx"
-
   vmdk: &vmdk
+    image_config:
+      kernel_options:
+        - "ro"
+        - "net.ifnames=0"
     partition_table:
       <<: *default_partition_tables
     package_sets: &vmdk_pkgsets
@@ -1192,9 +1784,92 @@ image_types:
             - "dracut-config-rescue"
             - "rng-tools"
 
-  ova: *vmdk
+  ova:
+    <<: *vmdk
 
   gce: &gce
+    # The configuration for non-RHUI images does not touch the RHSM configuration at all.
+    # https://issues.redhat.com/browse/COMPOSER-2157
+    image_config: &gce_image_config
+      timezone: "UTC"
+      time_synchronization:
+        servers:
+          - hostname: "metadata.google.internal"
+      firewall:
+        default_zone: "trusted"
+      enabled_services:
+        - "sshd"
+        - "rngd"
+        - "dnf-automatic.timer"
+      disabled_services:
+        - "sshd-keygen@"
+        - "reboot.target"
+      default_target: "multi-user.target"
+      keyboard:
+        keymap: "us"
+      dnf_config:
+        options:
+          - config:
+              main:
+                ipresolve: "4"
+      dnf_automatic_config:
+        config:
+          commands:
+            apply_updates: true
+            upgrade_type: "security"
+      yum_repos:
+        - filename: "google-cloud.repo"
+          repos:
+            - id: "google-compute-engine"
+              name: "Google Compute Engine"
+              # TODO: use el10 repo once it's available
+              baseurl:
+                - "https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable"
+              enabled: true
+              gpgcheck: true
+              repo_gpgcheck: false
+              gpgkey:
+                - "https://packages.cloud.google.com/yum/doc/yum-key.gpg"
+                - "https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg"
+      sshd_config:
+        config:
+          PasswordAuthentication: false
+          ClientAliveInterval: 420
+          PermitRootLogin: false
+      update_default_kernel: true
+      default_kernel: "kernel-core"
+      # XXX: ensure the "old" behavior is preserved (that is
+      # likely a bug) where for GCE the sysconfig network
+      # options are not set because the merge of imageConfig
+      # is shallow and the previous setup was changing the
+      # kernel without also changing the network options.
+      sysconfig: {}
+      modprobe:
+        - filename: "blacklist-floppy.conf"
+          commands:
+            - command: blacklist
+              modulename: "floppy"
+      gcp_guest_agent_config:
+        config_scope: "distro"
+        config:
+          "InstanceSetup":
+            set_boto_config: false
+      kernel_options: ["net.ifnames=0", "biosdevname=0", "scsi_mod.use_blk_mq=Y", "crashkernel=auto", "console=ttyS0,38400n8d"]
+      condition:
+        version_equal:
+          # NOTE(akoutsou): these are enabled in the package preset, but for
+          # some reason do not get enabled on 8.4.
+          # the reason is unknown and deeply mysterious
+          "8.4":
+            enabled_services:
+              - "sshd"
+              - "rngd"
+              - "dnf-automatic.timer"
+              - "google-oslogin-cache.timer"
+              - "google-guest-agent.service"
+              - "google-shutdown-scripts.service"
+              - "google-startup-scripts.service"
+              - "google-osconfig-agent.service"
     partition_table:
       <<: *default_partition_tables
     package_sets:
@@ -1203,24 +1878,37 @@ image_types:
 
   "gce-rhui":
     <<: *gce
+    image_config:
+      <<: *gce_image_config
+      rhsm_config:
+        "no-subscription":
+          subman:
+            rhsmcertd:
+              auto_registration: true
+            rhsm:
+              manage_repos: false
+        "with-subscription":
+          subman:
+            rhsmcertd:
+              auto_registration: true
+              # do not disable the redhat.repo management if the user
+              # explicitly request the system to be subscribed
     package_sets:
       os:
         - *gce_common_pkgset
         - include:
             - "google-rhui-client-rhel8"
 
-  qcow2: &qcow2
-    partition_table:
-      <<: *default_partition_tables
-    package_sets: &qcow2_pkgset
-      os:
-        - *qcow2_common_pkgset
-
-  oci: *qcow2
+  oci:
+    <<: *qcow2
 
   openstack:
-    partition_table:
-      <<: *default_partition_tables
+    <<: *qcow2
+    image_config:
+      kernel_options:
+        - "ro"
+        - "net.ifnames=0"
+    platforms:
     package_sets:
       os:
         - include:
@@ -1236,6 +1924,10 @@ image_types:
             - "rng-tools"
 
   wsl:
+    image_config:
+      no_selinux: true
+      wsl_config:
+        boot_systemd: true
     package_sets:
       os:
         - include:
@@ -1344,6 +2036,24 @@ image_types:
             - "xz"
 
   "minimal-raw":
+    image_config:
+      enabled_services:
+        - "NetworkManager.service"
+        - "firewalld.service"
+        - "sshd.service"
+        - "initial-setup.service"
+      files:
+        # NOTE: temporary workaround for a bug in initial-setup that
+        # requires a kickstart file in the root directory.
+        - path: "/root/anaconda-ks.cfg"
+          user: "root"
+          group: "root"
+          data: |
+            # Run initial-setup on first boot
+            # Created by osbuild
+            firstboot --reconfig
+            lang en_US.UTF-8
+      kernel_options: ["ro"]
     partition_table:
       <<: *default_partition_tables
     package_sets:

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -49,12 +49,12 @@ type ImageConfig struct {
 
 	// Do not use. Forces auto-relabelling on first boot.
 	// See https://github.com/osbuild/osbuild/commit/52cb27631b587c1df177cd17625c5b473e1e85d2
-	SELinuxForceRelabel *bool
+	SELinuxForceRelabel *bool `yaml:"selinux_force_relabel"`
 
 	// Disable documentation
 	ExcludeDocs *bool `yaml:"exclude_docs,omitempty"`
 
-	ShellInit []shell.InitFile
+	ShellInit []shell.InitFile `yaml:"shell_init,omitempty"`
 
 	// for RHSM configuration, we need to potentially distinguish the case
 	// when the user want the image to be subscribed on first boot and when not
@@ -79,8 +79,8 @@ type ImageConfig struct {
 	WAAgentConfig       *osbuild.WAAgentConfStageOptions        `yaml:"waagent_config,omitempty"`
 	Grub2Config         *osbuild.GRUB2Config                    `yaml:"grub2_config,omitempty"`
 	DNFAutomaticConfig  *osbuild.DNFAutomaticConfigStageOptions `yaml:"dnf_automatic_config"`
-	YumConfig           *osbuild.YumConfigStageOptions
-	YUMRepos            []*osbuild.YumReposStageOptions `yaml:"yum_repos,omitempty"`
+	YumConfig           *osbuild.YumConfigStageOptions          `yaml:"yum_config,omitempty"`
+	YUMRepos            []*osbuild.YumReposStageOptions         `yaml:"yum_repos,omitempty"`
 	Firewall            *osbuild.FirewallStageOptions
 	UdevRules           *osbuild.UdevRulesStageOptions      `yaml:"udev_rules,omitempty"`
 	GCPGuestAgentConfig *osbuild.GcpGuestAgentConfigOptions `yaml:"gcp_guest_agent_config,omitempty"`

--- a/pkg/distro/rhel/rhel8/ami.go
+++ b/pkg/distro/rhel/rhel8/ami.go
@@ -1,27 +1,11 @@
 package rhel8
 
 import (
-	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/customizations/subscription"
 	"github.com/osbuild/images/pkg/datasizes"
-	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
-	"github.com/osbuild/images/pkg/osbuild"
 )
 
-func amiX86KernelOptions() []string {
-	return []string{"console=tty0", "console=ttyS0,115200n8", "net.ifnames=0", "rd.blacklist=nouveau", "nvme_core.io_timeout=4294967295", "crashkernel=auto"}
-}
-
-func amiAarch64KernelOptions() []string {
-	return []string{"console=tty0", "console=ttyS0,115200n8", "net.ifnames=0", "rd.blacklist=nouveau", "nvme_core.io_timeout=4294967295", "iommu.strict=0", "crashkernel=auto"}
-}
-
-func amiSapKernelOptions() []string {
-	return []string{"console=tty0", "console=ttyS0,115200n8", "net.ifnames=0", "rd.blacklist=nouveau", "nvme_core.io_timeout=4294967295", "crashkernel=auto", "processor.max_cstate=1", "intel_idle.max_cstate=1"}
-}
-
-func mkAmiImgTypeX86_64() *rhel.ImageType {
+func mkAmiImgTypeX86_64(d *rhel.Distribution) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"ami",
 		"image.raw",
@@ -33,8 +17,7 @@ func mkAmiImgTypeX86_64() *rhel.ImageType {
 		[]string{"image"},
 	)
 
-	it.DefaultImageConfig = defaultAMIImageConfigX86_64()
-	it.DefaultImageConfig.KernelOptions = amiX86KernelOptions()
+	it.DefaultImageConfig = imageConfig(d, "x86_64", "ami")
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -55,8 +38,7 @@ func mkEc2ImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.DefaultImageConfig = defaultEc2ImageConfigX86_64(rd)
-	it.DefaultImageConfig.KernelOptions = amiX86KernelOptions()
+	it.DefaultImageConfig = imageConfig(rd, "x86_64", "ec2")
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -77,8 +59,7 @@ func mkEc2HaImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.DefaultImageConfig = defaultEc2ImageConfigX86_64(rd)
-	it.DefaultImageConfig.KernelOptions = amiX86KernelOptions()
+	it.DefaultImageConfig = imageConfig(rd, "x86_64", "ec2-ha")
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -86,7 +67,7 @@ func mkEc2HaImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 	return it
 }
 
-func mkAmiImgTypeAarch64() *rhel.ImageType {
+func mkAmiImgTypeAarch64(rd *rhel.Distribution) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"ami",
 		"image.raw",
@@ -98,8 +79,7 @@ func mkAmiImgTypeAarch64() *rhel.ImageType {
 		[]string{"image"},
 	)
 
-	it.DefaultImageConfig = defaultAMIImageConfig()
-	it.DefaultImageConfig.KernelOptions = amiAarch64KernelOptions()
+	it.DefaultImageConfig = imageConfig(rd, "aarch64", "ami")
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -120,8 +100,7 @@ func mkEc2ImgTypeAarch64(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.DefaultImageConfig = defaultEc2ImageConfig(rd)
-	it.DefaultImageConfig.KernelOptions = amiAarch64KernelOptions()
+	it.DefaultImageConfig = imageConfig(rd, "aarch64", "ec2")
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -142,210 +121,10 @@ func mkEc2SapImgTypeX86_64(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.DefaultImageConfig = defaultEc2SapImageConfigX86_64(rd)
-	it.DefaultImageConfig.KernelOptions = amiSapKernelOptions()
+	it.DefaultImageConfig = imageConfig(rd, "x86_64", "ec2-sap")
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
 
 	return it
-}
-
-// default EC2 images config (common for all architectures)
-func baseEc2ImageConfig() *distro.ImageConfig {
-	return &distro.ImageConfig{
-		Timezone: common.ToPtr("UTC"),
-		TimeSynchronization: &osbuild.ChronyStageOptions{
-			Servers: []osbuild.ChronyConfigServer{
-				{
-					Hostname: "169.254.169.123",
-					Prefer:   common.ToPtr(true),
-					Iburst:   common.ToPtr(true),
-					Minpoll:  common.ToPtr(4),
-					Maxpoll:  common.ToPtr(4),
-				},
-			},
-			// empty string will remove any occurrences of the option from the configuration
-			LeapsecTz: common.ToPtr(""),
-		},
-		Keyboard: &osbuild.KeymapStageOptions{
-			Keymap: "us",
-			X11Keymap: &osbuild.X11KeymapOptions{
-				Layouts: []string{"us"},
-			},
-		},
-		EnabledServices: []string{
-			"sshd",
-			"NetworkManager",
-			"nm-cloud-setup.service",
-			"nm-cloud-setup.timer",
-			"cloud-init",
-			"cloud-init-local",
-			"cloud-config",
-			"cloud-final",
-			"reboot.target",
-		},
-		DefaultTarget:       common.ToPtr("multi-user.target"),
-		UpdateDefaultKernel: common.ToPtr(true),
-		DefaultKernel:       common.ToPtr("kernel"),
-		Sysconfig: &distro.Sysconfig{
-			Networking:                  true,
-			NoZeroConf:                  true,
-			CreateDefaultNetworkScripts: true,
-		},
-		SystemdLogind: []*osbuild.SystemdLogindStageOptions{
-			{
-				Filename: "00-getty-fixes.conf",
-				Config: osbuild.SystemdLogindConfigDropin{
-					Login: osbuild.SystemdLogindConfigLoginSection{
-						NAutoVTs: common.ToPtr(0),
-					},
-				},
-			},
-		},
-		CloudInit: []*osbuild.CloudInitStageOptions{
-			{
-				Filename: "00-rhel-default-user.cfg",
-				Config: osbuild.CloudInitConfigFile{
-					SystemInfo: &osbuild.CloudInitConfigSystemInfo{
-						DefaultUser: &osbuild.CloudInitConfigDefaultUser{
-							Name: "ec2-user",
-						},
-					},
-				},
-			},
-		},
-		Modprobe: []*osbuild.ModprobeStageOptions{
-			{
-				Filename: "blacklist-nouveau.conf",
-				Commands: osbuild.ModprobeConfigCmdList{
-					osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
-				},
-			},
-			// COMPOSER-1807
-			{
-				Filename: "blacklist-amdgpu.conf",
-				Commands: osbuild.ModprobeConfigCmdList{
-					osbuild.NewModprobeConfigCmdBlacklist("amdgpu"),
-				},
-			},
-		},
-		DracutConf: []*osbuild.DracutConfStageOptions{
-			{
-				Filename: "sgdisk.conf",
-				Config: osbuild.DracutConfigFile{
-					Install: []string{"sgdisk"},
-				},
-			},
-		},
-		SystemdDropin: []*osbuild.SystemdUnitStageOptions{
-			// RHBZ#1822863
-			{
-				Unit:   "nm-cloud-setup.service",
-				Dropin: "10-rh-enable-for-ec2.conf",
-				Config: osbuild.SystemdServiceUnitDropin{
-					Service: &osbuild.SystemdUnitServiceSection{
-						Environment: []osbuild.EnvironmentVariable{{Key: "NM_CLOUD_SETUP_EC2", Value: "yes"}},
-					},
-				},
-			},
-		},
-		Authselect: &osbuild.AuthselectStageOptions{
-			Profile: "sssd",
-		},
-		SshdConfig: &osbuild.SshdConfigStageOptions{
-			Config: osbuild.SshdConfigConfig{
-				PasswordAuthentication: common.ToPtr(false),
-			},
-		},
-	}
-}
-
-func defaultEc2ImageConfig(rd *rhel.Distribution) *distro.ImageConfig {
-	ic := baseEc2ImageConfig()
-	// The RHSM configuration should not be applied since 8.7, but it is instead done by installing the
-	// redhat-cloud-client-configuration package. See COMPOSER-1804 for more information.
-	if rd.IsRHEL() && common.VersionLessThan(rd.OsVersion(), "8.7") {
-		ic = appendRHSM(ic)
-		// Disable RHSM redhat.repo management
-		rhsmConf := ic.RHSMConfig[subscription.RHSMConfigNoSubscription]
-		rhsmConf.SubMan.Rhsm = subscription.SubManRHSMConfig{ManageRepos: common.ToPtr(false)}
-		ic.RHSMConfig[subscription.RHSMConfigNoSubscription] = rhsmConf
-	}
-
-	return ic
-}
-
-func defaultEc2ImageConfigX86_64(rd *rhel.Distribution) *distro.ImageConfig {
-	ic := defaultEc2ImageConfig(rd)
-	return appendEC2DracutX86_64(ic)
-}
-
-// Default AMI (custom image built by users) images config.
-// The configuration does not touch the RHSM configuration at all.
-// https://issues.redhat.com/browse/COMPOSER-2157
-func defaultAMIImageConfig() *distro.ImageConfig {
-	return baseEc2ImageConfig()
-}
-
-// Default AMI x86_64 (custom image built by users) images config.
-// The configuration does not touch the RHSM configuration at all.
-// https://issues.redhat.com/browse/COMPOSER-2157
-func defaultAMIImageConfigX86_64() *distro.ImageConfig {
-	ic := defaultAMIImageConfig()
-	return appendEC2DracutX86_64(ic)
-}
-
-func defaultEc2SapImageConfigX86_64(rd *rhel.Distribution) *distro.ImageConfig {
-	// default EC2-SAP image config (x86_64)
-	return sapImageConfig(rd).InheritFrom(defaultEc2ImageConfigX86_64(rd))
-}
-
-// Add RHSM config options to ImageConfig.
-// Used for RHEL distros.
-func appendRHSM(ic *distro.ImageConfig) *distro.ImageConfig {
-	rhsm := &distro.ImageConfig{
-		RHSMConfig: map[subscription.RHSMStatus]*subscription.RHSMConfig{
-			subscription.RHSMConfigNoSubscription: {
-				// RHBZ#1932802
-				SubMan: subscription.SubManConfig{
-					Rhsmcertd: subscription.SubManRHSMCertdConfig{
-						AutoRegistration: common.ToPtr(true),
-					},
-					// Don't disable RHSM redhat.repo management on the AMI
-					// image, which is BYOS and does not use RHUI for content.
-					// Otherwise subscribing the system manually after booting
-					// it would result in empty redhat.repo. Without RHUI, such
-					// system would have no way to get Red Hat content, but
-					// enable the repo management manually, which would be very
-					// confusing.
-				},
-			},
-			subscription.RHSMConfigWithSubscription: {
-				// RHBZ#1932802
-				SubMan: subscription.SubManConfig{
-					Rhsmcertd: subscription.SubManRHSMCertdConfig{
-						AutoRegistration: common.ToPtr(true),
-					},
-					// do not disable the redhat.repo management if the user
-					// explicitly request the system to be subscribed
-				},
-			},
-		},
-	}
-	return rhsm.InheritFrom(ic)
-}
-
-func appendEC2DracutX86_64(ic *distro.ImageConfig) *distro.ImageConfig {
-	ic.DracutConf = append(ic.DracutConf,
-		&osbuild.DracutConfStageOptions{
-			Filename: "ec2.conf",
-			Config: osbuild.DracutConfigFile{
-				AddDrivers: []string{
-					"nvme",
-					"xen-blkfront",
-				},
-			},
-		})
-	return ic
 }

--- a/pkg/distro/rhel/rhel8/azure.go
+++ b/pkg/distro/rhel/rhel8/azure.go
@@ -3,7 +3,6 @@ package rhel8
 import (
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/datasizes"
-	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro/rhel"
 )
 
@@ -23,7 +22,7 @@ func mkAzureRhuiImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it.DefaultImageConfig = imageConfig(rd, a.String(), "azure-rhui")
 	it.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
-	it.BasePartitionTables = azureRhuiBasePartitionTables
+	it.BasePartitionTables = partitionTables
 
 	return it
 }
@@ -44,7 +43,7 @@ func mkAzureSapRhuiImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it.DefaultImageConfig = imageConfig(rd, a.String(), "azure-sap-rhui")
 	it.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
-	it.BasePartitionTables = azureRhuiBasePartitionTables
+	it.BasePartitionTables = partitionTables
 
 	return it
 }
@@ -106,231 +105,8 @@ func mkAzureEap7RhuiImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType 
 	it.DefaultImageConfig = imageConfig(rd, a.String(), "azure-eap7-rhui")
 	it.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
-	it.BasePartitionTables = azureRhuiBasePartitionTables
+	it.BasePartitionTables = partitionTables
 	it.Workload = eapWorkload()
 
 	return it
-}
-
-// PARTITION TABLES
-
-func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
-	switch t.Arch().Name() {
-	case arch.ARCH_X86_64.String():
-		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: disk.PT_GPT,
-			Size: 64 * datasizes.GibiByte,
-			Partitions: []disk.Partition{
-				{
-					Size: 500 * datasizes.MebiByte,
-					Type: disk.EFISystemPartitionGUID,
-					UUID: disk.EFISystemPartitionUUID,
-					Payload: &disk.Filesystem{
-						Type:         "vfat",
-						UUID:         disk.EFIFilesystemUUID,
-						Mountpoint:   "/boot/efi",
-						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-						FSTabFreq:    0,
-						FSTabPassNo:  2,
-					},
-				},
-				{
-					Size: 500 * datasizes.MebiByte,
-					Type: disk.FilesystemDataGUID,
-					UUID: disk.DataPartitionUUID,
-					Payload: &disk.Filesystem{
-						Type:         "xfs",
-						Mountpoint:   "/boot",
-						FSTabOptions: "defaults",
-						FSTabFreq:    0,
-						FSTabPassNo:  0,
-					},
-				},
-				{
-					Size:     2 * datasizes.MebiByte,
-					Bootable: true,
-					Type:     disk.BIOSBootPartitionGUID,
-					UUID:     disk.BIOSBootPartitionUUID,
-				},
-				{
-					Type: disk.LVMPartitionGUID,
-					UUID: disk.RootPartitionUUID,
-					Payload: &disk.LVMVolumeGroup{
-						Name:        "rootvg",
-						Description: "built with lvm2 and osbuild",
-						LogicalVolumes: []disk.LVMLogicalVolume{
-							{
-								Size: 1 * datasizes.GibiByte,
-								Name: "homelv",
-								Payload: &disk.Filesystem{
-									Type:         "xfs",
-									Label:        "home",
-									Mountpoint:   "/home",
-									FSTabOptions: "defaults",
-									FSTabFreq:    0,
-									FSTabPassNo:  0,
-								},
-							},
-							{
-								Size: 2 * datasizes.GibiByte,
-								Name: "rootlv",
-								Payload: &disk.Filesystem{
-									Type:         "xfs",
-									Label:        "root",
-									Mountpoint:   "/",
-									FSTabOptions: "defaults",
-									FSTabFreq:    0,
-									FSTabPassNo:  0,
-								},
-							},
-							{
-								Size: 2 * datasizes.GibiByte,
-								Name: "tmplv",
-								Payload: &disk.Filesystem{
-									Type:         "xfs",
-									Label:        "tmp",
-									Mountpoint:   "/tmp",
-									FSTabOptions: "defaults",
-									FSTabFreq:    0,
-									FSTabPassNo:  0,
-								},
-							},
-							{
-								Size: 10 * datasizes.GibiByte,
-								Name: "usrlv",
-								Payload: &disk.Filesystem{
-									Type:         "xfs",
-									Label:        "usr",
-									Mountpoint:   "/usr",
-									FSTabOptions: "defaults",
-									FSTabFreq:    0,
-									FSTabPassNo:  0,
-								},
-							},
-							{
-								Size: 10 * datasizes.GibiByte,
-								Name: "varlv",
-								Payload: &disk.Filesystem{
-									Type:         "xfs",
-									Label:        "var",
-									Mountpoint:   "/var",
-									FSTabOptions: "defaults",
-									FSTabFreq:    0,
-									FSTabPassNo:  0,
-								},
-							},
-						},
-					},
-				},
-			},
-		}, true
-
-	case arch.ARCH_AARCH64.String():
-		return disk.PartitionTable{
-			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-			Type: disk.PT_GPT,
-			Size: 64 * datasizes.GibiByte,
-			Partitions: []disk.Partition{
-				{
-					Size: 500 * datasizes.MebiByte,
-					Type: disk.EFISystemPartitionGUID,
-					UUID: disk.EFISystemPartitionUUID,
-					Payload: &disk.Filesystem{
-						Type:         "vfat",
-						UUID:         disk.EFIFilesystemUUID,
-						Mountpoint:   "/boot/efi",
-						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-						FSTabFreq:    0,
-						FSTabPassNo:  2,
-					},
-				},
-				{
-					Size: 500 * datasizes.MebiByte,
-					Type: disk.FilesystemDataGUID,
-					UUID: disk.DataPartitionUUID,
-					Payload: &disk.Filesystem{
-						Type:         "xfs",
-						Mountpoint:   "/boot",
-						FSTabOptions: "defaults",
-						FSTabFreq:    0,
-						FSTabPassNo:  0,
-					},
-				},
-				{
-					Type: disk.LVMPartitionGUID,
-					UUID: disk.RootPartitionUUID,
-					Payload: &disk.LVMVolumeGroup{
-						Name:        "rootvg",
-						Description: "built with lvm2 and osbuild",
-						LogicalVolumes: []disk.LVMLogicalVolume{
-							{
-								Size: 1 * datasizes.GibiByte,
-								Name: "homelv",
-								Payload: &disk.Filesystem{
-									Type:         "xfs",
-									Label:        "home",
-									Mountpoint:   "/home",
-									FSTabOptions: "defaults",
-									FSTabFreq:    0,
-									FSTabPassNo:  0,
-								},
-							},
-							{
-								Size: 2 * datasizes.GibiByte,
-								Name: "rootlv",
-								Payload: &disk.Filesystem{
-									Type:         "xfs",
-									Label:        "root",
-									Mountpoint:   "/",
-									FSTabOptions: "defaults",
-									FSTabFreq:    0,
-									FSTabPassNo:  0,
-								},
-							},
-							{
-								Size: 2 * datasizes.GibiByte,
-								Name: "tmplv",
-								Payload: &disk.Filesystem{
-									Type:         "xfs",
-									Label:        "tmp",
-									Mountpoint:   "/tmp",
-									FSTabOptions: "defaults",
-									FSTabFreq:    0,
-									FSTabPassNo:  0,
-								},
-							},
-							{
-								Size: 10 * datasizes.GibiByte,
-								Name: "usrlv",
-								Payload: &disk.Filesystem{
-									Type:         "xfs",
-									Label:        "usr",
-									Mountpoint:   "/usr",
-									FSTabOptions: "defaults",
-									FSTabFreq:    0,
-									FSTabPassNo:  0,
-								},
-							},
-							{
-								Size: 10 * datasizes.GibiByte,
-								Name: "varlv",
-								Payload: &disk.Filesystem{
-									Type:         "xfs",
-									Label:        "var",
-									Mountpoint:   "/var",
-									FSTabOptions: "defaults",
-									FSTabFreq:    0,
-									FSTabPassNo:  0,
-								},
-							},
-						},
-					},
-				},
-			},
-		}, true
-
-	default:
-		return disk.PartitionTable{}, false
-	}
 }

--- a/pkg/distro/rhel/rhel8/azure.go
+++ b/pkg/distro/rhel/rhel8/azure.go
@@ -1,23 +1,13 @@
 package rhel8
 
 import (
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
-	"github.com/osbuild/images/pkg/customizations/shell"
-	"github.com/osbuild/images/pkg/customizations/subscription"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
-	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
-	"github.com/osbuild/images/pkg/osbuild"
 )
 
-// use loglevel=3 as described in the RHEL documentation and used in existing RHEL images built by MSFT
-func defaultAzureKernelOptions() []string {
-	return []string{"ro", "loglevel=3", "crashkernel=auto", "console=tty1", "console=ttyS0", "earlyprintk=ttyS0", "rootdelay=300"}
-}
-
-func mkAzureRhuiImgType() *rhel.ImageType {
+func mkAzureRhuiImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"azure-rhui",
 		"disk.vhd.xz",
@@ -30,8 +20,7 @@ func mkAzureRhuiImgType() *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.DefaultImageConfig = defaultAzureRhuiImageConfig.InheritFrom(defaultVhdImageConfig())
-	it.DefaultImageConfig.KernelOptions = defaultAzureKernelOptions()
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "azure-rhui")
 	it.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.BasePartitionTables = azureRhuiBasePartitionTables
@@ -39,7 +28,7 @@ func mkAzureRhuiImgType() *rhel.ImageType {
 	return it
 }
 
-func mkAzureSapRhuiImgType(rd *rhel.Distribution) *rhel.ImageType {
+func mkAzureSapRhuiImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"azure-sap-rhui",
 		"disk.vhd.xz",
@@ -52,8 +41,7 @@ func mkAzureSapRhuiImgType(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.DefaultImageConfig = defaultAzureRhuiImageConfig.InheritFrom(sapAzureImageConfig(rd))
-	it.DefaultImageConfig.KernelOptions = defaultAzureKernelOptions()
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "azure-sap-rhui")
 	it.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.BasePartitionTables = azureRhuiBasePartitionTables
@@ -61,7 +49,7 @@ func mkAzureSapRhuiImgType(rd *rhel.Distribution) *rhel.ImageType {
 	return it
 }
 
-func mkAzureByosImgType() *rhel.ImageType {
+func mkAzureByosImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"vhd",
 		"disk.vhd",
@@ -73,8 +61,7 @@ func mkAzureByosImgType() *rhel.ImageType {
 		[]string{"vpc"},
 	)
 
-	it.DefaultImageConfig = defaultAzureByosImageConfig.InheritFrom(defaultVhdImageConfig())
-	it.DefaultImageConfig.KernelOptions = defaultAzureKernelOptions()
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "vhd")
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -83,7 +70,7 @@ func mkAzureByosImgType() *rhel.ImageType {
 }
 
 // Azure non-RHEL image type
-func mkAzureImgType() *rhel.ImageType {
+func mkAzureImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"vhd",
 		"disk.vhd",
@@ -95,8 +82,7 @@ func mkAzureImgType() *rhel.ImageType {
 		[]string{"vpc"},
 	)
 
-	it.DefaultImageConfig = defaultVhdImageConfig()
-	it.DefaultImageConfig.KernelOptions = defaultAzureKernelOptions()
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "vhd")
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -104,7 +90,7 @@ func mkAzureImgType() *rhel.ImageType {
 	return it
 }
 
-func mkAzureEap7RhuiImgType() *rhel.ImageType {
+func mkAzureEap7RhuiImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"azure-eap7-rhui",
 		"disk.vhd.xz",
@@ -117,8 +103,7 @@ func mkAzureEap7RhuiImgType() *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.DefaultImageConfig = defaultAzureEapImageConfig.InheritFrom(defaultAzureRhuiImageConfig.InheritFrom(defaultAzureImageConfig))
-	it.DefaultImageConfig.KernelOptions = defaultAzureKernelOptions()
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "azure-eap7-rhui")
 	it.Bootable = true
 	it.DefaultSize = 64 * datasizes.GibiByte
 	it.BasePartitionTables = azureRhuiBasePartitionTables
@@ -348,226 +333,4 @@ func azureRhuiBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool)
 	default:
 		return disk.PartitionTable{}, false
 	}
-}
-
-// based on https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deploying_rhel_8_on_microsoft_azure/assembly_deploying-a-rhel-image-as-a-virtual-machine-on-microsoft-azure_cloud-content-azure#making-configuration-changes_configure-the-image-azure
-var defaultAzureImageConfig = &distro.ImageConfig{
-	Timezone: common.ToPtr("Etc/UTC"),
-	Locale:   common.ToPtr("en_US.UTF-8"),
-	Keyboard: &osbuild.KeymapStageOptions{
-		Keymap: "us",
-		X11Keymap: &osbuild.X11KeymapOptions{
-			Layouts: []string{"us"},
-		},
-	},
-	DefaultKernel:       common.ToPtr("kernel-core"),
-	UpdateDefaultKernel: common.ToPtr(true),
-	Sysconfig: &distro.Sysconfig{
-		Networking: true,
-		NoZeroConf: true,
-	},
-	EnabledServices: []string{
-		"nm-cloud-setup.service",
-		"nm-cloud-setup.timer",
-		"sshd",
-		"waagent",
-	},
-	SshdConfig: &osbuild.SshdConfigStageOptions{
-		Config: osbuild.SshdConfigConfig{
-			ClientAliveInterval: common.ToPtr(180),
-		},
-	},
-	Modprobe: []*osbuild.ModprobeStageOptions{
-		{
-			Filename: "blacklist-amdgpu.conf",
-			Commands: osbuild.ModprobeConfigCmdList{
-				osbuild.NewModprobeConfigCmdBlacklist("amdgpu"),
-			},
-		},
-		{
-			Filename: "blacklist-intel-cstate.conf",
-			Commands: osbuild.ModprobeConfigCmdList{
-				osbuild.NewModprobeConfigCmdBlacklist("intel_cstate"),
-			},
-		},
-		{
-			Filename: "blacklist-floppy.conf",
-			Commands: osbuild.ModprobeConfigCmdList{
-				osbuild.NewModprobeConfigCmdBlacklist("floppy"),
-			},
-		},
-		{
-			Filename: "blacklist-nouveau.conf",
-			Commands: osbuild.ModprobeConfigCmdList{
-				osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
-				osbuild.NewModprobeConfigCmdBlacklist("lbm-nouveau"),
-			},
-		},
-		{
-			Filename: "blacklist-skylake-edac.conf",
-			Commands: osbuild.ModprobeConfigCmdList{
-				osbuild.NewModprobeConfigCmdBlacklist("skx_edac"),
-			},
-		},
-	},
-	CloudInit: []*osbuild.CloudInitStageOptions{
-		{
-			Filename: "10-azure-kvp.cfg",
-			Config: osbuild.CloudInitConfigFile{
-				Reporting: &osbuild.CloudInitConfigReporting{
-					Logging: &osbuild.CloudInitConfigReportingHandlers{
-						Type: "log",
-					},
-					Telemetry: &osbuild.CloudInitConfigReportingHandlers{
-						Type: "hyperv",
-					},
-				},
-			},
-		},
-		{
-			Filename: "91-azure_datasource.cfg",
-			Config: osbuild.CloudInitConfigFile{
-				Datasource: &osbuild.CloudInitConfigDatasource{
-					Azure: &osbuild.CloudInitConfigDatasourceAzure{
-						ApplyNetworkConfig: false,
-					},
-				},
-				DatasourceList: []string{
-					"Azure",
-				},
-			},
-		},
-	},
-	PwQuality: &osbuild.PwqualityConfStageOptions{
-		Config: osbuild.PwqualityConfConfig{
-			Minlen:   common.ToPtr(6),
-			Minclass: common.ToPtr(3),
-			Dcredit:  common.ToPtr(0),
-			Ucredit:  common.ToPtr(0),
-			Lcredit:  common.ToPtr(0),
-			Ocredit:  common.ToPtr(0),
-		},
-	},
-	WAAgentConfig: &osbuild.WAAgentConfStageOptions{
-		Config: osbuild.WAAgentConfig{
-			RDFormat:     common.ToPtr(false),
-			RDEnableSwap: common.ToPtr(false),
-		},
-	},
-	Grub2Config: &osbuild.GRUB2Config{
-		DisableRecovery: common.ToPtr(true),
-		DisableSubmenu:  common.ToPtr(true),
-		Distributor:     "$(sed 's, release .*$,,g' /etc/system-release)",
-		Terminal:        []string{"serial", "console"},
-		Serial:          "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1",
-		Timeout:         10,
-		TimeoutStyle:    osbuild.GRUB2ConfigTimeoutStyleCountdown,
-	},
-	UdevRules: &osbuild.UdevRulesStageOptions{
-		Filename: "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules",
-		Rules: osbuild.UdevRules{
-			osbuild.UdevRuleComment{
-				Comment: []string{
-					"Accelerated Networking on Azure exposes a new SRIOV interface to the VM.",
-					"This interface is transparently bonded to the synthetic interface,",
-					"so NetworkManager should just ignore any SRIOV interfaces.",
-				},
-			},
-			osbuild.NewUdevRule(
-				[]osbuild.UdevKV{
-					{K: "SUBSYSTEM", O: "==", V: "net"},
-					{K: "DRIVERS", O: "==", V: "hv_pci"},
-					{K: "ACTION", O: "==", V: "add"},
-					{K: "ENV", A: "NM_UNMANAGED", O: "=", V: "1"},
-				},
-			),
-		},
-	},
-	SystemdDropin: []*osbuild.SystemdUnitStageOptions{
-		{
-			Unit:   "nm-cloud-setup.service",
-			Dropin: "10-rh-enable-for-azure.conf",
-			Config: osbuild.SystemdServiceUnitDropin{
-				Service: &osbuild.SystemdUnitServiceSection{
-					Environment: []osbuild.EnvironmentVariable{{Key: "NM_CLOUD_SETUP_AZURE", Value: "yes"}},
-				},
-			},
-		},
-	},
-	DefaultTarget: common.ToPtr("multi-user.target"),
-}
-
-// Diff of the default Image Config compare to the `defaultAzureImageConfig`
-// The configuration for non-RHUI images does not touch the RHSM configuration at all.
-// https://issues.redhat.com/browse/COMPOSER-2157
-var defaultAzureByosImageConfig = &distro.ImageConfig{
-	GPGKeyFiles: []string{
-		"/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
-	},
-}
-
-// Diff of the default Image Config compare to the `defaultAzureImageConfig`
-var defaultAzureRhuiImageConfig = &distro.ImageConfig{
-	GPGKeyFiles: []string{
-		"/etc/pki/rpm-gpg/RPM-GPG-KEY-microsoft-azure-release",
-		"/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
-	},
-	RHSMConfig: map[subscription.RHSMStatus]*subscription.RHSMConfig{
-		subscription.RHSMConfigNoSubscription: {
-			DnfPlugins: subscription.SubManDNFPluginsConfig{
-				SubscriptionManager: subscription.DNFPluginConfig{
-					Enabled: common.ToPtr(false),
-				},
-			},
-			SubMan: subscription.SubManConfig{
-				Rhsmcertd: subscription.SubManRHSMCertdConfig{
-					AutoRegistration: common.ToPtr(true),
-				},
-				Rhsm: subscription.SubManRHSMConfig{
-					ManageRepos: common.ToPtr(false),
-				},
-			},
-		},
-		subscription.RHSMConfigWithSubscription: {
-			SubMan: subscription.SubManConfig{
-				Rhsmcertd: subscription.SubManRHSMCertdConfig{
-					AutoRegistration: common.ToPtr(true),
-				},
-				// do not disable the redhat.repo management if the user
-				// explicitly request the system to be subscribed
-			},
-		},
-	},
-}
-
-const wildflyPath = "/opt/rh/eap7/root/usr/share/wildfly"
-
-var defaultAzureEapImageConfig = &distro.ImageConfig{
-	// shell env vars for EAP
-	ShellInit: []shell.InitFile{
-		{
-			Filename: "eap_env.sh",
-			Variables: []shell.EnvironmentVariable{
-				{
-					Key:   "EAP_HOME",
-					Value: wildflyPath,
-				},
-				{
-					Key:   "JBOSS_HOME",
-					Value: wildflyPath,
-				},
-			},
-		},
-	},
-}
-
-func defaultVhdImageConfig() *distro.ImageConfig {
-	imageConfig := &distro.ImageConfig{
-		EnabledServices: append(defaultAzureImageConfig.EnabledServices, "firewalld"),
-	}
-	return imageConfig.InheritFrom(defaultAzureImageConfig)
-}
-
-func sapAzureImageConfig(rd *rhel.Distribution) *distro.ImageConfig {
-	return sapImageConfig(rd).InheritFrom(defaultVhdImageConfig())
 }

--- a/pkg/distro/rhel/rhel8/distro.go
+++ b/pkg/distro/rhel/rhel8/distro.go
@@ -80,8 +80,8 @@ func newDistro(name string, minor int) *rhel.Distribution {
 				QCOW2Compat: "0.10",
 			},
 		},
-		mkQcow2ImgType(rd),
-		mkOCIImgType(rd),
+		mkQcow2ImgType(rd, arch.ARCH_X86_64),
+		mkOCIImgType(rd, arch.ARCH_X86_64),
 	)
 
 	x86_64.AddImageTypes(
@@ -92,7 +92,7 @@ func newDistro(name string, minor int) *rhel.Distribution {
 				ImageFormat: platform.FORMAT_QCOW2,
 			},
 		},
-		mkOpenstackImgType(),
+		mkOpenstackImgType(rd, arch.ARCH_X86_64),
 	)
 
 	ec2X86Platform := &platform.X86{
@@ -113,7 +113,7 @@ func newDistro(name string, minor int) *rhel.Distribution {
 
 	x86_64.AddImageTypes(
 		ec2X86Platform,
-		mkAmiImgTypeX86_64(),
+		mkAmiImgTypeX86_64(rd),
 	)
 
 	bareMetalX86Platform := &platform.X86{
@@ -138,9 +138,9 @@ func newDistro(name string, minor int) *rhel.Distribution {
 
 	x86_64.AddImageTypes(
 		bareMetalX86Platform,
-		mkEdgeOCIImgType(rd),
-		mkEdgeCommitImgType(rd),
-		mkEdgeInstallerImgType(rd),
+		mkEdgeOCIImgType(rd, arch.ARCH_X86_64),
+		mkEdgeCommitImgType(rd, arch.ARCH_X86_64),
+		mkEdgeInstallerImgType(rd, arch.ARCH_X86_64),
 		mkImageInstaller(),
 	)
 
@@ -153,7 +153,7 @@ func newDistro(name string, minor int) *rhel.Distribution {
 
 	x86_64.AddImageTypes(
 		gceX86Platform,
-		mkGceImgType(rd),
+		mkGceImgType(rd, arch.ARCH_X86_64),
 	)
 
 	x86_64.AddImageTypes(
@@ -164,7 +164,7 @@ func newDistro(name string, minor int) *rhel.Distribution {
 				ImageFormat: platform.FORMAT_VMDK,
 			},
 		},
-		mkVmdkImgType(),
+		mkVmdkImgType(rd, arch.ARCH_X86_64),
 	)
 
 	x86_64.AddImageTypes(
@@ -175,13 +175,13 @@ func newDistro(name string, minor int) *rhel.Distribution {
 				ImageFormat: platform.FORMAT_OVA,
 			},
 		},
-		mkOvaImgType(),
+		mkOvaImgType(rd, arch.ARCH_X86_64),
 	)
 
 	x86_64.AddImageTypes(
 		&platform.X86{},
 		mkTarImgType(),
-		mkWslImgType(),
+		mkWslImgType(rd, arch.ARCH_X86_64),
 	)
 
 	aarch64.AddImageTypes(
@@ -192,7 +192,7 @@ func newDistro(name string, minor int) *rhel.Distribution {
 				QCOW2Compat: "0.10",
 			},
 		},
-		mkQcow2ImgType(rd),
+		mkQcow2ImgType(rd, arch.ARCH_AARCH64),
 	)
 
 	aarch64.AddImageTypes(
@@ -202,13 +202,13 @@ func newDistro(name string, minor int) *rhel.Distribution {
 				ImageFormat: platform.FORMAT_QCOW2,
 			},
 		},
-		mkOpenstackImgType(),
+		mkOpenstackImgType(rd, arch.ARCH_X86_64),
 	)
 
 	aarch64.AddImageTypes(
 		&platform.Aarch64{},
 		mkTarImgType(),
-		mkWslImgType(),
+		mkWslImgType(rd, arch.ARCH_AARCH64),
 	)
 
 	bareMetalAarch64Platform := &platform.Aarch64{
@@ -218,9 +218,9 @@ func newDistro(name string, minor int) *rhel.Distribution {
 
 	aarch64.AddImageTypes(
 		bareMetalAarch64Platform,
-		mkEdgeOCIImgType(rd),
-		mkEdgeCommitImgType(rd),
-		mkEdgeInstallerImgType(rd),
+		mkEdgeOCIImgType(rd, arch.ARCH_X86_64),
+		mkEdgeCommitImgType(rd, arch.ARCH_X86_64),
+		mkEdgeInstallerImgType(rd, arch.ARCH_X86_64),
 		mkImageInstaller(),
 	)
 
@@ -233,8 +233,8 @@ func newDistro(name string, minor int) *rhel.Distribution {
 
 	aarch64.AddImageTypes(
 		rawAarch64Platform,
-		mkAmiImgTypeAarch64(),
-		mkMinimalRawImgType(),
+		mkAmiImgTypeAarch64(rd),
+		mkMinimalRawImgType(rd, arch.ARCH_X86_64),
 	)
 
 	ppc64le.AddImageTypes(
@@ -245,7 +245,7 @@ func newDistro(name string, minor int) *rhel.Distribution {
 				QCOW2Compat: "0.10",
 			},
 		},
-		mkQcow2ImgType(rd),
+		mkQcow2ImgType(rd, arch.ARCH_PPC64LE),
 	)
 
 	ppc64le.AddImageTypes(
@@ -261,7 +261,7 @@ func newDistro(name string, minor int) *rhel.Distribution {
 				QCOW2Compat: "0.10",
 			},
 		},
-		mkQcow2ImgType(rd),
+		mkQcow2ImgType(rd, arch.ARCH_S390X),
 	)
 
 	s390x.AddImageTypes(
@@ -294,48 +294,50 @@ func newDistro(name string, minor int) *rhel.Distribution {
 
 	x86_64.AddImageTypes(
 		rawUEFIx86Platform,
-		mkMinimalRawImgType(),
+		mkMinimalRawImgType(rd, arch.ARCH_X86_64),
 	)
 
+	// XXX: note that this is reduandant and the else part can be dropped,
+	// we have only rhel8 based images, no centos or others
 	if rd.IsRHEL() {
 		if common.VersionGreaterThanOrEqual(rd.OsVersion(), "8.6") {
 			// image types only available on 8.6 and later on RHEL
 			// These edge image types require FDO which aren't available on older versions
 			x86_64.AddImageTypes(
 				bareMetalX86Platform,
-				mkEdgeRawImgType(),
+				mkEdgeRawImgType(rd, arch.ARCH_X86_64),
 			)
 
 			x86_64.AddImageTypes(
 				rawUEFIx86Platform,
-				mkEdgeSimplifiedInstallerImgType(rd),
+				mkEdgeSimplifiedInstallerImgType(rd, arch.ARCH_X86_64),
 			)
 
 			x86_64.AddImageTypes(
 				azureX64Platform,
-				mkAzureEap7RhuiImgType(),
+				mkAzureEap7RhuiImgType(rd, arch.ARCH_X86_64),
 			)
 
 			aarch64.AddImageTypes(
 				rawAarch64Platform,
-				mkEdgeRawImgType(),
-				mkEdgeSimplifiedInstallerImgType(rd),
+				mkEdgeRawImgType(rd, arch.ARCH_AARCH64),
+				mkEdgeSimplifiedInstallerImgType(rd, arch.ARCH_AARCH64),
 			)
 
 			// The Azure image types require hyperv-daemons which isn't available on older versions
 			aarch64.AddImageTypes(
 				azureAarch64Platform,
-				mkAzureRhuiImgType(),
-				mkAzureByosImgType(),
+				mkAzureRhuiImgType(rd, arch.ARCH_AARCH64),
+				mkAzureByosImgType(rd, arch.ARCH_AARCH64),
 			)
 		}
 
 		// add azure to RHEL distro only
 		x86_64.AddImageTypes(
 			azureX64Platform,
-			mkAzureRhuiImgType(),
-			mkAzureByosImgType(),
-			mkAzureSapRhuiImgType(rd),
+			mkAzureRhuiImgType(rd, arch.ARCH_X86_64),
+			mkAzureByosImgType(rd, arch.ARCH_X86_64),
+			mkAzureSapRhuiImgType(rd, arch.ARCH_X86_64),
 		)
 
 		// add ec2 image types to RHEL distro only
@@ -362,7 +364,7 @@ func newDistro(name string, minor int) *rhel.Distribution {
 		// add GCE RHUI image to RHEL only
 		x86_64.AddImageTypes(
 			gceX86Platform,
-			mkGceRhuiImgType(rd),
+			mkGceRhuiImgType(rd, arch.ARCH_X86_64),
 		)
 
 		// add s390x to RHEL distro only
@@ -370,28 +372,28 @@ func newDistro(name string, minor int) *rhel.Distribution {
 	} else {
 		x86_64.AddImageTypes(
 			bareMetalX86Platform,
-			mkEdgeRawImgType(),
+			mkEdgeRawImgType(rd, arch.ARCH_X86_64),
 		)
 
 		x86_64.AddImageTypes(
 			rawUEFIx86Platform,
-			mkEdgeSimplifiedInstallerImgType(rd),
+			mkEdgeSimplifiedInstallerImgType(rd, arch.ARCH_X86_64),
 		)
 
 		x86_64.AddImageTypes(
 			azureX64Platform,
-			mkAzureImgType(),
+			mkAzureImgType(rd, arch.ARCH_X86_64),
 		)
 
 		aarch64.AddImageTypes(
 			rawAarch64Platform,
-			mkEdgeRawImgType(),
-			mkEdgeSimplifiedInstallerImgType(rd),
+			mkEdgeRawImgType(rd, arch.ARCH_AARCH64),
+			mkEdgeSimplifiedInstallerImgType(rd, arch.ARCH_AARCH64),
 		)
 
 		aarch64.AddImageTypes(
 			azureAarch64Platform,
-			mkAzureImgType(),
+			mkAzureImgType(rd, arch.ARCH_AARCH64),
 		)
 	}
 	rd.AddArches(x86_64, aarch64, ppc64le)

--- a/pkg/distro/rhel/rhel8/edge.go
+++ b/pkg/distro/rhel/rhel8/edge.go
@@ -1,16 +1,14 @@
 package rhel8
 
 import (
-	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/customizations/fsnode"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
-	"github.com/osbuild/images/pkg/osbuild"
 )
 
-func mkEdgeCommitImgType(rd *rhel.Distribution) *rhel.ImageType {
+func mkEdgeCommitImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"edge-commit",
 		"commit.tar",
@@ -23,16 +21,13 @@ func mkEdgeCommitImgType(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.NameAliases = []string{"rhel-edge-commit"}
-	it.DefaultImageConfig = &distro.ImageConfig{
-		EnabledServices: edgeServices(rd),
-		DracutConf:      []*osbuild.DracutConfStageOptions{osbuild.FIPSDracutConfStageOptions},
-	}
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "edge-commit")
 	it.RPMOSTree = true
 
 	return it
 }
 
-func mkEdgeOCIImgType(rd *rhel.Distribution) *rhel.ImageType {
+func mkEdgeOCIImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"edge-container",
 		"container.tar",
@@ -45,16 +40,13 @@ func mkEdgeOCIImgType(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.NameAliases = []string{"rhel-edge-container"}
-	it.DefaultImageConfig = &distro.ImageConfig{
-		EnabledServices: edgeServices(rd),
-		DracutConf:      []*osbuild.DracutConfStageOptions{osbuild.FIPSDracutConfStageOptions},
-	}
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "edge-container")
 	it.RPMOSTree = true
 
 	return it
 }
 
-func mkEdgeRawImgType() *rhel.ImageType {
+func mkEdgeRawImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"edge-raw-image",
 		"image.raw.xz",
@@ -68,14 +60,7 @@ func mkEdgeRawImgType() *rhel.ImageType {
 
 	it.NameAliases = []string{"rhel-edge-raw-image"}
 	it.Compression = "xz"
-	it.DefaultImageConfig = &distro.ImageConfig{
-		Keyboard: &osbuild.KeymapStageOptions{
-			Keymap: "us",
-		},
-		Locale:        common.ToPtr("C.UTF-8"),
-		LockRootUser:  common.ToPtr(true),
-		KernelOptions: []string{"modprobe.blacklist=vc4"},
-	}
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "edge-raw-image")
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.RPMOSTree = true
 	it.Bootable = true
@@ -88,7 +73,7 @@ func mkEdgeRawImgType() *rhel.ImageType {
 	return it
 }
 
-func mkEdgeInstallerImgType(rd *rhel.Distribution) *rhel.ImageType {
+func mkEdgeInstallerImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"edge-installer",
 		"installer.iso",
@@ -101,9 +86,7 @@ func mkEdgeInstallerImgType(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.NameAliases = []string{"rhel-edge-installer"}
-	it.DefaultImageConfig = &distro.ImageConfig{
-		EnabledServices: edgeServices(rd),
-	}
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "edge-installer")
 	it.DefaultInstallerConfig = &distro.InstallerConfig{
 		AdditionalDracutModules: []string{
 			"ifcfg",
@@ -116,7 +99,7 @@ func mkEdgeInstallerImgType(rd *rhel.Distribution) *rhel.ImageType {
 	return it
 }
 
-func mkEdgeSimplifiedInstallerImgType(rd *rhel.Distribution) *rhel.ImageType {
+func mkEdgeSimplifiedInstallerImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"edge-simplified-installer",
 		"simplified-installer.iso",
@@ -129,15 +112,7 @@ func mkEdgeSimplifiedInstallerImgType(rd *rhel.Distribution) *rhel.ImageType {
 	)
 
 	it.NameAliases = []string{"rhel-edge-simplified-installer"}
-	it.DefaultImageConfig = &distro.ImageConfig{
-		EnabledServices: edgeServices(rd),
-		Keyboard: &osbuild.KeymapStageOptions{
-			Keymap: "us",
-		},
-		Locale:        common.ToPtr("C.UTF-8"),
-		LockRootUser:  common.ToPtr(true),
-		KernelOptions: []string{"modprobe.blacklist=vc4"},
-	}
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "edge-simplified-installer")
 	it.DefaultInstallerConfig = &distro.InstallerConfig{
 		AdditionalDracutModules: []string{
 			"prefixdevname",
@@ -158,7 +133,7 @@ func mkEdgeSimplifiedInstallerImgType(rd *rhel.Distribution) *rhel.ImageType {
 	return it
 }
 
-func mkMinimalRawImgType() *rhel.ImageType {
+func mkMinimalRawImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"minimal-raw",
 		"disk.raw.xz",
@@ -171,61 +146,10 @@ func mkMinimalRawImgType() *rhel.ImageType {
 	)
 
 	it.Compression = "xz"
-	it.DefaultImageConfig = &distro.ImageConfig{
-		EnabledServices: minimalrawServices,
-		// NOTE: temporary workaround for a bug in initial-setup that
-		// requires a kickstart file in the root directory.
-		Files:         []*fsnode.File{initialSetupKickstart()},
-		KernelOptions: []string{"ro"},
-	}
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "minimal-raw")
 	it.Bootable = true
 	it.DefaultSize = 2 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
 
 	return it
-}
-
-func edgeServices(rd *rhel.Distribution) []string {
-	// Common Services
-	var edgeServices = []string{"NetworkManager.service", "firewalld.service", "sshd.service"}
-
-	if rd.OsVersion() == "8.4" {
-		// greenboot services aren't enabled by default in 8.4
-		edgeServices = append(edgeServices,
-			"greenboot-grub2-set-counter",
-			"greenboot-grub2-set-success",
-			"greenboot-healthcheck",
-			"greenboot-rpm-ostree-grub2-check-fallback",
-			"greenboot-status",
-			"greenboot-task-runner",
-			"redboot-auto-reboot",
-			"redboot-task-runner")
-
-	}
-
-	if !(rd.IsRHEL() && common.VersionLessThan(rd.OsVersion(), "8.6")) {
-		// enable fdo-client only on RHEL 8.6+ and CS8
-
-		// TODO(runcom): move fdo-client-linuxapp.service to presets?
-		edgeServices = append(edgeServices, "fdo-client-linuxapp.service")
-	}
-
-	return edgeServices
-}
-
-var minimalrawServices = []string{
-	"NetworkManager.service",
-	"firewalld.service",
-	"sshd.service",
-	"initial-setup.service",
-}
-
-// initialSetupKickstart returns the File configuration for a kickstart file
-// that's required to enable initial-setup to run on first boot.
-func initialSetupKickstart() *fsnode.File {
-	file, err := fsnode.NewFile("/root/anaconda-ks.cfg", nil, "root", "root", []byte("# Run initial-setup on first boot\n# Created by osbuild\nfirstboot --reconfig\nlang en_US.UTF-8\n"))
-	if err != nil {
-		panic(err)
-	}
-	return file
 }

--- a/pkg/distro/rhel/rhel8/gce.go
+++ b/pkg/distro/rhel/rhel8/gce.go
@@ -1,15 +1,12 @@
 package rhel8
 
 import (
-	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/customizations/subscription"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/datasizes"
-	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
-	"github.com/osbuild/images/pkg/osbuild"
 )
 
-func mkGceImgType(rd distro.Distro) *rhel.ImageType {
+func mkGceImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"gce",
 		"image.tar.gz",
@@ -21,7 +18,7 @@ func mkGceImgType(rd distro.Distro) *rhel.ImageType {
 		[]string{"archive"},
 	)
 
-	it.DefaultImageConfig = defaultGceByosImageConfig(rd)
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "gce")
 	it.Bootable = true
 	it.DefaultSize = 20 * datasizes.GibiByte
 	// TODO: the base partition table still contains the BIOS boot partition, but the image is UEFI-only
@@ -30,7 +27,7 @@ func mkGceImgType(rd distro.Distro) *rhel.ImageType {
 	return it
 }
 
-func mkGceRhuiImgType(rd distro.Distro) *rhel.ImageType {
+func mkGceRhuiImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"gce-rhui",
 		"image.tar.gz",
@@ -42,151 +39,11 @@ func mkGceRhuiImgType(rd distro.Distro) *rhel.ImageType {
 		[]string{"archive"},
 	)
 
-	it.DefaultImageConfig = defaultGceRhuiImageConfig(rd)
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "gce-rhui")
 	it.Bootable = true
 	it.DefaultSize = 20 * datasizes.GibiByte
 	// TODO: the base partition table still contains the BIOS boot partition, but the image is UEFI-only
 	it.BasePartitionTables = partitionTables
 
 	return it
-}
-
-// The configuration for non-RHUI images does not touch the RHSM configuration at all.
-// https://issues.redhat.com/browse/COMPOSER-2157
-func defaultGceByosImageConfig(rd distro.Distro) *distro.ImageConfig {
-	ic := &distro.ImageConfig{
-		Timezone: common.ToPtr("UTC"),
-		TimeSynchronization: &osbuild.ChronyStageOptions{
-			Servers: []osbuild.ChronyConfigServer{{Hostname: "metadata.google.internal"}},
-		},
-		Firewall: &osbuild.FirewallStageOptions{
-			DefaultZone: "trusted",
-		},
-		EnabledServices: []string{
-			"sshd",
-			"rngd",
-			"dnf-automatic.timer",
-		},
-		DisabledServices: []string{
-			"sshd-keygen@",
-			"reboot.target",
-		},
-		DefaultTarget: common.ToPtr("multi-user.target"),
-		Locale:        common.ToPtr("en_US.UTF-8"),
-		Keyboard: &osbuild.KeymapStageOptions{
-			Keymap: "us",
-		},
-		DNFConfig: &distro.DNFConfig{
-			Options: []*osbuild.DNFConfigStageOptions{
-				{
-					Config: &osbuild.DNFConfig{
-						Main: &osbuild.DNFConfigMain{
-							IPResolve: "4",
-						},
-					},
-				},
-			},
-		},
-		DNFAutomaticConfig: &osbuild.DNFAutomaticConfigStageOptions{
-			Config: &osbuild.DNFAutomaticConfig{
-				Commands: &osbuild.DNFAutomaticConfigCommands{
-					ApplyUpdates: common.ToPtr(true),
-					UpgradeType:  osbuild.DNFAutomaticUpgradeTypeSecurity,
-				},
-			},
-		},
-		YUMRepos: []*osbuild.YumReposStageOptions{
-			{
-				Filename: "google-cloud.repo",
-				Repos: []osbuild.YumRepository{
-					{
-						Id:           "google-compute-engine",
-						Name:         "Google Compute Engine",
-						BaseURLs:     []string{"https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable"},
-						Enabled:      common.ToPtr(true),
-						GPGCheck:     common.ToPtr(true),
-						RepoGPGCheck: common.ToPtr(false),
-						GPGKey: []string{
-							"https://packages.cloud.google.com/yum/doc/yum-key.gpg",
-							"https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg",
-						},
-					},
-				},
-			},
-		},
-		SshdConfig: &osbuild.SshdConfigStageOptions{
-			Config: osbuild.SshdConfigConfig{
-				PasswordAuthentication: common.ToPtr(false),
-				ClientAliveInterval:    common.ToPtr(420),
-				PermitRootLogin:        osbuild.PermitRootLoginValueNo,
-			},
-		},
-		DefaultKernel:       common.ToPtr("kernel-core"),
-		UpdateDefaultKernel: common.ToPtr(true),
-		// XXX: ensure the "old" behavior is preserved (that is
-		// likely a bug) where for GCE the sysconfig network
-		// options are not set because the merge of imageConfig
-		// is shallow and the previous setup was changing the
-		// kernel without also changing the network options.
-		Sysconfig: &distro.Sysconfig{},
-		Modprobe: []*osbuild.ModprobeStageOptions{
-			{
-				Filename: "blacklist-floppy.conf",
-				Commands: osbuild.ModprobeConfigCmdList{
-					osbuild.NewModprobeConfigCmdBlacklist("floppy"),
-				},
-			},
-		},
-		GCPGuestAgentConfig: &osbuild.GcpGuestAgentConfigOptions{
-			ConfigScope: osbuild.GcpGuestAgentConfigScopeDistro,
-			Config: &osbuild.GcpGuestAgentConfig{
-				InstanceSetup: &osbuild.GcpGuestAgentConfigInstanceSetup{
-					SetBotoConfig: common.ToPtr(false),
-				},
-			},
-		},
-		KernelOptions: []string{"net.ifnames=0", "biosdevname=0", "scsi_mod.use_blk_mq=Y", "crashkernel=auto", "console=ttyS0,38400n8d"},
-	}
-	if rd.OsVersion() == "8.4" {
-		// NOTE(akoutsou): these are enabled in the package preset, but for
-		// some reason do not get enabled on 8.4.
-		// the reason is unknown and deeply mysterious
-		ic.EnabledServices = append(ic.EnabledServices,
-			"google-oslogin-cache.timer",
-			"google-guest-agent.service",
-			"google-shutdown-scripts.service",
-			"google-startup-scripts.service",
-			"google-osconfig-agent.service",
-		)
-	}
-
-	return ic
-}
-
-func defaultGceRhuiImageConfig(rd distro.Distro) *distro.ImageConfig {
-	ic := &distro.ImageConfig{
-		RHSMConfig: map[subscription.RHSMStatus]*subscription.RHSMConfig{
-			subscription.RHSMConfigNoSubscription: {
-				SubMan: subscription.SubManConfig{
-					Rhsmcertd: subscription.SubManRHSMCertdConfig{
-						AutoRegistration: common.ToPtr(true),
-					},
-					Rhsm: subscription.SubManRHSMConfig{
-						ManageRepos: common.ToPtr(false),
-					},
-				},
-			},
-			subscription.RHSMConfigWithSubscription: {
-				SubMan: subscription.SubManConfig{
-					Rhsmcertd: subscription.SubManRHSMCertdConfig{
-						AutoRegistration: common.ToPtr(true),
-					},
-					// do not disable the redhat.repo management if the user
-					// explicitly request the system to be subscribed
-				},
-			},
-		},
-	}
-	ic = ic.InheritFrom(defaultGceByosImageConfig(rd))
-	return ic
 }

--- a/pkg/distro/rhel/rhel8/package_sets.go
+++ b/pkg/distro/rhel/rhel8/package_sets.go
@@ -3,6 +3,8 @@ package rhel8
 // This file defines package sets that are used by more than one image type.
 
 import (
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -10,4 +12,8 @@ import (
 
 func packageSetLoader(t *rhel.ImageType) (map[string]rpmmd.PackageSet, error) {
 	return defs.PackageSets(t)
+}
+
+func imageConfig(d *rhel.Distribution, archName, imageType string) *distro.ImageConfig {
+	return common.Must(defs.ImageConfig(d.Name(), archName, imageType))
 }

--- a/pkg/distro/rhel/rhel8/qcow2.go
+++ b/pkg/distro/rhel/rhel8/qcow2.go
@@ -1,14 +1,12 @@
 package rhel8
 
 import (
-	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/customizations/subscription"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/datasizes"
-	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 )
 
-func mkQcow2ImgType(rd *rhel.Distribution) *rhel.ImageType {
+func mkQcow2ImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"qcow2",
 		"disk.qcow2",
@@ -20,7 +18,7 @@ func mkQcow2ImgType(rd *rhel.Distribution) *rhel.ImageType {
 		[]string{"qcow2"},
 	)
 
-	it.DefaultImageConfig = qcowImageConfig(rd)
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "qcow2")
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -28,7 +26,7 @@ func mkQcow2ImgType(rd *rhel.Distribution) *rhel.ImageType {
 	return it
 }
 
-func mkOCIImgType(rd *rhel.Distribution) *rhel.ImageType {
+func mkOCIImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"oci",
 		"disk.qcow2",
@@ -40,7 +38,7 @@ func mkOCIImgType(rd *rhel.Distribution) *rhel.ImageType {
 		[]string{"qcow2"},
 	)
 
-	it.DefaultImageConfig = qcowImageConfig(rd)
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "oci")
 	it.Bootable = true
 	it.DefaultSize = 10 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -48,7 +46,7 @@ func mkOCIImgType(rd *rhel.Distribution) *rhel.ImageType {
 	return it
 }
 
-func mkOpenstackImgType() *rhel.ImageType {
+func mkOpenstackImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"openstack",
 		"disk.qcow2",
@@ -59,34 +57,10 @@ func mkOpenstackImgType() *rhel.ImageType {
 		[]string{"os", "image", "qcow2"},
 		[]string{"qcow2"},
 	)
-	it.DefaultImageConfig = &distro.ImageConfig{
-		KernelOptions: []string{"ro", "net.ifnames=0"},
-	}
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "openstack")
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.Bootable = true
 	it.BasePartitionTables = partitionTables
 
 	return it
-}
-
-func qcowImageConfig(d *rhel.Distribution) *distro.ImageConfig {
-	ic := &distro.ImageConfig{
-		DefaultTarget: common.ToPtr("multi-user.target"),
-		KernelOptions: []string{"console=tty0", "console=ttyS0,115200n8", "no_timer_check", "net.ifnames=0", "crashkernel=auto"},
-	}
-	if d.IsRHEL() {
-		ic.RHSMConfig = map[subscription.RHSMStatus]*subscription.RHSMConfig{
-			subscription.RHSMConfigNoSubscription: {
-				DnfPlugins: subscription.SubManDNFPluginsConfig{
-					ProductID: subscription.DNFPluginConfig{
-						Enabled: common.ToPtr(false),
-					},
-					SubscriptionManager: subscription.DNFPluginConfig{
-						Enabled: common.ToPtr(false),
-					},
-				},
-			},
-		}
-	}
-	return ic
 }

--- a/pkg/distro/rhel/rhel8/ubi.go
+++ b/pkg/distro/rhel/rhel8/ubi.go
@@ -1,12 +1,11 @@
 package rhel8
 
 import (
-	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/distro/rhel"
 )
 
-func mkWslImgType() *rhel.ImageType {
+func mkWslImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"wsl",
 		"disk.tar.gz",
@@ -17,14 +16,7 @@ func mkWslImgType() *rhel.ImageType {
 		[]string{"os", "archive"},
 		[]string{"archive"},
 	)
-
-	it.DefaultImageConfig = &distro.ImageConfig{
-		Locale:    common.ToPtr("en_US.UTF-8"),
-		NoSElinux: common.ToPtr(true),
-		WSLConfig: &distro.WSLConfig{
-			BootSystemd: true,
-		},
-	}
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "wsl")
 
 	return it
 }

--- a/pkg/distro/rhel/rhel8/vmdk.go
+++ b/pkg/distro/rhel/rhel8/vmdk.go
@@ -1,16 +1,12 @@
 package rhel8
 
 import (
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/datasizes"
-	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 )
 
-func vmdkKernelOptions() []string {
-	return []string{"ro", "net.ifnames=0"}
-}
-
-func mkVmdkImgType() *rhel.ImageType {
+func mkVmdkImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"vmdk",
 		"disk.vmdk",
@@ -21,9 +17,7 @@ func mkVmdkImgType() *rhel.ImageType {
 		[]string{"os", "image", "vmdk"},
 		[]string{"vmdk"},
 	)
-	it.DefaultImageConfig = &distro.ImageConfig{
-		KernelOptions: vmdkKernelOptions(),
-	}
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "vmdk")
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables
@@ -31,7 +25,7 @@ func mkVmdkImgType() *rhel.ImageType {
 	return it
 }
 
-func mkOvaImgType() *rhel.ImageType {
+func mkOvaImgType(rd *rhel.Distribution, a arch.Arch) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"ova",
 		"image.ova",
@@ -42,9 +36,7 @@ func mkOvaImgType() *rhel.ImageType {
 		[]string{"os", "image", "vmdk", "ovf", "archive"},
 		[]string{"archive"},
 	)
-	it.DefaultImageConfig = &distro.ImageConfig{
-		KernelOptions: vmdkKernelOptions(),
-	}
+	it.DefaultImageConfig = imageConfig(rd, a.String(), "ova")
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
 	it.BasePartitionTables = partitionTables

--- a/pkg/osbuild/grub2_stage.go
+++ b/pkg/osbuild/grub2_stage.go
@@ -48,8 +48,8 @@ type GRUB2Config struct {
 	DisableSubmenu  *bool                   `json:"disable_submenu,omitempty" yaml:"disable_submenu,omitempty"`
 	Distributor     string                  `json:"distributor,omitempty"`
 	Terminal        []string                `json:"terminal,omitempty"`
-	TerminalInput   []string                `json:"terminal_input,omitempty"`
-	TerminalOutput  []string                `json:"terminal_output,omitempty"`
+	TerminalInput   []string                `json:"terminal_input,omitempty" yaml:"terminal_input,omitempty"`
+	TerminalOutput  []string                `json:"terminal_output,omitempty" yaml:"terminal_output,omitempty"`
 	Timeout         int                     `json:"timeout,omitempty"`
 	TimeoutStyle    GRUB2ConfigTimeoutStyle `json:"timeout_style,omitempty" yaml:"timeout_style,omitempty"`
 	Serial          string                  `json:"serial,omitempty"`

--- a/pkg/osbuild/yum_config_stage.go
+++ b/pkg/osbuild/yum_config_stage.go
@@ -5,7 +5,7 @@ import (
 )
 
 type YumConfigConfig struct {
-	HttpCaching *string `json:"http_caching,omitempty"`
+	HttpCaching *string `json:"http_caching,omitempty" yaml:"http_caching,omitempty"`
 }
 
 type YumConfigPlugins struct {


### PR DESCRIPTION
This PR moves the rhel8 image config into YAML.

This PR also shows some complexity with complex
image types that inherit like ec2-sap, we need to
create weird workarounds, we can hold this off
and chat how to make this cleaner. Note however
that the previous (in code) inheritance also has
their pitfalls as ImageConfig.InheritFrom() will
also do no merging but there are no conditions
there so the structure is simpler.

---

rhel8: move imageconfig into YAML

This commit moves all the image config of rhel-8 into pure
YAML.

---

rhel8: remove leftover partition loader coder

There was some leftover code that still defined the
azure-rhui partition table in code. This is all in
yaml and this commit removes it.
