### PR TITLE
distros: de-duplicate runner build packages for centos10

### DIFF
--- a/pkg/distro/defs/distros.yaml
+++ b/pkg/distro/defs/distros.yaml
@@ -76,7 +76,7 @@ distros:
     iso_label_tmpl: "RHEL-{{.Distro.MajorVersion}}-{{.Distro.MinorVersion}}-0-BaseOS-{{.Arch}}"
     runner:
       name: "org.osbuild.rhel{{.MajorVersion}}{{.MinorVersion}}"
-      build_packages: &rhel_runner_build_packages
+      build_packages: &rhel10_runner_build_packages
         - "glibc"  # ldconfig
         - "platform-python"  # osbuild
         - "systemd"  # systemd-tmpfiles and systemd-sysusers
@@ -137,11 +137,7 @@ distros:
     iso_label_tmpl: "CentOS-Stream-{{.Distro.MajorVersion}}-BaseOS-{{.Arch}}"
     runner:
       name: org.osbuild.centos10
-      build_packages:
-        - "glibc"  # ldconfig
-        - "platform-python"  # osbuild
-        - "systemd"  # systemd-tmpfiles and systemd-sysusers
-        - "python3"  # osbuild stages
+      build_packages: *rhel10_runner_build_packages
     oscap_profiles_allowlist: *oscap_profile_allowlist_rhel10
 
   - <<: *centos10


### PR DESCRIPTION
The centos10 runner has the same build package set as rhel10, just re-use that.