### PR TITLE
distro: allow AND and easier merging in conditions (HMS-8593)

### DIFF
--- a/pkg/distro/defs/export_test.go
+++ b/pkg/distro/defs/export_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 )
 
+type WhenCondition = whenCondition
+
 func MockDataFS(path string) (restore func()) {
 	saved := defaultDataFS
 	defaultDataFS = os.DirFS(path)

--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -167,15 +167,18 @@
     additional_dracut_modules:
       - "net-lib"
     squashfs_rootfs: true
-    condition:
-      version_less_than:
-        "42":
-          # config is fully replaced
+    conditions:
+      "f41 uses ifcfg in dract but already a squashfs rootfs":
+        when:
+          version_equal: "41"
+        override:
           additional_dracut_modules:
             - "ifcfg"
           squashfs_rootfs: true
-        "41":
-          # config is fully replaced
+      "f40 and lower uses ifcfg in dracut and no squashfs rootfs":
+        when:
+          version_less_than: "41"
+        override:
           additional_dracut_modules:
             - "ifcfg"
           squashfs_rootfs: false
@@ -195,9 +198,11 @@
         - "redboot-auto-reboot"
         - "redboot-task-runner"
       kernel_options: *ostree_deployment_kernel_options
-      condition:
-        version_less_than:
-          "42":
+      conditions:
+        "f41 and below used zezere and parsec":
+          when:
+            version_less_than: "42"
+          merge:
             enabled_services:
               - "NetworkManager.service"
               - "firewalld.service"
@@ -822,26 +827,39 @@ image_types:
             - "xfsprogs"
             - "xz"
             - "zram-generator"
-          condition:
-            version_less_than:
-              "41":
+          conditions:
+            "f40 and below use dnsmasq":
+              when:
+                version_less_than: "41"
+              append:
                 include:
                   - "dnsmasq"
-              "42":
+            "f41 and below uses parsec/zezere":
+              when:
+                version_less_than: "42"
+              append:
                 include:
                   - "dbus-parsec"
                   - "kernel-tools"
                   - "parsec"
                   - "policycoreutils-python-utils"
                   - "zezere-ignition"
-              "43":
+            "f42 and below uses basesystem":
+              when:
+                version_less_than: "43"
+              append:
                 include:
                   - "basesystem"
-            version_greater_or_equal:
-              "41":
+            "f41+ needs bootupd":
+              when:
+                version_greater_or_equal: "41"
+              append:
                 include:
                   - "bootupd"
-              "43":
+            "f43+ needs the filesystem pkg":
+              when:
+                version_greater_or_equal: "43"
+              append:
                 include:
                   - "filesystem"
 
@@ -922,9 +940,11 @@ image_types:
     partition_table:
       <<: *iot_base_partition_tables
     partition_tables_override:
-      condition:
-        version_greater_or_equal:
-          "42":
+      conditions:
+        "conditions for iot-raw-xz":
+          when:
+            version_greater_or_equal: "42"
+          override:
             x86_64:
               <<: *iot_base_partition_table_x86_64
               partitions:
@@ -1085,22 +1105,30 @@ image_types:
             - "nodejs"
             - "plymouth"         # for (datacenter/cloud oriented) servers we want to see the details by default.  https:#lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/HSMISZ3ETWQ4ETVLWZQJ55ARZT27AAV3/
             - "systemd-networkd"  # we use NetworkManager
-          condition:
-            architecture:
-              aarch64:
+          conditions:
+            "iot-bootable-container aarch64 extras":
+              when:
+                arch: "aarch64"
+              append:
                 include:
                   - "irqbalance"
                   - "ostree-grub2"
                 exclude:
                   - "perl"
                   - "perl-interpreter"
-              ppc64le:
+            "iot-bootable-container ppc64le extras":
+              when:
+                arch: "ppc64le"
+              append:
                 include:
                   - "irqbalance"
                   - "librtas"
                   - "powerpc-utils-core"
                   - "ppc64-diag-rtas"
-              x86_64:
+            "iot-bootable-container x86_64 extras":
+              when:
+                arch: "x86_64"
+              append:
                 include:
                   - "irqbalance"
                 exclude:
@@ -1156,9 +1184,11 @@ image_types:
         - "sshd.service"
       kernel_options:
         - "rw"
-      condition:
-        version_less_than:
-          "43":
+      conditions:
+        "f42 and below was quite different":
+          when:
+            version_less_than: "43"
+          merge:
             install_weak_deps: true
             mount_units: false
             enabled_services:
@@ -1183,16 +1213,20 @@ image_types:
             - "iwlwifi-mvm-firmware"
           exclude:
             - "dracut-config-rescue"
-          condition:
-            architecture:
-              riscv64:
+          conditions:
+            "riscv64 specific pkgs for minimal-raw-xz":
+              when:
+                arch: "riscv64"
+              append:
                 include:
                   # missing from @core in riscv64
                   - "dnf5"
                   - "policycoreutils"
                   - "selinux-policy-targeted"
-            version_greater_or_equal:
-              "43":
+            "no firewalld on f43+":
+              when:
+                version_greater_or_equal: "43"
+              append:
                 exclude:
                   - "firewalld"
   "minimal-raw-zst":
@@ -1373,15 +1407,20 @@ image_types:
             - "metacity"
             - "xrdb"
             - "xz"
-          condition:
-            architecture:
-              x86_64:
+          conditions:
+            "x86_64 specific anaconda pkgs":
+              when:
+                arch: "x86_64"
+              append:
                 include:
                   - "biosdevname"
                   - "dmidecode"
                   - "grub2-tools-efi"
                   - "memtest86+"
-              aarch64:
+            "aarch64 specific anaconda pkgs":
+              when:
+                arch: "aarch64"
+              append:
                 include:
                   - "dmidecode"
 
@@ -1409,9 +1448,11 @@ image_types:
       <<: *image_config_iot_enabled_services
       locale: "en_US.UTF-8"
       iso_rootfs_type: "squashfs"
-      condition:
-        version_less_than:
-          41:
+      conditions:
+        "f40 and below uses ext4 based iso rootfs":
+          when:
+            version_less_than: "41"
+          merge:
             iso_rootfs_type: "squashfs-ext4"
     package_sets:
       installer:
@@ -1442,11 +1483,12 @@ image_types:
     image_config:
       locale: "en_US.UTF-8"
       iso_rootfs_type: "squashfs"
-      condition:
-        version_less_than:
-          41:
+      conditions:
+        "f40 and below uses ext4 based iso rootfs":
+          when:
+            version_less_than: "41"
+          merge:
             iso_rootfs_type: "squashfs-ext4"
-
     package_sets:
       installer:
         - include:
@@ -1473,11 +1515,13 @@ image_types:
             - "gfs2-utils"
             - "reiserfs-utils"
             - "sdubby"
-          condition:
-            version_greater_or_equal:
-              # XXX: this was VERSION_RAWHIDE, if we need this again lets add
-              # "alias" to defs.DistroYAML
-              43:
+          conditions:
+            "include anaconda webui in 43+":
+              when:
+                version_greater_or_equal: "43"
+              append:
+                # XXX: this was VERSION_RAWHIDE, if we need this again lets add
+                # "alias" to defs.DistroYAML
                 include:
                   - "anaconda-webui"
     platforms:
@@ -1510,23 +1554,29 @@ image_types:
         - "net-lib"
         - "dbus-broker"
       squashfs_rootfs: true
-      condition:
-        # on match the config is fully replaced
-        version_less_than:
-          "41":
-            additional_dracut_modules: &additional_dracut_f41
+      conditions:
+        "on f40 we use ifcfg instead of net-lib":
+          when:
+            version_equal: "40"
+          override:
+            additional_dracut_modules: &additional_dracut_f40
               - "ifcfg"
               - "dbus-broker"
             squashfs_rootfs: false
-          "42":
-            additional_dracut_modules: *additional_dracut_f41
+        "on f41 use squashfs_rootfs":
+          when:
+            version_equal: "41"
+          override:
+            additional_dracut_modules: *additional_dracut_f40
             squashfs_rootfs: true
     image_config:
       locale: "en_US.UTF-8"
       iso_rootfs_type: "squashfs"
-      condition:
-        version_less_than:
-          41:
+      conditions:
+        "on f40 and below we used ext4 on squashfs":
+          when:
+            version_less_than: "41"
+          merge:
             iso_rootfs_type: "squashfs-ext4"
     platforms:
       - *x86_64_installer_platform
@@ -1618,9 +1668,11 @@ image_types:
       - arch: "x86_64"
     image_config:
       <<: *image_config_container
-      condition:
-        version_less_than:
-          "42":
+      conditions:
+        "on f42 and below we use cloud-init instead of wsl-setup":
+          when:
+            version_less_than: "42"
+          merge:
             wsl:
               config:
                 boot_systemd: true
@@ -1673,18 +1725,25 @@ image_types:
             - "trousers"
             - "whois-nls"
             - "xkeyboard-config"
-          condition:
-            version_greater_or_equal:
-              "41":
-                exclude:
-                  - "fuse-libs"
-              "42":
+          conditions:
+            "new f42 use the wsl-setup for setup":
+              when:
+                version_greater_or_equal: "42"
+              append:
                 include:
                   - "wsl-setup"
-            version_less_than:
-              "42":
+            "only f41 and below need cloud-init":
+              when:
+                version_less_than: "42"
+              append:
                 include:
                   - "cloud-init"
+            "f41+ drops fuse-libs":
+              when:
+                version_greater_or_equal: "41"
+              append:
+                exclude:
+                  - "fuse-libs"
 
   "iot-simplified-installer":
     filename: "simplified-installer.iso"
@@ -1758,9 +1817,11 @@ image_types:
             - "traceroute"
             - "util-linux"
             - "shadow-utils"  # includes passwd
-          condition:
-            version_less_than:
-              "41":
+          conditions:
+            "dnsmasq got deprecated in f41":
+              when:
+                version_less_than: "41"
+              append:
                 include:
                   - "dnsmasq"  # deprecated for F41+
     platforms:

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -11,14 +11,11 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"slices"
 	"sort"
 	"sync"
 	"text/template"
 
 	"github.com/gobwas/glob"
-	"github.com/hashicorp/go-version"
-	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 
 	"github.com/osbuild/images/internal/common"
@@ -186,12 +183,44 @@ type imageTypesYAML struct {
 }
 
 type distroImageConfig struct {
-	Default   *distro.ImageConfig          `yaml:"default"`
-	Condition *distroImageConfigConditions `yaml:"condition,omitempty"`
+	Default    *distro.ImageConfig                     `yaml:"default"`
+	Conditions map[string]*distroImageConfigConditions `yaml:"conditions,omitempty"`
+}
+
+// multiple whenConditions are considred AND
+type whenCondition struct {
+	DistroName            string `yaml:"distro_name,omitempty"`
+	Architecture          string `yaml:"arch,omitempty"`
+	VersionLessThan       string `yaml:"version_less_than,omitempty"`
+	VersionGreaterOrEqual string `yaml:"version_greater_or_equal,omitempty"`
+	VersionEqual          string `yaml:"version_equal,omitempty"`
+}
+
+func (wc *whenCondition) Eval(id *distro.ID, archStr string) bool {
+	match := true
+
+	if wc.DistroName != "" {
+		match = match && (wc.DistroName == id.Name)
+	}
+	if wc.Architecture != "" {
+		match = match && (wc.Architecture == archStr)
+	}
+	if wc.VersionLessThan != "" {
+		match = match && (common.VersionLessThan(versionStringForVerCmp(*id), wc.VersionLessThan))
+	}
+	if wc.VersionGreaterOrEqual != "" {
+		match = match && (common.VersionGreaterThanOrEqual(versionStringForVerCmp(*id), wc.VersionGreaterOrEqual))
+	}
+	if wc.VersionEqual != "" {
+		match = match && (id.VersionString() == wc.VersionEqual)
+	}
+
+	return match
 }
 
 type distroImageConfigConditions struct {
-	DistroName map[string]*distro.ImageConfig `yaml:"distro_name,omitempty"`
+	When  whenCondition       `yaml:"when,omitempty"`
+	Merge *distro.ImageConfig `yaml:"merge,omitempty"`
 }
 
 // XXX: this should eventually implement the "distro.ImageType"
@@ -259,78 +288,45 @@ func (it *imageType) Name() string {
 
 type imageConfig struct {
 	*distro.ImageConfig `yaml:",inline"`
-	Condition           *conditionsImgConf `yaml:"condition,omitempty"`
+	Conditions          map[string]*conditionsImgConf `yaml:"conditions,omitempty"`
 }
 
 type conditionsImgConf struct {
-	Architecture    map[string]*distro.ImageConfig `yaml:"architecture,omitempty"`
-	DistroName      map[string]*distro.ImageConfig `yaml:"distro_name,omitempty"`
-	VersionLessThan map[string]*distro.ImageConfig `yaml:"version_less_than,omitempty"`
+	When  whenCondition       `yaml:"when,omitempty"`
+	Merge *distro.ImageConfig `yaml:"merge"`
 }
 
 type installerConfig struct {
 	*distro.InstallerConfig `yaml:",inline"`
-	Condition               *conditionsInstallerConf `yaml:"condition,omitempty"`
+	Conditions              map[string]*conditionsInstallerConf `yaml:"conditions,omitempty"`
 }
 
 type conditionsInstallerConf struct {
-	Architecture    map[string]*distro.InstallerConfig `yaml:"architecture,omitempty"`
-	DistroName      map[string]*distro.InstallerConfig `yaml:"distro_name,omitempty"`
-	VersionLessThan map[string]*distro.InstallerConfig `yaml:"version_less_than,omitempty"`
+	When     whenCondition           `yaml:"when,omitempty"`
+	Override *distro.InstallerConfig `yaml:"override,omitempty"`
 }
 
 type packageSet struct {
-	Include   []string          `yaml:"include"`
-	Exclude   []string          `yaml:"exclude"`
-	Condition *pkgSetConditions `yaml:"condition,omitempty"`
+	Include    []string                     `yaml:"include"`
+	Exclude    []string                     `yaml:"exclude"`
+	Conditions map[string]*pkgSetConditions `yaml:"conditions,omitempty"`
 }
 
 type pkgSetConditions struct {
-	Architecture          map[string]packageSet `yaml:"architecture,omitempty"`
-	VersionLessThan       map[string]packageSet `yaml:"version_less_than,omitempty"`
-	VersionGreaterOrEqual map[string]packageSet `yaml:"version_greater_or_equal,omitempty"`
-	DistroName            map[string]packageSet `yaml:"distro_name,omitempty"`
+	When   whenCondition `yaml:"when,omitempty"`
+	Append struct {
+		Include []string `yaml:"include"`
+		Exclude []string `yaml:"exclude"`
+	} `yaml:"append,omitempty"`
 }
 
 type partitionTablesOverrides struct {
-	Condition *partitionTablesOverwriteCondition `yaml:"condition"`
+	Conditions map[string]*partitionTablesOverwriteCondition `yaml:"conditions"`
 }
 
 type partitionTablesOverwriteCondition struct {
-	DistroName            map[string]map[string]*disk.PartitionTable `yaml:"distro_name,omitempty"`
-	VersionGreaterOrEqual map[string]map[string]*disk.PartitionTable `yaml:"version_greater_or_equal,omitempty"`
-	VersionLessThan       map[string]map[string]*disk.PartitionTable `yaml:"version_less_than,omitempty"`
-}
-
-// XXX: use slices.Backward() once we move to go1.23
-// hint: use "git blame" on this comment and just revert
-// the commit that adds it and you will have the 1.23 version
-func backward[Slice ~[]E, E any](s Slice) []E {
-	out := make([]E, 0, len(s))
-	for i := len(s) - 1; i >= 0; i-- {
-		out = append(out, s[i])
-	}
-	return out
-}
-
-// XXX: use slices.SortedFunc() once we move to go1.23
-// hint: use "git blame" on this comment and just revert
-// the commit that adds it and you will have the 1.23 version
-func versionLessThanSortedKeys[T any](m map[string]T) []string {
-	versions := maps.Keys(m)
-	slices.SortFunc(versions, func(a, b string) int {
-		ver1 := version.Must(version.NewVersion(a))
-		ver2 := version.Must(version.NewVersion(b))
-		switch {
-		case ver1 == ver2:
-			return 0
-		case ver2.LessThan(ver1):
-			return -1
-		default:
-			return 1
-		}
-	})
-	return versions
+	When     whenCondition                   `yaml:"when,omitempty"`
+	Override map[string]*disk.PartitionTable `yaml:"override"`
 }
 
 // versionStringForVerCmp is a special version string for our version
@@ -360,17 +356,16 @@ func DistroImageConfig(distroNameVer string) (*distro.ImageConfig, error) {
 	}
 	imgConfig := toplevel.ImageConfig.Default
 
-	cond := toplevel.ImageConfig.Condition
-	if cond != nil {
+	condMap := toplevel.ImageConfig.Conditions
+	if condMap != nil {
 		id, err := distro.ParseID(distroNameVer)
 		if err != nil {
 			return nil, err
 		}
-		// XXX: we shoudl probably use a similar pattern like
-		// for the partition table overrides (via
-		// findElementIndexByJSONTag) but this if fine for now
-		if distroNameCnf, ok := cond.DistroName[id.Name]; ok {
-			imgConfig = distroNameCnf.InheritFrom(imgConfig)
+		for _, cond := range condMap {
+			if cond.When.Eval(id, "") {
+				imgConfig = cond.Merge.InheritFrom(imgConfig)
+			}
 		}
 	}
 
@@ -386,10 +381,6 @@ func PackageSets(it distro.ImageType) (map[string]rpmmd.PackageSet, error) {
 	archName := arch.Name()
 	distribution := arch.Distro()
 	distroNameVer := distribution.Name()
-	id, err := distro.ParseID(distroNameVer)
-	if err != nil {
-		return nil, err
-	}
 
 	// each imagetype can have multiple package sets, so that we can
 	// use yaml aliases/anchors to de-duplicate them
@@ -412,37 +403,17 @@ func PackageSets(it distro.ImageType) (map[string]rpmmd.PackageSet, error) {
 				Exclude: pkgSet.Exclude,
 			})
 
-			if pkgSet.Condition != nil {
-				// process conditions
-				if archSet, ok := pkgSet.Condition.Architecture[archName]; ok {
-					rpmmdPkgSet = rpmmdPkgSet.Append(rpmmd.PackageSet{
-						Include: archSet.Include,
-						Exclude: archSet.Exclude,
-					})
-				}
-				if distroNameSet, ok := pkgSet.Condition.DistroName[id.Name]; ok {
-					rpmmdPkgSet = rpmmdPkgSet.Append(rpmmd.PackageSet{
-						Include: distroNameSet.Include,
-						Exclude: distroNameSet.Exclude,
-					})
-				}
-				// note that we don't need to order here, as
-				// packageSets are strictly additive the order
-				// is irrelevant
-				for ltVer, ltSet := range pkgSet.Condition.VersionLessThan {
-					if common.VersionLessThan(versionStringForVerCmp(*id), ltVer) {
-						rpmmdPkgSet = rpmmdPkgSet.Append(rpmmd.PackageSet{
-							Include: ltSet.Include,
-							Exclude: ltSet.Exclude,
-						})
-					}
+			if pkgSet.Conditions != nil {
+				id, err := distro.ParseID(distroNameVer)
+				if err != nil {
+					return nil, err
 				}
 
-				for gteqVer, gteqSet := range pkgSet.Condition.VersionGreaterOrEqual {
-					if common.VersionGreaterThanOrEqual(versionStringForVerCmp(*id), gteqVer) {
+				for _, cond := range pkgSet.Conditions {
+					if cond.When.Eval(id, archName) {
 						rpmmdPkgSet = rpmmdPkgSet.Append(rpmmd.PackageSet{
-							Include: gteqSet.Include,
-							Exclude: gteqSet.Exclude,
+							Include: cond.Append.Include,
+							Exclude: cond.Append.Exclude,
 						})
 					}
 				}
@@ -482,33 +453,13 @@ func PartitionTable(it distro.ImageType) (*disk.PartitionTable, error) {
 	}
 
 	if imgType.PartitionTablesOverrides != nil {
-		cond := imgType.PartitionTablesOverrides.Condition
 		id, err := distro.ParseID(it.Arch().Distro().Name())
 		if err != nil {
 			return nil, err
 		}
-
-		for _, ltVer := range versionLessThanSortedKeys(cond.VersionLessThan) {
-			ltOverrides := cond.VersionLessThan[ltVer]
-			if common.VersionLessThan(versionStringForVerCmp(*id), ltVer) {
-				if newPt, ok := ltOverrides[archName]; ok {
-					pt = newPt
-				}
-			}
-		}
-
-		for _, gteqVer := range backward(versionLessThanSortedKeys(cond.VersionGreaterOrEqual)) {
-			geOverrides := cond.VersionGreaterOrEqual[gteqVer]
-			if common.VersionGreaterThanOrEqual(versionStringForVerCmp(*id), gteqVer) {
-				if newPt, ok := geOverrides[archName]; ok {
-					pt = newPt
-				}
-			}
-		}
-
-		if distroNameOverrides, ok := cond.DistroName[id.Name]; ok {
-			if newPt, ok := distroNameOverrides[archName]; ok {
-				pt = newPt
+		for _, cond := range imgType.PartitionTablesOverrides.Conditions {
+			if cond.When.Eval(id, archName) {
+				pt = cond.Override[archName]
 			}
 		}
 	}
@@ -629,40 +580,20 @@ func ImageConfig(distroNameVer, archName, typeName string) (*distro.ImageConfig,
 		return nil, fmt.Errorf("%w: %q", ErrImageTypeNotFound, typeName)
 	}
 	imgConfig := imgType.ImageConfig.ImageConfig
-	cond := imgType.ImageConfig.Condition
-	if cond != nil {
+	if imgType.ImageConfig.Conditions != nil {
 		id, err := distro.ParseID(distroNameVer)
 		if err != nil {
 			return nil, err
 		}
 
-		if distroNameCnf, ok := cond.DistroName[id.Name]; ok {
-			imgConfig = distroNameCnf.InheritFrom(imgConfig)
-		}
-		if archCnf, ok := cond.Architecture[archName]; ok {
-			imgConfig = archCnf.InheritFrom(imgConfig)
-		}
-		for _, ltVer := range versionLessThanSortedKeys(cond.VersionLessThan) {
-			ltOverrides := cond.VersionLessThan[ltVer]
-			if common.VersionLessThan(versionStringForVerCmp(*id), ltVer) {
-				imgConfig = ltOverrides.InheritFrom(imgConfig)
+		for _, cond := range imgType.ImageConfig.Conditions {
+			if cond.When.Eval(id, archName) {
+				imgConfig = cond.Merge.InheritFrom(imgConfig)
 			}
 		}
 	}
 
 	return imgConfig, nil
-}
-
-// nNonEmpty returns the number of non-empty maps in the given
-// input
-func nNonEmpty[K comparable, V any](maps ...map[K]V) int {
-	var nonEmpty int
-	for _, m := range maps {
-		if len(m) > 0 {
-			nonEmpty++
-		}
-	}
-	return nonEmpty
 }
 
 // InstallerConfig returns the InstallerConfig for the given imgType
@@ -678,27 +609,14 @@ func InstallerConfig(distroNameVer, archName, typeName string) (*distro.Installe
 		return nil, fmt.Errorf("%w: %q", ErrImageTypeNotFound, typeName)
 	}
 	installerConfig := imgType.InstallerConfig.InstallerConfig
-	cond := imgType.InstallerConfig.Condition
-	if cond != nil {
-		if nNonEmpty(cond.DistroName, cond.Architecture, cond.VersionLessThan) > 1 {
-			return nil, fmt.Errorf("only a single conditional allowed in installer config for %v", typeName)
-		}
-
-		id, err := distro.ParseID(distroNameVer)
-		if err != nil {
-			return nil, err
-		}
-
-		if distroNameCnf, ok := cond.DistroName[id.Name]; ok {
-			installerConfig = distroNameCnf
-		}
-		if archCnf, ok := cond.Architecture[archName]; ok {
-			installerConfig = archCnf
-		}
-		for _, ltVer := range versionLessThanSortedKeys(cond.VersionLessThan) {
-			ltOverrides := cond.VersionLessThan[ltVer]
-			if common.VersionLessThan(versionStringForVerCmp(*id), ltVer) {
-				installerConfig = ltOverrides
+	if imgType.InstallerConfig.Conditions != nil {
+		for _, cond := range imgType.InstallerConfig.Conditions {
+			id, err := distro.ParseID(distroNameVer)
+			if err != nil {
+				return nil, err
+			}
+			if cond.When.Eval(id, archName) {
+				installerConfig = cond.Override
 			}
 		}
 	}

--- a/pkg/distro/defs/rhel-10/distro.yaml
+++ b/pkg/distro/defs/rhel-10/distro.yaml
@@ -17,12 +17,17 @@
       - "tar"
       - "xfsprogs"
       - "xz"
-    condition:
-      architecture:
-        x86_64:
+    conditions:
+      "x86_64 specific packages for build pkgsset":
+        when:
+          arch: "x86_64"
+        append:
           include:
             - "grub2-pc"
-        ppc64el:
+      "ppc64le specific packages for build pkgsset":
+        when:
+          arch: "ppc64le"
+        append:
           include:
             - "grub2-ppc64le"
             - "grub2-ppc64le-modules"
@@ -181,9 +186,11 @@
       - "nss-softokn"
 
   anaconda_boot_pkgset: &anaconda_boot_pkgset
-    condition:
-      architecture:
-        x86_64:
+    conditions:
+      "x86 specific packages for the anaconda boot pkgset":
+        when:
+          arch: "x86_64"
+        append:
           include:
             # eficommon
             - "efibootmgr"
@@ -200,7 +207,10 @@
             - "shim-x64"
             - "syslinux"
             - "syslinux-nonlinux"
-        aarch64:
+      "aarch64 specific packages for the anaconda boot pkgset":
+        when:
+          arch: "aarch64"
+        append:
           include:
             # eficommon
             - "efibootmgr"
@@ -460,13 +470,17 @@
           "unmanaged-devices":
             - "driver:mlx4_core"
             - "driver:mlx5_core"
-    condition:
-      distro_name:
-        rhel:
+    conditions:
+      "rhel needs the rhel release rpm gpg key":
+        when:
+          distro_name: "rhel"
+        merge:
           gpgkey_files:
             - "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
-      architecture:
-        x86_64:
+      "x86_64 specific kernel commandline":
+        when:
+          arch: "x86_64"
+        merge:
           kernel_options:
             # common
             - "ro"
@@ -477,7 +491,10 @@
             - "console=ttyS0"
             - "earlyprintk=ttyS0"
             - "rootdelay=300"
-        aarch64:
+      "aarch64 specific kernel commandline":
+        when:
+          arch: "aarch64"
+        merge:
           kernel_options:
             # common
             - "ro"
@@ -497,9 +514,11 @@ image_config:
       no_zero_conf: true
     timezone: "UTC"
     update_default_kernel: true
-  condition:
-    distro_name:
-      centos:
+  conditions:
+    "centos oscap datastream path":
+      when:
+        distro_name: "centos"
+      merge:
         default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-cs10-ds.xml"
 
 image_types:
@@ -547,9 +566,11 @@ image_types:
             - "tuned"
           exclude:
             - "dracut-config-rescue"
-          condition:
-            distro_name:
-              rhel:
+          conditions:
+            "add subscription-manager-cockpit on rhel":
+              when:
+                distro_name: "rhel"
+              append:
                 include:
                   - "subscription-manager-cockpit"
 
@@ -557,9 +578,11 @@ image_types:
     image_config: &qcow2_image_config
       default_target: "multi-user.target"
       kernel_options: ["console=tty0", "console=ttyS0,115200n8", "no_timer_check"]
-      condition:
-        distro_name:
-          rhel:
+      conditions:
+        "tweak the rhsm config on rhel":
+          when:
+            distro_name: "rhel"
+          merge:
             rhsm_config:
               "no-subscription":
                 dnf_plugin:
@@ -628,9 +651,11 @@ image_types:
             - "plymouth"
             - "rng-tools"
             - "udisks2"
-          condition:
-            distro_name:
-              rhel:
+          conditions:
+            "add insights pkgs on rhel":
+              when:
+                distro_name: "rhel"
+              append:
                 include:
                   - "insights-client"
                   - "subscription-manager-cockpit"
@@ -759,9 +784,11 @@ image_types:
             - "rhnlib"
             - "rhnsd"
             - "usb_modeswitch"
-          condition:
-            distro_name:
-              rhel:
+          conditions: &conditions_pkgsets_insights_client_on_rhel
+            "add insights client on rhel":
+              when:
+                distro_name: "rhel"
+              append:
                 include:
                   - "insights-client"
 
@@ -969,22 +996,31 @@ image_types:
       sshd_config:
         config:
           PasswordAuthentication: false
-      condition:
-        architecture:
-          x86_64: &ami_image_config_cond_x86_64
+      conditions: &ami_image_config_cond
+        "we need dracut conf with nvme/xen on x86":
+          when:
+            arch: "x86_64"
+          merge:
             dracut_conf:
               - filename: "ec2.conf"
                 config:
                   add_drivers:
                     - "nvme"
                     - "xen-blkfront"
+        "x86_64 specific kopts":
+          when:
+            arch: "x86_64"
+          merge:
             # TODO: move these to the EC2 environment
             kernel_options:
               # common
               - "console=tty0"
               - "console=ttyS0,115200n8"
               - "nvme_core.io_timeout=4294967295"
-          aarch64:
+        "aarch64 specific kopts":
+          when:
+            arch: "aarch64"
+          merge:
             # TODO: move these to the EC2 environment
             kernel_options:
               # XXX: duplicated with above x86_64 kernel defaults
@@ -1047,11 +1083,8 @@ image_types:
             - "dracut-config-rescue"
             # RHBZ#2075815
             - "qemu-guest-agent"
-          condition:
-            distro_name:
-              rhel:
-                include:
-                  - "insights-client"
+          conditions:
+            <<: *conditions_pkgsets_insights_client_on_rhel
 
   ec2: *ami
 
@@ -1073,11 +1106,15 @@ image_types:
         - *sap_pkgset
     image_config:
       <<: [*ami_image_config, *sap_image_config]
-      condition:
-        architecture:
-          x86_64:
-            # XXX: this shows that merging at the yaml level is tricky
-            <<: *ami_image_config_cond_x86_64
+      conditions:
+        <<: *ami_image_config_cond
+        # this needs to override the original ami key because
+        # we want everything from the ami config *except* the
+        # kernel comandline
+        "x86_64 specific kopts":
+          when:
+            arch: "x86_64"
+          merge:
             kernel_options:
               # XXX: duplicated with ami.image_config.kernel_options :(
               - "console=tty0"
@@ -1107,9 +1144,11 @@ image_types:
             icon: /usr/share/pixmaps/fedora-logo.ico
           oobe: &wsl_distribution_oobe_config
             default_uid: 1000
-      condition:
-        distro_name:
-          rhel:
+      conditions:
+        "wsl config for rhel":
+          when:
+            distro_name: "rhel"
+          merge:
             wsl:
               <<: *wsl_config
               distribution_config:
@@ -1117,7 +1156,10 @@ image_types:
                 oobe:
                   <<: *wsl_distribution_oobe_config
                   default_name: RedHatEnterpriseLinux-%s
-          centos:
+        "wsl config for centos":
+          when:
+            distro_name: "centos"
+          merge:
             wsl:
               <<: *wsl_config
               distribution_config:
@@ -1125,15 +1167,23 @@ image_types:
                 oobe:
                   <<: *wsl_distribution_oobe_config
                   default_name: CentOS-%s
-          almalinux: &wsl_distribution_config_almalinux
-            wsl:
+        "wsl config for almalinux":
+          when:
+            distro_name: "almalinux"
+          merge:
+            wsl: &wsl_distribution_config_almalinux
               <<: *wsl_config
               distribution_config:
                 <<: *wsl_distribution_config
                 oobe:
                   <<: *wsl_distribution_oobe_config
                   default_name: AlmaLinux-%s
-          almalinux_kitten: *wsl_distribution_config_almalinux
+        "wsl config for almalinuxkitten":
+          when:
+            distro_name: "almalinux_kitten"
+          merge:
+            wsl:
+              <<: *wsl_distribution_config_almalinux
     package_sets:
       os:
         - include:
@@ -1307,15 +1357,20 @@ image_types:
             - "xfsdump"
             - "xfsprogs"
             - "xz"
-          condition:
-            architecture:
-              x86_64:
+          conditions:
+            "x86_64 specific pkgs for image installer":
+              when:
+                arch: "x86_64"
+              append:
                 include:
                   - "biosdevname"
                   - "dmidecode"
                   - "grub2-tools-efi"
                   - "memtest86+"
-              aarch64:
+            "aarch64 specific pkgs for image installer":
+              when:
+                arch: "aarch64"
+              append:
                 include:
                   - "dmidecode"
 
@@ -1471,11 +1526,8 @@ image_types:
             - "zd1211-firmware"
             # RHBZ#2075815
             - "qemu-guest-agent"
-          condition:
-            distro_name:
-              rhel:
-                include:
-                  - "insights-client"
+          conditions:
+            <<: *conditions_pkgsets_insights_client_on_rhel
 
   "azure-cvm":
     image_config:

--- a/pkg/distro/defs/rhel-7/distro.yaml
+++ b/pkg/distro/defs/rhel-7/distro.yaml
@@ -38,9 +38,11 @@
       - "mariadb-libs"
       - "NetworkManager-config-server"
       - "postfix"
-    condition:
-      distro_name:
-        "rhel":
+    conditions: &conditions_for_insights_client
+      "add insights client on rhel":
+        when:
+          distro_name: "rhel"
+        append:
           include:
             - "insights-client"
 
@@ -247,8 +249,5 @@ image_types:
             - "libertas-sd8686-firmware"
             - "libertas-sd8787-firmware"
             - "libertas-usb8388-firmware"
-          condition:
-            distro_name:
-              "rhel":
-                include:
-                  - "insights-client"
+          conditions:
+            <<: *conditions_for_insights_client

--- a/pkg/distro/defs/rhel-8/distro.yaml
+++ b/pkg/distro/defs/rhel-8/distro.yaml
@@ -50,9 +50,11 @@
       - "plymouth"
       # RHBZ#2075815
       - "qemu-guest-agent"
-    condition:
-      distro_name:
-        rhel:
+    conditions: &conditions_for_insights_client
+      "add insights client on rhel":
+        when:
+          distro_name: "rhel"
+        append:
           include:
             - "insights-client"
 
@@ -128,15 +130,13 @@
       - "rhnlib"
       - "rhnsd"
       - "usb_modeswitch"
-    condition:
-      distro_name:
-        "rhel":
-          include:
-            - "insights-client"
-            # XXX: this is defined in azure.go:commonPackageSets but
-            # there is a bug in the original code so this never gets
-            # actually added so we don't add it here either
-            # - "rhc"
+    conditions:
+      <<: *conditions_for_insights_client
+      # XXX: the below "rhc" is defined in
+      # azure.go:commonPackageSets but there is a bug in the
+      # original code so this never gets actually added so we
+      # don't add it here either
+      # - "rhc"
 
   sap_pkgset: &sap_pkgset
     include:
@@ -176,13 +176,17 @@
       - "tuned-profiles-sap-hana"
       # RHBZ#1961168
       - "libnsl"
-    condition:
-      version_less_than:
-        "8.6":
+    conditions:
+      "name of the ansible pkg rhel-8.6 and below":
+        when:
+          version_less_than: "8.6"
+        append:
           include:
             - "ansible"
-      version_greater_or_equal:
-        "8.6":
+      "name of the ansible pkg rhel-8.6+":
+        when:
+          version_greater_or_equal: "8.6"
+        append:
           include:
             - "ansible-core"
 
@@ -219,16 +223,20 @@
       - "tar"
       - "xfsprogs"
       - "xz"
-    condition:
-      architecture:
-        x86_64:
+    conditions:
+      "x86-64 needs biosdevname":
+        when:
+          arch: "x86_64"
+        append:
           include:
             - "biosdevname"
 
   anaconda_boot_pkgset: &anaconda_boot_pkgset
-    condition:
-      architecture:
-        x86_64:
+    conditions:
+      "x86_64 architecture dependant anaconda packages":
+        when:
+          arch: "x86_64"
+        append:
           include:
             # eficommon
             - "efibootmgr"
@@ -247,7 +255,10 @@
             - "shim-x64"
             - "syslinux"
             - "syslinux-nonlinux"
-        aarch64:
+      "aarch64 architecture dependant anaconda packages":
+        when:
+          arch: "aarch64"
+        append:
           include:
             # eficommon
             - "efibootmgr"
@@ -370,23 +381,23 @@
       - "xorg-x11-server-utils"
       - "xorg-x11-server-Xorg"
       - "xorg-x11-xauth"
-    condition:
-      architecture:
-        x86_64:
+      # XXX: this was originally centos or rhel
+      - "libreport-rhel-anaconda-bugzilla"
+    conditions:
+      "x86_64 architecture dependant packages for anaconda":
+        when:
+          arch: "x86_64"
+        append:
           include:
             - "biosdevname"
             - "dmidecode"
             - "memtest86+"
-        aarch64:
+      "aarch64 architecture dependant packages for anaconda":
+        when:
+          arch: "aarch64"
+        append:
           include:
             - "dmidecode"
-      distro_name:
-        rhel:
-          include:
-            - "libreport-rhel-anaconda-bugzilla"
-        centos:
-          include:
-            - "libreport-rhel-anaconda-bugzilla"
 
   gce_common_pkgset: &gce_common_pkgset
     include:
@@ -449,11 +460,8 @@
       - "zd1211-firmware"
       # RHBZ#2075815
       - "qemu-guest-agent"
-    condition:
-      distro_name:
-        rhel:
-          include:
-            - "insights-client"
+    conditions:
+      <<: *conditions_for_insights_client
 
   qcow2_common_pkgset: &qcow2_common_pkgset
     include:
@@ -523,9 +531,11 @@
       - "plymouth"
       - "rng-tools"
       - "udisks2"
-    condition:
-      distro_name:
-        rhel:
+    conditions: &condition_rhel_insights_clinet_subman
+      "add insights/subscription manager for copilot":
+        when:
+          distro_name: "rhel"
+        append:
           include:
             - "insights-client"
             - "subscription-manager-cockpit"
@@ -740,30 +750,31 @@
           - *ec2_partition_table_part_root
 
   ec2_partition_tables_override: &ec2_partition_tables_override
-    condition:
-      version_less_than:
-        "8.10":
-          aarch64:
+    conditions:
+      "rhel8.9  uses efi boot but small boot":
+        when:
+          version_equal: "8.9"
+        override:
+          x86_64:
+            <<: *ec2_partition_table_x86_64
+          aarch64: &ec2_partition_table_aarch64_8_9
             <<: *ec2_partition_table_aarch64
             partitions:
               - *ec2_partition_table_part_efi
               - *ec2_partition_table_part_boot512
               - *ec2_partition_table_part_root
-        "8.9":
+      "rhel-8.9 and below has no efi on x86 but is the same on aarch64":
+        when:
+          version_less_than: "8.9"
+          distro_name: "rhel"
+        override:
           x86_64:
             <<: *ec2_partition_table_x86_64
             partitions:
               - *default_partition_table_part_bios
               - *ec2_partition_table_part_root
-      distro_name:
-        # we need this override to ensure that centos always gets
-        # the latest partition-tables, otherwise "centos-8" is
-        # less than "8 <= 8.9"
-        "centos":
-          x86_64:
-            <<: *ec2_partition_table_x86_64
           aarch64:
-            <<: *ec2_partition_table_aarch64
+            <<: *ec2_partition_table_aarch64_8_9
 
 image_config:
   default:
@@ -777,9 +788,11 @@ image_config:
       no_zero_conf: true
     timezone: "America/New_York"
     update_default_kernel: true
-  condition:
-    distro_name:
-      centos:
+  conditions:
+    "centos has a different oscap path":
+      when:
+        distro_name: "centos"
+      merge:
         default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-centos8-ds.xml"
 
 image_types:
@@ -832,12 +845,8 @@ image_types:
             - "tar"
             - "tcpdump"
             - "yum"
-          condition:
-            distro_name:
-              rhel:
-                include:
-                  - "insights-client"
-                  - "subscription-manager-cockpit"
+          conditions:
+            <<: *condition_rhel_insights_clinet_subman
 
   ec2: &ec2
     partition_table:
@@ -851,9 +860,11 @@ image_types:
             - "rh-amazon-rhui-client"
           exclude:
             - "alsa-lib"
-          condition:
-            version_greater_or_equal:
-              "8.7":
+          conditions: &conditions_rh_cloud_client
+            "add redhat-cloud-client-configuration on rh8.7+":
+              when:
+                version_greater_or_equal: "8.7"
+              append:
                 include:
                   - "redhat-cloud-client-configuration"
 
@@ -869,11 +880,8 @@ image_types:
             - "rh-amazon-rhui-client-ha"
           exclude:
             - "alsa-lib"
-          condition:
-            version_greater_or_equal:
-              "8.7":
-                include:
-                  - "redhat-cloud-client-configuration"
+          conditions:
+            <<: *conditions_rh_cloud_client
 
   ami:
     <<: *ec2
@@ -887,18 +895,20 @@ image_types:
       os:
         - *ec2_common_pkgset
         - *sap_pkgset
-        - condition:
-            version_less_than:
-              "8.10":
+        - conditions:
+            <<: *conditions_rh_cloud_client
+            "rh-8.9 or below gets the e4s bundle":
+              when:
+                version_less_than: "8.10"
+              append:
                 include:
                   - "rh-amazon-rhui-client-sap-bundle-e4s"
-            version_greater_or_equal:
-              "8.10":
+            "rh-8.10+ get the rhui bundle":
+              when:
+                version_greater_or_equal: "8.10"
+              append:
                 include:
                   - "rh-amazon-rhui-client-sap-bundle"
-              "8.7":
-                include:
-                  - "redhat-cloud-client-configuration"
 
   "azure-rhui":
     package_sets:
@@ -917,13 +927,17 @@ image_types:
         - *sap_pkgset
         - include:
             - "firewalld"
-          condition:
-            version_greater_or_equal:
-              "8.10":
+          conditions:
+            "rh-8.10+ gets the the base sap ha pkgs":
+              when:
+                version_greater_or_equal: "8.10"
+              append:
                 include:
                   - "rhui-azure-rhel8-base-sap-ha"
-            version_less_than:
-              "8.10":
+            "rh-8.9 or below gets sap-ha":
+              when:
+                version_less_than: "8.10"
+              append:
                 include:
                   - "rhui-azure-rhel8-sap-ha"
 
@@ -1043,9 +1057,11 @@ image_types:
             - "xz"
           exclude:
             - "rng-tools"
-          condition:
-            architecture:
-              x86_64: &edge_commit_x86_64_pkgset
+          conditions: &conditions_pkgsets_edge_commit
+            "x86_64 specific packages for edge-commit":
+              when:
+                arch: "x86_64"
+              append: &edge_commit_x86_64_pkgset
                 include:
                   - "efibootmgr"
                   - "grub2"
@@ -1064,29 +1080,33 @@ image_types:
                   - "iwl7260-firmware"
                   - "microcode_ctl"
                   - "shim-x64"
-              aarch64: &edge_commit_aarch64_pkgset
+            "aarch64 specific packages for edge-commit":
+              when:
+                arch: "aarch64"
+              append: &edge_commit_aarch64_pkgset
                 include:
                   - "grub2-efi-aa64"
                   - "efibootmgr"
                   - "shim-aa64"
                   - "iwl7260-firmware"
-            version_less_than:
-              "8.6":
+            "rhel-8.5 or below uses greenboot":
+              when:
+                version_less_than: "8.6"
+              append:
                 include:
                   - "greenboot-grub2"
                   - "greenboot-reboot"
                   - "greenboot-rpm-ostree-grub2"
                   - "greenboot-status"
-            version_greater_or_equal:
-              "8.6": &edge_commit_new_rhel
+            "rhel-8.6+ uses fdo":
+              when:
+                version_greater_or_equal: "8.6"
+              append:
                 include:
                   - "fdo-client"
                   - "fdo-owner-cli"
                   - "greenboot-default-health-checks"
                   - "sos"
-            distro_name:
-              centos:
-                *edge_commit_new_rhel
 
   "edge-installer":
     package_sets:
@@ -1156,12 +1176,19 @@ image_types:
             - "sudo"
             - "traceroute"
             - "util-linux"
-          condition:
-            architecture:
-              x86_64:
-                *edge_commit_x86_64_pkgset
-              aarch64:
-                *edge_commit_aarch64_pkgset
+          conditions:
+            # XXX: should we instead "<<: *conditions_edge_commit" here?
+            # it will give different results
+            "x86_64 specific pkgset for edge-simplified-installer":
+              when:
+                arch: "x86_64"
+              append:
+                <<: *edge_commit_x86_64_pkgset
+            "aarch64 specific pkgset for edge-simplified-installer":
+              when:
+                arch: "aarch64"
+              append:
+                <<: *edge_commit_aarch64_pkgset
 
   "edge-container":
     package_sets:

--- a/pkg/distro/defs/rhel-9/distro.yaml
+++ b/pkg/distro/defs/rhel-9/distro.yaml
@@ -17,15 +17,29 @@
       - "tar"
       - "xfsprogs"
       - "xz"
-    condition:
-      architecture:
-        x86_64:
+    conditions:
+      "x86_64 specific packages for build pkgsset":
+        when:
+          arch: "x86_64"
+        append:
           include:
             - "grub2-pc"
-        ppc64el:
+      "ppc64le specific packages for build pkgsset":
+        when:
+          arch: "ppc64le"
+        append:
           include:
             - "grub2-ppc64le"
             - "grub2-ppc64le-modules"
+
+  common_conditions:
+    conditions: &conditions_pkgsets_insights_client_on_rhel
+      "add insights client on rhel":
+        when:
+          distro_name: "rhel"
+        append:
+          include:
+            - "insights-client"
 
   ec2_base_pkgset: &ec2_base_pkgset
     include:
@@ -78,13 +92,12 @@
       - "dracut-config-rescue"
       # RHBZ#2075815
       - "qemu-guest-agent"
-    condition:
-      distro_name:
-        rhel:
-          include:
-            - "insights-client"
-      version_greater_or_equal:
-        "9.6":
+    conditions:
+      <<: *conditions_pkgsets_insights_client_on_rhel
+      "rhel-9.6+ gets system-reinstall-bootc":
+        when:
+          version_greater_or_equal: "9.6"
+        append:
           include:
             - "system-reinstall-bootc"
 
@@ -178,16 +191,20 @@
       # pipeline.
       - "mdadm"
       - "nss-softokn"
-    condition:
-      architecture:
-        x86_64:
+    conditions:
+      "x86_64 specific installer packages":
+        when:
+          arch: "x86_64"
+        append:
           include:
             - "biosdevname"
 
   anaconda_boot_pkgset: &anaconda_boot_pkgset
-    condition:
-      architecture:
-        x86_64:
+    conditions:
+      "x86 specific packages for the anaconda boot pkgset":
+        when:
+          arch: "x86_64"
+        append:
           include:
             # eficommon
             - "efibootmgr"
@@ -204,7 +221,10 @@
             - "shim-x64"
             - "syslinux"
             - "syslinux-nonlinux"
-        aarch64:
+      "aarch64 specific packages for the anaconda boot pkgset":
+        when:
+          arch: "aarch64"
+        append:
           include:
             # eficommon
             - "efibootmgr"
@@ -354,15 +374,20 @@
       - "xorg-x11-server-Xorg"
       - "xorg-x11-xauth"
       - "xz"
-    condition:
-      architecture:
-        x86_64:
+    conditions:
+      "x86 specific packages for the anaconda pkgset":
+        when:
+          arch: "x86_64"
+        append:
           include:
             - "biosdevname"
             - "dmidecode"
             - "grub2-tools-efi"
             - "memtest86+"
-        aarch64:
+      "aarch64 specific packages for the anaconda pkgset":
+        when:
+          arch: "aarch64"
+        append:
           include:
             - "dmidecode"
 
@@ -488,9 +513,11 @@
             bootable: true
 
     ec2_partition_tables_override: &ec2_partition_tables_override
-      condition:
-        version_less_than:
-          "9.3":
+      conditions:
+        "rhel-9.2 and below have no efi partition":
+          when:
+            version_less_than: "9.3"
+          override:
             x86_64:
               <<: *default_partition_table_x86_64
               partitions:
@@ -498,6 +525,8 @@
                 # note no boot efi
                 - *default_partition_table_part_boot
                 - *default_partition_table_part_root
+            aarch64:
+              <<: *default_partition_table_aarch64
 
 image_config:
   default:
@@ -510,9 +539,11 @@ image_config:
       no_zero_conf: true
     timezone: "America/New_York"
     update_default_kernel: true
-  condition:
-    distro_name:
-      centos:
+  conditions:
+    "oscap needs a differnt path on centos":
+      when:
+        distro_name: "centos"
+      merge:
         default_oscap_datastream: "/usr/share/xml/scap/ssg/content/ssg-cs9-ds.xml"
 
 image_types:
@@ -562,9 +593,11 @@ image_types:
             - "tuned"
           exclude:
             - "dracut-config-rescue"
-          condition:
-            distro_name:
-              rhel:
+          conditions: &conditions_subscription_manager_cockpit
+            "add subscription-manager-cockpit on rhel":
+              when:
+                distro_name: "rhel"
+              append:
                 include:
                   - "subscription-manager-cockpit"
 
@@ -631,9 +664,11 @@ image_types:
             - "plymouth"
             - "rng-tools"
             - "udisks2"
-          condition:
-            distro_name:
-              rhel:
+          conditions: &conditions_pkgsets_insigths_pkgs
+            "add insights pkgs on rhel":
+              when:
+                distro_name: "rhel"
+              append:
                 include:
                   - "insights-client"
                   - "subscription-manager-cockpit"
@@ -716,13 +751,12 @@ image_types:
             - "rhnlib"
             - "rhnsd"
             - "usb_modeswitch"
-          condition:
-            distro_name:
-              rhel:
-                include:
-                  - "insights-client"
-            version_greater_or_equal:
-              "9.6":
+          conditions:
+            <<: *conditions_pkgsets_insights_client_on_rhel
+            "rhel-9.6+ gets system-reinstall-bootc and drops microcode_ctl":
+              when:
+                version_greater_or_equal: "9.6"
+              append:
                 include:
                   - "system-reinstall-bootc"
                 exclude:
@@ -942,11 +976,8 @@ image_types:
             - "zd1211-firmware"
             # RHBZ#2075815
             - "qemu-guest-agent"
-          condition:
-            distro_name:
-              rhel:
-                include:
-                  - "insights-client"
+          conditions:
+            <<: *conditions_pkgsets_insights_client_on_rhel
 
   "minimal-raw":
     package_sets:
@@ -1059,9 +1090,11 @@ image_types:
           exclude:
             - "rng-tools"
             - "bootupd"
-          condition:
-            architecture:
-              x86_64: &edge_commit_x86_64_pkgset
+          conditions: &conditions_pkgsets_edge_commit
+            "x86_64 specific packages for edge-commit":
+              when:
+                arch: "x86_64"
+              append: &edge_commit_x86_64_pkgset
                 include:
                   - "grub2"
                   - "grub2-efi-x64"
@@ -1079,20 +1112,27 @@ image_types:
                   - "iwl5150-firmware"
                   - "iwl6050-firmware"
                   - "iwl7260-firmware"
-              aarch64: &edge_commit_aarch64_pkgset
+            "aarch64 specific packages for edge-commit":
+              when:
+                arch: "aarch64"
+              append: &edge_commit_aarch64_pkgset
                 include:
                   - "grub2-efi-aa64"
                   - "efibootmgr"
                   - "shim-aa64"
                   - "iwl7260-firmware"
-            version_greater_or_equal:
-              "9.2":
+            "rhel-9.2+ gets ignition":
+              when:
+                version_greater_or_equal: "9.2"
+              append:
                 include:
                   - "ignition"
                   - "ignition-edge"
                   - "ssh-key-dir"
-            version_less_than:
-              "9.6":
+            "rhel-9.5 and below includes dnsmasq":
+              when:
+                version_less_than: "9.6"
+              append:
                 include:
                   # dnsmasq removed in 9.6+ but kept in older versions
                   - "dnsmasq"
@@ -1156,12 +1196,19 @@ image_types:
             - "sudo"
             - "traceroute"
             - "util-linux"
-          condition:
-            architecture:
-              x86_64:
-                *edge_commit_x86_64_pkgset
-              aarch64:
-                *edge_commit_aarch64_pkgset
+          conditions:
+            # XXX: should we instead "<<: *conditions_edge_commit" here?
+            # it will give different results
+            "x86_64 specific pkgset for edge-simplified-installer":
+              when:
+                arch: "x86_64"
+              append:
+                <<: *edge_commit_x86_64_pkgset
+            "aarch64 specific pkgset for edge-simplified-installer":
+              when:
+                arch: "aarch64"
+              append:
+                <<: *edge_commit_aarch64_pkgset
 
   "azure-cvm":
     package_sets:


### PR DESCRIPTION
This commit tweaks the condition handling in the YAMLs so that we can make merging easier on the YAML level.

This means that each condition now needs a unique description but that is probably good anyway to describe the reason for the condition.

The rhel-9 azure image type needs a logical AND for its image config. It checks for example that the arch is x86_64 and the rhel version >= 9.6.

This extends `when:` to allow multiple keys and when multiple keys are used they are put together as AND:

```yaml
image_types:
  "workstation-live-installer":
    ...
    image_config:
      locale: "en_US.UTF-8"
      iso_rootfs_type: "squashfs"
      conditions:
        "f40 and below uses ext4 based iso rootfs":
          when:
            version_less_than: "41"
            distro_name: "fedora"
          merge:
            iso_rootfs_type: "squashfs-ext4"
```
With that we can express all our intend nicely and we can also express what a "when" is doing, i.e. for some (like package sets) it will append, for others (image-types) it will merge and for installer-config it will override. All of this is now easier to read via:
```yaml
when: <expr>
override: ...
```

Alternative version to https://github.com/osbuild/images/pull/1600