### PR TITLE
docs/developer/README.md: fix link in the context of osbuild.org

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -31,7 +31,7 @@ Unit tests can be run using the standard `go test` command:
 go test ./...
 ```
 
-Integration tests run on GitLab using dynamic pipelines. See [the test README](/test/README.md) for full description.
+Integration tests run on GitLab using dynamic pipelines. See [the test README](../../test/README.md) for full description.
 
 ## Topics
 


### PR DESCRIPTION
Absolute links don't work when used in the context of osbuild.org, so we'll just use relative links.

This broke updating osbuild.org a while ago…