### PR TITLE
Revert "distro: drop `ImageType.BasePartitionTable()`"

### DIFF
--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -102,6 +102,10 @@ type ImageType interface {
 	// has no partition table. Only support for RHEL 8.5+
 	PartitionType() disk.PartitionTableType
 
+	// Return the base partition tabe for the given image type, will
+	// return `nil` if there is none
+	BasePartitionTable() (*disk.PartitionTable, error)
+
 	// Returns the corresponding boot mode ("legacy", "uefi", "hybrid") or "none"
 	BootMode() platform.BootMode
 

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -152,8 +152,12 @@ func (t *imageType) BootMode() platform.BootMode {
 	return platform.BOOT_NONE
 }
 
+func (t *imageType) BasePartitionTable() (*disk.PartitionTable, error) {
+	return t.ImageTypeYAML.PartitionTable(t.arch.distro.Name(), t.arch.name)
+}
+
 func (t *imageType) getPartitionTable(customizations *blueprint.Customizations, options distro.ImageOptions, rng *rand.Rand) (*disk.PartitionTable, error) {
-	basePartitionTable, err := t.ImageTypeYAML.PartitionTable(t.arch.distro.Name(), t.arch.name)
+	basePartitionTable, err := t.BasePartitionTable()
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +204,7 @@ func (t *imageType) getDefaultInstallerConfig() (*distro.InstallerConfig, error)
 }
 
 func (t *imageType) PartitionType() disk.PartitionTableType {
-	basePartitionTable, err := t.ImageTypeYAML.PartitionTable(t.arch.distro.Name(), t.arch.name)
+	basePartitionTable, err := t.BasePartitionTable()
 	if errors.Is(err, defs.ErrNoPartitionTableForImgType) {
 		return disk.PT_NONE
 	}


### PR DESCRIPTION
This reverts commit 05490a26c11dc198e54de800b91a4f81642a81b4.

This broke image-builder-cli who uses this feature in `describe`.

Thanks to Brian for reporting.