### PR TITLE
github/create-tag: allow passing the version when run manually

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -4,6 +4,11 @@ name: "Create and push release tag"
 
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to tag. Useful for making the first "dot" release from a rhel-x.y branch.'
+        required: false
+        default: ""
   schedule:
     - cron: "0 5 * * 1"
 
@@ -20,3 +25,4 @@ jobs:
           email: "imagebuilder-bots+imagebuilder-bot@redhat.com"
           semver: "true"
           semver_bump_type: "minor"
+          version: ${{ github.event.inputs.version }}


### PR DESCRIPTION
Modify the action to allow passing the version when run manually.  This is useful for making releases for fixes backported to older distro releases.