### PR TITLE
manifest: handle content template name with spaces

### DIFF
--- a/pkg/manifest/subscription.go
+++ b/pkg/manifest/subscription.go
@@ -123,7 +123,7 @@ func subscriptionService(subscriptionOptions subscription.ImageOptions, serviceO
 		if subscriptionOptions.TemplateUUID != "" {
 			curlToAssociateSystem = getCurlToAssociateSystem(subscriptionOptions)
 		} else if subscriptionOptions.TemplateName != "" {
-			rhcConnect += fmt.Sprintf(" --content-template %s", subscriptionOptions.TemplateName)
+			rhcConnect += fmt.Sprintf(" --content-template=\"%s\"", subscriptionOptions.TemplateName)
 		}
 		commands = append(commands, rhcConnect)
 		// execute the rhc post install script as the selinuxenabled check doesn't work in the buildroot container

--- a/pkg/manifest/subscription_test.go
+++ b/pkg/manifest/subscription_test.go
@@ -277,7 +277,7 @@ func TestSubscriptionService(t *testing.T) {
 				BaseUrl:       "thebaseurl-wir",
 				Insights:      true,
 				Rhc:           true,
-				TemplateName:  "template-name",
+				TemplateName:  "template name",
 			},
 			srvcOpts: nil,
 			expectedStage: &osbuild.Stage{
@@ -298,7 +298,7 @@ func TestSubscriptionService(t *testing.T) {
 						Service: &osbuild.ServiceSection{
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
-								"/usr/bin/rhc connect --organization=${ORG_ID} --activation-key=${ACTIVATION_KEY} --server theserverurl-wir --content-template template-name",
+								"/usr/bin/rhc connect --organization=${ORG_ID} --activation-key=${ACTIVATION_KEY} --server theserverurl-wir --content-template=\"template name\"",
 								"/usr/sbin/semanage permissive --add rhcd_t", // added when rhc is enabled
 								"/usr/bin/rm " + subkeyFilepath,
 							},


### PR DESCRIPTION
Fixes rhc command to support registering to content templates with or without spaces in the template name

Jira: [HMS-8657](https://issues.redhat.com/browse/HMS-8657)