### PR TITLE
distro: add support for `supported_partitioning_modes`

### DIFF
--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -38,6 +38,13 @@
       - "rw"
       - "coreos.no_persist_ip"
 
+  rpm_ostree_imgtype_common: &rpm_ostree_imgtype_common
+    rpm_ostree: true
+    supported_partitioning_modes:
+      - ""  # empty string means default partitioning mode
+      - "auto-lvm"
+      - "lvm"
+
   environments:
     kvm: &kvm_env
       packages:
@@ -747,10 +754,10 @@ image_types:
   # NOTE: keep in sync with official fedora-iot definitions:
   # https://pagure.io/fedora-iot/ostree/blob/main/f/fedora-iot-base.yaml
   "iot-commit": &iot_commit
+    <<: *rpm_ostree_imgtype_common
     name_aliases: ["fedora-iot-commit"]
     filename: "commit.tar"
     mime_type: "application/x-tar"
-    rpm_ostree: true
     image_func: "iot_commit"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "ostree-commit", "commit-archive"]
@@ -911,7 +918,6 @@ image_types:
     name_aliases: ["fedora-iot-container"]
     filename: "container.tar"
     mime_type: "application/x-tar"
-    rpm_ostree: true
     image_func: "iot_container"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "ostree-commit", "container-tree", "container"]
@@ -922,12 +928,12 @@ image_types:
       - *aarch64_installer_platform
 
   "iot-raw-xz":
+    <<: *rpm_ostree_imgtype_common
     name_aliases: ["iot-raw-image", "fedora-iot-raw-image"]
     filename: "image.raw.xz"
     compression: "xz"
     mime_type: "application/xz"
     default_size: 4_294_967_296  # 4 * datasizes.GibiByte
-    rpm_ostree: true
     bootable: true
     image_func: "iot"
     ostree:
@@ -1002,11 +1008,11 @@ image_types:
                 - *iot_base_partition_table_part_root_fstab_ro_aarch64
 
   "iot-qcow2":
+    <<: *rpm_ostree_imgtype_common
     name_aliases: ["iot-qcow2-image"]
     filename: "image.qcow2"
     mime_type: "application/x-qemu-disk"
     default_size: 10_737_418_240  # 10 * datasizes.GibiByte
-    rpm_ostree: true
     bootable: true
     image_func: "iot"
     ostree:
@@ -1031,9 +1037,9 @@ image_types:
         qcow2_compat: "1.1"
 
   "iot-bootable-container":
+    <<: *rpm_ostree_imgtype_common
     filename: "iot-bootable-container.tar"
     mime_type: "application/x-tar"
-    rpm_ostree: true
     image_func: "bootable_container"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "ostree-commit", "ostree-encapsulate"]
@@ -1468,10 +1474,10 @@ image_types:
                   - "dmidecode"
 
   "iot-installer":
+    <<: *rpm_ostree_imgtype_common
     name_aliases: ["fedora-iot-installer"]
     filename: "installer.iso"
     mime_type: "application/x-iso9660-image"
-    rpm_ostree: true
     boot_iso: true
     image_func: "iot_installer"
     iso_label: "IoT"
@@ -1807,9 +1813,9 @@ image_types:
                   - "fuse-libs"
 
   "iot-simplified-installer":
+    <<: *rpm_ostree_imgtype_common
     filename: "simplified-installer.iso"
     mime_type: "application/x-iso9660-image"
-    rpm_ostree: true
     bootable: true
     boot_iso: true
     default_size: 10_737_418_240  # 10 * datasizes.GibiByte

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -361,6 +361,8 @@ type ImageTypeYAML struct {
 	DiskImagePartTool     *osbuild.PartTool `yaml:"disk_image_part_tool"`
 	DiskImageVPCForceSize *bool             `yaml:"disk_image_vpc_force_size"`
 
+	SupportedPartitioningModes []disk.PartitioningMode `yaml:"supported_partitioning_modes"`
+
 	// name is set by the loader
 	name string
 }


### PR DESCRIPTION
This commit adds support for supported_partitioning_modes via YAML so that the RHEL-8 constraints for "edge-raw-image" and "edge-simplified-installer" can be expressed.

Note that the rhel code is using `unsupportedPartitionModes` but the downside of that approach is that every time a new mode is added there is a risk of forgeting to update the list of unsupported modes (this happend e.g. when we added btrfs partitioning and the unsupported partition modes list was not updated for rhel8).

We also add the new `supported_partitioning_types` mode into the fedora YAML distro definitions and drop the custom code to validate/mutate the partitioning for rpm_ostree from the go code, the discussion from
https://github.com/osbuild/images/pull/1654 is that we can drop the mutation entirely and just rely on the check. Technically this is a change in behavior, but arguably this is fixing a bug because without this change we one could specify a btrfs partitioning mode for IoT and get AutoLVM instead.

This is covered by the TestFedoraDistro_PartioningModeConstraints test.

Alternative version to https://github.com/osbuild/images/pull/1654 as suggested by @thozza (thanks!)