### PR TITLE
customizations/subscription: conditionally enable semanage call

### DIFF
--- a/pkg/customizations/subscription/subscription.go
+++ b/pkg/customizations/subscription/subscription.go
@@ -15,6 +15,7 @@ type ImageOptions struct {
 	BaseUrl       string `json:"base_url"`
 	Insights      bool   `json:"insights"`
 	Rhc           bool   `json:"rhc"`
+	PermissiveRHC bool   `json:"permissive_rhc"`
 	Proxy         string `json:"proxy"`
 	TemplateName  string `json:"template_name"`
 	TemplateUUID  string `json:"template_uuid"`

--- a/pkg/distro/rhel/images.go
+++ b/pkg/distro/rhel/images.go
@@ -3,6 +3,7 @@ package rhel
 import (
 	"fmt"
 	"math/rand"
+	"slices"
 
 	"github.com/osbuild/images/internal/workload"
 	"github.com/osbuild/images/pkg/blueprint"
@@ -245,6 +246,8 @@ func osCustomizations(
 		if options.Subscription.Proxy != "" {
 			osc.InsightsClientConfig = &osbuild.InsightsClientConfigStageOptions{Config: osbuild.InsightsClientConfig{Proxy: options.Subscription.Proxy}}
 		}
+		// selinux policy for rhc is set in registration service on rhel 9 and 10
+		options.Subscription.PermissiveRHC = slices.Contains([]string{"9", "10"}, t.Arch().Distro().Releasever())
 	} else {
 		subscriptionStatus = subscription.RHSMConfigNoSubscription
 	}

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -113,6 +113,7 @@ func TestRhcInsightsCommands(t *testing.T) {
 		BaseUrl:       "http://cdn.redhat.com/",
 		Insights:      false,
 		Rhc:           true,
+		PermissiveRHC: true,
 	}
 	pipeline := os.Serialize()
 	CheckSystemdStageOptions(t, pipeline.Stages, []string{

--- a/pkg/manifest/subscription.go
+++ b/pkg/manifest/subscription.go
@@ -126,8 +126,10 @@ func subscriptionService(subscriptionOptions subscription.ImageOptions, serviceO
 			rhcConnect += fmt.Sprintf(" --content-template=\"%s\"", subscriptionOptions.TemplateName)
 		}
 		commands = append(commands, rhcConnect)
-		// execute the rhc post install script as the selinuxenabled check doesn't work in the buildroot container
-		commands = append(commands, "/usr/sbin/semanage permissive --add rhcd_t")
+		if subscriptionOptions.PermissiveRHC {
+			// execute the rhc post install script as the selinuxenabled check doesn't work in the buildroot container
+			commands = append(commands, "/usr/sbin/semanage permissive --add rhcd_t")
+		}
 		// register to template if template uuid is specified
 		if curlToAssociateSystem != "" {
 			commands = append(commands, curlToAssociateSystem)

--- a/pkg/manifest/subscription_test.go
+++ b/pkg/manifest/subscription_test.go
@@ -177,7 +177,7 @@ func TestSubscriptionService(t *testing.T) {
 			expectedDirs:     make([]*fsnode.Directory, 0),
 			expectedServices: []string{serviceFilename},
 		},
-		"with-rhc": {
+		"with-rhc-no-permissive": {
 			subOpts: subscription.ImageOptions{
 				Organization:  "theorg-wr",
 				ActivationKey: "thekey-wr",
@@ -185,6 +185,7 @@ func TestSubscriptionService(t *testing.T) {
 				BaseUrl:       "thebaseurl-wr",
 				Insights:      false,
 				Rhc:           true,
+				PermissiveRHC: false,
 			},
 			srvcOpts: nil,
 			expectedStage: &osbuild.Stage{
@@ -206,7 +207,6 @@ func TestSubscriptionService(t *testing.T) {
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
 								"/usr/bin/rhc connect --organization=${ORG_ID} --activation-key=${ACTIVATION_KEY} --server theserverurl-wr",
-								"/usr/sbin/semanage permissive --add rhcd_t", // added when rhc is enabled
 								"/usr/bin/rm " + subkeyFilepath,
 							},
 							EnvironmentFile: []string{
@@ -231,6 +231,7 @@ func TestSubscriptionService(t *testing.T) {
 				BaseUrl:       "thebaseurl-wir",
 				Insights:      true,
 				Rhc:           true,
+				PermissiveRHC: true,
 			},
 			srvcOpts: nil,
 			expectedStage: &osbuild.Stage{
@@ -277,6 +278,7 @@ func TestSubscriptionService(t *testing.T) {
 				BaseUrl:       "thebaseurl-wir",
 				Insights:      true,
 				Rhc:           true,
+				PermissiveRHC: true,
 				TemplateName:  "template name",
 			},
 			srvcOpts: nil,
@@ -324,6 +326,7 @@ func TestSubscriptionService(t *testing.T) {
 				BaseUrl:       "thebaseurl-wir",
 				Insights:      true,
 				Rhc:           true,
+				PermissiveRHC: true,
 				TemplateName:  "template-name",
 				TemplateUUID:  "template-uuid",
 				Proxy:         "proxy-url",


### PR DESCRIPTION
Only set rhcd_t to permissive on rhel 9 and 10. The selinux module is
missing on rhel 8.
