### PR TITLE
distro: set `distro.ID` in `DistroYAML` by loader

### DIFF
--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -119,8 +119,7 @@ image_types:
 `
 	it := makeTestImageType(t, fakePkgsSetYaml)
 
-	pkgSet, err := it.PackageSets("test-distro-1", "x86_64")
-	assert.NoError(t, err)
+	pkgSet := it.PackageSets(distro.ID{Name: "test-distro", MajorVersion: 1}, "x86_64")
 	assert.Equal(t, map[string]rpmmd.PackageSet{
 		"os": {
 			Include: []string{"from-condition-inc2", "inc1"},
@@ -209,8 +208,7 @@ image_types:
 `
 	it := makeTestImageType(t, fakePkgsSetYaml)
 
-	pkgSet, err := it.PackageSets("test-distro-1", "x86_64")
-	assert.NoError(t, err)
+	pkgSet := it.PackageSets(distro.ID{Name: "test-distro", MajorVersion: 1}, "x86_64")
 	assert.Equal(t, map[string]rpmmd.PackageSet{
 		"os": {
 			Include: []string{"from-base-condition-inc", "from-base-inc", "from-condition-inc", "from-other-type-inc", "from-type-inc"},
@@ -264,7 +262,7 @@ image_types:
 `
 	it := makeTestImageType(t, fakeDistroYaml)
 
-	partTable, err := it.PartitionTable("test-distro-1", "test_arch")
+	partTable, err := it.PartitionTable(distro.ID{Name: "test-distro", MajorVersion: 1}, "test_arch")
 	require.NoError(t, err)
 	assert.Equal(t, &disk.PartitionTable{
 		Size: 1_000_000_000,
@@ -381,7 +379,7 @@ image_types:
 func TestDefsPartitionTableOverrideGreatEqual(t *testing.T) {
 	it := makeTestImageType(t, fakeImageTypesYaml)
 
-	partTable, err := it.PartitionTable("test-distro-1", "test_arch")
+	partTable, err := it.PartitionTable(distro.ID{Name: "test-distro", MajorVersion: 1}, "test_arch")
 	require.NoError(t, err)
 	assert.Equal(t, &disk.PartitionTable{
 		Size: 1_000_000_000,
@@ -441,7 +439,7 @@ image_types:
 `
 	it := makeTestImageType(t, fakeDistroYaml)
 
-	partTable, err := it.PartitionTable("test-distro-1", "test_arch")
+	partTable, err := it.PartitionTable(distro.ID{Name: "test-distro", MajorVersion: 1}, "test_arch")
 	require.NoError(t, err)
 	assert.Equal(t, &disk.PartitionTable{
 		Size: 1_000_000_000,
@@ -488,7 +486,7 @@ image_types:
 `
 	it := makeTestImageType(t, fakeDistroYaml)
 
-	partTable, err := it.PartitionTable("test-distro-1", "test_arch")
+	partTable, err := it.PartitionTable(distro.ID{Name: "test-distro", MajorVersion: 1}, "test_arch")
 	require.NoError(t, err)
 	assert.Equal(t, &disk.PartitionTable{
 		Partitions: []disk.Partition{
@@ -552,7 +550,7 @@ image_types:
 	} {
 		it := makeTestImageType(t, tc.badYaml)
 
-		_, err := it.PartitionTable("test-distro-1", "test_arch")
+		_, err := it.PartitionTable(distro.ID{Name: "test-distro", MajorVersion: 1}, "test_arch")
 		assert.ErrorIs(t, err, tc.expectedErr)
 	}
 }
@@ -595,8 +593,7 @@ image_types:
 `
 	it := makeTestImageType(t, fakeDistroYaml)
 
-	imgConfig, err := it.ImageConfig("test-distro-1", "test_arch")
-	require.NoError(t, err)
+	imgConfig := it.ImageConfig(distro.ID{Name: "test-distro", MajorVersion: 1, MinorVersion: -1}, "test_arch")
 	assert.Equal(t, &distro.ImageConfig{
 		Hostname:      common.ToPtr("test-arch-hn"),
 		Locale:        common.ToPtr("en_US.UTF-8"),
@@ -702,8 +699,7 @@ image_types:
 func TestImageTypeInstallerConfig(t *testing.T) {
 	it := makeTestImageType(t, fakeDistroYamlInstallerConf)
 
-	installerConfig, err := it.InstallerConfig("test-distro-1", "test_arch")
-	require.NoError(t, err)
+	installerConfig := it.InstallerConfig(distro.ID{Name: "test-distro", MajorVersion: 1}, "test_arch")
 	assert.Equal(t, &distro.InstallerConfig{
 		AdditionalDracutModules: []string{"base-dracut-mod1"},
 		AdditionalDrivers:       []string{"base-drv1"},
@@ -723,8 +719,7 @@ func TestImageTypeInstallerConfigMergeVerLT(t *testing.T) {
 `
 	it := makeTestImageType(t, fakeDistroYaml)
 
-	installerConfig, err := it.InstallerConfig("test-distro-1", "test_arch")
-	require.NoError(t, err)
+	installerConfig := it.InstallerConfig(distro.ID{Name: "test-distro", MajorVersion: 1}, "test_arch")
 	assert.Equal(t, &distro.InstallerConfig{
 		// AdditionalDrivers,SquashfsRootfs merged from parent
 		AdditionalDrivers:       []string{"base-drv1"},
@@ -747,8 +742,7 @@ func TestImageTypeInstallerConfigMergeDistroName(t *testing.T) {
 `
 	it := makeTestImageType(t, fakeDistroYaml)
 
-	installerConfig, err := it.InstallerConfig("test-distro-1", "test_arch")
-	require.NoError(t, err)
+	installerConfig := it.InstallerConfig(distro.ID{Name: "test-distro", MajorVersion: 1}, "test_arch")
 	assert.Equal(t, &distro.InstallerConfig{
 		AdditionalDracutModules: []string{"override-dracut-mod1"},
 		AdditionalDrivers:       []string{"override-drv1"},
@@ -769,8 +763,7 @@ func TestImageTypeInstallerConfigMergeArch(t *testing.T) {
 `
 	it := makeTestImageType(t, fakeDistroYaml)
 
-	installerConfig, err := it.InstallerConfig("test-distro-1", "test_arch")
-	require.NoError(t, err)
+	installerConfig := it.InstallerConfig(distro.ID{Name: "test-distro", MajorVersion: 1}, "test_arch")
 	assert.Equal(t, &distro.InstallerConfig{
 		AdditionalDrivers: []string{"override-drv1"},
 		// AdditionalDracutModules,SquashfsRootfs merged from parent
@@ -1002,18 +995,18 @@ func TestDistrosLoadingNotFound(t *testing.T) {
 
 func TestWhenConditionEvalEmpty(t *testing.T) {
 	wc := &defs.WhenCondition{}
-	assert.Equal(t, wc.Eval(&distro.ID{Name: "foo"}, "arch"), true)
+	assert.Equal(t, wc.Eval(distro.ID{Name: "foo"}, "arch"), true)
 }
 
 func TestWhenConditionEvalSimple(t *testing.T) {
 	wc := &defs.WhenCondition{DistroName: "distro"}
-	assert.Equal(t, wc.Eval(&distro.ID{Name: "distro"}, "other-arch"), true)
+	assert.Equal(t, wc.Eval(distro.ID{Name: "distro"}, "other-arch"), true)
 }
 
 func TestWhenConditionEvalAnd(t *testing.T) {
 	wc := &defs.WhenCondition{DistroName: "distro", Architecture: "arch"}
-	assert.Equal(t, wc.Eval(&distro.ID{Name: "distro"}, "other-arch"), false)
-	assert.Equal(t, wc.Eval(&distro.ID{Name: "distro"}, "arch"), true)
+	assert.Equal(t, wc.Eval(distro.ID{Name: "distro"}, "other-arch"), false)
+	assert.Equal(t, wc.Eval(distro.ID{Name: "distro"}, "arch"), true)
 }
 
 func TestImageTypesPlatformOverrides(t *testing.T) {
@@ -1062,7 +1055,7 @@ distros:
 		imgTypes := distro.ImageTypes()
 		assert.Len(t, imgTypes, 1)
 		imgType := imgTypes["server-qcow2"]
-		platforms, err := imgType.PlatformsFor(tc.distroNameVer)
+		platforms, err := imgType.PlatformsFor(distro.ID)
 		assert.NoError(t, err)
 		assert.Equal(t, []platform.PlatformConf{
 			{
@@ -1104,8 +1097,7 @@ image_types:
 	imgTypes := distro.ImageTypes()
 	assert.Len(t, imgTypes, 1)
 	imgType := imgTypes["test_type"]
-	require.NotNil(t, imgType)
-	_, err = imgType.PlatformsFor("test-distro-1")
+	_, err = imgType.PlatformsFor(distro.ID)
 	assert.EqualError(t, err, `platform conditionals for image type "test_type" should match only once but matched 2 times`)
 }
 

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -841,9 +841,9 @@ func TestDistrosLoadingExact(t *testing.T) {
 	restore := defs.MockDataFS(baseDir)
 	defer restore()
 
-	distro, err := defs.NewDistroYAML("fedora-43")
+	dist, err := defs.NewDistroYAML("fedora-43")
 	require.NoError(t, err)
-	assert.Equal(t, &defs.DistroYAML{
+	assert.Equal(t, dist, &defs.DistroYAML{
 		Name:             "fedora-43",
 		Preview:          true,
 		OsVersion:        "43",
@@ -863,11 +863,12 @@ func TestDistrosLoadingExact(t *testing.T) {
 		OscapProfilesAllowList: []oscap.Profile{
 			oscap.Ospp,
 		},
-	}, distro)
+		ID: distro.ID{Name: "fedora", MajorVersion: 43, MinorVersion: -1},
+	})
 
-	distro, err = defs.NewDistroYAML("centos-10")
+	dist, err = defs.NewDistroYAML("centos-10")
 	require.NoError(t, err)
-	assert.Equal(t, &defs.DistroYAML{
+	assert.Equal(t, dist, &defs.DistroYAML{
 		Name:             "centos-10",
 		Vendor:           "centos",
 		OsVersion:        "10-stream",
@@ -877,7 +878,8 @@ func TestDistrosLoadingExact(t *testing.T) {
 		OSTreeRefTmpl:    "centos/10/%s/edge",
 		DefsPath:         "rhel-10",
 		DefaultFSType:    disk.FS_XFS,
-	}, distro)
+		ID:               distro.ID{Name: "centos", MajorVersion: 10, MinorVersion: -1},
+	})
 }
 
 func TestDistrosLoadingFactoryCompat(t *testing.T) {
@@ -885,9 +887,9 @@ func TestDistrosLoadingFactoryCompat(t *testing.T) {
 	restore := defs.MockDataFS(baseDir)
 	defer restore()
 
-	distro, err := defs.NewDistroYAML("rhel-10.1")
+	dist, err := defs.NewDistroYAML("rhel-10.1")
 	require.NoError(t, err)
-	assert.Equal(t, &defs.DistroYAML{
+	assert.Equal(t, dist, &defs.DistroYAML{
 		Name:             "rhel-10.1",
 		Match:            "rhel-10.*",
 		Vendor:           "redhat",
@@ -898,11 +900,12 @@ func TestDistrosLoadingFactoryCompat(t *testing.T) {
 		OSTreeRefTmpl:    "rhel/10/%s/edge",
 		DefsPath:         "rhel-10",
 		DefaultFSType:    disk.FS_XFS,
-	}, distro)
+		ID:               distro.ID{Name: "rhel", MajorVersion: 10, MinorVersion: 1},
+	})
 
-	distro, err = defs.NewDistroYAML("fedora-40")
+	dist, err = defs.NewDistroYAML("fedora-40")
 	require.NoError(t, err)
-	assert.Equal(t, &defs.DistroYAML{
+	assert.Equal(t, dist, &defs.DistroYAML{
 		Name:             "fedora-40",
 		Match:            "fedora-[0-9]*",
 		OsVersion:        "40",
@@ -922,7 +925,8 @@ func TestDistrosLoadingFactoryCompat(t *testing.T) {
 		OscapProfilesAllowList: []oscap.Profile{
 			oscap.Ospp,
 		},
-	}, distro)
+		ID: distro.ID{Name: "fedora", MajorVersion: 40, MinorVersion: -1},
+	})
 }
 
 func TestDistroYAMLCondition(t *testing.T) {
@@ -1130,14 +1134,15 @@ distros:
 		{"rhel-8.10", "rhel-8.10", "8.10"},
 		{"rhel-810", "rhel-8.10", "8.10"},
 	} {
-		distro, err := defs.NewDistroYAML(tc.nameVer)
+		dist, err := defs.NewDistroYAML(tc.nameVer)
 		require.NoError(t, err)
-		assert.Equal(t, &defs.DistroYAML{
+		assert.Equal(t, dist, &defs.DistroYAML{
 			Name:             tc.expectedDistroNameVer,
 			Match:            `(?P<name>rhel)-(?P<major>8)\.?(?P<minor>[0-9]+)`,
 			OsVersion:        tc.expectedOsVersion,
 			ReleaseVersion:   "8",
 			ModulePlatformID: "platform:el8",
-		}, distro)
+			ID:               *common.Must(distro.ParseID(tc.expectedDistroNameVer)),
+		})
 	}
 }

--- a/pkg/distro/generic/distro.go
+++ b/pkg/distro/generic/distro.go
@@ -88,7 +88,7 @@ func newDistro(nameVer string) (distro.Distro, error) {
 		if imgTypeYAML.Filename == "" {
 			continue
 		}
-		platforms, err := imgTypeYAML.PlatformsFor(nameVer)
+		platforms, err := imgTypeYAML.PlatformsFor(distroYAML.ID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -26,10 +26,9 @@ import (
 )
 
 func osCustomizations(t *imageType, osPackageSet rpmmd.PackageSet, options distro.ImageOptions, containers []container.SourceSpec, c *blueprint.Customizations) (manifest.OSCustomizations, error) {
-	imageConfig := t.getDefaultImageConfig()
-
 	osc := manifest.OSCustomizations{}
 
+	imageConfig := t.getDefaultImageConfig()
 	if t.ImageTypeYAML.Bootable || t.ImageTypeYAML.RPMOSTree {
 		// TODO: for now the only image types that define a default kernel are
 		// ones that use UKIs and don't allow overriding, so this works.
@@ -326,10 +325,9 @@ func ostreeDeploymentCustomizations(
 	if !t.ImageTypeYAML.RPMOSTree || !t.ImageTypeYAML.Bootable {
 		return manifest.OSTreeDeploymentCustomizations{}, fmt.Errorf("ostree deployment customizations are only supported for bootable rpm-ostree images")
 	}
-
-	imageConfig := t.getDefaultImageConfig()
 	deploymentConf := manifest.OSTreeDeploymentCustomizations{}
 
+	imageConfig := t.getDefaultImageConfig()
 	kernelOptions := imageConfig.KernelOptions
 	if bpKernel := c.GetKernel(); bpKernel != nil && bpKernel.Append != "" {
 		kernelOptions = append(kernelOptions, bpKernel.Append)
@@ -523,13 +521,14 @@ func liveInstallerImage(workload workload.Workload,
 
 	img.Filename = t.Filename()
 
-	if locale := t.getDefaultImageConfig().Locale; locale != nil {
+	imgConfig := t.getDefaultImageConfig()
+	if locale := imgConfig.Locale; locale != nil {
 		img.Locale = *locale
 	}
-	if isoroot := t.getDefaultImageConfig().ISORootfsType; isoroot != nil {
+	if isoroot := imgConfig.ISORootfsType; isoroot != nil {
 		img.RootfsType = *isoroot
 	}
-	if isoboot := t.getDefaultImageConfig().ISOBootType; isoboot != nil {
+	if isoboot := imgConfig.ISOBootType; isoboot != nil {
 		img.ISOBoot = *isoboot
 	}
 
@@ -633,10 +632,11 @@ func imageInstallerImage(workload workload.Workload,
 	img.Filename = t.Filename()
 
 	img.RootfsCompression = "xz" // This also triggers using the bcj filter
-	if isoroot := t.getDefaultImageConfig().ISORootfsType; isoroot != nil {
+	imgConfig := t.getDefaultImageConfig()
+	if isoroot := imgConfig.ISORootfsType; isoroot != nil {
 		img.RootfsType = *isoroot
 	}
-	if isoboot := t.getDefaultImageConfig().ISOBootType; isoboot != nil {
+	if isoboot := imgConfig.ISOBootType; isoboot != nil {
 		img.ISOBoot = *isoboot
 	}
 
@@ -665,11 +665,9 @@ func iotCommitImage(workload workload.Workload,
 	}
 
 	imgConfig := t.getDefaultImageConfig()
-	if imgConfig != nil {
-		img.OSCustomizations.Presets = imgConfig.Presets
-		if imgConfig.InstallWeakDeps != nil {
-			img.InstallWeakDeps = *imgConfig.InstallWeakDeps
-		}
+	img.OSCustomizations.Presets = imgConfig.Presets
+	if imgConfig.InstallWeakDeps != nil {
+		img.InstallWeakDeps = *imgConfig.InstallWeakDeps
 	}
 
 	img.Environment = &t.ImageTypeYAML.Environment
@@ -741,11 +739,9 @@ func iotContainerImage(workload workload.Workload,
 	}
 
 	imgConfig := t.getDefaultImageConfig()
-	if imgConfig != nil {
-		img.OSCustomizations.Presets = imgConfig.Presets
-		if imgConfig.InstallWeakDeps != nil {
-			img.OSCustomizations.InstallWeakDeps = *imgConfig.InstallWeakDeps
-		}
+	img.OSCustomizations.Presets = imgConfig.Presets
+	if imgConfig.InstallWeakDeps != nil {
+		img.OSCustomizations.InstallWeakDeps = *imgConfig.InstallWeakDeps
 	}
 
 	img.ContainerLanguage = img.OSCustomizations.Language
@@ -837,13 +833,14 @@ func iotInstallerImage(workload workload.Workload,
 	img.Filename = t.Filename()
 
 	img.RootfsCompression = "xz" // This also triggers using the bcj filter
-	if locale := t.getDefaultImageConfig().Locale; locale != nil {
+	imgConfig := t.getDefaultImageConfig()
+	if locale := imgConfig.Locale; locale != nil {
 		img.Locale = *locale
 	}
-	if isoroot := t.getDefaultImageConfig().ISORootfsType; isoroot != nil {
+	if isoroot := imgConfig.ISORootfsType; isoroot != nil {
 		img.RootfsType = *isoroot
 	}
-	if isoboot := t.getDefaultImageConfig().ISOBootType; isoboot != nil {
+	if isoboot := imgConfig.ISOBootType; isoboot != nil {
 		img.ISOBoot = *isoboot
 	}
 

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -153,7 +153,7 @@ func (t *imageType) BootMode() platform.BootMode {
 }
 
 func (t *imageType) BasePartitionTable() (*disk.PartitionTable, error) {
-	return t.ImageTypeYAML.PartitionTable(t.arch.distro.Name(), t.arch.name)
+	return t.ImageTypeYAML.PartitionTable(t.arch.distro.ID, t.arch.name)
 }
 
 func (t *imageType) getPartitionTable(customizations *blueprint.Customizations, options distro.ImageOptions, rng *rand.Rand) (*disk.PartitionTable, error) {
@@ -191,7 +191,7 @@ func (t *imageType) getPartitionTable(customizations *blueprint.Customizations, 
 }
 
 func (t *imageType) getDefaultImageConfig() *distro.ImageConfig {
-	imageConfig := common.Must(t.ImageConfig(t.arch.distro.Name(), t.arch.name))
+	imageConfig := t.ImageConfig(t.arch.distro.ID, t.arch.name)
 	return imageConfig.InheritFrom(t.arch.distro.ImageConfig())
 
 }
@@ -200,7 +200,7 @@ func (t *imageType) getDefaultInstallerConfig() (*distro.InstallerConfig, error)
 	if !t.ImageTypeYAML.BootISO {
 		return nil, fmt.Errorf("image type %q is not an ISO", t.Name())
 	}
-	return t.InstallerConfig(t.arch.distro.Name(), t.arch.name)
+	return t.InstallerConfig(t.arch.distro.ID, t.arch.name), nil
 }
 
 func (t *imageType) PartitionType() disk.PartitionTableType {
@@ -232,10 +232,7 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 
 	// don't add any static packages if Minimal was selected
 	if !bp.Minimal {
-		pkgSets, err := t.ImageTypeYAML.PackageSets(t.arch.distro.Name(), t.arch.name)
-		if err != nil {
-			return nil, nil, err
-		}
+		pkgSets := t.ImageTypeYAML.PackageSets(t.arch.distro.ID, t.arch.name)
 		for name, pkgSet := range pkgSets {
 			staticPackageSets[name] = pkgSet
 		}


### PR DESCRIPTION
distro: set `distro.ID` in `DistroYAML` by loader

By setting the parsed distro.ID into DistroYAML we can
simplify a lot of the cases where we currently use
`nameVer string` for the various helpers. By using the
id we avoid re-parsing the name and potentially raising
error. This will simplify the code in the comming commits.

---

distro: add/use `DistroYAML.ID` consistently

We use(d) `distroNameVer` a lot when accessing YAML
data because that is what we had when transitioning
from fedora/rhel distro abstraction to the generic
distro. But now that everything is a generic distro
we can actually use `distro.ID` everywhere which
simplifies a lot of code and avoids (re)parsing
the `distroNameVer`.

