### PR TITLE
image: grow the anaconda rootfs image to 10 GiB

### DIFF
--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -98,7 +98,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoLabel := fmt.Sprintf(img.ISOLabelTempl, img.Platform.GetArch())
 
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)
-	rootfsImagePipeline.Size = 4 * common.GibiByte
+	rootfsImagePipeline.Size = 10 * common.GibiByte // NOTE: should be big enough to fit the anaconda-tree
 
 	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
 	bootTreePipeline.Platform = img.Platform


### PR DESCRIPTION
With newer versions of RHEL 8.10 packages, the anaconda-tree for the edge-installer has grown to be larger than 4 GiB.  This makes it impossible to build edge-installers with osbuild-composer on RHEL 8.10.

Grow the anaconda rootfs image to 10 GiB, which should be big enough to fit even future growth.  This shouldn't affect the size of the ISO since it's compressed using squashfs.

NOTE: This PR is made against a new branch called `quickfix/rhel-8.10/iso-rootfs/10GB`.  The plan is to use this branch to build an unsigned osbuild-composer for a user facing the issue.