### PR TITLE
generic: apply partition mode mutation only on fedora

### DIFF
--- a/pkg/distro/generic/export_test.go
+++ b/pkg/distro/generic/export_test.go
@@ -3,6 +3,7 @@ package generic
 import (
 	"math/rand"
 
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
@@ -12,16 +13,29 @@ import (
 /* #nosec G404 */
 var rng = rand.New(rand.NewSource(0))
 
-func GetPartitionTable(it distro.ImageType) (*disk.PartitionTable, error) {
-	return it.(*imageType).getPartitionTable(&blueprint.Customizations{}, distro.ImageOptions{}, rng)
+func GetPartitionTable(it distro.ImageType, opts *distro.ImageOptions) (*disk.PartitionTable, error) {
+	if opts == nil {
+		opts = &distro.ImageOptions{}
+	}
+	return it.(*imageType).getPartitionTable(&blueprint.Customizations{}, *opts, rng)
 }
 
 func BootstrapContainerFor(it distro.ImageType) string {
 	return bootstrapContainerFor(it.(*imageType))
 }
 
-type ImageType = imageType
+type (
+	ImageType = imageType
+)
 
 func (t *imageType) GetDefaultImageConfig() *distro.ImageConfig {
 	return t.getDefaultImageConfig()
+}
+
+func MockDiskNewPartitionTable(f func(basePT *disk.PartitionTable, mountpoints []blueprint.FilesystemCustomization, imageSize uint64, mode disk.PartitioningMode, architecture arch.Arch, requiredSizes map[string]uint64, rng *rand.Rand) (*disk.PartitionTable, error)) (restore func()) {
+	saved := diskNewPartitionTable
+	diskNewPartitionTable = f
+	return func() {
+		diskNewPartitionTable = saved
+	}
 }

--- a/pkg/distro/generic/fedora_test.go
+++ b/pkg/distro/generic/fedora_test.go
@@ -1029,7 +1029,7 @@ func TestDistro_DiskCustomizationRunsValidateLayoutConstraints(t *testing.T) {
 
 func TestESP(t *testing.T) {
 	distro_test_common.TestESP(t, fedoraFamilyDistros, func(it distro.ImageType) (*disk.PartitionTable, error) {
-		return generic.GetPartitionTable(it)
+		return generic.GetPartitionTable(it, nil)
 	})
 }
 

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -129,6 +129,8 @@ func (t *imageType) BasePartitionTable() (*disk.PartitionTable, error) {
 	return t.ImageTypeYAML.PartitionTable(t.arch.distro.Name(), t.arch.name)
 }
 
+var diskNewPartitionTable = disk.NewPartitionTable
+
 func (t *imageType) getPartitionTable(customizations *blueprint.Customizations, options distro.ImageOptions, rng *rand.Rand) (*disk.PartitionTable, error) {
 	basePartitionTable, err := t.BasePartitionTable()
 	if err != nil {
@@ -160,7 +162,9 @@ func (t *imageType) getPartitionTable(customizations *blueprint.Customizations, 
 	}
 
 	partitioningMode := options.PartitioningMode
-	if t.ImageTypeYAML.RPMOSTree {
+	// XXX: on fedora we had this code, we need to keep it for
+	// compatibility
+	if t.arch.distro.DistroYAML.DistroLike == manifest.DISTRO_FEDORA && t.ImageTypeYAML.RPMOSTree {
 		// IoT supports only LVM, force it.
 		// Raw is not supported, return an error if it is requested
 		// TODO Need a central location for logic like this
@@ -171,7 +175,7 @@ func (t *imageType) getPartitionTable(customizations *blueprint.Customizations, 
 	}
 
 	mountpoints := customizations.GetFilesystems()
-	return disk.NewPartitionTable(basePartitionTable, mountpoints, imageSize, partitioningMode, t.platform.GetArch(), t.ImageTypeYAML.RequiredPartitionSizes, rng)
+	return diskNewPartitionTable(basePartitionTable, mountpoints, imageSize, partitioningMode, t.platform.GetArch(), t.ImageTypeYAML.RequiredPartitionSizes, rng)
 }
 
 func (t *imageType) getDefaultImageConfig() *distro.ImageConfig {

--- a/pkg/distro/generic/imagetype_test.go
+++ b/pkg/distro/generic/imagetype_test.go
@@ -1,0 +1,118 @@
+package generic_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/pkg/blueprint"
+	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distro/generic"
+)
+
+func TestGetPartitionTable_FedoraIoTPartitioningModeSpecialCase(t *testing.T) {
+	// witness what partition mode was used
+	var partMode disk.PartitioningMode
+	restore := generic.MockDiskNewPartitionTable(func(basePT *disk.PartitionTable, mountpoints []blueprint.FilesystemCustomization, imageSize uint64, mode disk.PartitioningMode, architecture arch.Arch, requiredSizes map[string]uint64, rng *rand.Rand) (*disk.PartitionTable, error) {
+		partMode = mode
+		return nil, nil
+	})
+	defer restore()
+
+	// TODO: ideally we would just construct a test distro
+	// based on YAML that contains "rpm_ostree: true" and
+	// "distro_like: fedora,rhel8" etc and test more targeted
+	// but currently this is (quite) cumbersome so we use this
+	// method.
+	type testCase struct {
+		distroNameVer    string
+		imageTypeName    string
+		partitioningMode disk.PartitioningMode
+		expectError      string
+		expectPartMode   disk.PartitioningMode
+	}
+	testCases := []testCase{
+		// fedora IoT error for raw mode (but not btfs :(
+		{
+			distroNameVer:    "fedora-43",
+			imageTypeName:    "iot-raw-xz",
+			partitioningMode: disk.RawPartitioningMode,
+			expectError:      "partitioning mode raw not supported for iot-raw-xz",
+		},
+		{
+			distroNameVer:    "fedora-43",
+			imageTypeName:    "iot-qcow2",
+			partitioningMode: disk.RawPartitioningMode,
+			expectError:      "partitioning mode raw not supported for iot-qcow2",
+		},
+		// fedora IoT *mutates* the partitioning mode
+		{
+			distroNameVer:    "fedora-43",
+			imageTypeName:    "iot-raw-xz",
+			partitioningMode: disk.LVMPartitioningMode,
+			expectError:      "",
+			expectPartMode:   disk.AutoLVMPartitioningMode,
+		},
+		// no modifications/mutations/errors for non-rpmostree
+		{
+			distroNameVer:    "fedora-43",
+			imageTypeName:    "server-qcow2",
+			partitioningMode: disk.RawPartitioningMode,
+			expectError:      "",
+			expectPartMode:   disk.RawPartitioningMode,
+		},
+		{
+			distroNameVer:    "fedora-43",
+			imageTypeName:    "server-qcow2",
+			partitioningMode: disk.LVMPartitioningMode,
+			expectError:      "",
+			expectPartMode:   disk.LVMPartitioningMode,
+		},
+		// no edge/iot for rhel7,10 so we only test normal
+		// images only
+		{
+			distroNameVer:    "rhel-10.1",
+			imageTypeName:    "qcow2",
+			partitioningMode: disk.RawPartitioningMode,
+			expectError:      "",
+			expectPartMode:   disk.RawPartitioningMode,
+		},
+		{
+			distroNameVer:    "rhel-7.10",
+			imageTypeName:    "ec2",
+			partitioningMode: disk.LVMPartitioningMode,
+			expectError:      "",
+			expectPartMode:   disk.LVMPartitioningMode,
+		},
+
+		// XXX: add rhel8,rhel9 once it becomes a generic
+		// distro
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s-%s-%v", tc.distroNameVer, tc.imageTypeName, tc.partitioningMode), func(t *testing.T) {
+			d := generic.DistroFactory(tc.distroNameVer)
+			require.NotNil(t, d)
+			a, err := d.GetArch("x86_64")
+			require.NoError(t, err)
+			imgType, err := a.GetImageType(tc.imageTypeName)
+			require.NoError(t, err)
+
+			opts := &distro.ImageOptions{
+				PartitioningMode: tc.partitioningMode,
+			}
+			_, err = generic.GetPartitionTable(imgType, opts)
+			if tc.expectError != "" {
+				assert.ErrorContains(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expectPartMode, partMode)
+		})
+	}
+}


### PR DESCRIPTION
This commit fixes an issue that we currently mutate the partitioning mode for any images that uses rpm_ostree to AutoLVMPartitioningMode.

This will be a problem when we move to rhel8 where we have the opposite - for the `edge-raw-image` there we disallow `lvm` and `auto-lvm`.

So this commit changes the partition table code to only mutate the partitioning mode when fedora is used and add tests (this almost went unnoticed as we had no tests for this area and the manifest tests generate a partition table but do not capture the partitioning mode directly).

The mutation is problematic, ideally we would instead just use `unsupported_partitioning_mode` for IoT on fedora but that is a backwards incompatible change as currently one can pass `BtrfsPartitioningMode`
to IoT on fedora and it will silently convert it to `AutoLVMPartitioningMode`.

C.f. PR#1643