### PR TITLE
many: start converging images and bootc-image-builder

### DIFF
--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -155,9 +155,9 @@ func osCustomizations(t *imageType, osPackageSet rpmmd.PackageSet, options distr
 		osc.ChronyConfig = imageConfig.TimeSynchronization
 	}
 
-	// Relabel the tree, unless the `NoSElinux` flag is explicitly set to `true`
-	if imageConfig.NoSElinux == nil || imageConfig.NoSElinux != nil && !*imageConfig.NoSElinux {
-		osc.SElinux = "targeted"
+	// Relabel the tree, unless the `NoSELinux` flag is explicitly set to `true`
+	if imageConfig.NoSELinux == nil || imageConfig.NoSELinux != nil && !*imageConfig.NoSELinux {
+		osc.SELinux = "targeted"
 		osc.SELinuxForceRelabel = imageConfig.SELinuxForceRelabel
 	}
 

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -46,7 +46,7 @@ type ImageConfig struct {
 	GPGKeyFiles []string `yaml:"gpgkey_files,omitempty"`
 
 	// Disable SELinux labelling
-	NoSElinux *bool `yaml:"no_selinux,omitempty"`
+	NoSELinux *bool `yaml:"no_selinux,omitempty"`
 
 	// Do not use. Forces auto-relabelling on first boot.
 	// See https://github.com/osbuild/osbuild/commit/52cb27631b587c1df177cd17625c5b473e1e85d2

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -154,9 +154,9 @@ func osCustomizations(
 		osc.ChronyConfig = imageConfig.TimeSynchronization
 	}
 
-	// Relabel the tree, unless the `NoSElinux` flag is explicitly set to `true`
-	if imageConfig.NoSElinux == nil || imageConfig.NoSElinux != nil && !*imageConfig.NoSElinux {
-		osc.SElinux = "targeted"
+	// Relabel the tree, unless the `NoSELinux` flag is explicitly set to `true`
+	if imageConfig.NoSELinux == nil || imageConfig.NoSELinux != nil && !*imageConfig.NoSELinux {
+		osc.SELinux = "targeted"
 		osc.SELinuxForceRelabel = imageConfig.SELinuxForceRelabel
 	}
 

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -77,8 +77,8 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	livePipeline.Biosdevname = (img.Platform.GetArch() == arch.ARCH_X86_64)
 	livePipeline.Locale = img.Locale
 
-	// The live installer has SElinux enabled and targeted
-	livePipeline.SElinux = "targeted"
+	// The live installer has SELinux enabled and targeted
+	livePipeline.SELinux = "targeted"
 
 	livePipeline.Checkpoint()
 

--- a/pkg/image/bootc_disk_legacy.go
+++ b/pkg/image/bootc_disk_legacy.go
@@ -44,9 +44,9 @@ func (img *BootcLegacyDiskImage) InstantiateManifestFromContainers(m *manifest.M
 	}
 	ostreeImg.Platform = img.bootcImg.Platform
 	ostreeImg.PartitionTable = img.bootcImg.PartitionTable
-	ostreeImg.OSTreeDeploymentCustomizations.KernelOptionsAppend = img.bootcImg.KernelOptionsAppend
-	ostreeImg.OSTreeDeploymentCustomizations.Users = img.bootcImg.Users
-	ostreeImg.OSTreeDeploymentCustomizations.Groups = img.bootcImg.Groups
+	ostreeImg.OSTreeDeploymentCustomizations.KernelOptionsAppend = img.bootcImg.OSCustomizations.KernelOptionsAppend
+	ostreeImg.OSTreeDeploymentCustomizations.Users = img.bootcImg.OSCustomizations.Users
+	ostreeImg.OSTreeDeploymentCustomizations.Groups = img.bootcImg.OSCustomizations.Groups
 
 	buildPipeline := manifest.NewBuildFromContainer(m, runner, containers, &manifest.BuildOptions{ContainerBuildable: true})
 	buildPipeline.Checkpoint()

--- a/pkg/image/bootc_disk_test.go
+++ b/pkg/image/bootc_disk_test.go
@@ -76,12 +76,12 @@ func makeBootcDiskImageOsbuildManifest(t *testing.T, opts *bootcDiskImageTestOpt
 	require.NotNil(t, img)
 	img.Platform = makeFakePlatform(opts)
 	img.PartitionTable = testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
-	img.KernelOptionsAppend = opts.KernelOptionsAppend
-	img.Users = opts.Users
-	img.Groups = opts.Groups
-	img.SELinux = opts.SELinux
-	img.Files = opts.Files
-	img.Directories = opts.Directories
+	img.OSCustomizations.KernelOptionsAppend = opts.KernelOptionsAppend
+	img.OSCustomizations.Users = opts.Users
+	img.OSCustomizations.Groups = opts.Groups
+	img.OSCustomizations.SELinux = opts.SELinux
+	img.OSCustomizations.Files = opts.Files
+	img.OSCustomizations.Directories = opts.Directories
 
 	m := &manifest.Manifest{}
 	runi := &runner.Fedora{}

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -86,7 +86,7 @@ type AnacondaInstaller struct {
 	// SELinux policy, when set it enables the labeling of the installer
 	// tree with the selected profile and selects the required package
 	// for depsolving
-	SElinux string
+	SELinux string
 
 	// Locale for the installer. This should be set to the same locale as the
 	// ISO OS payload, if known.
@@ -167,8 +167,8 @@ func (p *AnacondaInstaller) getBuildPackages(Distro) []string {
 		)
 	}
 
-	if p.SElinux != "" {
-		packages = append(packages, "policycoreutils", fmt.Sprintf("selinux-policy-%s", p.SElinux))
+	if p.SELinux != "" {
+		packages = append(packages, "policycoreutils", fmt.Sprintf("selinux-policy-%s", p.SELinux))
 	}
 
 	return packages
@@ -183,8 +183,8 @@ func (p *AnacondaInstaller) getPackageSetChain(Distro) []rpmmd.PackageSet {
 		packages = append(packages, "biosdevname")
 	}
 
-	if p.SElinux != "" {
-		packages = append(packages, fmt.Sprintf("selinux-policy-%s", p.SElinux))
+	if p.SELinux != "" {
+		packages = append(packages, fmt.Sprintf("selinux-policy-%s", p.SELinux))
 	}
 
 	return []rpmmd.PackageSet{
@@ -328,10 +328,10 @@ func (p *AnacondaInstaller) payloadStages() []*osbuild.Stage {
 
 	stages = append(stages, osbuild.NewSELinuxConfigStage(&osbuild.SELinuxConfigStageOptions{State: osbuild.SELinuxStatePermissive}))
 
-	// SElinux is not supported on the non-live-installers (see the previous
+	// SELinux is not supported on the non-live-installers (see the previous
 	// stage setting SELinux to permissive. It's an error to set it to anything
 	// that isn't an empty string
-	if p.SElinux != "" {
+	if p.SELinux != "" {
 		panic("payload installers do not support SELinux policies")
 	}
 
@@ -400,9 +400,9 @@ func (p *AnacondaInstaller) liveStages() []*osbuild.Stage {
 	dracutOptions := p.dracutStageOptions()
 	stages = append(stages, osbuild.NewDracutStage(dracutOptions))
 
-	if p.SElinux != "" {
+	if p.SELinux != "" {
 		stages = append(stages, osbuild.NewSELinuxStage(&osbuild.SELinuxStageOptions{
-			FileContexts: fmt.Sprintf("etc/selinux/%s/contexts/files/file_contexts", p.SElinux),
+			FileContexts: fmt.Sprintf("etc/selinux/%s/contexts/files/file_contexts", p.SELinux),
 		}))
 	}
 

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -85,9 +85,12 @@ type OSCustomizations struct {
 	MaskedServices   []string
 	DefaultTarget    string
 
-	// SELinux policy, when set it enables the labeling of the tree with the
-	// selected profile
+	// SELinux policy, when set it enables the labeling of the
+	// tree with the selected profile
 	SELinux string
+	// BuildSELinux policy, when set it enables the labeling of
+	// the *build tree* with the selected profile
+	BuildSELinux string
 
 	SELinuxForceRelabel *bool
 

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -87,7 +87,7 @@ type OSCustomizations struct {
 
 	// SELinux policy, when set it enables the labeling of the tree with the
 	// selected profile
-	SElinux string
+	SELinux string
 
 	SELinuxForceRelabel *bool
 
@@ -253,8 +253,8 @@ func (p *OS) getPackageSetChain(Distro) []rpmmd.PackageSet {
 		customizationPackages = append(customizationPackages, "chrony")
 	}
 
-	if p.OSCustomizations.SElinux != "" {
-		customizationPackages = append(customizationPackages, fmt.Sprintf("selinux-policy-%s", p.OSCustomizations.SElinux))
+	if p.OSCustomizations.SELinux != "" {
+		customizationPackages = append(customizationPackages, fmt.Sprintf("selinux-policy-%s", p.OSCustomizations.SELinux))
 	}
 
 	if p.OSCustomizations.OpenSCAPRemediationConfig != nil {
@@ -372,8 +372,8 @@ func (p *OS) getBuildPackages(distro Distro) []string {
 	if p.OSTreeRef != "" {
 		packages = append(packages, "rpm-ostree")
 	}
-	if p.OSCustomizations.SElinux != "" {
-		packages = append(packages, "policycoreutils", fmt.Sprintf("selinux-policy-%s", p.OSCustomizations.SElinux))
+	if p.OSCustomizations.SELinux != "" {
+		packages = append(packages, "policycoreutils", fmt.Sprintf("selinux-policy-%s", p.OSCustomizations.SELinux))
 	}
 	if len(p.OSCustomizations.CloudInit) > 0 {
 		switch distro {
@@ -912,9 +912,9 @@ func (p *OS) serialize() osbuild.Pipeline {
 		}))
 	}
 
-	if p.OSCustomizations.SElinux != "" {
+	if p.OSCustomizations.SELinux != "" {
 		pipeline.AddStage(osbuild.NewSELinuxStage(&osbuild.SELinuxStageOptions{
-			FileContexts:     fmt.Sprintf("etc/selinux/%s/contexts/files/file_contexts", p.OSCustomizations.SElinux),
+			FileContexts:     fmt.Sprintf("etc/selinux/%s/contexts/files/file_contexts", p.OSCustomizations.SELinux),
 			ForceAutorelabel: p.OSCustomizations.SELinuxForceRelabel,
 		}))
 	}


### PR DESCRIPTION
image: make BootcDiskImage use `OSCustomizations` explicitly

This commit makes the OSCustomizations in BootcDiskImage
explicit instead of embedding them. This is similar to
PR#1386.

(this will require some mechanical change in bib but it allows us to re-use the osCustomizations() helper in pkg/distro/generic later)

---

pkg: rename `SElinux` -> `SELinux` for conistency

This commit changes `SElinux` -> `SELinux` for conistency, we
almost everywhere spell it SELinux so lets do it really everywhere.
