### PR TITLE
github: disable Go dep updates through dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,3 @@
-# Basic test trying dependabot
 ---
 
 version: 2
@@ -12,16 +11,3 @@ updates:
       time: "04:00"
     open-pull-requests-limit: 5
     rebase-strategy: "disabled"
-
-  # Maintain dependencies for Go
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      time: "04:00"
-    groups:
-      go-deps:
-        patterns:
-          - "*"  # group all dependency updates into one PR
-    open-pull-requests-limit: 1
-    rebase-strategy: "auto"


### PR DESCRIPTION
We now use gobump to manage Go dependencies.  gobump supports holding back dependency updates that require newer go compiler versions than the one specified in the project's go.mod.