### PR TITLE
many: add support for http{,s} uris in manifest file customizations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,8 +85,12 @@ jobs:
 
       # We need to run the test as root, since we use the root
       # containers-storage for the local resolvers
-      - name: Run unit tests
+      - name: Run container unit tests
         run: sudo go test ./pkg/container/... --force-local-resolver
+
+      # We need to run these tests as root, as they build real images
+      - name: Run go integration tests
+        run: sudo go test ./test/integration
 
   unit-tests-cs:
     strategy:

--- a/pkg/blueprint/fsnode_customizations.go
+++ b/pkg/blueprint/fsnode_customizations.go
@@ -190,6 +190,17 @@ type FileCustomization struct {
 	Mode string `json:"mode,omitempty" toml:"mode,omitempty"`
 	// Data is the file content in plain text
 	Data string `json:"data,omitempty" toml:"data,omitempty"`
+
+	// URI references the given URI, this makes the manifest alone
+	// no-longer portable (but future offline manifest bundles
+	// will fix that). It will still be reproducible as the
+	// manifest will include all the hashes of the content so any
+	// change will make the build fail.
+	//
+	// Initially only single files are supported, but this can be
+	// expanded to dirs (which will just be added recursively) and
+	// http{,s}.
+	URI string `json:"uri,omitempty" toml:"uri,omitempty"`
 }
 
 // Custom TOML unmarshalling for FileCustomization with validation
@@ -245,6 +256,15 @@ func (f *FileCustomization) UnmarshalTOML(data interface{}) error {
 		return fmt.Errorf("UnmarshalTOML: data must be a string")
 	}
 
+	switch uri := dataMap["uri"].(type) {
+	case string:
+		file.URI = uri
+	case nil:
+		break
+	default:
+		return fmt.Errorf("UnmarshalTOML: uri must be a string")
+	}
+
 	// try converting to fsnode.File to validate all values
 	_, err := file.ToFsNodeFile()
 	if err != nil {
@@ -291,6 +311,10 @@ func (f *FileCustomization) UnmarshalJSON(data []byte) error {
 
 // ToFsNodeFile converts the FileCustomization to an fsnode.File
 func (f FileCustomization) ToFsNodeFile() (*fsnode.File, error) {
+	if f.Data != "" && f.URI != "" {
+		return nil, fmt.Errorf("cannot specify both data %q and URI %q", f.Data, f.URI)
+	}
+
 	var data []byte
 	if f.Data != "" {
 		data = []byte(f.Data)
@@ -309,6 +333,9 @@ func (f FileCustomization) ToFsNodeFile() (*fsnode.File, error) {
 		mode = common.ToPtr(os.FileMode(modeNum))
 	}
 
+	if f.URI != "" {
+		return fsnode.NewFileForURI(f.Path, mode, f.User, f.Group, f.URI)
+	}
 	return fsnode.NewFile(f.Path, mode, f.User, f.Group, data)
 }
 

--- a/pkg/blueprint/fsnode_customizations_test.go
+++ b/pkg/blueprint/fsnode_customizations_test.go
@@ -2,14 +2,18 @@ package blueprint
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/pathpolicy"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDirectoryCustomizationToFsNodeDirectory(t *testing.T) {
@@ -725,6 +729,10 @@ func TestFileCustomizationsToFsNodeFiles(t *testing.T) {
 }
 
 func TestFileCustomizationUnmarshalTOML(t *testing.T) {
+	tmpdir := t.TempDir()
+	err := os.WriteFile(filepath.Join(tmpdir, "some-file.txt"), nil, 0644)
+	require.NoError(t, err)
+
 	testCases := []struct {
 		Name  string
 		TOML  string
@@ -744,6 +752,24 @@ path = "/etc/file"
 			Want: []FileCustomization{
 				{
 					Path: "/etc/file",
+				},
+			},
+		},
+		{
+			Name: "file-with-uri",
+			TOML: fmt.Sprintf(`
+name = "test"
+description = "Test"
+version = "0.0.0"
+
+[[customizations.files]]
+path = "/etc/file"
+uri = "file://%s/some-file.txt"
+`, tmpdir),
+			Want: []FileCustomization{
+				{
+					Path: "/etc/file",
+					URI:  fmt.Sprintf("file://%s/some-file.txt", tmpdir),
 				},
 			},
 		},
@@ -834,7 +860,7 @@ group = -1
 			if tc.Error {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, blueprint.Customizations)
 				assert.Len(t, blueprint.Customizations.Files, len(tc.Want))
 				assert.EqualValues(t, tc.Want, blueprint.Customizations.Files)
@@ -844,6 +870,10 @@ group = -1
 }
 
 func TestFileCustomizationUnmarshalJSON(t *testing.T) {
+	tmpdir := t.TempDir()
+	err := os.WriteFile(filepath.Join(tmpdir, "some-file.txt"), nil, 0644)
+	require.NoError(t, err)
+
 	testCases := []struct {
 		Name  string
 		JSON  string
@@ -868,6 +898,29 @@ func TestFileCustomizationUnmarshalJSON(t *testing.T) {
 			Want: []FileCustomization{
 				{
 					Path: "/etc/file",
+				},
+			},
+		},
+		{
+			Name: "file-with-uri",
+			JSON: fmt.Sprintf(`
+{
+	"name": "test",
+	"description": "Test",
+	"version": "0.0.0",
+	"customizations": {
+		"files": [
+			{
+				"path": "/etc/file",
+                                "uri": "file://%s/some-file.txt"
+			}
+		]
+	}
+}`, tmpdir),
+			Want: []FileCustomization{
+				{
+					Path: "/etc/file",
+					URI:  fmt.Sprintf("file://%s/some-file.txt", tmpdir),
 				},
 			},
 		},
@@ -968,7 +1021,7 @@ func TestFileCustomizationUnmarshalJSON(t *testing.T) {
 			if tc.Error {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, blueprint.Customizations)
 				assert.Len(t, blueprint.Customizations.Files, len(tc.Want))
 				assert.EqualValues(t, tc.Want, blueprint.Customizations.Files)
@@ -1251,4 +1304,28 @@ func TestCheckDirectoryCustomizationsPolicy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestToFileNodeNoMixingOfPathAndData(t *testing.T) {
+	fc := FileCustomization{
+		URI:  "/some/ref",
+		Data: "some-data",
+	}
+	_, err := fc.ToFsNodeFile()
+	assert.EqualError(t, err, `cannot specify both data "some-data" and URI "/some/ref"`)
+}
+
+func TestToFileNodeForRef(t *testing.T) {
+	testFile := filepath.Join(t.TempDir(), "test1.txt")
+	err := os.WriteFile(testFile, nil, 0644)
+	assert.NoError(t, err)
+
+	fc := FileCustomization{
+		Path: "/some/path",
+		URI:  testFile,
+	}
+	file, err := fc.ToFsNodeFile()
+	assert.NoError(t, err)
+	assert.Equal(t, "/some/path", file.Path())
+	assert.Equal(t, testFile, file.URI())
 }

--- a/pkg/customizations/fsnode/file.go
+++ b/pkg/customizations/fsnode/file.go
@@ -3,6 +3,8 @@ package fsnode
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/osbuild/images/internal/common"
@@ -11,6 +13,8 @@ import (
 type File struct {
 	baseFsNode
 	data []byte
+
+	uri string
 }
 
 func (f *File) Data() []byte {
@@ -41,9 +45,49 @@ func (f *File) UnmarshalYAML(unmarshal func(any) error) error {
 	return common.UnmarshalYAMLviaJSON(f, unmarshal)
 }
 
+func (f *File) URI() string {
+	return f.uri
+}
+
 // NewFile creates a new file with the given path, data, mode, user and group.
 // user and group can be either a string (user name/group name), an int64 (UID/GID) or nil.
 func NewFile(path string, mode *os.FileMode, user interface{}, group interface{}, data []byte) (*File, error) {
+	return newFile(path, mode, user, group, data, "")
+}
+
+// NewFleForURI creates a new file from the given "URI" (currently
+// only local file are supported).
+func NewFileForURI(targetPath string, mode *os.FileMode, user interface{}, group interface{}, uriStr string) (*File, error) {
+	uri, err := url.Parse(uriStr)
+	if err != nil {
+		return nil, err
+	}
+	switch uri.Scheme {
+	case "", "file":
+		return newFileForURILocalFile(targetPath, mode, user, group, uri)
+	default:
+		return nil, fmt.Errorf("unsupported scheme for %v (try file://)", uri)
+	}
+}
+
+func newFileForURILocalFile(targetPath string, mode *os.FileMode, user interface{}, group interface{}, uri *url.URL) (*File, error) {
+	st, err := os.Stat(uri.Path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot include blueprint file: %w", err)
+	}
+	if !st.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", uri.Path)
+	}
+	if mode == nil {
+		mode = common.ToPtr(st.Mode())
+	}
+	// note that user/group are not take from the local file, just
+	// default to unset which means root
+
+	return newFile(targetPath, mode, user, group, nil, uri.Path)
+}
+
+func newFile(path string, mode *os.FileMode, user interface{}, group interface{}, data []byte, uri string) (*File, error) {
 	baseNode, err := newBaseFsNode(path, mode, user, group)
 
 	if err != nil {
@@ -53,5 +97,6 @@ func NewFile(path string, mode *os.FileMode, user interface{}, group interface{}
 	return &File{
 		baseFsNode: *baseNode,
 		data:       data,
+		uri:        uri,
 	}, nil
 }

--- a/pkg/customizations/fsnode/file.go
+++ b/pkg/customizations/fsnode/file.go
@@ -65,8 +65,10 @@ func NewFileForURI(targetPath string, mode *os.FileMode, user interface{}, group
 	switch uri.Scheme {
 	case "", "file":
 		return newFileForURILocalFile(targetPath, mode, user, group, uri)
+	case "http", "https":
+		return newFile(targetPath, mode, user, group, nil, uriStr)
 	default:
-		return nil, fmt.Errorf("unsupported scheme for %v (try file://)", uri)
+		return nil, fmt.Errorf("unsupported scheme for %v (try file:// or https://)", uri)
 	}
 }
 

--- a/pkg/customizations/fsnode/file_test.go
+++ b/pkg/customizations/fsnode/file_test.go
@@ -76,7 +76,7 @@ func TestNewFile(t *testing.T) {
 	}
 }
 
-func TestNewFileForURI(t *testing.T) {
+func TestNewFileForURILocalFile(t *testing.T) {
 	testFile1 := filepath.Join(t.TempDir(), "test1.txt")
 	err := os.WriteFile(testFile1, nil, 0511)
 	assert.NoError(t, err)
@@ -91,6 +91,12 @@ func TestNewFileForURI(t *testing.T) {
 	assert.Equal(t, nil, file.Group())
 }
 
+func TestNewFileForURIFromHttp(t *testing.T) {
+	file, err := NewFileForURI("/target/path", nil, nil, nil, "http://example.com/test.txt")
+	assert.NoError(t, err)
+	assert.Equal(t, "http://example.com/test.txt", file.URI())
+}
+
 func TestNewFileForURIBadURIs(t *testing.T) {
 	tmpdir := t.TempDir()
 
@@ -100,7 +106,7 @@ func TestNewFileForURIBadURIs(t *testing.T) {
 	}{
 		{"/not/exists", `cannot include blueprint file: stat /not/exists: no such file or directory`},
 		{"file://%g", `parse "file://%g": invalid URL escape "%g"`},
-		{"gopher://foo.txt", "unsupported scheme for gopher://foo.txt (try file://)"},
+		{"gopher://foo.txt", "unsupported scheme for gopher://foo.txt (try file:// or https://)"},
 		{tmpdir, fmt.Sprintf("%s is not a regular file", tmpdir)},
 	} {
 

--- a/pkg/customizations/fsnode/fsnode.go
+++ b/pkg/customizations/fsnode/fsnode.go
@@ -82,7 +82,7 @@ func (f *baseFsNodeJSON) validate() error {
 		return fmt.Errorf("path must not be empty")
 	}
 	if f.Path[0] != '/' {
-		return fmt.Errorf("path must be absolute")
+		return fmt.Errorf("path %q must be absolute", f.Path)
 	}
 	if f.Path[len(f.Path)-1] == '/' {
 		return fmt.Errorf("path must not end with a slash")

--- a/pkg/hashutil/sha256sum.go
+++ b/pkg/hashutil/sha256sum.go
@@ -1,0 +1,26 @@
+package hashutil
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Sha256sum() is a convenience wrapper to generate
+// the sha256 hex digest of a file. The hash is the
+// same as from the sha256sum util.
+func Sha256sum(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}

--- a/pkg/hashutil/sha256sum.go
+++ b/pkg/hashutil/sha256sum.go
@@ -2,25 +2,49 @@ package hashutil
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"os"
 )
 
 // Sha256sum() is a convenience wrapper to generate
 // the sha256 hex digest of a file. The hash is the
 // same as from the sha256sum util.
-func Sha256sum(path string) (string, error) {
-	f, err := os.Open(path)
+func Sha256sum(uri string) (string, error) {
+	u, err := url.Parse(uri)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("invalid URI for sha256sum: %w", err)
 	}
-	defer f.Close()
+
+	var r io.ReadCloser
+	switch u.Scheme {
+	case "", "file":
+		var err error
+		r, err = os.Open(u.Path)
+		if err != nil {
+			return "", fmt.Errorf("sha256sum: %w", err)
+		}
+	case "http", "https":
+		resp, err := http.Get(u.String())
+		if err != nil {
+			return "", fmt.Errorf("sha256sum cannot get %s: %w", uri, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("sha256sum cannot fetch %s: %s", uri, resp.Status)
+		}
+		r = resp.Body
+	default:
+		return "", fmt.Errorf("sha256sum does not support scheme %q", u.Scheme)
+	}
+	defer r.Close()
 
 	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
+	if _, err := io.Copy(h, r); err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("%x", h.Sum(nil)), nil
+	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/pkg/hashutil/sha256sum_test.go
+++ b/pkg/hashutil/sha256sum_test.go
@@ -1,0 +1,43 @@
+package hashutil_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/hashutil"
+)
+
+func TestSha256sum(t *testing.T) {
+	for _, tc := range []struct {
+		inp      string
+		expected string
+	}{
+		// test vectors from
+		// https://www.di-mgt.com.au/sha_testvectors.html
+		{
+			"", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		}, {
+			"abc", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+		}, {
+			"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
+			"248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
+		},
+	} {
+		t.Run(tc.inp, func(t *testing.T) {
+			tmpf := filepath.Join(t.TempDir(), "inp.txt")
+			err := os.WriteFile(tmpf, []byte(tc.inp), 0644)
+			assert.NoError(t, err)
+			hash, err := hashutil.Sha256sum(tmpf)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, hash)
+		})
+	}
+}
+
+func TestSha256sumError(t *testing.T) {
+	_, err := hashutil.Sha256sum("non-existing-file")
+	assert.EqualError(t, err, `open non-existing-file: no such file or directory`)
+}

--- a/pkg/hashutil/sha256sum_test.go
+++ b/pkg/hashutil/sha256sum_test.go
@@ -1,6 +1,9 @@
 package hashutil_test
 
 import (
+	"fmt"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,34 +13,58 @@ import (
 	"github.com/osbuild/images/pkg/hashutil"
 )
 
-func TestSha256sum(t *testing.T) {
-	for _, tc := range []struct {
-		inp      string
-		expected string
-	}{
-		// test vectors from
-		// https://www.di-mgt.com.au/sha_testvectors.html
-		{
-			"", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-		}, {
-			"abc", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
-		}, {
-			"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
-			"248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
-		},
-	} {
-		t.Run(tc.inp, func(t *testing.T) {
+// test vectors from https://www.di-mgt.com.au/sha_testvectors.html
+var testVectors = map[string]string{
+	"":    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+	"abc": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+	"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq": "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
+}
+
+func TestSha256sumLocalFile(t *testing.T) {
+	for inp, expected := range testVectors {
+		t.Run(fmt.Sprintf("test-%s", inp), func(t *testing.T) {
 			tmpf := filepath.Join(t.TempDir(), "inp.txt")
-			err := os.WriteFile(tmpf, []byte(tc.inp), 0644)
+			err := os.WriteFile(tmpf, []byte(inp), 0644)
 			assert.NoError(t, err)
 			hash, err := hashutil.Sha256sum(tmpf)
 			assert.NoError(t, err)
-			assert.Equal(t, tc.expected, hash)
+			assert.Equal(t, expected, hash)
 		})
 	}
 }
 
-func TestSha256sumError(t *testing.T) {
+func TestSha256sumHttp(t *testing.T) {
+	ln, err := net.Listen("tcp", "localhost:0")
+	assert.NoError(t, err)
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := w.Write([]byte(r.URL.Path[1.:]))
+			assert.NoError(t, err)
+		}),
+	}
+	defer srv.Close()
+	go srv.Serve(ln)
+
+	for inp, expected := range testVectors {
+		t.Run(fmt.Sprintf("test-http-%s", inp), func(t *testing.T) {
+			hash, err := hashutil.Sha256sum("http://" + ln.Addr().String() + "/" + inp)
+			assert.NoError(t, err)
+			assert.Equal(t, expected, hash)
+		})
+	}
+}
+
+func TestSha256sumErrorLocal(t *testing.T) {
 	_, err := hashutil.Sha256sum("non-existing-file")
-	assert.EqualError(t, err, `open non-existing-file: no such file or directory`)
+	assert.EqualError(t, err, `sha256sum: open non-existing-file: no such file or directory`)
+}
+
+func TestSha256sumErrorHttp(t *testing.T) {
+	_, err := hashutil.Sha256sum("http://example.com/non-existing-file")
+	assert.EqualError(t, err, `sha256sum cannot fetch http://example.com/non-existing-file: 404 Not Found`)
+}
+
+func TestSha256sumErrorScheme(t *testing.T) {
+	_, err := hashutil.Sha256sum("unknown://example.com/file")
+	assert.EqualError(t, err, `sha256sum does not support scheme "unknown"`)
 }

--- a/pkg/manifest/export_test.go
+++ b/pkg/manifest/export_test.go
@@ -67,6 +67,10 @@ func (p *OS) GetInline() []string {
 	return p.getInline()
 }
 
+func (p *OS) FileUris() []string {
+	return p.fileUris()
+}
+
 // NewTestOS is used in both internal and external package tests.
 // TODO: make all tests external and define this only in the manifest_test
 // package.

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -166,7 +166,7 @@ func (m Manifest) Serialize(depsolvedSets map[string]dnfjson.DepsolveResult, con
 		mergedInputs.Depsolved.Repos = append(mergedInputs.Depsolved.Repos, depsolvedSets[pipeline.Name()].Repos...)
 		mergedInputs.Containers = append(mergedInputs.Containers, pipeline.getContainerSpecs()...)
 		mergedInputs.InlineData = append(mergedInputs.InlineData, pipeline.getInline()...)
-		mergedInputs.FileRefs = append(mergedInputs.FileRefs, pipeline.fileRefs()...)
+		mergedInputs.FileUris = append(mergedInputs.FileUris, pipeline.fileUris()...)
 	}
 	for _, pipeline := range m.pipelines {
 		pipeline.serializeEnd()

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -161,12 +161,12 @@ func (m Manifest) Serialize(depsolvedSets map[string]dnfjson.DepsolveResult, con
 	var mergedInputs osbuild.SourceInputs
 	for _, pipeline := range m.pipelines {
 		pipelines = append(pipelines, pipeline.serialize())
-
 		mergedInputs.Commits = append(mergedInputs.Commits, pipeline.getOSTreeCommits()...)
 		mergedInputs.Depsolved.Packages = append(mergedInputs.Depsolved.Packages, depsolvedSets[pipeline.Name()].Packages...)
 		mergedInputs.Depsolved.Repos = append(mergedInputs.Depsolved.Repos, depsolvedSets[pipeline.Name()].Repos...)
 		mergedInputs.Containers = append(mergedInputs.Containers, pipeline.getContainerSpecs()...)
 		mergedInputs.InlineData = append(mergedInputs.InlineData, pipeline.getInline()...)
+		mergedInputs.FileRefs = append(mergedInputs.FileRefs, pipeline.fileRefs()...)
 	}
 	for _, pipeline := range m.pipelines {
 		pipeline.serializeEnd()

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -1164,12 +1164,12 @@ func (p *OS) addInlineDataAndStages(pipeline *osbuild.Pipeline, files []*fsnode.
 	}
 }
 
-// fileRefs ensures that any files from customizations that require fetching data
+// fileUris ensures that any files from customizations that require fetching data
 // (e.g. via the "uri" key in customizations) are added to the manifests "sources"
 //
 // Note that the actual copy/chmod/... stages are generated via addInlineDataAndStages
-func (p *OS) fileRefs() []string {
-	var fileRefs []string
+func (p *OS) fileUris() []string {
+	var fileUris []string
 
 	for _, file := range p.OSCustomizations.Files {
 		if uriStr := file.URI(); uriStr != "" {
@@ -1179,13 +1179,15 @@ func (p *OS) fileRefs() []string {
 			}
 
 			switch uri.Scheme {
-			case "", "file":
-				fileRefs = append(fileRefs, uri.Path)
+			case "":
+				fileUris = append(fileUris, "file://"+uri.Path)
+			case "file", "http", "https":
+				fileUris = append(fileUris, uri.String())
 			default:
 				panic(fmt.Errorf("internal error: unsupported schema for OSCustomizations.Files: %v", uriStr))
 			}
 		}
 	}
 
-	return fileRefs
+	return fileUris
 }

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -554,3 +554,14 @@ func TestHMACStageInclusion(t *testing.T) {
 		assert.NotContains(t, directories, "/boot/efi/EFI/Linux/ffffffffffffffffffffffffffffffff-13.3-7.el9.x86_64.efi.extra.d")
 	})
 }
+
+func TestOSUriRefsGetNormalized(t *testing.T) {
+	os := manifest.NewTestOS()
+	os.OSCustomizations.Files = []*fsnode.File{
+		// this gets a "file://" prefix
+		common.Must(fsnode.NewFileForURI("/local/path", nil, nil, nil, "/etc/os-release")),
+		common.Must(fsnode.NewFileForURI("/other/path", nil, nil, nil, "file:///etc/fstab")),
+		common.Must(fsnode.NewFileForURI("/local/path", nil, nil, nil, "http://example.com/path")),
+	}
+	assert.Equal(t, []string{"file:///etc/os-release", "file:///etc/fstab", "http://example.com/path"}, os.FileUris())
+}

--- a/pkg/manifest/pipeline.go
+++ b/pkg/manifest/pipeline.go
@@ -69,6 +69,9 @@ type Pipeline interface {
 	// getInline returns the list of inlined data content that will be used to
 	// embed files in the pipeline tree.
 	getInline() []string
+
+	// files generated from url references
+	fileRefs() []string
 }
 
 // A Base represents the core functionality shared between each of the pipeline
@@ -146,6 +149,10 @@ func (p Base) getContainerSpecs() []container.Spec {
 
 func (p Base) getInline() []string {
 	return []string{}
+}
+
+func (p Base) fileRefs() []string {
+	return nil
 }
 
 // NewBase returns a generic Pipeline object. The name is mandatory, immutable and must

--- a/pkg/manifest/pipeline.go
+++ b/pkg/manifest/pipeline.go
@@ -70,8 +70,8 @@ type Pipeline interface {
 	// embed files in the pipeline tree.
 	getInline() []string
 
-	// files generated from url references
-	fileRefs() []string
+	// files generated from uri references
+	fileUris() []string
 }
 
 // A Base represents the core functionality shared between each of the pipeline
@@ -151,7 +151,7 @@ func (p Base) getInline() []string {
 	return []string{}
 }
 
-func (p Base) fileRefs() []string {
+func (p Base) fileUris() []string {
 	return nil
 }
 

--- a/pkg/osbuild/fsnode_test.go
+++ b/pkg/osbuild/fsnode_test.go
@@ -4,11 +4,13 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGenFileNodesStages(t *testing.T) {
@@ -269,4 +271,20 @@ func TestGenDirectoryNodesStages(t *testing.T) {
 			assert.EqualValues(t, tc.expected, gotStages)
 		})
 	}
+}
+
+func TestGenFileNodeStage(t *testing.T) {
+	testFile := filepath.Join(t.TempDir(), "testfile.txt")
+	err := os.WriteFile(testFile, []byte("content"), 0644)
+	assert.NoError(t, err)
+	// sha256sum("content")
+	sha256sum := "ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73"
+
+	fsNodeFile, err := fsnode.NewFileForURI("/some/path", nil, nil, nil, testFile)
+	assert.NoError(t, err)
+
+	files := []*fsnode.File{fsNodeFile}
+	stages := GenFileNodesStages(files)
+	st := stages[0]
+	assert.Contains(t, st.Options.(*CopyStageOptions).Paths[0].From, sha256sum)
 }

--- a/pkg/osbuild/source.go
+++ b/pkg/osbuild/source.go
@@ -30,8 +30,8 @@ type SourceInputs struct {
 	Commits    []ostree.CommitSpec
 	// InlineData contans the inline data for fsnode.Files
 	InlineData []string
-	// FileRefs contains the references of paths/urls for fsnode.Files
-	FileRefs []string
+	// FileUris contains the references of paths/urls for fsnode.Files
+	FileUris []string
 }
 
 // A Sources map contains all the sources made available to an osbuild run
@@ -174,20 +174,20 @@ func GenSources(inputs SourceInputs, rpmDownloader RpmDownloader) (Sources, erro
 		}
 	}
 
-	// collect host resources
-	if len(inputs.FileRefs) > 0 {
+	// collect host/external resources
+	if len(inputs.FileUris) > 0 {
 		// XXX: fugly
 		curl, ok := sources["org.osbuild.curl"].(*CurlSource)
 		if !ok || curl == nil {
 			curl = NewCurlSource()
 		}
-		for _, hostRes := range inputs.FileRefs {
+		for _, hostRes := range inputs.FileUris {
 			checksum, err := hashutil.Sha256sum(hostRes)
 			if err != nil {
 				return nil, err
 			}
 			curl.Items["sha256:"+checksum] = &CurlSourceOptions{
-				URL: fmt.Sprintf("file:%s", hostRes),
+				URL: hostRes,
 			}
 		}
 		sources["org.osbuild.curl"] = curl

--- a/pkg/osbuild/source_test.go
+++ b/pkg/osbuild/source_test.go
@@ -3,6 +3,9 @@ package osbuild
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -337,4 +340,27 @@ func TestGenSourcesRpmBad(t *testing.T) {
 	}
 	_, err := GenSources(inputs, 99)
 	assert.EqualError(t, err, "unknown rpm downloader 99")
+}
+
+func TestGenSourcesFileRefs(t *testing.T) {
+	testFile := filepath.Join(t.TempDir(), "test1.txt")
+	err := os.WriteFile(testFile, nil, 0644)
+	assert.NoError(t, err)
+
+	sources, err := GenSources(SourceInputs{
+		FileRefs: []string{testFile},
+	}, 0)
+	assert.NoError(t, err)
+
+	jsonOutput, err := json.MarshalIndent(sources, "", "  ")
+	assert.NoError(t, err)
+	assert.Equal(t, string(jsonOutput), fmt.Sprintf(`{
+  "org.osbuild.curl": {
+    "items": {
+      "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+        "url": "file:%s"
+      }
+    }
+  }
+}`, testFile))
 }

--- a/pkg/osbuild/source_test.go
+++ b/pkg/osbuild/source_test.go
@@ -348,7 +348,7 @@ func TestGenSourcesFileRefs(t *testing.T) {
 	assert.NoError(t, err)
 
 	sources, err := GenSources(SourceInputs{
-		FileRefs: []string{testFile},
+		FileUris: []string{testFile},
 	}, 0)
 	assert.NoError(t, err)
 

--- a/test/integration/fscust_test.go
+++ b/test/integration/fscust_test.go
@@ -1,0 +1,65 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var fsCustConfigFmt = `{
+  "name": "fs-customizations from local file",
+  "blueprint": {
+    "customizations": {
+      "files": [
+	{
+	  "path": "/etc/file-from-host",
+	  "uri": "file://%s"
+	}
+      ]
+    }
+  }
+}
+`
+
+func TestFileCustomizationFromURI(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("this test needs to run as root")
+	}
+
+	tmpdir := t.TempDir()
+	canaryString := "testdata"
+	canaryPath := filepath.Join(tmpdir, "canary.txt")
+	err := os.WriteFile(canaryPath, []byte(canaryString), 0644)
+	assert.NoError(t, err)
+	buildConfigPath := filepath.Join(tmpdir, "buildConfig.json")
+	err = os.WriteFile(buildConfigPath, []byte(fmt.Sprintf(fsCustConfigFmt, canaryPath)), 0644)
+	assert.NoError(t, err)
+
+	cmd := exec.Command(
+		"go", "run", "./cmd/build",
+		"-distro", "centos-10",
+		"-type", "tar",
+		"-config", buildConfigPath,
+		"--output", tmpdir,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Dir = "../.."
+	err = cmd.Run()
+	assert.NoError(t, err)
+
+	// using ibcli would make this easier as we have --output-name here
+	l, err := filepath.Glob(tmpdir + "/*/archive/*.tar.xz")
+	assert.NoError(t, err)
+	require.Equal(t, 1, len(l))
+
+	// ensure we get the expected content from the locally added file
+	output, err := exec.Command("tar", "xOf", l[0], "./etc/file-from-host").CombinedOutput()
+	assert.NoError(t, err, "tar output: %s", output)
+	assert.Equal(t, canaryString, string(output))
+}


### PR DESCRIPTION
[build on top of https://github.com/osbuild/images/pull/1157]

Followup for https://github.com/osbuild/images/pull/1157#discussion_r2163501911 that implements "http{,s}" on top of the new "uri" support in file customizations in blueprints.

[There is a bit of discussion around this approach in https://github.com/osbuild/images/pull/1157#discussion_r2162113654 just FTR]

Note that there is a concern about that with this PR for external URIs we will have to fetch the external files twice:
1. when we calculate the hash of the external URI
2. when we actually build the image

In the common case, i.e. when one just runs "ibcli build" this is wasteful as manifest generation and build are happening right away. So we probably should think about caching, e.g. reusing the osbuild cache or add our own (if only http HEAD could give us hashes!)