### PR TITLE
manifest-gen: add `-buildconfig-allow-unknown` flag

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -51,7 +51,7 @@ func run() error {
 	}
 
 	distroFac := distrofactory.NewDefault()
-	config, err := buildconfig.New(configFile)
+	config, err := buildconfig.New(configFile, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -168,7 +168,7 @@ func loadConfigMap(configPath string) *BuildConfigs {
 			cfgDir := filepath.Dir(configPath)
 			path = filepath.Join(cfgDir, path)
 		}
-		config, err := buildconfig.New(path)
+		config, err := buildconfig.New(path, nil)
 		if err != nil {
 			panic(err)
 		}
@@ -192,7 +192,7 @@ func loadConfigMap(configPath string) *BuildConfigs {
 // image types.
 func loadImgConfig(configPath string) *BuildConfigs {
 	cm := newBuildConfigs()
-	config, err := buildconfig.New(configPath)
+	config, err := buildconfig.New(configPath, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/buildconfig/buildconfig_test.go
+++ b/internal/buildconfig/buildconfig_test.go
@@ -1,0 +1,93 @@
+package buildconfig_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/internal/buildconfig"
+	"github.com/osbuild/images/pkg/blueprint"
+	"github.com/osbuild/images/pkg/distro"
+)
+
+func makeConfig(t *testing.T, content string) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "config.json")
+	err := os.WriteFile(tmpFile, []byte(content), 0644)
+	require.NoError(t, err)
+	return tmpFile
+}
+
+func TestNew_Success(t *testing.T) {
+	content := `{
+		"name": "test-image",
+		"blueprint": {
+			"name": "bp"
+		},
+		"options": {
+			"size": 1234
+		}
+	}`
+	path := makeConfig(t, content)
+
+	conf, err := buildconfig.New(path, nil)
+	require.NoError(t, err)
+	assert.Equal(t, &buildconfig.BuildConfig{
+		Name: "test-image",
+		Blueprint: &blueprint.Blueprint{
+			Name: "bp",
+		},
+		Options: distro.ImageOptions{
+			Size: uint64(1234),
+		},
+	}, conf)
+}
+
+func TestNew_InvalidJSON(t *testing.T) {
+	content := `{invalid json}`
+	path := makeConfig(t, content)
+
+	_, err := buildconfig.New(path, nil)
+	assert.ErrorContains(t, err, "cannot decode build config: ")
+}
+
+func TestNew_ExtraData(t *testing.T) {
+	content := `{
+		"name": "test",
+		"options": {}
+	} {"name": "extra", "options": {}}`
+	path := makeConfig(t, content)
+
+	_, err := buildconfig.New(path, nil)
+	assert.ErrorContains(t, err, "multiple configuration objects or extra data found in ")
+}
+
+func TestNew_UnknownFields(t *testing.T) {
+	content := `{
+		"name": "test",
+		"options": {},
+		"unknown": 42
+	}`
+	for _, tc := range []struct {
+		opts        *buildconfig.Options
+		expectedErr string
+	}{
+		{nil, `cannot decode build config: json: unknown field "unknown"`},
+		{&buildconfig.Options{AllowUnknownFields: false}, `cannot decode build config: json: unknown field "unknown"`},
+		{&buildconfig.Options{AllowUnknownFields: true}, ""},
+	} {
+		path := makeConfig(t, content)
+
+		_, err := buildconfig.New(path, tc.opts)
+		if tc.expectedErr == "" {
+			assert.NoError(t, err)
+		} else {
+			assert.EqualError(t, err, tc.expectedErr)
+		}
+	}
+}


### PR DESCRIPTION
This commit adds support for `-buildconfig-allow-unknown` that
allows to turn off stict unmarshal mode in json for the configs
in test/ - this is useful in `gen-manifests-diff` where we always
run the "old" gen-manifests against the new branch. If the new
code contains unknown (to the old code) fields it errors. With
this new addition we can run the "old" gen-manifest with
`-buildconfig-allow-unknown` and the new one without.

This allows us to diff manifests even if the build config changes,
like in PR#1656 where `distro.ImageOptions` grows a new
`Bootc` option (similar to OSTree).

---

buildconfig: add option to allow unknown fields

This commit adds an option to allow unknown fields when reading the
build config. This is important for "gen-manifests-diff" when it
needs to read configs that contain potentially new fields.

