### PR TITLE
disk: Add support for raw partitions,  custom types and UKIBoot partition layout

### DIFF
--- a/pkg/blueprint/disk_customizations.go
+++ b/pkg/blueprint/disk_customizations.go
@@ -370,7 +370,7 @@ func (v *PartitionCustomization) UnmarshalTOML(data any) error {
 //   - Plain filesystem types are valid for the partition type
 //   - All non-empty properties are valid for the partition type (e.g.
 //     LogicalVolumes is empty when the type is "plain" or "btrfs")
-//   - Filesystems with FSType set to "swap" do not specify a mountpoint.
+//   - Filesystems with FSType set to "none" or "swap" do not specify a mountpoint.
 //
 // Note that in *addition* consumers should also call
 // ValidateLayoutConstraints() to validate that the policy for disk
@@ -593,6 +593,14 @@ func (p *PartitionCustomization) ValidatePartitionLabel(ptType string) error {
 }
 
 func (p *PartitionCustomization) validatePlain(mountpoints map[string]bool) error {
+	if p.FSType == "none" {
+		// make sure the mountpoint is empty and return
+		if p.Mountpoint != "" {
+			return fmt.Errorf("mountpoint for none partition must be empty (got %q)", p.Mountpoint)
+		}
+		return nil
+	}
+
 	if p.FSType == "swap" {
 		// make sure the mountpoint is empty and return
 		if p.Mountpoint != "" {

--- a/pkg/blueprint/disk_customizations_test.go
+++ b/pkg/blueprint/disk_customizations_test.go
@@ -863,6 +863,25 @@ func TestPartitioningValidation(t *testing.T) {
 			},
 			expectedMsg: "invalid partitioning customizations:\nunknown partition type: what",
 		},
+		"unhappy-none-with-mountpoint": {
+			partitioning: &blueprint.DiskCustomization{
+				Partitions: []blueprint.PartitionCustomization{
+					{
+						FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+							FSType:     "ext4",
+							Mountpoint: "/home",
+						},
+					},
+					{
+						FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+							FSType:     "none",
+							Mountpoint: "/none",
+						},
+					},
+				},
+			},
+			expectedMsg: "invalid partitioning customizations:\nmountpoint for none partition must be empty (got \"/none\")",
+		},
 		"unhappy-swap-with-mountpoint": {
 			partitioning: &blueprint.DiskCustomization{
 				Partitions: []blueprint.PartitionCustomization{

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -1427,6 +1427,8 @@ func addPlainPartition(pt *PartitionTable, partition blueprint.PartitionCustomiz
 			typeName = "usr"
 		case partition.Mountpoint == "/boot":
 			typeName = "boot"
+		case fstype == "none":
+			typeName = "data"
 		case fstype == "swap":
 			typeName = "swap"
 		default:
@@ -1441,6 +1443,8 @@ func addPlainPartition(pt *PartitionTable, partition blueprint.PartitionCustomiz
 
 	var payload PayloadEntity
 	switch fstype {
+	case "none":
+		payload = nil
 	case "swap":
 		payload = &Swap{
 			Label:        partition.Label,


### PR DESCRIPTION
This pull-request  adds the capability to create raw (unformatted) partitions, for custom boot setups that require partitions with specific GPT types but without a filesystem (e.g: ukiboot).

It also adds the specific GPT type UUIDs for UKIBoot (UKIBootPartitionUUID) and the UKIBoot control (UKIBootCtlPartitionUUID) partition types. And the logic to properly map these types with the UKIBoot partitions, based on their labels.

Having this support will allow bootc-image-builder to embedded customization files to generate images that can be booted using UKIBoot.