### PR TITLE
defs: add missing `bootstrap_containers`

### DIFF
--- a/pkg/distro/defs/distros.yaml
+++ b/pkg/distro/defs/distros.yaml
@@ -112,6 +112,11 @@ distros:
       - "xccdf_org.ssgproject.content_profile_pci-dss"
       - "xccdf_org.ssgproject.content_profile_stig"
       - "xccdf_org.ssgproject.content_profile_stig_gui"
+    bootstrap_containers:
+      x86_64: "registry.access.redhat.com/ubi{{.MajorVersion}}/ubi:latest"
+      aarch64: "registry.access.redhat.com/ubi{{.MajorVersion}}/ubi:latest"
+      ppc64le: "registry.access.redhat.com/ubi{{.MajorVersion}}/ubi:latest"
+      s390x: "registry.access.redhat.com/ubi{{.MajorVersion}}/ubi:latest"
 
   - <<: *rhel10
     name: "almalinux-{{.MajorVersion}}.{{.MinorVersion}}"
@@ -138,6 +143,11 @@ distros:
       name: org.osbuild.centos10
       build_packages: *rhel10_runner_build_packages
     oscap_profiles_allowlist: *oscap_profile_allowlist_rhel
+    bootstrap_containers:
+      # we need the toolbox container because stock centos has e.g. no
+      # mount util
+      x86_64: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
+      aarch64: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
 
   - <<: *centos10
     name: "almalinux_kitten-10"
@@ -310,3 +320,7 @@ distros:
         # https://github.com/osbuild/osbuild/blob/ea8261cad6c5c606c00c0f2824c3f483c01a0cc9/runners/org.osbuild.rhel82#L61
         # Install python36 explicitly for RHEL 8.
         - "python36"
+    bootstrap_containers:
+      x86_64: "registry.access.redhat.com/ubi{{.MajorVersion}}/ub i:latest"
+      ppc64le: "registry.access.redhat.com/ubi{{.MajorVersion}}/ubi:latest"
+      s390x: "registry.access.redhat.com/ubi{{.MajorVersion}}/ubi:latest"

--- a/pkg/distro/generic/distro_test.go
+++ b/pkg/distro/generic/distro_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/images/pkg/distro/defs"
+	testrepos "github.com/osbuild/images/test/data/repositories"
 )
 
 func TestISOLabel(t *testing.T) {
@@ -24,4 +25,21 @@ func TestISOLabel(t *testing.T) {
 
 	isoLabelFunc := d.getISOLabelFunc("iso-label")
 	assert.Equal(t, "name:rhel,major:9,minor:1,product:some-product,arch:some-arch,iso-label:iso-label", isoLabelFunc(imgType))
+}
+
+func TestBootstrapContainers(t *testing.T) {
+	repos, err := testrepos.New()
+	assert.NoError(t, err)
+
+	for _, distroName := range repos.ListDistros() {
+		t.Run(distroName, func(t *testing.T) {
+			d := DistroFactory(distroName)
+			// TODO: remove once everthing is a generic distro
+			if d == nil {
+				t.Skipf("%s not a generic distro yet", distroName)
+			}
+			assert.NotNil(t, d)
+			assert.NotEmpty(t, d.(*distribution).DistroYAML.BootstrapContainers)
+		})
+	}
 }


### PR DESCRIPTION
This commit re-adds the `bootstrap_containers` for rhel{7,10}.