### PR TITLE
[RFC] image: drop `InstallWeakDeps` from image.DiskImage

### DIFF
--- a/pkg/image/disk.go
+++ b/pkg/image/disk.go
@@ -35,10 +35,6 @@ type DiskImage struct {
 	OSProduct string
 	OSVersion string
 	OSNick    string
-
-	// InstallWeakDeps enables installation of weak dependencies for packages
-	// that are statically defined for the payload pipeline of the image.
-	InstallWeakDeps *bool
 }
 
 func NewDiskImage() *DiskImage {
@@ -64,10 +60,6 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.OSProduct = img.OSProduct
 	osPipeline.OSVersion = img.OSVersion
 	osPipeline.OSNick = img.OSNick
-
-	if img.InstallWeakDeps != nil {
-		osPipeline.OSCustomizations.InstallWeakDeps = *img.InstallWeakDeps
-	}
 
 	rawImagePipeline := manifest.NewRawImage(buildPipeline, osPipeline)
 	rawImagePipeline.PartTool = img.PartTool


### PR DESCRIPTION
This commit drops `InstallWeakDeps` from `image.DiskImage`. We already define this in `manifest.OSCustomizations` and in `distro.ImageConfig` and this var is no longer used (and actually confusing given that we have these two other places).

(adding RFC as their might be something I'm missing but I don't see what)