### PR TITLE
image: add conditions as strings via starlark

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/ubccr/kerby v0.0.0-20230802201021-412be7bfaee5
 	github.com/vmware/govmomi v0.48.1
+	go.starlark.net v0.0.0-20250603171236-27fdb1d4744d
 	golang.org/x/exp v0.0.0-20250103183323-7d7fa50e5329
 	golang.org/x/oauth2 v0.26.0
 	golang.org/x/sys v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -466,6 +466,8 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.2.0 h1:pVeZGk7nXDC9O2hncA6nHldxEjm6LByfA2aN8IOkz94=
 go.opentelemetry.io/proto/otlp v1.2.0/go.mod h1:gGpR8txAl5M03pDhMC79G6SdqNV26naRm/KDsgaHD8A=
+go.starlark.net v0.0.0-20250603171236-27fdb1d4744d h1:FubZUgwT1cKKeI+fybmPehRDxqv/SurjGzaCXv5IeLs=
+go.starlark.net v0.0.0-20250603171236-27fdb1d4744d/go.mod h1:YKMCv9b1WrfWmeqdV5MAuEHWsu5iC+fe6kYl2sQjdI8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -168,17 +168,18 @@
       - "net-lib"
     squashfs_rootfs: true
     condition:
-      version_less_than:
-        "42":
-          # config is fully replaced
-          additional_dracut_modules:
-            - "ifcfg"
-          squashfs_rootfs: true
-        "41":
-          # config is fully replaced
-          additional_dracut_modules:
-            - "ifcfg"
-          squashfs_rootfs: false
+      "installer_config for installer config":
+        version_less_than:
+          "42":
+            # config is fully replaced
+            additional_dracut_modules:
+              - "ifcfg"
+            squashfs_rootfs: true
+          "41":
+            # config is fully replaced
+            additional_dracut_modules:
+              - "ifcfg"
+            squashfs_rootfs: false
 
   image_config:
     iot_enabled_services: &image_config_iot_enabled_services
@@ -196,25 +197,26 @@
         - "redboot-task-runner"
       kernel_options: *ostree_deployment_kernel_options
       condition:
-        version_less_than:
-          "42":
-            enabled_services:
-              - "NetworkManager.service"
-              - "firewalld.service"
-              - "sshd.service"
-              - "greenboot-grub2-set-counter"
-              - "greenboot-grub2-set-success"
-              - "greenboot-healthcheck"
-              - "greenboot-rpm-ostree-grub2-check-fallback"
-              - "greenboot-status"
-              - "greenboot-task-runner"
-              - "redboot-auto-reboot"
-              - "redboot-task-runner"
-              # only in < 42
-              - "zezere_ignition.timer"
-              - "zezere_ignition_banner.service"
-              - "parsec"
-              - "dbus-parsec"
+        "conditions for iot_enabled_services":
+          version_less_than:
+            "42":
+              enabled_services:
+                - "NetworkManager.service"
+                - "firewalld.service"
+                - "sshd.service"
+                - "greenboot-grub2-set-counter"
+                - "greenboot-grub2-set-success"
+                - "greenboot-healthcheck"
+                - "greenboot-rpm-ostree-grub2-check-fallback"
+                - "greenboot-status"
+                - "greenboot-task-runner"
+                - "redboot-auto-reboot"
+                - "redboot-task-runner"
+                # only in < 42
+                - "zezere_ignition.timer"
+                - "zezere_ignition_banner.service"
+                - "parsec"
+                - "dbus-parsec"
     iot: &image_config_iot
       <<: *image_config_iot_enabled_services
       keyboard:
@@ -823,27 +825,28 @@ image_types:
             - "xz"
             - "zram-generator"
           condition:
-            version_less_than:
-              "41":
-                include:
-                  - "dnsmasq"
-              "42":
-                include:
-                  - "dbus-parsec"
-                  - "kernel-tools"
-                  - "parsec"
-                  - "policycoreutils-python-utils"
-                  - "zezere-ignition"
-              "43":
-                include:
-                  - "basesystem"
-            version_greater_or_equal:
-              "41":
-                include:
-                  - "bootupd"
-              "43":
-                include:
-                  - "filesystem"
+            "pkgs for iot commit":
+              version_less_than:
+                "41":
+                  include:
+                    - "dnsmasq"
+                "42":
+                  include:
+                    - "dbus-parsec"
+                    - "kernel-tools"
+                    - "parsec"
+                    - "policycoreutils-python-utils"
+                    - "zezere-ignition"
+                "43":
+                  include:
+                    - "basesystem"
+              version_greater_or_equal:
+                "41":
+                  include:
+                    - "bootupd"
+                "43":
+                  include:
+                    - "filesystem"
 
   "iot-container":
     <<: *iot_commit
@@ -923,20 +926,21 @@ image_types:
       <<: *iot_base_partition_tables
     partition_tables_override:
       condition:
-        version_greater_or_equal:
-          "42":
-            x86_64:
-              <<: *iot_base_partition_table_x86_64
-              partitions:
-                - *iot_base_partition_table_part_efi
-                - *iot_base_partition_table_part_boot
-                - *iot_base_partition_table_part_root_fstab_ro
-            aarch64:
-              <<: *iot_base_partition_table_aarch64
-              partitions:
-                - *iot_base_partition_table_part_efi_aarch64
-                - *iot_base_partition_table_part_boot_aarch64
-                - *iot_base_partition_table_part_root_fstab_ro_aarch64
+        "conditions for iot-raw-xz":
+          version_greater_or_equal:
+            "42":
+              x86_64:
+                <<: *iot_base_partition_table_x86_64
+                partitions:
+                  - *iot_base_partition_table_part_efi
+                  - *iot_base_partition_table_part_boot
+                  - *iot_base_partition_table_part_root_fstab_ro
+              aarch64:
+                <<: *iot_base_partition_table_aarch64
+                partitions:
+                  - *iot_base_partition_table_part_efi_aarch64
+                  - *iot_base_partition_table_part_boot_aarch64
+                  - *iot_base_partition_table_part_root_fstab_ro_aarch64
 
   "iot-qcow2":
     name_aliases: ["iot-qcow2-image"]
@@ -1086,26 +1090,27 @@ image_types:
             - "plymouth"         # for (datacenter/cloud oriented) servers we want to see the details by default.  https:#lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/HSMISZ3ETWQ4ETVLWZQJ55ARZT27AAV3/
             - "systemd-networkd"  # we use NetworkManager
           condition:
-            architecture:
-              aarch64:
-                include:
-                  - "irqbalance"
-                  - "ostree-grub2"
-                exclude:
-                  - "perl"
-                  - "perl-interpreter"
-              ppc64le:
-                include:
-                  - "irqbalance"
-                  - "librtas"
-                  - "powerpc-utils-core"
-                  - "ppc64-diag-rtas"
-              x86_64:
-                include:
-                  - "irqbalance"
-                exclude:
-                  - "perl"
-                  - "perl-interpreter"
+            "conditions for iot-bootable-container":
+              architecture:
+                aarch64:
+                  include:
+                    - "irqbalance"
+                    - "ostree-grub2"
+                  exclude:
+                    - "perl"
+                    - "perl-interpreter"
+                ppc64le:
+                  include:
+                    - "irqbalance"
+                    - "librtas"
+                    - "powerpc-utils-core"
+                    - "ppc64-diag-rtas"
+                x86_64:
+                  include:
+                    - "irqbalance"
+                  exclude:
+                    - "perl"
+                    - "perl-interpreter"
 
   "minimal-raw-xz": &minimal_raw_xz
     name_aliases: ["minimal-raw"]
@@ -1157,17 +1162,18 @@ image_types:
       kernel_options:
         - "rw"
       condition:
-        version_less_than:
-          "43":
-            install_weak_deps: true
-            mount_units: false
-            enabled_services:
-              - "NetworkManager.service"
-              - "initial-setup.service"
-              - "sshd.service"
-              - "firewalld.service"
-            kernel_options:
-              - "ro"
+        "conditions for iot-raw-xz":
+          version_less_than:
+            "43":
+              install_weak_deps: true
+              mount_units: false
+              enabled_services:
+                - "NetworkManager.service"
+                - "initial-setup.service"
+                - "sshd.service"
+                - "firewalld.service"
+              kernel_options:
+                - "ro"
     partition_table:
       <<: *minimal_raw_partition_tables
     package_sets:
@@ -1184,17 +1190,18 @@ image_types:
           exclude:
             - "dracut-config-rescue"
           condition:
-            architecture:
-              riscv64:
-                include:
-                  # missing from @core in riscv64
-                  - "dnf5"
-                  - "policycoreutils"
-                  - "selinux-policy-targeted"
-            version_greater_or_equal:
-              "43":
-                exclude:
-                  - "firewalld"
+            "condition for minimal raw pkgs":
+              architecture:
+                riscv64:
+                  include:
+                    # missing from @core in riscv64
+                    - "dnf5"
+                    - "policycoreutils"
+                    - "selinux-policy-targeted"
+              version_greater_or_equal:
+                "43":
+                  exclude:
+                    - "firewalld"
   "minimal-raw-zst":
     <<: *minimal_raw_xz
     name_aliases: []
@@ -1374,16 +1381,17 @@ image_types:
             - "xrdb"
             - "xz"
           condition:
-            architecture:
-              x86_64:
-                include:
-                  - "biosdevname"
-                  - "dmidecode"
-                  - "grub2-tools-efi"
-                  - "memtest86+"
-              aarch64:
-                include:
-                  - "dmidecode"
+            "conditions for anaconda arch":
+              architecture:
+                x86_64:
+                  include:
+                    - "biosdevname"
+                    - "dmidecode"
+                    - "grub2-tools-efi"
+                    - "memtest86+"
+                aarch64:
+                  include:
+                    - "dmidecode"
 
   "iot-installer":
     name_aliases: ["fedora-iot-installer"]
@@ -1410,9 +1418,10 @@ image_types:
       locale: "en_US.UTF-8"
       iso_rootfs_type: "squashfs"
       condition:
-        version_less_than:
-          41:
-            iso_rootfs_type: "squashfs-ext4"
+        "condition for iot-installer":
+          version_less_than:
+            41:
+              iso_rootfs_type: "squashfs-ext4"
     package_sets:
       installer:
         - *anaconda_pkgset
@@ -1443,10 +1452,10 @@ image_types:
       locale: "en_US.UTF-8"
       iso_rootfs_type: "squashfs"
       condition:
-        version_less_than:
-          41:
-            iso_rootfs_type: "squashfs-ext4"
-
+        "conditions for workstation-live-installer":
+          version_less_than:
+            41:
+              iso_rootfs_type: "squashfs-ext4"
     package_sets:
       installer:
         - include:
@@ -1474,12 +1483,13 @@ image_types:
             - "reiserfs-utils"
             - "sdubby"
           condition:
-            version_greater_or_equal:
-              # XXX: this was VERSION_RAWHIDE, if we need this again lets add
-              # "alias" to defs.DistroYAML
-              43:
-                include:
-                  - "anaconda-webui"
+            "include anaconda webui in 43+":
+              version_greater_or_equal:
+                # XXX: this was VERSION_RAWHIDE, if we need this again lets add
+                # "alias" to defs.DistroYAML
+                43:
+                  include:
+                    - "anaconda-webui"
     platforms:
       - *x86_64_installer_platform
       - *aarch64_installer_platform
@@ -1511,23 +1521,25 @@ image_types:
         - "dbus-broker"
       squashfs_rootfs: true
       condition:
-        # on match the config is fully replaced
-        version_less_than:
-          "41":
-            additional_dracut_modules: &additional_dracut_f41
-              - "ifcfg"
-              - "dbus-broker"
-            squashfs_rootfs: false
-          "42":
-            additional_dracut_modules: *additional_dracut_f41
-            squashfs_rootfs: true
+        "conditional for minimal installer":
+          # on match the config is fully replaced
+          version_less_than:
+            "41":
+              additional_dracut_modules: &additional_dracut_f41
+                - "ifcfg"
+                - "dbus-broker"
+              squashfs_rootfs: false
+            "42":
+              additional_dracut_modules: *additional_dracut_f41
+              squashfs_rootfs: true
     image_config:
       locale: "en_US.UTF-8"
       iso_rootfs_type: "squashfs"
       condition:
-        version_less_than:
-          41:
-            iso_rootfs_type: "squashfs-ext4"
+        "old fedora used ext4 on squashfs":
+          version_less_than:
+            41:
+              iso_rootfs_type: "squashfs-ext4"
     platforms:
       - *x86_64_installer_platform
       - *aarch64_installer_platform
@@ -1619,18 +1631,19 @@ image_types:
     image_config:
       <<: *image_config_container
       condition:
-        version_less_than:
-          "42":
-            wsl_config:
-              boot_systemd: true
-            cloud_init:
-              - filename: "99_wsl.cfg"
-                config:
-                  datasource_list:
-                    - "WSL"
-                    - "None"
-                  network:
-                    config: "disabled"
+        "new f43 use the wsl-setup for setup":
+          version_less_than:
+            "42":
+              wsl_config:
+                boot_systemd: true
+              cloud_init:
+                - filename: "99_wsl.cfg"
+                  config:
+                    datasource_list:
+                      - "WSL"
+                      - "None"
+                    network:
+                      config: "disabled"
     package_sets:
       os:
         - include:
@@ -1673,17 +1686,18 @@ image_types:
             - "whois-nls"
             - "xkeyboard-config"
           condition:
-            version_greater_or_equal:
-              "41":
-                exclude:
-                  - "fuse-libs"
-              "42":
-                include:
-                  - "wsl-setup"
-            version_less_than:
-              "42":
-                include:
-                  - "cloud-init"
+            "new f43 use the wsl-setup for setup":
+              version_greater_or_equal:
+                "41":
+                  exclude:
+                    - "fuse-libs"
+                "42":
+                  include:
+                    - "wsl-setup"
+              version_less_than:
+                "42":
+                  include:
+                    - "cloud-init"
 
   "iot-simplified-installer":
     filename: "simplified-installer.iso"
@@ -1758,10 +1772,11 @@ image_types:
             - "util-linux"
             - "shadow-utils"  # includes passwd
           condition:
-            version_less_than:
-              "41":
-                include:
-                  - "dnsmasq"  # deprecated for F41+
+            "dnsmasq got deprecated in f41":
+              version_less_than:
+                "41":
+                  include:
+                    - "dnsmasq"  # deprecated for F41+
     platforms:
       - <<: *x86_64_uefi_platform
         packages:

--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -167,19 +167,19 @@
     additional_dracut_modules:
       - "net-lib"
     squashfs_rootfs: true
-    condition:
-      "installer_config for installer config":
-        version_less_than:
-          "42":
-            # config is fully replaced
-            additional_dracut_modules:
-              - "ifcfg"
-            squashfs_rootfs: true
-          "41":
-            # config is fully replaced
-            additional_dracut_modules:
-              - "ifcfg"
-            squashfs_rootfs: false
+    conditions:
+      "f41 uses ifcfg in dract but already a squashfs rootfs":
+        when: distro_version == "41"
+        override:
+          additional_dracut_modules:
+            - "ifcfg"
+          squashfs_rootfs: true
+      "f40 and lower uses ifcfg in dracut and no squashfs rootfs":
+        when: version_less_than("41")
+        override:
+          additional_dracut_modules:
+            - "ifcfg"
+          squashfs_rootfs: false
 
   image_config:
     iot_enabled_services: &image_config_iot_enabled_services
@@ -196,27 +196,27 @@
         - "redboot-auto-reboot"
         - "redboot-task-runner"
       kernel_options: *ostree_deployment_kernel_options
-      condition:
-        "conditions for iot_enabled_services":
-          version_less_than:
-            "42":
-              enabled_services:
-                - "NetworkManager.service"
-                - "firewalld.service"
-                - "sshd.service"
-                - "greenboot-grub2-set-counter"
-                - "greenboot-grub2-set-success"
-                - "greenboot-healthcheck"
-                - "greenboot-rpm-ostree-grub2-check-fallback"
-                - "greenboot-status"
-                - "greenboot-task-runner"
-                - "redboot-auto-reboot"
-                - "redboot-task-runner"
-                # only in < 42
-                - "zezere_ignition.timer"
-                - "zezere_ignition_banner.service"
-                - "parsec"
-                - "dbus-parsec"
+      conditions:
+        "f41 and below used zezere and parsec":
+          when: version_less_than("42")
+          merge:
+            enabled_services:
+              - "NetworkManager.service"
+              - "firewalld.service"
+              - "sshd.service"
+              - "greenboot-grub2-set-counter"
+              - "greenboot-grub2-set-success"
+              - "greenboot-healthcheck"
+              - "greenboot-rpm-ostree-grub2-check-fallback"
+              - "greenboot-status"
+              - "greenboot-task-runner"
+              - "redboot-auto-reboot"
+              - "redboot-task-runner"
+              # only in < 42
+              - "zezere_ignition.timer"
+              - "zezere_ignition_banner.service"
+              - "parsec"
+              - "dbus-parsec"
     iot: &image_config_iot
       <<: *image_config_iot_enabled_services
       keyboard:
@@ -824,29 +824,36 @@ image_types:
             - "xfsprogs"
             - "xz"
             - "zram-generator"
-          condition:
-            "pkgs for iot commit":
-              version_less_than:
-                "41":
-                  include:
-                    - "dnsmasq"
-                "42":
-                  include:
-                    - "dbus-parsec"
-                    - "kernel-tools"
-                    - "parsec"
-                    - "policycoreutils-python-utils"
-                    - "zezere-ignition"
-                "43":
-                  include:
-                    - "basesystem"
-              version_greater_or_equal:
-                "41":
-                  include:
-                    - "bootupd"
-                "43":
-                  include:
-                    - "filesystem"
+          conditions:
+            "f40 and below use dnsmasq":
+              when: version_less_than("41")
+              append:
+                include:
+                  - "dnsmasq"
+            "f41 and below uses parsec/zezere":
+              when: version_less_than("42")
+              append:
+                include:
+                  - "dbus-parsec"
+                  - "kernel-tools"
+                  - "parsec"
+                  - "policycoreutils-python-utils"
+                  - "zezere-ignition"
+            "f42 and below uses basesystem":
+              when: version_less_than("43")
+              append:
+                include:
+                  - "basesystem"
+            "f41+ needs bootupd":
+              when: version_greater_or_equal("41")
+              append:
+                include:
+                  - "bootupd"
+            "f43+ needs the filesystem pkg":
+              when: version_greater_or_equal("43")
+              append:
+                include:
+                  - "filesystem"
 
   "iot-container":
     <<: *iot_commit
@@ -925,22 +932,22 @@ image_types:
     partition_table:
       <<: *iot_base_partition_tables
     partition_tables_override:
-      condition:
+      conditions:
         "conditions for iot-raw-xz":
-          version_greater_or_equal:
-            "42":
-              x86_64:
-                <<: *iot_base_partition_table_x86_64
-                partitions:
-                  - *iot_base_partition_table_part_efi
-                  - *iot_base_partition_table_part_boot
-                  - *iot_base_partition_table_part_root_fstab_ro
-              aarch64:
-                <<: *iot_base_partition_table_aarch64
-                partitions:
-                  - *iot_base_partition_table_part_efi_aarch64
-                  - *iot_base_partition_table_part_boot_aarch64
-                  - *iot_base_partition_table_part_root_fstab_ro_aarch64
+          when: version_greater_or_equal("42")
+          override:
+            x86_64:
+              <<: *iot_base_partition_table_x86_64
+              partitions:
+                - *iot_base_partition_table_part_efi
+                - *iot_base_partition_table_part_boot
+                - *iot_base_partition_table_part_root_fstab_ro
+            aarch64:
+              <<: *iot_base_partition_table_aarch64
+              partitions:
+                - *iot_base_partition_table_part_efi_aarch64
+                - *iot_base_partition_table_part_boot_aarch64
+                - *iot_base_partition_table_part_root_fstab_ro_aarch64
 
   "iot-qcow2":
     name_aliases: ["iot-qcow2-image"]
@@ -1089,28 +1096,32 @@ image_types:
             - "nodejs"
             - "plymouth"         # for (datacenter/cloud oriented) servers we want to see the details by default.  https:#lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/HSMISZ3ETWQ4ETVLWZQJ55ARZT27AAV3/
             - "systemd-networkd"  # we use NetworkManager
-          condition:
-            "conditions for iot-bootable-container":
-              architecture:
-                aarch64:
-                  include:
-                    - "irqbalance"
-                    - "ostree-grub2"
-                  exclude:
-                    - "perl"
-                    - "perl-interpreter"
-                ppc64le:
-                  include:
-                    - "irqbalance"
-                    - "librtas"
-                    - "powerpc-utils-core"
-                    - "ppc64-diag-rtas"
-                x86_64:
-                  include:
-                    - "irqbalance"
-                  exclude:
-                    - "perl"
-                    - "perl-interpreter"
+          conditions:
+            "iot-bootable-container aarch64 extras":
+              when: arch == "aarch64"
+              append:
+                include:
+                  - "irqbalance"
+                  - "ostree-grub2"
+                exclude:
+                  - "perl"
+                  - "perl-interpreter"
+            "iot-bootable-container ppc64le extras":
+              when: arch == "ppc64le"
+              append:
+                include:
+                  - "irqbalance"
+                  - "librtas"
+                  - "powerpc-utils-core"
+                  - "ppc64-diag-rtas"
+            "iot-bootable-container x86_64 extras":
+              when: arch == "x86_64"
+              append:
+                include:
+                  - "irqbalance"
+                exclude:
+                  - "perl"
+                  - "perl-interpreter"
 
   "minimal-raw-xz": &minimal_raw_xz
     name_aliases: ["minimal-raw"]
@@ -1161,19 +1172,19 @@ image_types:
         - "sshd.service"
       kernel_options:
         - "rw"
-      condition:
-        "conditions for iot-raw-xz":
-          version_less_than:
-            "43":
-              install_weak_deps: true
-              mount_units: false
-              enabled_services:
-                - "NetworkManager.service"
-                - "initial-setup.service"
-                - "sshd.service"
-                - "firewalld.service"
-              kernel_options:
-                - "ro"
+      conditions:
+        "f42 and below was quite different":
+          when: version_less_than("43")
+          merge:
+            install_weak_deps: true
+            mount_units: false
+            enabled_services:
+              - "NetworkManager.service"
+              - "initial-setup.service"
+              - "sshd.service"
+              - "firewalld.service"
+            kernel_options:
+              - "ro"
     partition_table:
       <<: *minimal_raw_partition_tables
     package_sets:
@@ -1189,19 +1200,20 @@ image_types:
             - "iwlwifi-mvm-firmware"
           exclude:
             - "dracut-config-rescue"
-          condition:
-            "condition for minimal raw pkgs":
-              architecture:
-                riscv64:
-                  include:
-                    # missing from @core in riscv64
-                    - "dnf5"
-                    - "policycoreutils"
-                    - "selinux-policy-targeted"
-              version_greater_or_equal:
-                "43":
-                  exclude:
-                    - "firewalld"
+          conditions:
+            "riscv64 specific pkgs for minimal-raw-xz":
+              when: arch == "riscv64"
+              append:
+                include:
+                  # missing from @core in riscv64
+                  - "dnf5"
+                  - "policycoreutils"
+                  - "selinux-policy-targeted"
+            "no firewalld on f43+":
+              when: version_greater_or_equal("43")
+              append:
+                exclude:
+                  - "firewalld"
   "minimal-raw-zst":
     <<: *minimal_raw_xz
     name_aliases: []
@@ -1380,18 +1392,20 @@ image_types:
             - "metacity"
             - "xrdb"
             - "xz"
-          condition:
-            "conditions for anaconda arch":
-              architecture:
-                x86_64:
-                  include:
-                    - "biosdevname"
-                    - "dmidecode"
-                    - "grub2-tools-efi"
-                    - "memtest86+"
-                aarch64:
-                  include:
-                    - "dmidecode"
+          conditions:
+            "x86_64 specific anaconda pkgs":
+              when: arch == "x86_64"
+              append:
+                include:
+                  - "biosdevname"
+                  - "dmidecode"
+                  - "grub2-tools-efi"
+                  - "memtest86+"
+            "aarch64 specific anaconda pkgs":
+              when: arch == "aarch64"
+              append:
+                include:
+                  - "dmidecode"
 
   "iot-installer":
     name_aliases: ["fedora-iot-installer"]
@@ -1417,11 +1431,11 @@ image_types:
       <<: *image_config_iot_enabled_services
       locale: "en_US.UTF-8"
       iso_rootfs_type: "squashfs"
-      condition:
-        "condition for iot-installer":
-          version_less_than:
-            41:
-              iso_rootfs_type: "squashfs-ext4"
+      conditions:
+        "f40 and below uses ext4 based iso rootfs":
+          when: version_less_than("41")
+          merge:
+            iso_rootfs_type: "squashfs-ext4"
     package_sets:
       installer:
         - *anaconda_pkgset
@@ -1451,11 +1465,11 @@ image_types:
     image_config:
       locale: "en_US.UTF-8"
       iso_rootfs_type: "squashfs"
-      condition:
-        "conditions for workstation-live-installer":
-          version_less_than:
-            41:
-              iso_rootfs_type: "squashfs-ext4"
+      conditions:
+        "f40 and below uses ext4 based iso rootfs":
+          when: version_less_than("41")
+          merge:
+            iso_rootfs_type: "squashfs-ext4"
     package_sets:
       installer:
         - include:
@@ -1482,14 +1496,14 @@ image_types:
             - "gfs2-utils"
             - "reiserfs-utils"
             - "sdubby"
-          condition:
+          conditions:
             "include anaconda webui in 43+":
-              version_greater_or_equal:
+              when: version_greater_or_equal("43")
+              append:
                 # XXX: this was VERSION_RAWHIDE, if we need this again lets add
                 # "alias" to defs.DistroYAML
-                43:
-                  include:
-                    - "anaconda-webui"
+                include:
+                  - "anaconda-webui"
     platforms:
       - *x86_64_installer_platform
       - *aarch64_installer_platform
@@ -1520,26 +1534,27 @@ image_types:
         - "net-lib"
         - "dbus-broker"
       squashfs_rootfs: true
-      condition:
-        "conditional for minimal installer":
-          # on match the config is fully replaced
-          version_less_than:
-            "41":
-              additional_dracut_modules: &additional_dracut_f41
-                - "ifcfg"
-                - "dbus-broker"
-              squashfs_rootfs: false
-            "42":
-              additional_dracut_modules: *additional_dracut_f41
-              squashfs_rootfs: true
+      conditions:
+        "on f40 we use ifcfg instead of net-lib":
+          when: distro_version == "40"
+          override:
+            additional_dracut_modules: &additional_dracut_f40
+              - "ifcfg"
+              - "dbus-broker"
+            squashfs_rootfs: false
+        "on f41 use squashfs_rootfs":
+          when: distro_version == "41"
+          override:
+            additional_dracut_modules: *additional_dracut_f40
+            squashfs_rootfs: true
     image_config:
       locale: "en_US.UTF-8"
       iso_rootfs_type: "squashfs"
-      condition:
-        "old fedora used ext4 on squashfs":
-          version_less_than:
-            41:
-              iso_rootfs_type: "squashfs-ext4"
+      conditions:
+        "on f40 and below we used ext4 on squashfs":
+          when: version_less_than("41")
+          merge:
+            iso_rootfs_type: "squashfs-ext4"
     platforms:
       - *x86_64_installer_platform
       - *aarch64_installer_platform
@@ -1630,20 +1645,20 @@ image_types:
       - arch: "x86_64"
     image_config:
       <<: *image_config_container
-      condition:
-        "new f43 use the wsl-setup for setup":
-          version_less_than:
-            "42":
-              wsl_config:
-                boot_systemd: true
-              cloud_init:
-                - filename: "99_wsl.cfg"
-                  config:
-                    datasource_list:
-                      - "WSL"
-                      - "None"
-                    network:
-                      config: "disabled"
+      conditions:
+        "on f42 and below we use cloud-init instead of wsl-setup":
+          when: version_less_than("42")
+          merge:
+            wsl_config:
+              boot_systemd: true
+            cloud_init:
+              - filename: "99_wsl.cfg"
+                config:
+                  datasource_list:
+                    - "WSL"
+                    - "None"
+                  network:
+                    config: "disabled"
     package_sets:
       os:
         - include:
@@ -1685,19 +1700,22 @@ image_types:
             - "trousers"
             - "whois-nls"
             - "xkeyboard-config"
-          condition:
-            "new f43 use the wsl-setup for setup":
-              version_greater_or_equal:
-                "41":
-                  exclude:
-                    - "fuse-libs"
-                "42":
-                  include:
-                    - "wsl-setup"
-              version_less_than:
-                "42":
-                  include:
-                    - "cloud-init"
+          conditions:
+            "new f42 use the wsl-setup for setup":
+              when: version_greater_or_equal("42")
+              append:
+                include:
+                  - "wsl-setup"
+            "only f41 and below need cloud-init":
+              when: version_less_than("42")
+              append:
+                include:
+                  - "cloud-init"
+            "f41+ drops fuse-libs":
+              when: version_greater_or_equal("41")
+              append:
+                exclude:
+                  - "fuse-libs"
 
   "iot-simplified-installer":
     filename: "simplified-installer.iso"
@@ -1771,12 +1789,12 @@ image_types:
             - "traceroute"
             - "util-linux"
             - "shadow-utils"  # includes passwd
-          condition:
+          conditions:
             "dnsmasq got deprecated in f41":
-              version_less_than:
-                "41":
-                  include:
-                    - "dnsmasq"  # deprecated for F41+
+              when: version_less_than("41")
+              append:
+                include:
+                  - "dnsmasq"  # deprecated for F41+
     platforms:
       - <<: *x86_64_uefi_platform
         packages:

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -11,16 +11,13 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"slices"
 	"sort"
 	"sync"
 	"text/template"
 
 	"github.com/gobwas/glob"
-	"github.com/hashicorp/go-version"
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
-	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 
 	"github.com/osbuild/images/internal/common"
@@ -301,37 +298,6 @@ type partitionTablesOverrides struct {
 type partitionTablesOverwriteCondition struct {
 	When     string                          `yaml:"when"`
 	Override map[string]*disk.PartitionTable `yaml:"override"`
-}
-
-// XXX: use slices.Backward() once we move to go1.23
-// hint: use "git blame" on this comment and just revert
-// the commit that adds it and you will have the 1.23 version
-func backward[Slice ~[]E, E any](s Slice) []E {
-	out := make([]E, 0, len(s))
-	for i := len(s) - 1; i >= 0; i-- {
-		out = append(out, s[i])
-	}
-	return out
-}
-
-// XXX: use slices.SortedFunc() once we move to go1.23
-// hint: use "git blame" on this comment and just revert
-// the commit that adds it and you will have the 1.23 version
-func versionLessThanSortedKeys[T any](m map[string]T) []string {
-	versions := maps.Keys(m)
-	slices.SortFunc(versions, func(a, b string) int {
-		ver1 := version.Must(version.NewVersion(a))
-		ver2 := version.Must(version.NewVersion(b))
-		switch {
-		case ver1 == ver2:
-			return 0
-		case ver2.LessThan(ver1):
-			return -1
-		default:
-			return 1
-		}
-	})
-	return versions
 }
 
 type evalEnv struct {

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -349,7 +349,10 @@ func evalCondition(cond string, env *evalEnv) (bool, error) {
 	}
 	script := fmt.Sprintf("res = %v", cond)
 
+	// limit execution just to be on the safe side
 	t := &starlark.Thread{}
+	// 640 steps ought to be enough for anybody
+	t.SetMaxExecutionSteps(640)
 	t.SetLocal("distro_version", *env.DistroID)
 	globals, err := starlark.ExecFileOptions(&syntax.FileOptions{}, t, "condition.star", script, predeclared)
 	if err != nil {

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -18,6 +18,8 @@ import (
 
 	"github.com/gobwas/glob"
 	"github.com/hashicorp/go-version"
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
 	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 
@@ -186,12 +188,13 @@ type imageTypesYAML struct {
 }
 
 type distroImageConfig struct {
-	Default   *distro.ImageConfig                     `yaml:"default"`
-	Condition map[string]*distroImageConfigConditions `yaml:"condition,omitempty"`
+	Default    *distro.ImageConfig                     `yaml:"default"`
+	Conditions map[string]*distroImageConfigConditions `yaml:"conditions,omitempty"`
 }
 
 type distroImageConfigConditions struct {
-	DistroName map[string]*distro.ImageConfig `yaml:"distro_name,omitempty"`
+	When  string              `yaml:"when,omitempty"`
+	Merge *distro.ImageConfig `yaml:"merge,omitempty"`
 }
 
 // XXX: this should eventually implement the "distro.ImageType"
@@ -259,47 +262,45 @@ func (it *imageType) Name() string {
 
 type imageConfig struct {
 	*distro.ImageConfig `yaml:",inline"`
-	Condition           map[string]*conditionsImgConf `yaml:"condition,omitempty"`
+	Conditions          map[string]*conditionsImgConf `yaml:"conditions,omitempty"`
 }
 
 type conditionsImgConf struct {
-	Architecture    map[string]*distro.ImageConfig `yaml:"architecture,omitempty"`
-	DistroName      map[string]*distro.ImageConfig `yaml:"distro_name,omitempty"`
-	VersionLessThan map[string]*distro.ImageConfig `yaml:"version_less_than,omitempty"`
+	When  string              `yaml:"when,omitempty"`
+	Merge *distro.ImageConfig `yaml:"merge"`
 }
 
 type installerConfig struct {
 	*distro.InstallerConfig `yaml:",inline"`
-	Condition               map[string]*conditionsInstallerConf `yaml:"condition,omitempty"`
+	Conditions              map[string]*conditionsInstallerConf `yaml:"conditions,omitempty"`
 }
 
 type conditionsInstallerConf struct {
-	Architecture    map[string]*distro.InstallerConfig `yaml:"architecture,omitempty"`
-	DistroName      map[string]*distro.InstallerConfig `yaml:"distro_name,omitempty"`
-	VersionLessThan map[string]*distro.InstallerConfig `yaml:"version_less_than,omitempty"`
+	When     string                  `yaml:"when"`
+	Override *distro.InstallerConfig `yaml:"override,omitempty"`
 }
 
 type packageSet struct {
-	Include   []string                     `yaml:"include"`
-	Exclude   []string                     `yaml:"exclude"`
-	Condition map[string]*pkgSetConditions `yaml:"condition,omitempty"`
+	Include    []string                     `yaml:"include"`
+	Exclude    []string                     `yaml:"exclude"`
+	Conditions map[string]*pkgSetConditions `yaml:"conditions,omitempty"`
 }
 
 type pkgSetConditions struct {
-	Architecture          map[string]packageSet `yaml:"architecture,omitempty"`
-	VersionLessThan       map[string]packageSet `yaml:"version_less_than,omitempty"`
-	VersionGreaterOrEqual map[string]packageSet `yaml:"version_greater_or_equal,omitempty"`
-	DistroName            map[string]packageSet `yaml:"distro_name,omitempty"`
+	When   string `yaml:"when,omitempty"`
+	Append struct {
+		Include []string `yaml:"include"`
+		Exclude []string `yaml:"exclude"`
+	} `yaml:"append,omitempty"`
 }
 
 type partitionTablesOverrides struct {
-	Condition map[string]*partitionTablesOverwriteCondition `yaml:"condition"`
+	Conditions map[string]*partitionTablesOverwriteCondition `yaml:"conditions"`
 }
 
 type partitionTablesOverwriteCondition struct {
-	DistroName            map[string]map[string]*disk.PartitionTable `yaml:"distro_name,omitempty"`
-	VersionGreaterOrEqual map[string]map[string]*disk.PartitionTable `yaml:"version_greater_or_equal,omitempty"`
-	VersionLessThan       map[string]map[string]*disk.PartitionTable `yaml:"version_less_than,omitempty"`
+	When     string                          `yaml:"when"`
+	Override map[string]*disk.PartitionTable `yaml:"override"`
 }
 
 // XXX: use slices.Backward() once we move to go1.23
@@ -333,21 +334,67 @@ func versionLessThanSortedKeys[T any](m map[string]T) []string {
 	return versions
 }
 
-// versionStringForVerCmp is a special version string for our version
-// compare that will assume that any version with no minor is
-// automatically higher than any compare with a minor version.
-//
-// The rational is that "centos-9" is always higher than any "rhel-9.X"
-// version for our version compare (centos is always "rolling").
-//
-// TODO: this should become an explicit chose in "distro.yaml" but until
-// we have everything converted to generic.Distro accessing the properites
-// from an image type is very hard so we start here.
-func versionStringForVerCmp(u distro.ID) string {
-	if u.MinorVersion == -1 {
-		u.MinorVersion = 999
+type evalEnv struct {
+	DistroID *distro.ID
+	Arch     string
+}
+
+func versionCmpHelperStarlark(t *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple, cmp func(a, b string) bool) (starlark.Value, error) {
+	var ver string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "ver", &ver); err != nil {
+		return nil, err
 	}
-	return u.VersionString()
+
+	// generate as special version string for our version
+	// compare that will assume that any version with no minor is
+	// automatically higher than any compare with a minor version.
+	//
+	// The rational is that "centos-9" is always higher than any "rhel-9.X"
+	// version for our version compare (centos is always "rolling").
+	//
+	// TODO: this should become an explicit chose in "distro.yaml" but until
+	// we have everything converted to generic.Distro accessing the properites
+	// from an image type is very hard so we start here.
+	versionForCmp := t.Local("distro_version").(distro.ID)
+	if versionForCmp.MinorVersion == -1 {
+		versionForCmp.MinorVersion = 999
+	}
+
+	return starlark.Bool(cmp(versionForCmp.VersionString(), ver)), nil
+}
+
+func versionLessThanStarlark(t *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return versionCmpHelperStarlark(t, b, args, kwargs, common.VersionLessThan)
+}
+
+func versionGreaterOrEqual(t *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return versionCmpHelperStarlark(t, b, args, kwargs, common.VersionGreaterThanOrEqual)
+}
+
+func evalCondition(cond string, env *evalEnv) (bool, error) {
+	predeclared := starlark.StringDict{
+		"distro_name":              starlark.String(env.DistroID.Name),
+		"distro_version":           starlark.String(env.DistroID.VersionString()),
+		"distro_major":             starlark.MakeInt(env.DistroID.MajorVersion),
+		"distro_minor":             starlark.MakeInt(env.DistroID.MinorVersion),
+		"arch":                     starlark.String(env.Arch),
+		"version_less_than":        starlark.NewBuiltin("version_less_than", versionLessThanStarlark),
+		"version_greater_or_equal": starlark.NewBuiltin("version_greater_or_equal", versionGreaterOrEqual),
+	}
+	script := fmt.Sprintf("res = %v", cond)
+
+	t := &starlark.Thread{}
+	t.SetLocal("distro_version", *env.DistroID)
+	globals, err := starlark.ExecFileOptions(&syntax.FileOptions{}, t, "condition.star", script, predeclared)
+	if err != nil {
+		return false, err
+	}
+	res, ok := globals["res"].(starlark.Bool)
+	if !ok {
+		return false, fmt.Errorf("res not bool but %T", res)
+	}
+
+	return bool(res), nil
 }
 
 // DistroImageConfig returns the distro wide ImageConfig.
@@ -360,15 +407,19 @@ func DistroImageConfig(distroNameVer string) (*distro.ImageConfig, error) {
 	}
 	imgConfig := toplevel.ImageConfig.Default
 
-	condMap := toplevel.ImageConfig.Condition
+	condMap := toplevel.ImageConfig.Conditions
 	if condMap != nil {
 		id, err := distro.ParseID(distroNameVer)
 		if err != nil {
 			return nil, err
 		}
 		for _, cond := range condMap {
-			if distroNameCnf, ok := cond.DistroName[id.Name]; ok {
-				imgConfig = distroNameCnf.InheritFrom(imgConfig)
+			res, err := evalCondition(cond.When, &evalEnv{DistroID: id})
+			if err != nil {
+				return nil, err
+			}
+			if res {
+				imgConfig = cond.Merge.InheritFrom(imgConfig)
 			}
 		}
 	}
@@ -385,10 +436,6 @@ func PackageSets(it distro.ImageType) (map[string]rpmmd.PackageSet, error) {
 	archName := arch.Name()
 	distribution := arch.Distro()
 	distroNameVer := distribution.Name()
-	id, err := distro.ParseID(distroNameVer)
-	if err != nil {
-		return nil, err
-	}
 
 	// each imagetype can have multiple package sets, so that we can
 	// use yaml aliases/anchors to de-duplicate them
@@ -411,40 +458,22 @@ func PackageSets(it distro.ImageType) (map[string]rpmmd.PackageSet, error) {
 				Exclude: pkgSet.Exclude,
 			})
 
-			if pkgSet.Condition != nil {
-				for _, cond := range pkgSet.Condition {
-					// process conditions
-					if archSet, ok := cond.Architecture[archName]; ok {
-						rpmmdPkgSet = rpmmdPkgSet.Append(rpmmd.PackageSet{
-							Include: archSet.Include,
-							Exclude: archSet.Exclude,
-						})
-					}
-					if distroNameSet, ok := cond.DistroName[id.Name]; ok {
-						rpmmdPkgSet = rpmmdPkgSet.Append(rpmmd.PackageSet{
-							Include: distroNameSet.Include,
-							Exclude: distroNameSet.Exclude,
-						})
-					}
-					// note that we don't need to order here, as
-					// packageSets are strictly additive the order
-					// is irrelevant
-					for ltVer, ltSet := range cond.VersionLessThan {
-						if common.VersionLessThan(versionStringForVerCmp(*id), ltVer) {
-							rpmmdPkgSet = rpmmdPkgSet.Append(rpmmd.PackageSet{
-								Include: ltSet.Include,
-								Exclude: ltSet.Exclude,
-							})
-						}
-					}
+			if pkgSet.Conditions != nil {
+				id, err := distro.ParseID(distroNameVer)
+				if err != nil {
+					return nil, err
+				}
 
-					for gteqVer, gteqSet := range cond.VersionGreaterOrEqual {
-						if common.VersionGreaterThanOrEqual(versionStringForVerCmp(*id), gteqVer) {
-							rpmmdPkgSet = rpmmdPkgSet.Append(rpmmd.PackageSet{
-								Include: gteqSet.Include,
-								Exclude: gteqSet.Exclude,
-							})
-						}
+				for _, cond := range pkgSet.Conditions {
+					res, err := evalCondition(cond.When, &evalEnv{DistroID: id, Arch: archName})
+					if err != nil {
+						return nil, err
+					}
+					if res {
+						rpmmdPkgSet = rpmmdPkgSet.Append(rpmmd.PackageSet{
+							Include: cond.Append.Include,
+							Exclude: cond.Append.Exclude,
+						})
 					}
 				}
 			}
@@ -487,28 +516,13 @@ func PartitionTable(it distro.ImageType) (*disk.PartitionTable, error) {
 		if err != nil {
 			return nil, err
 		}
-		for _, cond := range imgType.PartitionTablesOverrides.Condition {
-			for _, ltVer := range versionLessThanSortedKeys(cond.VersionLessThan) {
-				ltOverrides := cond.VersionLessThan[ltVer]
-				if common.VersionLessThan(versionStringForVerCmp(*id), ltVer) {
-					if newPt, ok := ltOverrides[archName]; ok {
-						pt = newPt
-					}
-				}
+		for _, cond := range imgType.PartitionTablesOverrides.Conditions {
+			res, err := evalCondition(cond.When, &evalEnv{DistroID: id, Arch: archName})
+			if err != nil {
+				return nil, err
 			}
-
-			for _, gteqVer := range backward(versionLessThanSortedKeys(cond.VersionGreaterOrEqual)) {
-				geOverrides := cond.VersionGreaterOrEqual[gteqVer]
-				if common.VersionGreaterThanOrEqual(versionStringForVerCmp(*id), gteqVer) {
-					if newPt, ok := geOverrides[archName]; ok {
-						pt = newPt
-					}
-				}
-			}
-			if distroNameOverrides, ok := cond.DistroName[id.Name]; ok {
-				if newPt, ok := distroNameOverrides[archName]; ok {
-					pt = newPt
-				}
+			if res {
+				pt = cond.Override[archName]
 			}
 		}
 	}
@@ -629,40 +643,24 @@ func ImageConfig(distroNameVer, archName, typeName string) (*distro.ImageConfig,
 		return nil, fmt.Errorf("%w: %q", ErrImageTypeNotFound, typeName)
 	}
 	imgConfig := imgType.ImageConfig.ImageConfig
-	if imgType.ImageConfig.Condition != nil {
+	if imgType.ImageConfig.Conditions != nil {
 		id, err := distro.ParseID(distroNameVer)
 		if err != nil {
 			return nil, err
 		}
-		for _, cond := range imgType.ImageConfig.Condition {
-			if distroNameCnf, ok := cond.DistroName[id.Name]; ok {
-				imgConfig = distroNameCnf.InheritFrom(imgConfig)
+
+		for _, cond := range imgType.ImageConfig.Conditions {
+			res, err := evalCondition(cond.When, &evalEnv{DistroID: id, Arch: archName})
+			if err != nil {
+				return nil, err
 			}
-			if archCnf, ok := cond.Architecture[archName]; ok {
-				imgConfig = archCnf.InheritFrom(imgConfig)
-			}
-			for _, ltVer := range versionLessThanSortedKeys(cond.VersionLessThan) {
-				ltOverrides := cond.VersionLessThan[ltVer]
-				if common.VersionLessThan(versionStringForVerCmp(*id), ltVer) {
-					imgConfig = ltOverrides.InheritFrom(imgConfig)
-				}
+			if res {
+				imgConfig = cond.Merge.InheritFrom(imgConfig)
 			}
 		}
 	}
 
 	return imgConfig, nil
-}
-
-// nNonEmpty returns the number of non-empty maps in the given
-// input
-func nNonEmpty[K comparable, V any](maps ...map[K]V) int {
-	var nonEmpty int
-	for _, m := range maps {
-		if len(m) > 0 {
-			nonEmpty++
-		}
-	}
-	return nonEmpty
 }
 
 // InstallerConfig returns the InstallerConfig for the given imgType
@@ -678,28 +676,18 @@ func InstallerConfig(distroNameVer, archName, typeName string) (*distro.Installe
 		return nil, fmt.Errorf("%w: %q", ErrImageTypeNotFound, typeName)
 	}
 	installerConfig := imgType.InstallerConfig.InstallerConfig
-	if imgType.InstallerConfig.Condition != nil {
-		for _, cond := range imgType.InstallerConfig.Condition {
-			if nNonEmpty(cond.DistroName, cond.Architecture, cond.VersionLessThan) > 1 {
-				return nil, fmt.Errorf("only a single conditional allowed in installer config for %v", typeName)
-			}
-
+	if imgType.InstallerConfig.Conditions != nil {
+		for _, cond := range imgType.InstallerConfig.Conditions {
 			id, err := distro.ParseID(distroNameVer)
 			if err != nil {
 				return nil, err
 			}
-
-			if distroNameCnf, ok := cond.DistroName[id.Name]; ok {
-				installerConfig = distroNameCnf
+			res, err := evalCondition(cond.When, &evalEnv{DistroID: id, Arch: archName})
+			if err != nil {
+				return nil, err
 			}
-			if archCnf, ok := cond.Architecture[archName]; ok {
-				installerConfig = archCnf
-			}
-			for _, ltVer := range versionLessThanSortedKeys(cond.VersionLessThan) {
-				ltOverrides := cond.VersionLessThan[ltVer]
-				if common.VersionLessThan(versionStringForVerCmp(*id), ltVer) {
-					installerConfig = ltOverrides
-				}
+			if res {
+				installerConfig = cond.Override
 			}
 		}
 	}

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -75,13 +75,14 @@ image_types:
         - include: [inc1]
           exclude: [exc1]
           condition:
-            distro_name:
-              test-distro:
-                include: [from-condition-inc2]
-                exclude: [from-condition-exc2]
-              other-distro:
-                include: [inc3]
-                exclude: [exc3]
+            "some-description-1":
+              distro_name:
+                test-distro:
+                  include: [from-condition-inc2]
+                  exclude: [from-condition-exc2]
+                other-distro:
+                  include: [inc3]
+                  exclude: [exc3]
       container:
         - include: [inc-cnt1]
           exclude: [exc-cnt1]
@@ -160,10 +161,11 @@ func TestLoadYamlMergingWorks(t *testing.T) {
     include: [from-base-inc]
     exclude: [from-base-exc]
     condition:
-      distro_name:
-        test-distro:
-          include: [from-base-condition-inc]
-          exclude: [from-base-condition-exc]
+      "some description 1":
+        distro_name:
+          test-distro:
+            include: [from-base-condition-inc]
+            exclude: [from-base-condition-exc]
 image_types:
   other_type:
     package_sets:
@@ -179,10 +181,11 @@ image_types:
       - include: [from-type-inc]
         exclude: [from-type-exc]
         condition:
-          distro_name:
-            test-distro:
-              include: [from-condition-inc]
-              exclude: [from-condition-exc]
+          "some description 2":
+            distro_name:
+              test-distro:
+                include: [from-condition-inc]
+                exclude: [from-condition-exc]
 `
 	// XXX: we cannot use distro.Name() as it will give us a name+ver
 	baseDir := makeFakeDefs(t, test_distro.TestDistroNameBase, fakePkgsSetYaml)
@@ -323,31 +326,32 @@ image_types:
               fstab_options: "defaults"
     partition_tables_override:
       condition:
-        version_greater_or_equal:
-          # overrides are applied in order
-          "0":
-            test_arch:
-              <<: *test_arch_pt
-              partitions:
-                - <<: *default_part_0
-                  size: 111_111_111
-          "1":
-            test_arch:
-              <<: *test_arch_pt
-              partitions:
-                - <<: *default_part_0
-                  size: 222_222_222
-                - <<: *default_part_1
-                  payload:
-                    <<: *default_part_1_payload
-                    fstab_options: "defaults,ro"
-          "2":
-            test_arch:
-              <<: *test_arch_pt
-              partitions:
-                - <<: *default_part_0
-                  size: 333_333_333
-                - *default_part_1
+        "some description":
+          version_greater_or_equal:
+            # overrides are applied in order
+            "0":
+              test_arch:
+                <<: *test_arch_pt
+                partitions:
+                  - <<: *default_part_0
+                    size: 111_111_111
+            "1":
+              test_arch:
+                <<: *test_arch_pt
+                partitions:
+                  - <<: *default_part_0
+                    size: 222_222_222
+                  - <<: *default_part_1
+                    payload:
+                      <<: *default_part_1_payload
+                      fstab_options: "defaults,ro"
+            "2":
+              test_arch:
+                <<: *test_arch_pt
+                partitions:
+                  - <<: *default_part_0
+                    size: 333_333_333
+                  - *default_part_1
 `
 
 func TestDefsPartitionTableOverrideGreatEqual(t *testing.T) {
@@ -430,12 +434,13 @@ image_types:
             bootable: true
     partition_tables_override:
       condition:
-        distro_name:
-          "test-distro":
-              test_arch:
-                partitions:
-                  - <<: *default_part_0
-                    size: 111_111_111
+        "some description":
+          distro_name:
+            "test-distro":
+                test_arch:
+                  partitions:
+                    - <<: *default_part_0
+                      size: 111_111_111
 `
 	// XXX: we cannot use distro.Name() as it will give us a name+ver
 	baseDir := makeFakeDefs(t, test_distro.TestDistroNameBase, fakeDistroYaml)
@@ -463,9 +468,10 @@ image_config:
     users:
       - name: testuser
   condition:
-    distro_name:
-      "test-distro":
-        timezone: "OverrideTZ"
+    "some description":
+      distro_name:
+        "test-distro":
+          timezone: "OverrideTZ"
 `
 	fakeDistroName := "test-distro"
 	fakeDistroVer := "42"
@@ -535,18 +541,19 @@ image_types:
       timezone: "DefaultTZ"
       default_kernel_name: kernel
       condition:
-        version_less_than:
-          "2":
-            timezone: "OverrideTZ"
-          # test-distro is version "1" (no minor) so considered "1" is > "1.4"
-          "1.4":
-            default_kernel_name: kernel-lt-14
-        distro_name:
-          "test-distro":
-            locale: "en_US.UTF-8"
-        architecture:
-          "test_arch":
-            hostname: "test-arch-hn"
+        "some description":
+          version_less_than:
+            "2":
+              timezone: "OverrideTZ"
+            # test-distro is version "1" (no minor) so considered "1" is > "1.4"
+            "1.4":
+              default_kernel_name: kernel-lt-14
+          distro_name:
+            "test-distro":
+              locale: "en_US.UTF-8"
+          architecture:
+            "test_arch":
+              hostname: "test-arch-hn"
 `
 	fakeDistroName := "test-distro"
 	baseDir := makeFakeDefs(t, fakeDistroName, fakeDistroYaml)
@@ -659,12 +666,13 @@ func TestImageTypeInstallerConfig(t *testing.T) {
 func TestImageTypeInstallerConfigErrorMultiple(t *testing.T) {
 	fakeDistroYaml := fakeDistroYamlInstallerConf + `
       condition:
-        version_less_than:
-          "2":
-            additional_dracut_modules:
-              - override-dracut-mod1
-        distro_name:
-          "test-distro":
+        "some description":
+          version_less_than:
+            "2":
+              additional_dracut_modules:
+                - override-dracut-mod1
+          distro_name:
+            "test-distro":
 `
 
 	fakeDistroName := "test-distro"
@@ -679,11 +687,12 @@ func TestImageTypeInstallerConfigErrorMultiple(t *testing.T) {
 func TestImageTypeInstallerConfigOverrideVerLT(t *testing.T) {
 	fakeDistroYaml := fakeDistroYamlInstallerConf + `
       condition:
-        version_less_than:
-          "2":
-            # Note that this fully override the installer config
-            additional_dracut_modules:
-              - override-dracut-mod1
+        "some description":
+          version_less_than:
+            "2":
+              # Note that this fully override the installer config
+              additional_dracut_modules:
+                - override-dracut-mod1
 `
 	fakeDistroName := "test-distro"
 	baseDir := makeFakeDefs(t, fakeDistroName, fakeDistroYaml)
@@ -703,12 +712,13 @@ func TestImageTypeInstallerConfigOverrideVerLT(t *testing.T) {
 func TestImageTypeInstallerConfigOverrideDistroName(t *testing.T) {
 	fakeDistroYaml := fakeDistroYamlInstallerConf + `
       condition:
-        distro_name:
-          "test-distro":
-            additional_dracut_modules:
-              - override-dracut-mod1
-            additional_drivers:
-             - override-drv1
+        "some description":
+          distro_name:
+            "test-distro":
+              additional_dracut_modules:
+                - override-dracut-mod1
+              additional_drivers:
+               - override-drv1
 `
 
 	fakeDistroName := "test-distro"
@@ -727,10 +737,11 @@ func TestImageTypeInstallerConfigOverrideDistroName(t *testing.T) {
 func TestImageTypeInstallerConfigOverrideArch(t *testing.T) {
 	fakeDistroYaml := fakeDistroYamlInstallerConf + `
       condition:
-        architecture:
-          "test_arch":
-            additional_drivers:
-             - override-drv1
+        "some description":
+          architecture:
+            "test_arch":
+              additional_drivers:
+               - override-drv1
 `
 
 	fakeDistroName := "test-distro"

--- a/pkg/distro/defs/rhel-10/distro.yaml
+++ b/pkg/distro/defs/rhel-10/distro.yaml
@@ -18,14 +18,15 @@
       - "xfsprogs"
       - "xz"
     condition:
-      architecture:
-        x86_64:
-          include:
-            - "grub2-pc"
-        ppc64el:
-          include:
-            - "grub2-ppc64le"
-            - "grub2-ppc64le-modules"
+      "condition for build_pkgsset":
+        architecture:
+          x86_64:
+            include:
+              - "grub2-pc"
+          ppc64el:
+            include:
+              - "grub2-ppc64le"
+              - "grub2-ppc64le-modules"
 
   sap_image_config: &sap_image_config
     selinux_config:
@@ -182,37 +183,38 @@
 
   anaconda_boot_pkgset: &anaconda_boot_pkgset
     condition:
-      architecture:
-        x86_64:
-          include:
-            # eficommon
-            - "efibootmgr"
-            # XXX: de-dup?
-            # grub-common
-            - "grub2-tools"
-            - "grub2-tools-extra"
-            - "grub2-tools-minimal"
-            # arch specific
-            - "grub2-efi-x64"
-            - "grub2-efi-x64-cdboot"
-            - "grub2-pc"
-            - "grub2-pc-modules"
-            - "shim-x64"
-            - "syslinux"
-            - "syslinux-nonlinux"
-        aarch64:
-          include:
-            # eficommon
-            - "efibootmgr"
-            # XXX: de-dup?
-            # grub-common
-            - "grub2-tools"
-            - "grub2-tools-extra"
-            - "grub2-tools-minimal"
-            # arch specific
-            - "grub2-efi-aa64-cdboot"
-            - "grub2-efi-aa64"
-            - "shim-aa64"
+      "condition for anaconda boot pkgset":
+        architecture:
+          x86_64:
+            include:
+              # eficommon
+              - "efibootmgr"
+              # XXX: de-dup?
+              # grub-common
+              - "grub2-tools"
+              - "grub2-tools-extra"
+              - "grub2-tools-minimal"
+              # arch specific
+              - "grub2-efi-x64"
+              - "grub2-efi-x64-cdboot"
+              - "grub2-pc"
+              - "grub2-pc-modules"
+              - "shim-x64"
+              - "syslinux"
+              - "syslinux-nonlinux"
+          aarch64:
+            include:
+              # eficommon
+              - "efibootmgr"
+              # XXX: de-dup?
+              # grub-common
+              - "grub2-tools"
+              - "grub2-tools-extra"
+              - "grub2-tools-minimal"
+              # arch specific
+              - "grub2-efi-aa64-cdboot"
+              - "grub2-efi-aa64"
+              - "shim-aa64"
 
   partitioning:
     ids:
@@ -461,30 +463,31 @@
             - "driver:mlx4_core"
             - "driver:mlx5_core"
     condition:
-      distro_name:
-        rhel:
-          gpgkey_files:
-            - "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
-      architecture:
-        x86_64:
-          kernel_options:
-            # common
-            - "ro"
-            - "loglevel=3"
-            - "nvme_core.io_timeout=240"
-            # x86
-            - "console=tty1"
-            - "console=ttyS0"
-            - "earlyprintk=ttyS0"
-            - "rootdelay=300"
-        aarch64:
-          kernel_options:
-            # common
-            - "ro"
-            - "loglevel=3"
-            - "nvme_core.io_timeout=240"
-            # aarch64
-            - "console=ttyAMA0"
+      "image config for azure":
+        distro_name:
+          rhel:
+            gpgkey_files:
+              - "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+        architecture:
+          x86_64:
+            kernel_options:
+              # common
+              - "ro"
+              - "loglevel=3"
+              - "nvme_core.io_timeout=240"
+              # x86
+              - "console=tty1"
+              - "console=ttyS0"
+              - "earlyprintk=ttyS0"
+              - "rootdelay=300"
+          aarch64:
+            kernel_options:
+              # common
+              - "ro"
+              - "loglevel=3"
+              - "nvme_core.io_timeout=240"
+              # aarch64
+              - "console=ttyAMA0"
 
 image_config:
   default:
@@ -498,9 +501,10 @@ image_config:
     timezone: "UTC"
     update_default_kernel: true
   condition:
-    distro_name:
-      centos:
-        default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-cs10-ds.xml"
+    "oscap needs a differnt path on centos":
+      distro_name:
+        centos:
+          default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-cs10-ds.xml"
 
 image_types:
   # XXX: not a real pkgset but the "os" pipeline pkgset for image-installer
@@ -548,25 +552,27 @@ image_types:
           exclude:
             - "dracut-config-rescue"
           condition:
-            distro_name:
-              rhel:
-                include:
-                  - "subscription-manager-cockpit"
+            "add subscription-manager-cockpit":
+              distro_name:
+                rhel:
+                  include:
+                    - "subscription-manager-cockpit"
 
   qcow2: &qcow2
     image_config:
       default_target: "multi-user.target"
       kernel_options: ["console=tty0", "console=ttyS0,115200n8", "no_timer_check"]
       condition:
-        distro_name:
-          rhel:
-            rhsm_config:
-              "no-subscription":
-                dnf_plugin:
-                  product_id:
-                    enabled: false
-                  subscription_manager:
-                    enabled: false
+        "conditions for qcow2":
+          distro_name:
+            rhel:
+              rhsm_config:
+                "no-subscription":
+                  dnf_plugin:
+                    product_id:
+                      enabled: false
+                    subscription_manager:
+                      enabled: false
     partition_table:
       <<: *default_partition_tables
     package_sets:
@@ -628,11 +634,12 @@ image_types:
             - "rng-tools"
             - "udisks2"
           condition:
-            distro_name:
-              rhel:
-                include:
-                  - "insights-client"
-                  - "subscription-manager-cockpit"
+            "add insights pkgs":
+              distro_name:
+                rhel:
+                  include:
+                    - "insights-client"
+                    - "subscription-manager-cockpit"
 
   oci: *qcow2
 
@@ -740,10 +747,11 @@ image_types:
             - "rhnsd"
             - "usb_modeswitch"
           condition:
-            distro_name:
-              rhel:
-                include:
-                  - "insights-client"
+            "add insights client":
+              distro_name:
+                rhel:
+                  include:
+                    - "insights-client"
 
   "azure-rhui": &azure_rhui
     <<: *vhd
@@ -949,30 +957,34 @@ image_types:
       sshd_config:
         config:
           PasswordAuthentication: false
-      condition:
-        architecture:
-          x86_64: &ami_image_config_cond_x86_64
-            dracut_conf:
-              - filename: "ec2.conf"
-                config:
-                  add_drivers:
-                    - "nvme"
-                    - "xen-blkfront"
-            # TODO: move these to the EC2 environment
-            kernel_options:
-              # common
-              - "console=tty0"
-              - "console=ttyS0,115200n8"
-              - "nvme_core.io_timeout=4294967295"
-          aarch64:
-            # TODO: move these to the EC2 environment
-            kernel_options:
-              # XXX: duplicated with above x86_64 kernel defaults
-              - "console=tty0"
-              - "console=ttyS0,115200n8"
-              - "nvme_core.io_timeout=4294967295"
-              # aarch64 specific
-              - "iommu.strict=0"
+      condition: &ami_image_config_cond
+        "conditions for ami arch dracut":
+          architecture:
+            x86_64:
+              dracut_conf:
+                - filename: "ec2.conf"
+                  config:
+                    add_drivers:
+                      - "nvme"
+                      - "xen-blkfront"
+        "conditions for ami arch kopts":
+          architecture:
+            x86_64:
+              # TODO: move these to the EC2 environment
+              kernel_options:
+                # common
+                - "console=tty0"
+                - "console=ttyS0,115200n8"
+                - "nvme_core.io_timeout=4294967295"
+            aarch64:
+              # TODO: move these to the EC2 environment
+              kernel_options:
+                # XXX: duplicated with above x86_64 kernel defaults
+                - "console=tty0"
+                - "console=ttyS0,115200n8"
+                - "nvme_core.io_timeout=4294967295"
+                # aarch64 specific
+                - "iommu.strict=0"
     partition_table:
       <<: *default_partition_tables
     package_sets:
@@ -1028,10 +1040,11 @@ image_types:
             # RHBZ#2075815
             - "qemu-guest-agent"
           condition:
-            distro_name:
-              rhel:
-                include:
-                  - "insights-client"
+            "add insights client":
+              distro_name:
+                rhel:
+                  include:
+                    - "insights-client"
 
   ec2: *ami
 
@@ -1054,18 +1067,19 @@ image_types:
     image_config:
       <<: [*ami_image_config, *sap_image_config]
       condition:
-        architecture:
-          x86_64:
-            # XXX: this shows that merging at the yaml level is tricky
-            <<: *ami_image_config_cond_x86_64
-            kernel_options:
-              # XXX: duplicated with ami.image_config.kernel_options :(
-              - "console=tty0"
-              - "console=ttyS0,115200n8"
-              - "nvme_core.io_timeout=4294967295"
-              # amiSapKernelOptions()
-              - "processor.max_cstate=1"
-              - "intel_idle.max_cstate=1"
+        <<: *ami_image_config_cond
+        # this needs to override the original ami key
+        "conditions for ami arch kopts":
+          architecture:
+            x86_64:
+              kernel_options:
+                # XXX: duplicated with ami.image_config.kernel_options :(
+                - "console=tty0"
+                - "console=ttyS0,115200n8"
+                - "nvme_core.io_timeout=4294967295"
+                # amiSapKernelOptions()
+                - "processor.max_cstate=1"
+                - "intel_idle.max_cstate=1"
 
   wsl:
     image_config:
@@ -1253,16 +1267,17 @@ image_types:
             - "xfsprogs"
             - "xz"
           condition:
-            architecture:
-              x86_64:
-                include:
-                  - "biosdevname"
-                  - "dmidecode"
-                  - "grub2-tools-efi"
-                  - "memtest86+"
-              aarch64:
-                include:
-                  - "dmidecode"
+            "arch pkgs for image installer":
+              architecture:
+                x86_64:
+                  include:
+                    - "biosdevname"
+                    - "dmidecode"
+                    - "grub2-tools-efi"
+                    - "memtest86+"
+                aarch64:
+                  include:
+                    - "dmidecode"
 
   gce:
     image_config:
@@ -1417,10 +1432,11 @@ image_types:
             # RHBZ#2075815
             - "qemu-guest-agent"
           condition:
-            distro_name:
-              rhel:
-                include:
-                  - "insights-client"
+            "add insights client":
+              distro_name:
+                rhel:
+                  include:
+                    - "insights-client"
 
   "azure-cvm":
     image_config:

--- a/pkg/distro/defs/rhel-10/distro.yaml
+++ b/pkg/distro/defs/rhel-10/distro.yaml
@@ -17,16 +17,18 @@
       - "tar"
       - "xfsprogs"
       - "xz"
-    condition:
-      "condition for build_pkgsset":
-        architecture:
-          x86_64:
-            include:
-              - "grub2-pc"
-          ppc64el:
-            include:
-              - "grub2-ppc64le"
-              - "grub2-ppc64le-modules"
+    conditions:
+      "x86_64 specific packages for build pkgsset":
+        when: arch == "x86_64"
+        append:
+          include:
+            - "grub2-pc"
+      "ppc64le specific packages for build pkgsset":
+        when: arch == "ppc64le"
+        append:
+          include:
+            - "grub2-ppc64le"
+            - "grub2-ppc64le-modules"
 
   sap_image_config: &sap_image_config
     selinux_config:
@@ -182,39 +184,41 @@
       - "nss-softokn"
 
   anaconda_boot_pkgset: &anaconda_boot_pkgset
-    condition:
-      "condition for anaconda boot pkgset":
-        architecture:
-          x86_64:
-            include:
-              # eficommon
-              - "efibootmgr"
-              # XXX: de-dup?
-              # grub-common
-              - "grub2-tools"
-              - "grub2-tools-extra"
-              - "grub2-tools-minimal"
-              # arch specific
-              - "grub2-efi-x64"
-              - "grub2-efi-x64-cdboot"
-              - "grub2-pc"
-              - "grub2-pc-modules"
-              - "shim-x64"
-              - "syslinux"
-              - "syslinux-nonlinux"
-          aarch64:
-            include:
-              # eficommon
-              - "efibootmgr"
-              # XXX: de-dup?
-              # grub-common
-              - "grub2-tools"
-              - "grub2-tools-extra"
-              - "grub2-tools-minimal"
-              # arch specific
-              - "grub2-efi-aa64-cdboot"
-              - "grub2-efi-aa64"
-              - "shim-aa64"
+    conditions:
+      "x86 specific packages for the anaconda boot pkgset":
+        when: arch == "x86_64"
+        append:
+          include:
+            # eficommon
+            - "efibootmgr"
+            # XXX: de-dup?
+            # grub-common
+            - "grub2-tools"
+            - "grub2-tools-extra"
+            - "grub2-tools-minimal"
+            # arch specific
+            - "grub2-efi-x64"
+            - "grub2-efi-x64-cdboot"
+            - "grub2-pc"
+            - "grub2-pc-modules"
+            - "shim-x64"
+            - "syslinux"
+            - "syslinux-nonlinux"
+      "aarch64 specific packages for the anaconda boot pkgset":
+        when: arch == "aarch64"
+        append:
+          include:
+            # eficommon
+            - "efibootmgr"
+            # XXX: de-dup?
+            # grub-common
+            - "grub2-tools"
+            - "grub2-tools-extra"
+            - "grub2-tools-minimal"
+            # arch specific
+            - "grub2-efi-aa64-cdboot"
+            - "grub2-efi-aa64"
+            - "shim-aa64"
 
   partitioning:
     ids:
@@ -462,32 +466,35 @@
           "unmanaged-devices":
             - "driver:mlx4_core"
             - "driver:mlx5_core"
-    condition:
-      "image config for azure":
-        distro_name:
-          rhel:
-            gpgkey_files:
-              - "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
-        architecture:
-          x86_64:
-            kernel_options:
-              # common
-              - "ro"
-              - "loglevel=3"
-              - "nvme_core.io_timeout=240"
-              # x86
-              - "console=tty1"
-              - "console=ttyS0"
-              - "earlyprintk=ttyS0"
-              - "rootdelay=300"
-          aarch64:
-            kernel_options:
-              # common
-              - "ro"
-              - "loglevel=3"
-              - "nvme_core.io_timeout=240"
-              # aarch64
-              - "console=ttyAMA0"
+    conditions:
+      "rhel needs the rhel release rpm gpg key":
+        when: distro_name == "rhel"
+        merge:
+          gpgkey_files:
+            - "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+      "x86_64 specific kernel commandline":
+        when: arch == "x86_64"
+        merge:
+          kernel_options:
+            # common
+            - "ro"
+            - "loglevel=3"
+            - "nvme_core.io_timeout=240"
+            # x86
+            - "console=tty1"
+            - "console=ttyS0"
+            - "earlyprintk=ttyS0"
+            - "rootdelay=300"
+      "aarch64 specific kernel commandline":
+        when: arch == "aarch64"
+        merge:
+          kernel_options:
+            # common
+            - "ro"
+            - "loglevel=3"
+            - "nvme_core.io_timeout=240"
+            # aarch64
+            - "console=ttyAMA0"
 
 image_config:
   default:
@@ -500,11 +507,11 @@ image_config:
       no_zero_conf: true
     timezone: "UTC"
     update_default_kernel: true
-  condition:
-    "oscap needs a differnt path on centos":
-      distro_name:
-        centos:
-          default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-cs10-ds.xml"
+  conditions:
+    "centos oscap datastream path":
+      when: distro_name == "centos"
+      merge:
+        default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-cs10-ds.xml"
 
 image_types:
   # XXX: not a real pkgset but the "os" pipeline pkgset for image-installer
@@ -551,28 +558,28 @@ image_types:
             - "tuned"
           exclude:
             - "dracut-config-rescue"
-          condition:
-            "add subscription-manager-cockpit":
-              distro_name:
-                rhel:
-                  include:
-                    - "subscription-manager-cockpit"
+          conditions:
+            "add subscription-manager-cockpit on rhel":
+              when: distro_name == "rhel"
+              append:
+                include:
+                  - "subscription-manager-cockpit"
 
   qcow2: &qcow2
     image_config:
       default_target: "multi-user.target"
       kernel_options: ["console=tty0", "console=ttyS0,115200n8", "no_timer_check"]
-      condition:
-        "conditions for qcow2":
-          distro_name:
-            rhel:
-              rhsm_config:
-                "no-subscription":
-                  dnf_plugin:
-                    product_id:
-                      enabled: false
-                    subscription_manager:
-                      enabled: false
+      conditions:
+        "tweak the rhsm config on rhel":
+          when: distro_name == "rhel"
+          merge:
+            rhsm_config:
+              "no-subscription":
+                dnf_plugin:
+                  product_id:
+                    enabled: false
+                  subscription_manager:
+                    enabled: false
     partition_table:
       <<: *default_partition_tables
     package_sets:
@@ -633,13 +640,13 @@ image_types:
             - "plymouth"
             - "rng-tools"
             - "udisks2"
-          condition:
-            "add insights pkgs":
-              distro_name:
-                rhel:
-                  include:
-                    - "insights-client"
-                    - "subscription-manager-cockpit"
+          conditions:
+            "add insights pkgs on rhel":
+              when: distro_name == "rhel"
+              append:
+                include:
+                  - "insights-client"
+                  - "subscription-manager-cockpit"
 
   oci: *qcow2
 
@@ -746,12 +753,12 @@ image_types:
             - "rhnlib"
             - "rhnsd"
             - "usb_modeswitch"
-          condition:
-            "add insights client":
-              distro_name:
-                rhel:
-                  include:
-                    - "insights-client"
+          conditions: &conditions_pkgsets_insights_client_on_rhel
+            "add insights client on rhel":
+              when: distro_name == "rhel"
+              append:
+                include:
+                  - "insights-client"
 
   "azure-rhui": &azure_rhui
     <<: *vhd
@@ -957,34 +964,36 @@ image_types:
       sshd_config:
         config:
           PasswordAuthentication: false
-      condition: &ami_image_config_cond
-        "conditions for ami arch dracut":
-          architecture:
-            x86_64:
-              dracut_conf:
-                - filename: "ec2.conf"
-                  config:
-                    add_drivers:
-                      - "nvme"
-                      - "xen-blkfront"
-        "conditions for ami arch kopts":
-          architecture:
-            x86_64:
-              # TODO: move these to the EC2 environment
-              kernel_options:
-                # common
-                - "console=tty0"
-                - "console=ttyS0,115200n8"
-                - "nvme_core.io_timeout=4294967295"
-            aarch64:
-              # TODO: move these to the EC2 environment
-              kernel_options:
-                # XXX: duplicated with above x86_64 kernel defaults
-                - "console=tty0"
-                - "console=ttyS0,115200n8"
-                - "nvme_core.io_timeout=4294967295"
-                # aarch64 specific
-                - "iommu.strict=0"
+      conditions: &ami_image_config_cond
+        "we need dracut conf with nvme/xen on x86":
+          when: arch == "x86_64"
+          merge:
+            dracut_conf:
+              - filename: "ec2.conf"
+                config:
+                  add_drivers:
+                    - "nvme"
+                    - "xen-blkfront"
+        "x86_64 specific kopts":
+          when: arch == "x86_64"
+          merge:
+            # TODO: move these to the EC2 environment
+            kernel_options:
+              # common
+              - "console=tty0"
+              - "console=ttyS0,115200n8"
+              - "nvme_core.io_timeout=4294967295"
+        "aarch64 specific kopts":
+          when: arch == "aarch64"
+          merge:
+            # TODO: move these to the EC2 environment
+            kernel_options:
+              # XXX: duplicated with above x86_64 kernel defaults
+              - "console=tty0"
+              - "console=ttyS0,115200n8"
+              - "nvme_core.io_timeout=4294967295"
+              # aarch64 specific
+              - "iommu.strict=0"
     partition_table:
       <<: *default_partition_tables
     package_sets:
@@ -1039,12 +1048,8 @@ image_types:
             - "dracut-config-rescue"
             # RHBZ#2075815
             - "qemu-guest-agent"
-          condition:
-            "add insights client":
-              distro_name:
-                rhel:
-                  include:
-                    - "insights-client"
+          conditions:
+            <<: *conditions_pkgsets_insights_client_on_rhel
 
   ec2: *ami
 
@@ -1066,20 +1071,22 @@ image_types:
         - *sap_pkgset
     image_config:
       <<: [*ami_image_config, *sap_image_config]
-      condition:
+      conditions:
         <<: *ami_image_config_cond
-        # this needs to override the original ami key
-        "conditions for ami arch kopts":
-          architecture:
-            x86_64:
-              kernel_options:
-                # XXX: duplicated with ami.image_config.kernel_options :(
-                - "console=tty0"
-                - "console=ttyS0,115200n8"
-                - "nvme_core.io_timeout=4294967295"
-                # amiSapKernelOptions()
-                - "processor.max_cstate=1"
-                - "intel_idle.max_cstate=1"
+        # this needs to override the original ami key because
+        # we want everything from the ami config *except* the
+        # kernel comandline
+        "x86_64 specific kopts":
+          when: arch == "x86_64"
+          merge:
+            kernel_options:
+              # XXX: duplicated with ami.image_config.kernel_options :(
+              - "console=tty0"
+              - "console=ttyS0,115200n8"
+              - "nvme_core.io_timeout=4294967295"
+              # amiSapKernelOptions()
+              - "processor.max_cstate=1"
+              - "intel_idle.max_cstate=1"
 
   wsl:
     image_config:
@@ -1266,18 +1273,20 @@ image_types:
             - "xfsdump"
             - "xfsprogs"
             - "xz"
-          condition:
-            "arch pkgs for image installer":
-              architecture:
-                x86_64:
-                  include:
-                    - "biosdevname"
-                    - "dmidecode"
-                    - "grub2-tools-efi"
-                    - "memtest86+"
-                aarch64:
-                  include:
-                    - "dmidecode"
+          conditions:
+            "x86_64 specific pkgs for image installer":
+              when: arch == "x86_64"
+              append:
+                include:
+                  - "biosdevname"
+                  - "dmidecode"
+                  - "grub2-tools-efi"
+                  - "memtest86+"
+            "aarch64 specific pkgs for image installer":
+              when: arch == "aarch64"
+              append:
+                include:
+                  - "dmidecode"
 
   gce:
     image_config:
@@ -1431,12 +1440,8 @@ image_types:
             - "zd1211-firmware"
             # RHBZ#2075815
             - "qemu-guest-agent"
-          condition:
-            "add insights client":
-              distro_name:
-                rhel:
-                  include:
-                    - "insights-client"
+          conditions:
+            <<: *conditions_pkgsets_insights_client_on_rhel
 
   "azure-cvm":
     image_config:

--- a/pkg/distro/defs/rhel-7/distro.yaml
+++ b/pkg/distro/defs/rhel-7/distro.yaml
@@ -38,12 +38,12 @@
       - "mariadb-libs"
       - "NetworkManager-config-server"
       - "postfix"
-    condition:
+    conditions: &conditions_for_insights_client
       "add insights client on rhel":
-        distro_name:
-          "rhel":
-            include:
-              - "insights-client"
+        when: distro_name == "rhel"
+        append:
+          include:
+            - "insights-client"
 
   partitioning:
     ids:
@@ -248,9 +248,5 @@ image_types:
             - "libertas-sd8686-firmware"
             - "libertas-sd8787-firmware"
             - "libertas-usb8388-firmware"
-          condition:
-            "add insights client on rhel":
-              distro_name:
-                "rhel":
-                  include:
-                    - "insights-client"
+          conditions:
+            <<: *conditions_for_insights_client

--- a/pkg/distro/defs/rhel-7/distro.yaml
+++ b/pkg/distro/defs/rhel-7/distro.yaml
@@ -39,10 +39,11 @@
       - "NetworkManager-config-server"
       - "postfix"
     condition:
-      distro_name:
-        "rhel":
-          include:
-            - "insights-client"
+      "add insights client on rhel":
+        distro_name:
+          "rhel":
+            include:
+              - "insights-client"
 
   partitioning:
     ids:
@@ -248,7 +249,8 @@ image_types:
             - "libertas-sd8787-firmware"
             - "libertas-usb8388-firmware"
           condition:
-            distro_name:
-              "rhel":
-                include:
-                  - "insights-client"
+            "add insights client on rhel":
+              distro_name:
+                "rhel":
+                  include:
+                    - "insights-client"

--- a/pkg/distro/defs/rhel-8/distro.yaml
+++ b/pkg/distro/defs/rhel-8/distro.yaml
@@ -50,12 +50,12 @@
       - "plymouth"
       # RHBZ#2075815
       - "qemu-guest-agent"
-    condition:
+    conditions: &conditions_for_insights_client
       "add insights client on rhel":
-        distro_name:
-          rhel:
-            include:
-              - "insights-client"
+        when: distro_name == "rhel"
+        append:
+          include:
+            - "insights-client"
 
   azure_common_pkgset: &azure_common_pkgset
     include:
@@ -129,16 +129,13 @@
       - "rhnlib"
       - "rhnsd"
       - "usb_modeswitch"
-    condition:
-      "add insights client on rhel":
-        distro_name:
-          "rhel":
-            include:
-              - "insights-client"
-              # XXX: this is defined in azure.go:commonPackageSets but
-              # there is a bug in the original code so this never gets
-              # actually added so we don't add it here either
-              # - "rhc"
+    conditions:
+      <<: *conditions_for_insights_client
+      # XXX: the below "rhc" is defined in
+      # azure.go:commonPackageSets but there is a bug in the
+      # original code so this never gets actually added so we
+      # don't add it here either
+      # - "rhc"
 
   sap_pkgset: &sap_pkgset
     include:
@@ -178,16 +175,17 @@
       - "tuned-profiles-sap-hana"
       # RHBZ#1961168
       - "libnsl"
-    condition:
-      "ansible changed name in rhel-8.6":
-        version_less_than:
-          "8.6":
-            include:
-              - "ansible"
-        version_greater_or_equal:
-          "8.6":
-            include:
-              - "ansible-core"
+    conditions:
+      "name of the ansible pkg rhel-8.6 and below":
+        when: version_less_than("8.6")
+        append:
+          include:
+            - "ansible"
+      "name of the ansible pkg rhel-8.6+":
+        when: version_greater_or_equal("8.6")
+        append:
+          include:
+            - "ansible-core"
 
   installer_pkgset: &installer_pkgset
     include:
@@ -222,49 +220,51 @@
       - "tar"
       - "xfsprogs"
       - "xz"
-    condition:
+    conditions:
       "x86-64 needs biosdevname":
-        architecture:
-          x86_64:
-            include:
-              - "biosdevname"
+        when: arch == "x86_64"
+        append:
+          include:
+            - "biosdevname"
 
   anaconda_boot_pkgset: &anaconda_boot_pkgset
-    condition:
-      "architecture dependant anaconda package set":
-        architecture:
-          x86_64:
-            include:
-              # eficommon
-              - "efibootmgr"
-              # XXX: de-dup?
-              # grub-common
-              - "grub2-tools"
-              - "grub2-tools-extra"
-              - "grub2-tools-minimal"
-              # arch specific
-              - "grub2-efi-ia32-cdboot"
-              - "grub2-efi-x64"
-              - "grub2-efi-x64-cdboot"
-              - "grub2-pc"
-              - "grub2-pc-modules"
-              - "shim-ia32"
-              - "shim-x64"
-              - "syslinux"
-              - "syslinux-nonlinux"
-          aarch64:
-            include:
-              # eficommon
-              - "efibootmgr"
-              # XXX: de-dup?
-              # grub-common
-              - "grub2-tools"
-              - "grub2-tools-extra"
-              - "grub2-tools-minimal"
-              # arch specific
-              - "grub2-efi-aa64-cdboot"
-              - "grub2-efi-aa64"
-              - "shim-aa64"
+    conditions:
+      "x86_64 architecture dependant anaconda packages":
+        when: arch == "x86_64"
+        append:
+          include:
+            # eficommon
+            - "efibootmgr"
+            # XXX: de-dup?
+            # grub-common
+            - "grub2-tools"
+            - "grub2-tools-extra"
+            - "grub2-tools-minimal"
+            # arch specific
+            - "grub2-efi-ia32-cdboot"
+            - "grub2-efi-x64"
+            - "grub2-efi-x64-cdboot"
+            - "grub2-pc"
+            - "grub2-pc-modules"
+            - "shim-ia32"
+            - "shim-x64"
+            - "syslinux"
+            - "syslinux-nonlinux"
+      "aarch64 architecture dependant anaconda packages":
+        when: arch == "aarch64"
+        append:
+          include:
+            # eficommon
+            - "efibootmgr"
+            # XXX: de-dup?
+            # grub-common
+            - "grub2-tools"
+            - "grub2-tools-extra"
+            - "grub2-tools-minimal"
+            # arch specific
+            - "grub2-efi-aa64-cdboot"
+            - "grub2-efi-aa64"
+            - "shim-aa64"
 
   anaconda_pkgset: &anaconda_pkgset
     include:
@@ -375,24 +375,24 @@
       - "xorg-x11-server-utils"
       - "xorg-x11-server-Xorg"
       - "xorg-x11-xauth"
-    condition:
-      "architecture dependant packages for anaconda":
-        architecture:
-          x86_64:
-            include:
-              - "biosdevname"
-              - "dmidecode"
-              - "memtest86+"
-          aarch64:
-            include:
-              - "dmidecode"
-        distro_name:
-          rhel:
-            include:
-              - "libreport-rhel-anaconda-bugzilla"
-          centos:
-            include:
-              - "libreport-rhel-anaconda-bugzilla"
+    conditions:
+      "x86_64 architecture dependant packages for anaconda":
+        when: arch == "x86_64"
+        append:
+          include:
+            - "biosdevname"
+            - "dmidecode"
+            - "memtest86+"
+      "aarch64 architecture dependant packages for anaconda":
+        when: arch == "aarch64"
+        append:
+          include:
+            - "dmidecode"
+      "rhel/centos need libreport-rhel-anaconda-bugzilla":
+        when: distro_name == "rhel" or distro_name == "centos"
+        append:
+          include:
+            - "libreport-rhel-anaconda-bugzilla"
 
   gce_common_pkgset: &gce_common_pkgset
     include:
@@ -455,12 +455,8 @@
       - "zd1211-firmware"
       # RHBZ#2075815
       - "qemu-guest-agent"
-    condition:
-      "add insights client":
-        distro_name:
-          rhel:
-            include:
-              - "insights-client"
+    conditions:
+      <<: *conditions_for_insights_client
 
   qcow2_common_pkgset: &qcow2_common_pkgset
     include:
@@ -530,13 +526,13 @@
       - "plymouth"
       - "rng-tools"
       - "udisks2"
-    condition:
+    conditions: &condition_rhel_insights_clinet_subman
       "add insights/subscription manager for copilot":
-        distro_name:
-          rhel:
-            include:
-              - "insights-client"
-              - "subscription-manager-cockpit"
+        when: distro_name == "rhel"
+        append:
+          include:
+            - "insights-client"
+            - "subscription-manager-cockpit"
 
   partitioning:
     ids:
@@ -748,31 +744,28 @@
           - *ec2_partition_table_part_root
 
   ec2_partition_tables_override: &ec2_partition_tables_override
-    condition:
-      "ec2 partition table overrides":
-        version_less_than:
-          "8.10":
-            aarch64:
-              <<: *ec2_partition_table_aarch64
-              partitions:
-                - *ec2_partition_table_part_efi
-                - *ec2_partition_table_part_boot512
-                - *ec2_partition_table_part_root
-          "8.9":
-            x86_64:
-              <<: *ec2_partition_table_x86_64
-              partitions:
-                - *default_partition_table_part_bios
-                - *ec2_partition_table_part_root
-        distro_name:
-          # we need this override to ensure that centos always gets
-          # the latest partition-tables, otherwise "centos-8" is
-          # less than "8 <= 8.9"
-          "centos":
-            x86_64:
-              <<: *ec2_partition_table_x86_64
-            aarch64:
-              <<: *ec2_partition_table_aarch64
+    conditions:
+      "rhel8.9  uses efi boot but small boot":
+        when: distro_version == "8.9"
+        override:
+          x86_64:
+            <<: *ec2_partition_table_x86_64
+          aarch64: &ec2_partition_table_aarch64_8_9
+            <<: *ec2_partition_table_aarch64
+            partitions:
+              - *ec2_partition_table_part_efi
+              - *ec2_partition_table_part_boot512
+              - *ec2_partition_table_part_root
+      "rhel-8.9 and below has no efi on x86 but is the same on aarch64":
+        when: version_less_than("8.9") and distro_name == "rhel"
+        override:
+          x86_64:
+            <<: *ec2_partition_table_x86_64
+            partitions:
+              - *default_partition_table_part_bios
+              - *ec2_partition_table_part_root
+          aarch64:
+            <<: *ec2_partition_table_aarch64_8_9
 
 image_config:
   default:
@@ -786,11 +779,11 @@ image_config:
       no_zero_conf: true
     timezone: "America/New_York"
     update_default_kernel: true
-  condition:
+  conditions:
     "centos has a different oscap path":
-      distro_name:
-        centos:
-          default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-centos8-ds.xml"
+      when: distro_name == "centos"
+      merge:
+        default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-centos8-ds.xml"
 
 image_types:
   # XXX: not a real pkgset but the "os" pipeline pkgset for image-installer
@@ -842,13 +835,8 @@ image_types:
             - "tar"
             - "tcpdump"
             - "yum"
-          condition:
-            "add insights packages":
-              distro_name:
-                rhel:
-                  include:
-                    - "insights-client"
-                    - "subscription-manager-cockpit"
+          conditions:
+            <<: *condition_rhel_insights_clinet_subman
 
   ec2: &ec2
     partition_table:
@@ -862,12 +850,12 @@ image_types:
             - "rh-amazon-rhui-client"
           exclude:
             - "alsa-lib"
-          condition:
-            "later rhel gets extra packages":
-              version_greater_or_equal:
-                "8.7":
-                  include:
-                    - "redhat-cloud-client-configuration"
+          conditions: &conditions_rh_cloud_client
+            "add redhat-cloud-client-configuration on rh8.7+":
+              when: version_greater_or_equal("8.7")
+              append:
+                include:
+                  - "redhat-cloud-client-configuration"
 
   "ec2-ha":
     <<: *ec2
@@ -881,12 +869,8 @@ image_types:
             - "rh-amazon-rhui-client-ha"
           exclude:
             - "alsa-lib"
-          condition:
-            "later rhel gets extra packages":
-              version_greater_or_equal:
-                "8.7":
-                  include:
-                    - "redhat-cloud-client-configuration"
+          conditions:
+            <<: *conditions_rh_cloud_client
 
   ami:
     <<: *ec2
@@ -900,20 +884,18 @@ image_types:
       os:
         - *ec2_common_pkgset
         - *sap_pkgset
-        - condition:
-            "sap specific ec2 packages":
-              version_less_than:
-                "8.10":
-                  include:
-                    - "rh-amazon-rhui-client-sap-bundle-e4s"
-              version_greater_or_equal:
-                "8.10":
-                  include:
-                    - "rh-amazon-rhui-client-sap-bundle"
-                # XXX: can this be removed
-                "8.7":
-                  include:
-                    - "redhat-cloud-client-configuration"
+        - conditions:
+            <<: *conditions_rh_cloud_client
+            "rh-8.9 or below gets the e4s bundle":
+              when: version_less_than("8.10")
+              append:
+                include:
+                  - "rh-amazon-rhui-client-sap-bundle-e4s"
+            "rh-8.10+ get the rhui bundle":
+              when: version_greater_or_equal("8.10")
+              append:
+                include:
+                  - "rh-amazon-rhui-client-sap-bundle"
 
   "azure-rhui":
     package_sets:
@@ -932,16 +914,17 @@ image_types:
         - *sap_pkgset
         - include:
             - "firewalld"
-          condition:
-            "sap rhui specific pkgs":
-              version_greater_or_equal:
-                "8.10":
-                  include:
-                    - "rhui-azure-rhel8-base-sap-ha"
-              version_less_than:
-                "8.10":
-                  include:
-                    - "rhui-azure-rhel8-sap-ha"
+          conditions:
+            "rh-8.10+ gets the the base sap ha pkgs":
+              when: version_greater_or_equal("8.10")
+              append:
+                include:
+                  - "rhui-azure-rhel8-base-sap-ha"
+            "rh-8.9 or below gets sap-ha":
+              when: version_less_than("8.10")
+              append:
+                include:
+                  - "rhui-azure-rhel8-sap-ha"
 
   "azure-eap7-rhui":
     package_sets:
@@ -1059,51 +1042,52 @@ image_types:
             - "xz"
           exclude:
             - "rng-tools"
-          condition:
-            "condtions for edge-commit":
-              architecture:
-                x86_64: &edge_commit_x86_64_pkgset
-                  include:
-                    - "efibootmgr"
-                    - "grub2"
-                    - "grub2-efi-x64"
-                    - "iwl1000-firmware"
-                    - "iwl100-firmware"
-                    - "iwl105-firmware"
-                    - "iwl135-firmware"
-                    - "iwl2000-firmware"
-                    - "iwl2030-firmware"
-                    - "iwl3160-firmware"
-                    - "iwl5000-firmware"
-                    - "iwl5150-firmware"
-                    - "iwl6000-firmware"
-                    - "iwl6050-firmware"
-                    - "iwl7260-firmware"
-                    - "microcode_ctl"
-                    - "shim-x64"
-                aarch64: &edge_commit_aarch64_pkgset
-                  include:
-                    - "grub2-efi-aa64"
-                    - "efibootmgr"
-                    - "shim-aa64"
-                    - "iwl7260-firmware"
-              version_less_than:
-                "8.6":
-                  include:
-                    - "greenboot-grub2"
-                    - "greenboot-reboot"
-                    - "greenboot-rpm-ostree-grub2"
-                    - "greenboot-status"
-              version_greater_or_equal:
-                "8.6": &edge_commit_new_rhel
-                  include:
-                    - "fdo-client"
-                    - "fdo-owner-cli"
-                    - "greenboot-default-health-checks"
-                    - "sos"
-              distro_name:
-                centos:
-                  *edge_commit_new_rhel
+          conditions: &conditions_pkgsets_edge_commit
+            "x86_64 specific packages for edge-commit":
+              when: arch == "x86_64"
+              append: &edge_commit_x86_64_pkgset
+                include:
+                  - "efibootmgr"
+                  - "grub2"
+                  - "grub2-efi-x64"
+                  - "iwl1000-firmware"
+                  - "iwl100-firmware"
+                  - "iwl105-firmware"
+                  - "iwl135-firmware"
+                  - "iwl2000-firmware"
+                  - "iwl2030-firmware"
+                  - "iwl3160-firmware"
+                  - "iwl5000-firmware"
+                  - "iwl5150-firmware"
+                  - "iwl6000-firmware"
+                  - "iwl6050-firmware"
+                  - "iwl7260-firmware"
+                  - "microcode_ctl"
+                  - "shim-x64"
+            "aarch64 specific packages for edge-commit":
+              when: arch == "aarch64"
+              append: &edge_commit_aarch64_pkgset
+                include:
+                  - "grub2-efi-aa64"
+                  - "efibootmgr"
+                  - "shim-aa64"
+                  - "iwl7260-firmware"
+            "rhel-8.5 or below uses greenboot":
+              when: version_less_than("8.6") and distro_name != "centos"
+              append:
+                include:
+                  - "greenboot-grub2"
+                  - "greenboot-reboot"
+                  - "greenboot-rpm-ostree-grub2"
+                  - "greenboot-status"
+            "rhel-8.6+ uses fdo":
+              when: version_greater_or_equal("8.6")
+              append:
+                include:
+                  - "fdo-client"
+                  - "fdo-owner-cli"
+                  - "greenboot-default-health-checks"
+                  - "sos"
 
   "edge-installer":
     package_sets:
@@ -1173,13 +1157,17 @@ image_types:
             - "sudo"
             - "traceroute"
             - "util-linux"
-          condition:
-            "condtions for edge-simplified-installer":
-              architecture:
-                x86_64:
-                  *edge_commit_x86_64_pkgset
-                aarch64:
-                  *edge_commit_aarch64_pkgset
+          conditions:
+            # XXX: should we instead "<<: *conditions_edge_commit" here?
+            # it will give different results
+            "x86_64 specific pkgset for edge-simplified-installer":
+              when: arch == "x86_64"
+              append:
+                <<: *edge_commit_x86_64_pkgset
+            "aarch64 specific pkgset for edge-simplified-installer":
+              when: arch == "aarch64"
+              append:
+                <<: *edge_commit_aarch64_pkgset
 
   "edge-container":
     package_sets:

--- a/pkg/distro/defs/rhel-8/distro.yaml
+++ b/pkg/distro/defs/rhel-8/distro.yaml
@@ -51,10 +51,11 @@
       # RHBZ#2075815
       - "qemu-guest-agent"
     condition:
-      distro_name:
-        rhel:
-          include:
-            - "insights-client"
+      "add insights client on rhel":
+        distro_name:
+          rhel:
+            include:
+              - "insights-client"
 
   azure_common_pkgset: &azure_common_pkgset
     include:
@@ -129,14 +130,15 @@
       - "rhnsd"
       - "usb_modeswitch"
     condition:
-      distro_name:
-        "rhel":
-          include:
-            - "insights-client"
-            # XXX: this is defined in azure.go:commonPackageSets but
-            # there is a bug in the original code so this never gets
-            # actually added so we don't add it here either
-            # - "rhc"
+      "add insights client on rhel":
+        distro_name:
+          "rhel":
+            include:
+              - "insights-client"
+              # XXX: this is defined in azure.go:commonPackageSets but
+              # there is a bug in the original code so this never gets
+              # actually added so we don't add it here either
+              # - "rhc"
 
   sap_pkgset: &sap_pkgset
     include:
@@ -177,14 +179,15 @@
       # RHBZ#1961168
       - "libnsl"
     condition:
-      version_less_than:
-        "8.6":
-          include:
-            - "ansible"
-      version_greater_or_equal:
-        "8.6":
-          include:
-            - "ansible-core"
+      "ansible changed name in rhel-8.6":
+        version_less_than:
+          "8.6":
+            include:
+              - "ansible"
+        version_greater_or_equal:
+          "8.6":
+            include:
+              - "ansible-core"
 
   installer_pkgset: &installer_pkgset
     include:
@@ -220,46 +223,48 @@
       - "xfsprogs"
       - "xz"
     condition:
-      architecture:
-        x86_64:
-          include:
-            - "biosdevname"
+      "x86-64 needs biosdevname":
+        architecture:
+          x86_64:
+            include:
+              - "biosdevname"
 
   anaconda_boot_pkgset: &anaconda_boot_pkgset
     condition:
-      architecture:
-        x86_64:
-          include:
-            # eficommon
-            - "efibootmgr"
-            # XXX: de-dup?
-            # grub-common
-            - "grub2-tools"
-            - "grub2-tools-extra"
-            - "grub2-tools-minimal"
-            # arch specific
-            - "grub2-efi-ia32-cdboot"
-            - "grub2-efi-x64"
-            - "grub2-efi-x64-cdboot"
-            - "grub2-pc"
-            - "grub2-pc-modules"
-            - "shim-ia32"
-            - "shim-x64"
-            - "syslinux"
-            - "syslinux-nonlinux"
-        aarch64:
-          include:
-            # eficommon
-            - "efibootmgr"
-            # XXX: de-dup?
-            # grub-common
-            - "grub2-tools"
-            - "grub2-tools-extra"
-            - "grub2-tools-minimal"
-            # arch specific
-            - "grub2-efi-aa64-cdboot"
-            - "grub2-efi-aa64"
-            - "shim-aa64"
+      "architecture dependant anaconda package set":
+        architecture:
+          x86_64:
+            include:
+              # eficommon
+              - "efibootmgr"
+              # XXX: de-dup?
+              # grub-common
+              - "grub2-tools"
+              - "grub2-tools-extra"
+              - "grub2-tools-minimal"
+              # arch specific
+              - "grub2-efi-ia32-cdboot"
+              - "grub2-efi-x64"
+              - "grub2-efi-x64-cdboot"
+              - "grub2-pc"
+              - "grub2-pc-modules"
+              - "shim-ia32"
+              - "shim-x64"
+              - "syslinux"
+              - "syslinux-nonlinux"
+          aarch64:
+            include:
+              # eficommon
+              - "efibootmgr"
+              # XXX: de-dup?
+              # grub-common
+              - "grub2-tools"
+              - "grub2-tools-extra"
+              - "grub2-tools-minimal"
+              # arch specific
+              - "grub2-efi-aa64-cdboot"
+              - "grub2-efi-aa64"
+              - "shim-aa64"
 
   anaconda_pkgset: &anaconda_pkgset
     include:
@@ -371,22 +376,23 @@
       - "xorg-x11-server-Xorg"
       - "xorg-x11-xauth"
     condition:
-      architecture:
-        x86_64:
-          include:
-            - "biosdevname"
-            - "dmidecode"
-            - "memtest86+"
-        aarch64:
-          include:
-            - "dmidecode"
-      distro_name:
-        rhel:
-          include:
-            - "libreport-rhel-anaconda-bugzilla"
-        centos:
-          include:
-            - "libreport-rhel-anaconda-bugzilla"
+      "architecture dependant packages for anaconda":
+        architecture:
+          x86_64:
+            include:
+              - "biosdevname"
+              - "dmidecode"
+              - "memtest86+"
+          aarch64:
+            include:
+              - "dmidecode"
+        distro_name:
+          rhel:
+            include:
+              - "libreport-rhel-anaconda-bugzilla"
+          centos:
+            include:
+              - "libreport-rhel-anaconda-bugzilla"
 
   gce_common_pkgset: &gce_common_pkgset
     include:
@@ -450,10 +456,11 @@
       # RHBZ#2075815
       - "qemu-guest-agent"
     condition:
-      distro_name:
-        rhel:
-          include:
-            - "insights-client"
+      "add insights client":
+        distro_name:
+          rhel:
+            include:
+              - "insights-client"
 
   qcow2_common_pkgset: &qcow2_common_pkgset
     include:
@@ -524,11 +531,12 @@
       - "rng-tools"
       - "udisks2"
     condition:
-      distro_name:
-        rhel:
-          include:
-            - "insights-client"
-            - "subscription-manager-cockpit"
+      "add insights/subscription manager for copilot":
+        distro_name:
+          rhel:
+            include:
+              - "insights-client"
+              - "subscription-manager-cockpit"
 
   partitioning:
     ids:
@@ -741,29 +749,30 @@
 
   ec2_partition_tables_override: &ec2_partition_tables_override
     condition:
-      version_less_than:
-        "8.10":
-          aarch64:
-            <<: *ec2_partition_table_aarch64
-            partitions:
-              - *ec2_partition_table_part_efi
-              - *ec2_partition_table_part_boot512
-              - *ec2_partition_table_part_root
-        "8.9":
-          x86_64:
-            <<: *ec2_partition_table_x86_64
-            partitions:
-              - *default_partition_table_part_bios
-              - *ec2_partition_table_part_root
-      distro_name:
-        # we need this override to ensure that centos always gets
-        # the latest partition-tables, otherwise "centos-8" is
-        # less than "8 <= 8.9"
-        "centos":
-          x86_64:
-            <<: *ec2_partition_table_x86_64
-          aarch64:
-            <<: *ec2_partition_table_aarch64
+      "ec2 partition table overrides":
+        version_less_than:
+          "8.10":
+            aarch64:
+              <<: *ec2_partition_table_aarch64
+              partitions:
+                - *ec2_partition_table_part_efi
+                - *ec2_partition_table_part_boot512
+                - *ec2_partition_table_part_root
+          "8.9":
+            x86_64:
+              <<: *ec2_partition_table_x86_64
+              partitions:
+                - *default_partition_table_part_bios
+                - *ec2_partition_table_part_root
+        distro_name:
+          # we need this override to ensure that centos always gets
+          # the latest partition-tables, otherwise "centos-8" is
+          # less than "8 <= 8.9"
+          "centos":
+            x86_64:
+              <<: *ec2_partition_table_x86_64
+            aarch64:
+              <<: *ec2_partition_table_aarch64
 
 image_config:
   default:
@@ -778,9 +787,10 @@ image_config:
     timezone: "America/New_York"
     update_default_kernel: true
   condition:
-    distro_name:
-      centos:
-        default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-centos8-ds.xml"
+    "centos has a different oscap path":
+      distro_name:
+        centos:
+          default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-centos8-ds.xml"
 
 image_types:
   # XXX: not a real pkgset but the "os" pipeline pkgset for image-installer
@@ -833,11 +843,12 @@ image_types:
             - "tcpdump"
             - "yum"
           condition:
-            distro_name:
-              rhel:
-                include:
-                  - "insights-client"
-                  - "subscription-manager-cockpit"
+            "add insights packages":
+              distro_name:
+                rhel:
+                  include:
+                    - "insights-client"
+                    - "subscription-manager-cockpit"
 
   ec2: &ec2
     partition_table:
@@ -852,10 +863,11 @@ image_types:
           exclude:
             - "alsa-lib"
           condition:
-            version_greater_or_equal:
-              "8.7":
-                include:
-                  - "redhat-cloud-client-configuration"
+            "later rhel gets extra packages":
+              version_greater_or_equal:
+                "8.7":
+                  include:
+                    - "redhat-cloud-client-configuration"
 
   "ec2-ha":
     <<: *ec2
@@ -870,10 +882,11 @@ image_types:
           exclude:
             - "alsa-lib"
           condition:
-            version_greater_or_equal:
-              "8.7":
-                include:
-                  - "redhat-cloud-client-configuration"
+            "later rhel gets extra packages":
+              version_greater_or_equal:
+                "8.7":
+                  include:
+                    - "redhat-cloud-client-configuration"
 
   ami:
     <<: *ec2
@@ -888,17 +901,19 @@ image_types:
         - *ec2_common_pkgset
         - *sap_pkgset
         - condition:
-            version_less_than:
-              "8.10":
-                include:
-                  - "rh-amazon-rhui-client-sap-bundle-e4s"
-            version_greater_or_equal:
-              "8.10":
-                include:
-                  - "rh-amazon-rhui-client-sap-bundle"
-              "8.7":
-                include:
-                  - "redhat-cloud-client-configuration"
+            "sap specific ec2 packages":
+              version_less_than:
+                "8.10":
+                  include:
+                    - "rh-amazon-rhui-client-sap-bundle-e4s"
+              version_greater_or_equal:
+                "8.10":
+                  include:
+                    - "rh-amazon-rhui-client-sap-bundle"
+                # XXX: can this be removed
+                "8.7":
+                  include:
+                    - "redhat-cloud-client-configuration"
 
   "azure-rhui":
     package_sets:
@@ -918,14 +933,15 @@ image_types:
         - include:
             - "firewalld"
           condition:
-            version_greater_or_equal:
-              "8.10":
-                include:
-                  - "rhui-azure-rhel8-base-sap-ha"
-            version_less_than:
-              "8.10":
-                include:
-                  - "rhui-azure-rhel8-sap-ha"
+            "sap rhui specific pkgs":
+              version_greater_or_equal:
+                "8.10":
+                  include:
+                    - "rhui-azure-rhel8-base-sap-ha"
+              version_less_than:
+                "8.10":
+                  include:
+                    - "rhui-azure-rhel8-sap-ha"
 
   "azure-eap7-rhui":
     package_sets:
@@ -1044,49 +1060,50 @@ image_types:
           exclude:
             - "rng-tools"
           condition:
-            architecture:
-              x86_64: &edge_commit_x86_64_pkgset
-                include:
-                  - "efibootmgr"
-                  - "grub2"
-                  - "grub2-efi-x64"
-                  - "iwl1000-firmware"
-                  - "iwl100-firmware"
-                  - "iwl105-firmware"
-                  - "iwl135-firmware"
-                  - "iwl2000-firmware"
-                  - "iwl2030-firmware"
-                  - "iwl3160-firmware"
-                  - "iwl5000-firmware"
-                  - "iwl5150-firmware"
-                  - "iwl6000-firmware"
-                  - "iwl6050-firmware"
-                  - "iwl7260-firmware"
-                  - "microcode_ctl"
-                  - "shim-x64"
-              aarch64: &edge_commit_aarch64_pkgset
-                include:
-                  - "grub2-efi-aa64"
-                  - "efibootmgr"
-                  - "shim-aa64"
-                  - "iwl7260-firmware"
-            version_less_than:
-              "8.6":
-                include:
-                  - "greenboot-grub2"
-                  - "greenboot-reboot"
-                  - "greenboot-rpm-ostree-grub2"
-                  - "greenboot-status"
-            version_greater_or_equal:
-              "8.6": &edge_commit_new_rhel
-                include:
-                  - "fdo-client"
-                  - "fdo-owner-cli"
-                  - "greenboot-default-health-checks"
-                  - "sos"
-            distro_name:
-              centos:
-                *edge_commit_new_rhel
+            "condtions for edge-commit":
+              architecture:
+                x86_64: &edge_commit_x86_64_pkgset
+                  include:
+                    - "efibootmgr"
+                    - "grub2"
+                    - "grub2-efi-x64"
+                    - "iwl1000-firmware"
+                    - "iwl100-firmware"
+                    - "iwl105-firmware"
+                    - "iwl135-firmware"
+                    - "iwl2000-firmware"
+                    - "iwl2030-firmware"
+                    - "iwl3160-firmware"
+                    - "iwl5000-firmware"
+                    - "iwl5150-firmware"
+                    - "iwl6000-firmware"
+                    - "iwl6050-firmware"
+                    - "iwl7260-firmware"
+                    - "microcode_ctl"
+                    - "shim-x64"
+                aarch64: &edge_commit_aarch64_pkgset
+                  include:
+                    - "grub2-efi-aa64"
+                    - "efibootmgr"
+                    - "shim-aa64"
+                    - "iwl7260-firmware"
+              version_less_than:
+                "8.6":
+                  include:
+                    - "greenboot-grub2"
+                    - "greenboot-reboot"
+                    - "greenboot-rpm-ostree-grub2"
+                    - "greenboot-status"
+              version_greater_or_equal:
+                "8.6": &edge_commit_new_rhel
+                  include:
+                    - "fdo-client"
+                    - "fdo-owner-cli"
+                    - "greenboot-default-health-checks"
+                    - "sos"
+              distro_name:
+                centos:
+                  *edge_commit_new_rhel
 
   "edge-installer":
     package_sets:
@@ -1157,11 +1174,12 @@ image_types:
             - "traceroute"
             - "util-linux"
           condition:
-            architecture:
-              x86_64:
-                *edge_commit_x86_64_pkgset
-              aarch64:
-                *edge_commit_aarch64_pkgset
+            "condtions for edge-simplified-installer":
+              architecture:
+                x86_64:
+                  *edge_commit_x86_64_pkgset
+                aarch64:
+                  *edge_commit_aarch64_pkgset
 
   "edge-container":
     package_sets:

--- a/pkg/distro/defs/rhel-9/distro.yaml
+++ b/pkg/distro/defs/rhel-9/distro.yaml
@@ -17,16 +17,26 @@
       - "tar"
       - "xfsprogs"
       - "xz"
-    condition:
-      "condition for build_pkgsset":
-        architecture:
-          x86_64:
-            include:
-              - "grub2-pc"
-          ppc64el:
-            include:
-              - "grub2-ppc64le"
-              - "grub2-ppc64le-modules"
+    conditions:
+      "x86_64 specific packages for build pkgsset":
+        when: arch == "x86_64"
+        append:
+          include:
+            - "grub2-pc"
+      "ppc64le specific packages for build pkgsset":
+        when: arch == "ppc64le"
+        append:
+          include:
+            - "grub2-ppc64le"
+            - "grub2-ppc64le-modules"
+
+  common_conditions:
+    conditions: &conditions_pkgsets_insights_client_on_rhel
+      "add insights client on rhel":
+        when: distro_name == "rhel"
+        append:
+          include:
+            - "insights-client"
 
   ec2_base_pkgset: &ec2_base_pkgset
     include:
@@ -79,16 +89,13 @@
       - "dracut-config-rescue"
       # RHBZ#2075815
       - "qemu-guest-agent"
-    condition:
-      "condition for ec2 basepkgset":
-        distro_name:
-          rhel:
-            include:
-              - "insights-client"
-        version_greater_or_equal:
-          "9.6":
-            include:
-              - "system-reinstall-bootc"
+    conditions:
+      <<: *conditions_pkgsets_insights_client_on_rhel
+      "rhel-9.6+ gets system-reinstall-bootc":
+        when: version_greater_or_equal("9.6")
+        append:
+          include:
+            - "system-reinstall-bootc"
 
   sap_pkgset: &sap_pkgset
     include:
@@ -180,47 +187,49 @@
       # pipeline.
       - "mdadm"
       - "nss-softokn"
-    condition:
-      "condition for installer pkgset":
-        architecture:
-          x86_64:
-            include:
-              - "biosdevname"
+    conditions:
+      "x86_64 specific installer packages":
+        when: arch == "x86_64"
+        append:
+          include:
+            - "biosdevname"
 
   anaconda_boot_pkgset: &anaconda_boot_pkgset
-    condition:
-      "condition for anaconda boot pkgset":
-        architecture:
-          x86_64:
-            include:
-              # eficommon
-              - "efibootmgr"
-              # XXX: de-dup?
-              # grub-common
-              - "grub2-tools"
-              - "grub2-tools-extra"
-              - "grub2-tools-minimal"
-              # arch specific
-              - "grub2-efi-x64"
-              - "grub2-efi-x64-cdboot"
-              - "grub2-pc"
-              - "grub2-pc-modules"
-              - "shim-x64"
-              - "syslinux"
-              - "syslinux-nonlinux"
-          aarch64:
-            include:
-              # eficommon
-              - "efibootmgr"
-              # XXX: de-dup?
-              # grub-common
-              - "grub2-tools"
-              - "grub2-tools-extra"
-              - "grub2-tools-minimal"
-              # arch specific
-              - "grub2-efi-aa64-cdboot"
-              - "grub2-efi-aa64"
-              - "shim-aa64"
+    conditions:
+      "x86 specific packages for the anaconda boot pkgset":
+        when: arch == "x86_64"
+        append:
+          include:
+            # eficommon
+            - "efibootmgr"
+            # XXX: de-dup?
+            # grub-common
+            - "grub2-tools"
+            - "grub2-tools-extra"
+            - "grub2-tools-minimal"
+            # arch specific
+            - "grub2-efi-x64"
+            - "grub2-efi-x64-cdboot"
+            - "grub2-pc"
+            - "grub2-pc-modules"
+            - "shim-x64"
+            - "syslinux"
+            - "syslinux-nonlinux"
+      "aarch64 specific packages for the anaconda boot pkgset":
+        when: arch == "aarch64"
+        append:
+          include:
+            # eficommon
+            - "efibootmgr"
+            # XXX: de-dup?
+            # grub-common
+            - "grub2-tools"
+            - "grub2-tools-extra"
+            - "grub2-tools-minimal"
+            # arch specific
+            - "grub2-efi-aa64-cdboot"
+            - "grub2-efi-aa64"
+            - "shim-aa64"
 
   anaconda_pkgset: &anaconda_pkgset
     include:
@@ -358,18 +367,20 @@
       - "xorg-x11-server-Xorg"
       - "xorg-x11-xauth"
       - "xz"
-    condition:
-      "condition for anaconda pkgset":
-        architecture:
-          x86_64:
-            include:
-              - "biosdevname"
-              - "dmidecode"
-              - "grub2-tools-efi"
-              - "memtest86+"
-          aarch64:
-            include:
-              - "dmidecode"
+    conditions:
+      "x86 specific packages for the anaconda pkgset":
+        when: arch == "x86_64"
+        append:
+          include:
+            - "biosdevname"
+            - "dmidecode"
+            - "grub2-tools-efi"
+            - "memtest86+"
+      "aarch64 specific packages for the anaconda pkgset":
+        when: arch == "aarch64"
+        append:
+          include:
+            - "dmidecode"
 
   partitioning:
     ids:
@@ -493,30 +504,19 @@
             bootable: true
 
     ec2_partition_tables_override: &ec2_partition_tables_override
-      condition:
-        "condition for ec2 part table":
-          version_less_than:
-            "9.3":
-              x86_64:
-                <<: *default_partition_table_x86_64
-                partitions:
-                  - *default_partition_table_part_bios
-                  # note no boot efi
-                  - *default_partition_table_part_boot
-                  - *default_partition_table_part_root
-          distro_name:
-            # we need this override to ensure that centos always gets
-            # the latest partition-tables, othersie "centos-9" is
-            # less then "9 <= 9.3"
-            "centos":
-              x86_64:
-                <<: *default_partition_table_x86_64
-              aarch64:
-                <<: *default_partition_table_aarch64
-              ppc64le:
-                <<: *default_partition_table_ppc64le
-              s390x:
-                <<: *default_partition_table_s390x
+      conditions:
+        "rhel-9.2 and below have no efi partition":
+          when: version_less_than("9.3") and distro_name != "centos"
+          override:
+            x86_64:
+              <<: *default_partition_table_x86_64
+              partitions:
+                - *default_partition_table_part_bios
+                # note no boot efi
+                - *default_partition_table_part_boot
+                - *default_partition_table_part_root
+            aarch64:
+              <<: *default_partition_table_aarch64
 
 image_config:
   default:
@@ -529,11 +529,11 @@ image_config:
       no_zero_conf: true
     timezone: "America/New_York"
     update_default_kernel: true
-  condition:
+  conditions:
     "oscap needs a differnt path on centos":
-      distro_name:
-        centos:
-          default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-cs9-ds.xml"
+      when: distro_name == "centos"
+      merge:
+        default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-cs9-ds.xml"
 
 image_types:
   # XXX: not a real pkgset but the "os" pipeline pkgset for image-installer
@@ -582,12 +582,12 @@ image_types:
             - "tuned"
           exclude:
             - "dracut-config-rescue"
-          condition:
-            "add subscription-manager-co":
-              distro_name:
-                rhel:
-                  include:
-                    - "subscription-manager-cockpit"
+          conditions: &conditions_subscription_manager_cockpit
+            "add subscription-manager-cockpit on rhel":
+              when: distro_name == "rhel"
+              append:
+                include:
+                  - "subscription-manager-cockpit"
 
   qcow2: &qcow2
     partition_table:
@@ -652,13 +652,13 @@ image_types:
             - "plymouth"
             - "rng-tools"
             - "udisks2"
-          condition:
-            "add insights pkgs":
-              distro_name:
-                rhel:
-                  include:
-                    - "insights-client"
-                    - "subscription-manager-cockpit"
+          conditions: &conditions_pkgsets_insigths_pkgs
+            "add insights pkgs on rhel":
+              when: distro_name == "rhel"
+              append:
+                include:
+                  - "insights-client"
+                  - "subscription-manager-cockpit"
 
   oci: *qcow2
 
@@ -738,18 +738,15 @@ image_types:
             - "rhnlib"
             - "rhnsd"
             - "usb_modeswitch"
-          condition:
-            "vhd specific pkgs":
-              distro_name:
-                rhel:
-                  include:
-                    - "insights-client"
-              version_greater_or_equal:
-                "9.6":
-                  include:
-                    - "system-reinstall-bootc"
-                  exclude:
-                    - "microcode_ctl"
+          conditions:
+            <<: *conditions_pkgsets_insights_client_on_rhel
+            "rhel-9.6+ gets system-reinstall-bootc and drops microcode_ctl":
+              when: version_greater_or_equal("9.6")
+              append:
+                include:
+                  - "system-reinstall-bootc"
+                exclude:
+                  - "microcode_ctl"
 
   "azure-rhui": *vhd
 
@@ -965,12 +962,8 @@ image_types:
             - "zd1211-firmware"
             # RHBZ#2075815
             - "qemu-guest-agent"
-          condition:
-            "add insights":
-              distro_name:
-                rhel:
-                  include:
-                    - "insights-client"
+          conditions:
+            <<: *conditions_pkgsets_insights_client_on_rhel
 
   "minimal-raw":
     package_sets:
@@ -1083,51 +1076,48 @@ image_types:
           exclude:
             - "rng-tools"
             - "bootupd"
-          condition:
-            "arch specific packages for edge-commit":
-              architecture:
-                x86_64: &edge_commit_x86_64_pkgset
-                  include:
-                    - "grub2"
-                    - "grub2-efi-x64"
-                    - "efibootmgr"
-                    - "shim-x64"
-                    - "microcode_ctl"
-                    - "iwl1000-firmware"
-                    - "iwl100-firmware"
-                    - "iwl105-firmware"
-                    - "iwl135-firmware"
-                    - "iwl2000-firmware"
-                    - "iwl2030-firmware"
-                    - "iwl3160-firmware"
-                    - "iwl5000-firmware"
-                    - "iwl5150-firmware"
-                    - "iwl6050-firmware"
-                    - "iwl7260-firmware"
-                aarch64: &edge_commit_aarch64_pkgset
-                  include:
-                    - "grub2-efi-aa64"
-                    - "efibootmgr"
-                    - "shim-aa64"
-                    - "iwl7260-firmware"
-              distro_name:
-                centos:
-                  include:
-                    # XXX: duplicated to >= rhel-9.2
-                    - "ignition"
-                    - "ignition-edge"
-                    - "ssh-key-dir"
-              version_greater_or_equal:
-                "9.2":
-                  include:
-                    - "ignition"
-                    - "ignition-edge"
-                    - "ssh-key-dir"
-              version_less_than:
-                "9.6":
-                  include:
-                    # dnsmasq removed in 9.6+ but kept in older versions
-                    - "dnsmasq"
+          conditions: &conditions_pkgsets_edge_commit
+            "x86_64 specific packages for edge-commit":
+              when: arch == "x86_64"
+              append: &edge_commit_x86_64_pkgset
+                include:
+                  - "grub2"
+                  - "grub2-efi-x64"
+                  - "efibootmgr"
+                  - "shim-x64"
+                  - "microcode_ctl"
+                  - "iwl1000-firmware"
+                  - "iwl100-firmware"
+                  - "iwl105-firmware"
+                  - "iwl135-firmware"
+                  - "iwl2000-firmware"
+                  - "iwl2030-firmware"
+                  - "iwl3160-firmware"
+                  - "iwl5000-firmware"
+                  - "iwl5150-firmware"
+                  - "iwl6050-firmware"
+                  - "iwl7260-firmware"
+            "aarch64 specific packages for edge-commit":
+              when: arch == "aarch64"
+              append: &edge_commit_aarch64_pkgset
+                include:
+                  - "grub2-efi-aa64"
+                  - "efibootmgr"
+                  - "shim-aa64"
+                  - "iwl7260-firmware"
+            "rhel-9.2+ gets ignition":
+              when: version_greater_or_equal("9.2") or distro_name == "centos"
+              append:
+                include:
+                  - "ignition"
+                  - "ignition-edge"
+                  - "ssh-key-dir"
+            "rhel-9.5 and below includes dnsmasq":
+              when: version_less_than("9.6")
+              append:
+                include:
+                  # dnsmasq removed in 9.6+ but kept in older versions
+                  - "dnsmasq"
 
   "edge-container":
     package_sets:
@@ -1188,13 +1178,17 @@ image_types:
             - "sudo"
             - "traceroute"
             - "util-linux"
-          condition:
-            "arch specific packages for simplified edge installer":
-              architecture:
-                x86_64:
-                  *edge_commit_x86_64_pkgset
-                aarch64:
-                  *edge_commit_aarch64_pkgset
+          conditions:
+            # XXX: should we instead "<<: *conditions_edge_commit" here?
+            # it will give different results
+            "x86_64 specific pkgset for edge-simplified-installer":
+              when: arch == "x86_64"
+              append:
+                <<: *edge_commit_x86_64_pkgset
+            "aarch64 specific pkgset for edge-simplified-installer":
+              when: arch == "aarch64"
+              append:
+                <<: *edge_commit_aarch64_pkgset
 
   "azure-cvm":
     package_sets:

--- a/pkg/distro/defs/rhel-9/distro.yaml
+++ b/pkg/distro/defs/rhel-9/distro.yaml
@@ -18,14 +18,15 @@
       - "xfsprogs"
       - "xz"
     condition:
-      architecture:
-        x86_64:
-          include:
-            - "grub2-pc"
-        ppc64el:
-          include:
-            - "grub2-ppc64le"
-            - "grub2-ppc64le-modules"
+      "condition for build_pkgsset":
+        architecture:
+          x86_64:
+            include:
+              - "grub2-pc"
+          ppc64el:
+            include:
+              - "grub2-ppc64le"
+              - "grub2-ppc64le-modules"
 
   ec2_base_pkgset: &ec2_base_pkgset
     include:
@@ -79,14 +80,15 @@
       # RHBZ#2075815
       - "qemu-guest-agent"
     condition:
-      distro_name:
-        rhel:
-          include:
-            - "insights-client"
-      version_greater_or_equal:
-        "9.6":
-          include:
-            - "system-reinstall-bootc"
+      "condition for ec2 basepkgset":
+        distro_name:
+          rhel:
+            include:
+              - "insights-client"
+        version_greater_or_equal:
+          "9.6":
+            include:
+              - "system-reinstall-bootc"
 
   sap_pkgset: &sap_pkgset
     include:
@@ -179,44 +181,46 @@
       - "mdadm"
       - "nss-softokn"
     condition:
-      architecture:
-        x86_64:
-          include:
-            - "biosdevname"
+      "condition for installer pkgset":
+        architecture:
+          x86_64:
+            include:
+              - "biosdevname"
 
   anaconda_boot_pkgset: &anaconda_boot_pkgset
     condition:
-      architecture:
-        x86_64:
-          include:
-            # eficommon
-            - "efibootmgr"
-            # XXX: de-dup?
-            # grub-common
-            - "grub2-tools"
-            - "grub2-tools-extra"
-            - "grub2-tools-minimal"
-            # arch specific
-            - "grub2-efi-x64"
-            - "grub2-efi-x64-cdboot"
-            - "grub2-pc"
-            - "grub2-pc-modules"
-            - "shim-x64"
-            - "syslinux"
-            - "syslinux-nonlinux"
-        aarch64:
-          include:
-            # eficommon
-            - "efibootmgr"
-            # XXX: de-dup?
-            # grub-common
-            - "grub2-tools"
-            - "grub2-tools-extra"
-            - "grub2-tools-minimal"
-            # arch specific
-            - "grub2-efi-aa64-cdboot"
-            - "grub2-efi-aa64"
-            - "shim-aa64"
+      "condition for anaconda boot pkgset":
+        architecture:
+          x86_64:
+            include:
+              # eficommon
+              - "efibootmgr"
+              # XXX: de-dup?
+              # grub-common
+              - "grub2-tools"
+              - "grub2-tools-extra"
+              - "grub2-tools-minimal"
+              # arch specific
+              - "grub2-efi-x64"
+              - "grub2-efi-x64-cdboot"
+              - "grub2-pc"
+              - "grub2-pc-modules"
+              - "shim-x64"
+              - "syslinux"
+              - "syslinux-nonlinux"
+          aarch64:
+            include:
+              # eficommon
+              - "efibootmgr"
+              # XXX: de-dup?
+              # grub-common
+              - "grub2-tools"
+              - "grub2-tools-extra"
+              - "grub2-tools-minimal"
+              # arch specific
+              - "grub2-efi-aa64-cdboot"
+              - "grub2-efi-aa64"
+              - "shim-aa64"
 
   anaconda_pkgset: &anaconda_pkgset
     include:
@@ -355,16 +359,17 @@
       - "xorg-x11-xauth"
       - "xz"
     condition:
-      architecture:
-        x86_64:
-          include:
-            - "biosdevname"
-            - "dmidecode"
-            - "grub2-tools-efi"
-            - "memtest86+"
-        aarch64:
-          include:
-            - "dmidecode"
+      "condition for anaconda pkgset":
+        architecture:
+          x86_64:
+            include:
+              - "biosdevname"
+              - "dmidecode"
+              - "grub2-tools-efi"
+              - "memtest86+"
+          aarch64:
+            include:
+              - "dmidecode"
 
   partitioning:
     ids:
@@ -489,15 +494,29 @@
 
     ec2_partition_tables_override: &ec2_partition_tables_override
       condition:
-        version_less_than:
-          "9.3":
-            x86_64:
-              <<: *default_partition_table_x86_64
-              partitions:
-                - *default_partition_table_part_bios
-                # note no boot efi
-                - *default_partition_table_part_boot
-                - *default_partition_table_part_root
+        "condition for ec2 part table":
+          version_less_than:
+            "9.3":
+              x86_64:
+                <<: *default_partition_table_x86_64
+                partitions:
+                  - *default_partition_table_part_bios
+                  # note no boot efi
+                  - *default_partition_table_part_boot
+                  - *default_partition_table_part_root
+          distro_name:
+            # we need this override to ensure that centos always gets
+            # the latest partition-tables, othersie "centos-9" is
+            # less then "9 <= 9.3"
+            "centos":
+              x86_64:
+                <<: *default_partition_table_x86_64
+              aarch64:
+                <<: *default_partition_table_aarch64
+              ppc64le:
+                <<: *default_partition_table_ppc64le
+              s390x:
+                <<: *default_partition_table_s390x
 
 image_config:
   default:
@@ -511,9 +530,10 @@ image_config:
     timezone: "America/New_York"
     update_default_kernel: true
   condition:
-    distro_name:
-      centos:
-        default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-cs9-ds.xml"
+    "oscap needs a differnt path on centos":
+      distro_name:
+        centos:
+          default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-cs9-ds.xml"
 
 image_types:
   # XXX: not a real pkgset but the "os" pipeline pkgset for image-installer
@@ -563,10 +583,11 @@ image_types:
           exclude:
             - "dracut-config-rescue"
           condition:
-            distro_name:
-              rhel:
-                include:
-                  - "subscription-manager-cockpit"
+            "add subscription-manager-co":
+              distro_name:
+                rhel:
+                  include:
+                    - "subscription-manager-cockpit"
 
   qcow2: &qcow2
     partition_table:
@@ -632,11 +653,12 @@ image_types:
             - "rng-tools"
             - "udisks2"
           condition:
-            distro_name:
-              rhel:
-                include:
-                  - "insights-client"
-                  - "subscription-manager-cockpit"
+            "add insights pkgs":
+              distro_name:
+                rhel:
+                  include:
+                    - "insights-client"
+                    - "subscription-manager-cockpit"
 
   oci: *qcow2
 
@@ -717,16 +739,17 @@ image_types:
             - "rhnsd"
             - "usb_modeswitch"
           condition:
-            distro_name:
-              rhel:
-                include:
-                  - "insights-client"
-            version_greater_or_equal:
-              "9.6":
-                include:
-                  - "system-reinstall-bootc"
-                exclude:
-                  - "microcode_ctl"
+            "vhd specific pkgs":
+              distro_name:
+                rhel:
+                  include:
+                    - "insights-client"
+              version_greater_or_equal:
+                "9.6":
+                  include:
+                    - "system-reinstall-bootc"
+                  exclude:
+                    - "microcode_ctl"
 
   "azure-rhui": *vhd
 
@@ -943,10 +966,11 @@ image_types:
             # RHBZ#2075815
             - "qemu-guest-agent"
           condition:
-            distro_name:
-              rhel:
-                include:
-                  - "insights-client"
+            "add insights":
+              distro_name:
+                rhel:
+                  include:
+                    - "insights-client"
 
   "minimal-raw":
     package_sets:
@@ -1060,42 +1084,50 @@ image_types:
             - "rng-tools"
             - "bootupd"
           condition:
-            architecture:
-              x86_64: &edge_commit_x86_64_pkgset
-                include:
-                  - "grub2"
-                  - "grub2-efi-x64"
-                  - "efibootmgr"
-                  - "shim-x64"
-                  - "microcode_ctl"
-                  - "iwl1000-firmware"
-                  - "iwl100-firmware"
-                  - "iwl105-firmware"
-                  - "iwl135-firmware"
-                  - "iwl2000-firmware"
-                  - "iwl2030-firmware"
-                  - "iwl3160-firmware"
-                  - "iwl5000-firmware"
-                  - "iwl5150-firmware"
-                  - "iwl6050-firmware"
-                  - "iwl7260-firmware"
-              aarch64: &edge_commit_aarch64_pkgset
-                include:
-                  - "grub2-efi-aa64"
-                  - "efibootmgr"
-                  - "shim-aa64"
-                  - "iwl7260-firmware"
-            version_greater_or_equal:
-              "9.2":
-                include:
-                  - "ignition"
-                  - "ignition-edge"
-                  - "ssh-key-dir"
-            version_less_than:
-              "9.6":
-                include:
-                  # dnsmasq removed in 9.6+ but kept in older versions
-                  - "dnsmasq"
+            "arch specific packages for edge-commit":
+              architecture:
+                x86_64: &edge_commit_x86_64_pkgset
+                  include:
+                    - "grub2"
+                    - "grub2-efi-x64"
+                    - "efibootmgr"
+                    - "shim-x64"
+                    - "microcode_ctl"
+                    - "iwl1000-firmware"
+                    - "iwl100-firmware"
+                    - "iwl105-firmware"
+                    - "iwl135-firmware"
+                    - "iwl2000-firmware"
+                    - "iwl2030-firmware"
+                    - "iwl3160-firmware"
+                    - "iwl5000-firmware"
+                    - "iwl5150-firmware"
+                    - "iwl6050-firmware"
+                    - "iwl7260-firmware"
+                aarch64: &edge_commit_aarch64_pkgset
+                  include:
+                    - "grub2-efi-aa64"
+                    - "efibootmgr"
+                    - "shim-aa64"
+                    - "iwl7260-firmware"
+              distro_name:
+                centos:
+                  include:
+                    # XXX: duplicated to >= rhel-9.2
+                    - "ignition"
+                    - "ignition-edge"
+                    - "ssh-key-dir"
+              version_greater_or_equal:
+                "9.2":
+                  include:
+                    - "ignition"
+                    - "ignition-edge"
+                    - "ssh-key-dir"
+              version_less_than:
+                "9.6":
+                  include:
+                    # dnsmasq removed in 9.6+ but kept in older versions
+                    - "dnsmasq"
 
   "edge-container":
     package_sets:
@@ -1157,11 +1189,12 @@ image_types:
             - "traceroute"
             - "util-linux"
           condition:
-            architecture:
-              x86_64:
-                *edge_commit_x86_64_pkgset
-              aarch64:
-                *edge_commit_aarch64_pkgset
+            "arch specific packages for simplified edge installer":
+              architecture:
+                x86_64:
+                  *edge_commit_x86_64_pkgset
+                aarch64:
+                  *edge_commit_aarch64_pkgset
 
   "azure-cvm":
     package_sets:


### PR DESCRIPTION
When working on the rhel-9 image config I ran into the
issue that the rhel-9 azure images needs to adjust
the kernel options based on multiple conditions:
c.f. https://github.com/osbuild/images/blob/v0.152.0/pkg/distro/rhel/rhel9/azure.go#L337

Expressing this via our existing YAML conditions is
impossible and shoehorning^Wadding it to our existing
handling is rather cumbersome, it could be done via e.g.
a new "conditions-and" that would allow multiple expressions,
but when trying this it became a bit ugly both in code and
in the resulting yaml so I thought about alternatives.

This PR contains the result of this, it replaces the existing
```yaml
condition:
 # f40 and below uses ext4 based iso rootfs
 version_less_than:
   "41":
     iso_rootfs_type: "squashfs-ext4"
```
with a new single condition line that can be expressed in
(python/starlark) code:
```yaml
conditions:
  "f40 and below uses ext4 based iso rootfs"
  when: version_less_than("f41")
  merge:
    iso_rootfs_type: "squashfs-ext4"
```
and with that we can also express and/or in a single
line. By making conditions a mapping yaml based
merging becomes easy, having the description of
the condition as the key forces us to document what
the condition is about and adding the extra "merge"
(or "append" for package sets, see below) allows
us to clearly communicate what the condition will
do. As a nice side-effect in the code all conditions
are now handled by the same code path.

This allows to express the azure imageconfig
in rhel-9 nicely via and conditions:
```yaml
.common:
  azure_image_config:
  ...
  conditions:
      "x86_64 specific kernel commandline for rhel-9.6+":
        when: arch == "x86_64" and version_greater_or_equal("9.6")
        merge:
          kernel_options:
            - "ro"
            ...
            # rhel-9.6+
            - "nvme_core.io_timeout=240"
      "x86_64 specific kernel options rhel-9.5 or below":
        when: arch == "x86_64" and version_less_than("9.6")
        merge:
          kernel_options:
            - "ro"
            ...
```
(c.f. https://github.com/osbuild/images/compare/main...mvo5:yaml-imageconfig-rhel9-starlark?expand=1#diff-e7e897e693914080ff244ecce4ce1b92ca8c8ce9439af5365924647bf076a130R694

Of course having a way in pure YAML to merge seq and not just mappings would be even better but https://github.com/yaml/yaml/issues/48 :/

Starlark is designed to be safe and fast and is
maintained by google and potentially has move uses
in images but for now making conditions simpler seems
a great start.

---

The rhel-9 azure image type needs logical operations for its
image config. It checks for example that the arch is x86_64
and the rhel version >= 9.6. Expressing this via pure YAML
becomes rather cumbersome, so after some experiments this
PR seems to be a really nice way forward.

The idea is to use `starlark` which is a dialect of python
optimized for configuration languages and used in e.g.
bezel. With that we can simplify our conditionals to be
python expressions and they now look like:
```yaml
image_types:
  "workstation-live-installer":
    ...
    image_config:
      locale: "en_US.UTF-8"
      iso_rootfs_type: "squashfs"
      conditions:
        "f40 and below uses ext4 based iso rootfs":
          when: version_less_than("41")
          merge:
            iso_rootfs_type: "squashfs-ext4"
```
The following keys are supported inside the `when`:
- distro_name
- distro_version
- distro_major
- distro_minor
- arch
And the following helper functions:
- version_less_than()
- version_greater_or_equal()
With that we can express all our intend nicely and we can
also express what a "when" is doing, i.e. for some (like
package sets) it will append, for others (image-types) it
will merge and for installer-config it will override. All
of this is now easier to read via:
```yaml
when: <expr>
override: ...
``

---

distro: tweak the condition handling in the YAMLs

This commit tweaks the condition handling in the YAMLs so that
we can make merging easier on the YAML level.

This means that each condition now needs a unique description
but that is probably good anyway to describe the reason for
the condition.
