### PR TITLE
distro: exclude container relative packages in ami

### DIFF
--- a/pkg/distro/defs/rhel-10/distro.yaml
+++ b/pkg/distro/defs/rhel-10/distro.yaml
@@ -1121,6 +1121,23 @@ image_types:
             - "dracut-config-rescue"
             # RHBZ#2075815
             - "qemu-guest-agent"
+            # RHEL-96793
+            - "conmon"
+            - "containers-common"
+            - "containers-common-extra"
+            - "container-selinux"
+            - "criu"
+            - "criu-libs"
+            - "crun"
+            - "libnet"
+            - "libnftnl"
+            - "netavark"
+            - "nftables"
+            - "passt"
+            - "passt-selinux"
+            - "podman"
+            - "protobuf-c"
+            - "shadow-utils-subid"
           conditions:
             <<: *conditions_pkgsets_insights_client_on_rhel
 

--- a/pkg/distro/defs/rhel-9/distro.yaml
+++ b/pkg/distro/defs/rhel-9/distro.yaml
@@ -92,6 +92,31 @@
       - "dracut-config-rescue"
       # RHBZ#2075815
       - "qemu-guest-agent"
+      # RHEL-96793
+      - "aardvark-dns"
+      - "conmon"
+      - "containers-common"
+      - "container-selinux"
+      - "criu"
+      - "criu-libs"
+      - "crun"
+      - "fuse3"
+      - "fuse3-libs"
+      - "fuse-common"
+      - "fuse-overlayfs"
+      - "iptables-nft"
+      - "libnet"
+      - "libnftnl"
+      - "libslirp"
+      - "netavark"
+      - "nftables"
+      - "passt"
+      - "passt-selinux"
+      - "podman"
+      - "protobuf-c"
+      - "shadow-utils-subid"
+      - "slirp4netns"
+      - "yajl"
     conditions:
       <<: *conditions_pkgsets_insights_client_on_rhel
       "rhel-9.6+ gets system-reinstall-bootc":


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHEL-96793

Other type of images do not have container packages installed or exclude in distro files. But RHEL-10.0 and RHEL-9.6 updates AMIs have more packages than GA version which is not expected change. So exclude them in this change.