### PR TITLE
distro: add conditionals when ignoring image_types for a distro

### DIFF
--- a/pkg/distro/defs/distros.yaml
+++ b/pkg/distro/defs/distros.yaml
@@ -81,6 +81,18 @@ distros:
         - "platform-python"  # osbuild
         - "systemd"  # systemd-tmpfiles and systemd-sysusers
         - "python3"  # osbuild stages
+    conditions:
+      "some image types are rhel-only":
+        when:
+          not_distro_name: "rhel"
+        ignore_image_types:
+          - azure-cvm
+          - azure-rhui
+          - azure-sap-rhui
+          - azure-sapapps-rhui
+          - ec2
+          - ec2-sap
+          - ec2-ha
     # rhel9 & cs9 share the same list
     # of allowed profiles so a single
     # allow list can be used
@@ -111,6 +123,7 @@ distros:
     iso_label_tmpl: "AlmaLinux-{{.Distro.MajorVersion}}-{{.Distro.MinorVersion}}-{{.Arch}}-dvd"
 
   - &centos10
+    <<: *rhel10
     name: centos-10
     distro_like: rhel-10
     product: "CentOS Stream"
@@ -122,14 +135,6 @@ distros:
     default_fs_type: "xfs"
     defs_path: rhel-10
     iso_label_tmpl: "CentOS-Stream-{{.Distro.MajorVersion}}-BaseOS-{{.Arch}}"
-    ignore_image_types:
-      - azure-cvm
-      - azure-rhui
-      - azure-sap-rhui
-      - azure-sapapps-rhui
-      - ec2
-      - ec2-sap
-      - ec2-ha
     runner:
       name: org.osbuild.centos10
       build_packages:

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -101,7 +101,7 @@ type DistroYAML struct {
 	imageConfig *distro.ImageConfig `yaml:"default"`
 
 	// ignore the given image types
-	IgnoreImageTypes []string `yaml:"ignore_image_types"`
+	Conditions map[string]distroConditions `yaml:"conditions"`
 
 	// XXX: remove this in favor of a better abstraction, this
 	// is currently needed because the manifest pkg has conditionals
@@ -119,6 +119,18 @@ func (d *DistroYAML) ImageTypes() map[string]ImageTypeYAML {
 // Each ImageType gets this as their default ImageConfig.
 func (d *DistroYAML) ImageConfig() *distro.ImageConfig {
 	return d.imageConfig
+}
+
+func (d *DistroYAML) SkipImageType(imgTypeName, archName string) bool {
+	id := common.Must(distro.ParseID(d.Name))
+
+	for _, cond := range d.Conditions {
+		if cond.When.Eval(id, archName) && slices.Contains(cond.IgnoreImageTypes, imgTypeName) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (d *DistroYAML) runTemplates(nameVer string) error {
@@ -216,9 +228,6 @@ func NewDistroYAML(nameVer string) (*DistroYAML, error) {
 	if len(toplevel.ImageTypes) > 0 {
 		foundDistro.imageTypes = make(map[string]ImageTypeYAML, len(toplevel.ImageTypes))
 		for name := range toplevel.ImageTypes {
-			if slices.Contains(foundDistro.IgnoreImageTypes, name) {
-				continue
-			}
 			v := toplevel.ImageTypes[name]
 			v.name = name
 			if err := v.runTemplates(foundDistro); err != nil {
@@ -252,6 +261,7 @@ type distroImageConfig struct {
 // multiple whenConditions are considred AND
 type whenCondition struct {
 	DistroName            string `yaml:"distro_name,omitempty"`
+	NotDistroName         string `yaml:"not_distro_name,omitempty"`
 	Architecture          string `yaml:"arch,omitempty"`
 	VersionLessThan       string `yaml:"version_less_than,omitempty"`
 	VersionGreaterOrEqual string `yaml:"version_greater_or_equal,omitempty"`
@@ -263,6 +273,9 @@ func (wc *whenCondition) Eval(id *distro.ID, archStr string) bool {
 
 	if wc.DistroName != "" {
 		match = match && (wc.DistroName == id.Name)
+	}
+	if wc.NotDistroName != "" {
+		match = match && (wc.NotDistroName != id.Name)
 	}
 	if wc.Architecture != "" {
 		match = match && (wc.Architecture == archStr)
@@ -304,6 +317,11 @@ func (di *distroImageConfig) For(nameVer string) (*distro.ImageConfig, error) {
 type distroImageConfigConditions struct {
 	When         whenCondition       `yaml:"when,omitempty"`
 	ShallowMerge *distro.ImageConfig `yaml:"shallow_merge,omitempty"`
+}
+
+type distroConditions struct {
+	When             *whenCondition `yaml:"when"`
+	IgnoreImageTypes []string       `yaml:"ignore_image_types"`
 }
 
 type ImageTypeYAML struct {

--- a/pkg/distro/generic/distro.go
+++ b/pkg/distro/generic/distro.go
@@ -102,6 +102,9 @@ func newDistro(nameVer string) (distro.Distro, error) {
 				ar = newArchitecture(rd, pl.Arch.String())
 				rd.arches[pl.Arch.String()] = ar
 			}
+			if distroYAML.SkipImageType(imgTypeYAML.Name(), pl.Arch.String()) {
+				continue
+			}
 			it := newImageTypeFrom(rd, ar, imgTypeYAML)
 			if err := ar.addImageType(&pl, it); err != nil {
 				return nil, err


### PR DESCRIPTION
This commit adds the ability to skip image types bases on conditions on the distro level. This solves two problems:
1. At the rhel distro level we now define that some image types like "ec2" are only relevant for rhel and all derrived distros use this.
2. When we move rhel8 to the generic distro we will be able to express that certain image types like "azure-eap7-rhui" are only availalbe after version 8.6 or "vhd" for arm64 is only available after 8.6 [0]

As part of the commit the ignore_image_types list is moved to rhel then and a `not_distro_name` in the condition is added so that we can express:
```yaml
    conditions:
      "some image types are rhel-only":
        when:
          not_distro_name: "rhel"
        ignore_image_types:
          - azure-cvm
```

Extracted and cleaned up from PR#1643

[0] See https://github.com/osbuild/images/pull/1643/files#diff-60186016b8822c15f8962540442db9bd32acfb5fc8c7d50655873395f0a3aca0R172