### PR TITLE
distro/rhel-10: new `vagrant-libvirt` image type (HMS-6116)

### DIFF
--- a/pkg/distro/defs/rhel-10/distro.yaml
+++ b/pkg/distro/defs/rhel-10/distro.yaml
@@ -554,7 +554,7 @@ image_types:
                   - "subscription-manager-cockpit"
 
   qcow2: &qcow2
-    image_config:
+    image_config: &qcow2_image_config
       default_target: "multi-user.target"
       kernel_options: ["console=tty0", "console=ttyS0,115200n8", "no_timer_check"]
       condition:
@@ -571,7 +571,8 @@ image_types:
       <<: *default_partition_tables
     package_sets:
       os:
-        - include:
+        - &qcow2_pkgset
+          include:
             - "@core"
             - "chrony"
             - "cloud-init"
@@ -633,6 +634,25 @@ image_types:
                 include:
                   - "insights-client"
                   - "subscription-manager-cockpit"
+
+  "vagrant-libvirt":
+    <<: *qcow2
+    image_config:
+      <<: *qcow2_image_config
+      users:
+        - name: "vagrant"
+          # yamllint disable rule:line-length
+          key: |
+            ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key
+            ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN1YdxBpNlzxDqfJyw/QKow1F+wvG9hXGoqiysfJOn5Y vagrant insecure public key
+          # yamllint enable rule:line-length
+      files:
+        - path: "/etc/sudoers.d/vagrant"
+          user: "root"
+          group: "root"
+          mode: 440
+          data: |
+            vagrant ALL=(ALL) NOPASSWD: ALL
 
   oci: *qcow2
 

--- a/pkg/distro/rhel/rhel10/distro.go
+++ b/pkg/distro/rhel/rhel10/distro.go
@@ -110,6 +110,17 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 	)
 
 	x86_64.AddImageTypes(
+		&platform.X86{
+			BIOS:       true,
+			UEFIVendor: rd.Vendor(),
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_VAGRANT_LIBVIRT,
+			},
+		},
+		mkVagrantLibvirtImgType(rd, arch.ARCH_X86_64),
+	)
+
+	x86_64.AddImageTypes(
 		&platform.X86{},
 		mkTarImgType(),
 		mkWSLImgType(rd),
@@ -130,6 +141,16 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 			},
 		},
 		mkQcow2ImgType(rd, arch.ARCH_AARCH64),
+	)
+
+	aarch64.AddImageTypes(
+		&platform.Aarch64{
+			UEFIVendor: rd.Vendor(),
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_VAGRANT_LIBVIRT,
+			},
+		},
+		mkVagrantLibvirtImgType(rd, arch.ARCH_AARCH64),
 	)
 
 	ppc64le.AddImageTypes(

--- a/pkg/distro/rhel/rhel10/distro_test.go
+++ b/pkg/distro/rhel/rhel10/distro_test.go
@@ -288,6 +288,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"ec2",
 				"ec2-ha",
 				"ec2-sap",
+				"vagrant-libvirt",
 			},
 		},
 		{
@@ -301,6 +302,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"image-installer",
 				"azure-rhui",
 				"ec2",
+				"vagrant-libvirt",
 			},
 		},
 		{

--- a/pkg/distro/rhel/rhel10/vagrant.go
+++ b/pkg/distro/rhel/rhel10/vagrant.go
@@ -1,0 +1,27 @@
+package rhel10
+
+import (
+	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/pkg/datasizes"
+	"github.com/osbuild/images/pkg/distro/rhel"
+)
+
+func mkVagrantLibvirtImgType(d *rhel.Distribution, a arch.Arch) *rhel.ImageType {
+	it := rhel.NewImageType(
+		"vagrant-libvirt",
+		"vagrant-libvirt.box",
+		"application/x-tar",
+		packageSetLoader,
+		rhel.DiskImage,
+		[]string{"build"},
+		[]string{"os", "image", "vagrant", "archive"},
+		[]string{"archive"},
+	)
+
+	it.DefaultImageConfig = imageConfig(d, a.String(), "vagrant-libvirt")
+	it.DefaultSize = 10 * datasizes.GibiByte
+	it.Bootable = true
+	it.BasePartitionTables = defaultBasePartitionTables
+
+	return it
+}

--- a/test/config-map.json
+++ b/test/config-map.json
@@ -149,6 +149,7 @@
       "ova",
       "qcow2",
       "tar",
+      "vagrant-libvirt",
       "vhd",
       "vmdk",
       "wsl"

--- a/test/data/manifest-checksums.txt
+++ b/test/data/manifest-checksums.txt
@@ -8,6 +8,7 @@ c4b1bd0e5caea2320d29534f838c660ff57d3b53  centos_10-aarch64-image_installer-unat
 ce2fc4269d4a095a6888dc6c77eb415d93346177  centos_10-aarch64-qcow2-all_with_fips.json
 4114301f0ba6de10564a7146e5dda684014db3cf  centos_10-aarch64-qcow2-empty_rhel.json
 44ad36bdc1c9ec52988661d393be994d947fbb22  centos_10-aarch64-tar-empty_rhel.json
+e7537d467765bcf1ed10324359bb0997947e38bc  centos_10-aarch64-vagrant_libvirt-empty_rhel.json
 8dae84eadfbac3808173635f05d9e2fbf7cfcc51  centos_10-aarch64-vhd-empty_rhel.json
 2091cbc73f5132e351ecc2aa06aac70d76b52d8e  centos_10-aarch64-wsl-empty_rhel.json
 209bc492d409219bd95df6f5fc82cd0a12c9630d  centos_10-ppc64le-qcow2-all_with_fips.json
@@ -29,6 +30,7 @@ fa3cc34e03c48bc88d63cd134649f57bfb4cb020  centos_10-x86_64-ova-empty_rhel.json
 b1e5e9a17c6e7c64f1cadee29f51b11a1bba0dda  centos_10-x86_64-qcow2-all_with_fips.json
 23156d188c7344ca6a6fef49673ee753c4bf7f1f  centos_10-x86_64-qcow2-empty_rhel.json
 dedb2581a8bcec0075af61cb4faefdce08c89e40  centos_10-x86_64-tar-empty_rhel.json
+bfe4b5aa7eac06307a445d9d8b1b1da695833013  centos_10-x86_64-vagrant_libvirt-empty_rhel.json
 6b6d82020ecbad3bfb465c6f816d645459d23285  centos_10-x86_64-vhd-empty_rhel.json
 d0a50d599e6bece6180bd2b1e39c6173d4bc275f  centos_10-x86_64-vmdk-empty_rhel.json
 f3a32b59496828a50a38db2e19cd594b6783702a  centos_10-x86_64-wsl-empty_rhel.json
@@ -436,6 +438,7 @@ ade27cbc8d36087e29be2ef3d3b56c346dd94e82  rhel_10.0-aarch64-image_installer-empt
 0904455456993f60aebcee9b29b7473494aba50f  rhel_10.0-aarch64-qcow2-empty_rhel.json
 f1f59edba9479ad8e109c57e5fd3d4a489b309df  rhel_10.0-aarch64-qcow2-rhsm.json
 5dd68ae3b9c6fc671398a6842e8d91cf82ae15c6  rhel_10.0-aarch64-tar-empty_rhel.json
+30077545dad3f5e9544bb21d5ca50629efca5c57  rhel_10.0-aarch64-vagrant_libvirt-empty_rhel.json
 f828f3dbb76aee19640d1f1591889c22f436a47f  rhel_10.0-aarch64-vhd-empty_rhel.json
 ae1bde811d1f2a3585b16f08e320481c97d7ac21  rhel_10.0-aarch64-wsl-empty_rhel.json
 1173aedfada1c5486d38244e0c78567de3b89ed5  rhel_10.0-ppc64le-qcow2-empty_rhel.json
@@ -465,6 +468,7 @@ ef6f23b6b578b3bf40ececdf8d68435002dc69ca  rhel_10.0-x86_64-ova-empty_rhel.json
 efc616d67affb205bd7b9a3fc853054b5ef8dfa2  rhel_10.0-x86_64-qcow2-empty_rhel.json
 e2f6fa28353c959990eb1657babe52d1b4657d9c  rhel_10.0-x86_64-qcow2-rhsm.json
 b5a5ad3e4e331611ba674cfebb0a8e142e31dd8d  rhel_10.0-x86_64-tar-empty_rhel.json
+5a46f5ac33096731b25338472e45d8d7228fdea1  rhel_10.0-x86_64-vagrant_libvirt-empty_rhel.json
 d17ff5788a0ba8c07d7b447b49a70a608467f548  rhel_10.0-x86_64-vhd-empty_rhel.json
 98718b1bd67a0f383a1b305f41a3b79e7b4e329e  rhel_10.0-x86_64-vmdk-empty_rhel.json
 65758b2c21c38bcd53b5bbc246a50197e660977d  rhel_10.0-x86_64-wsl-empty_rhel.json
@@ -480,6 +484,7 @@ e303be927c5a147a265c6f9e900604483d3a954a  rhel_10.1-aarch64-image_installer-empt
 15b8b5578d676d76f8c929de77ff1e509d39237e  rhel_10.1-aarch64-image_installer-unattended_iso.json
 9bc5f49e007d98b09a08862e7029f1ccafc28478  rhel_10.1-aarch64-qcow2-empty_rhel.json
 2d9b6b9310cf176d38c25efec961cdb139582500  rhel_10.1-aarch64-tar-empty_rhel.json
+1364e2b20becd3d84c663077af5d8258f516a0fa  rhel_10.1-aarch64-vagrant_libvirt-empty_rhel.json
 beb8998ba0ea11b5da2d7dc0fd56bab398db09ce  rhel_10.1-aarch64-vhd-empty_rhel.json
 52c38f0b72bc65fa1f807ce15d0c10f06fc9c83f  rhel_10.1-aarch64-wsl-empty_rhel.json
 83cf0bfc9695808ac5cdcd269266129e18493f95  rhel_10.1-ppc64le-qcow2-empty_rhel.json
@@ -505,6 +510,7 @@ f3f6e103a4b3c3bf5610bbaa1bcbc56cb52ae526  rhel_10.1-x86_64-oci-empty_rhel.json
 bf840816abbef6fb88d0bc8a484e629bfc440dad  rhel_10.1-x86_64-ova-empty_rhel.json
 7100463ca9eb86b9fe6cbb326ef735dd43258ea5  rhel_10.1-x86_64-qcow2-empty_rhel.json
 a7bc8c56070efbc2ac52cf4820c2c78dc1940349  rhel_10.1-x86_64-tar-empty_rhel.json
+c1c432a833febe13829e6de3d09563424e5e60ff  rhel_10.1-x86_64-vagrant_libvirt-empty_rhel.json
 a75ccf09727f37554304ba435e291c606e03d15f  rhel_10.1-x86_64-vhd-empty_rhel.json
 4c00bd0b4c332585b7ddddc413205d8051440fcb  rhel_10.1-x86_64-vmdk-empty_rhel.json
 848e2babfb75b4407f894ec2cd1f736dd156d87a  rhel_10.1-x86_64-wsl-empty_rhel.json


### PR DESCRIPTION
This image type was previously updated and improved for Fedora. I wanted to hold out for the full YAML changes but have now decided to land these faster.

Image was manually tested, might need refinement in followup(s) it is currently similar to the QCOW2 image type.