### PR TITLE
[RFC/wild-idea] distro: drop {Build,Payload}Pipelines from imagetypes

### DIFF
--- a/pkg/distro/defs/fedora/distro.yaml
+++ b/pkg/distro/defs/fedora/distro.yaml
@@ -549,8 +549,6 @@ image_types:
     bootable: true
     default_size: 5_368_709_120  # 5 * datasizes.GibiByte
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "vagrant", "archive"]
     exports: ["archive"]
     required_partition_sizes: *default_required_dir_sizes
     image_config: &image_config_vagrant
@@ -611,8 +609,6 @@ image_types:
     bootable: true
     default_size: 5_368_709_120  # 5 * datasizes.GibiByte
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "qcow2"]
     exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
     image_config: &image_config_qcow2
@@ -653,7 +649,6 @@ image_types:
     name_aliases: ["ami"]
     filename: "image.raw"
     mime_type: "application/octet-stream"
-    payload_pipelines: ["os", "image"]
     exports: ["image"]
     environment: *ec2_env
     platforms:
@@ -687,7 +682,6 @@ image_types:
     name_aliases: ["vhd"]
     filename: "disk.vhd"
     mime_type: "application/x-vhd"
-    payload_pipelines: ["os", "image", "vpc"]
     exports: ["vpc"]
     environment: *azure_env
     platforms:
@@ -714,8 +708,6 @@ image_types:
     bootable: true
     default_size: 2_147_483_648  # 2 * datasizes.GibiByte
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "vmdk"]
     exports: ["vmdk"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
@@ -764,7 +756,6 @@ image_types:
     name_aliases: ["ova"]
     filename: "image.ova"
     mime_type: "application/ovf"
-    payload_pipelines: ["os", "image", "vmdk", "ovf", "archive"]
     exports: ["archive"]
     platforms:
       - <<: *x86_64_bios_platform
@@ -778,8 +769,6 @@ image_types:
     filename: "commit.tar"
     mime_type: "application/x-tar"
     image_func: "iot_commit"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "ostree-commit", "commit-archive"]
     exports: ["commit-archive"]
     required_partition_sizes: *default_required_dir_sizes
     image_config: &image_config_iot_commit
@@ -939,8 +928,6 @@ image_types:
     filename: "container.tar"
     mime_type: "application/x-tar"
     image_func: "iot_container"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "ostree-commit", "container-tree", "container"]
     exports: ["container"]
     required_partition_sizes: *default_required_dir_sizes
     image_config:
@@ -962,8 +949,6 @@ image_types:
     ostree:
       name: "fedora-iot"
       remote_name: "fedora-iot"
-    build_pipelines: ["build"]
-    payload_pipelines: ["ostree-deployment", "image", "xz"]
     exports: ["xz"]
     # Passing an empty map into the required partition sizes disables the
     # default partition sizes normally set so our `basePartitionTables` can
@@ -1041,8 +1026,6 @@ image_types:
     ostree:
       name: "fedora-iot"
       remote_name: "fedora-iot"
-    build_pipelines: ["build"]
-    payload_pipelines: ["ostree-deployment", "image", "qcow2"]
     exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
     image_config:
@@ -1064,8 +1047,6 @@ image_types:
     filename: "iot-bootable-container.tar"
     mime_type: "application/x-tar"
     image_func: "bootable_container"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "ostree-commit", "ostree-encapsulate"]
     exports: ["ostree-encapsulate"]
     required_partition_sizes: *default_required_dir_sizes
     image_config:
@@ -1215,8 +1196,6 @@ image_types:
     bootable: true
     default_size: 2_147_483_648  # 2 * datasizes.GibiByte
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "xz"]
     exports: ["xz"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
@@ -1306,7 +1285,6 @@ image_types:
     name_aliases: []
     filename: "disk.raw.zst"
     compression: zstd
-    payload_pipelines: ["os", "image", "zstd"]
     exports: ["zstd"]
 
   installer:
@@ -1508,12 +1486,6 @@ image_types:
     ostree:
       name: "fedora-iot"
       remote_name: "fedora-iot"
-    build_pipelines: ["build"]
-    payload_pipelines:
-      - "anaconda-tree"
-      - "efiboot-tree"
-      - "bootiso-tree"
-      - "bootiso"
     exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     installer_config: *default_installer_config
@@ -1549,12 +1521,6 @@ image_types:
     boot_iso: true
     image_func: "live_installer"
     iso_label: "Workstation"
-    build_pipelines: ["build"]
-    payload_pipelines:
-      - "anaconda-tree"
-      - "efiboot-tree"
-      - "bootiso-tree"
-      - "bootiso"
     exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     installer_config: *default_installer_config
@@ -1623,13 +1589,6 @@ image_types:
     iso_label: "Unknown"
     # We don't know the variant that goes into the OS pipeline that gets installed
     variant: "Unknown"
-    build_pipelines: ["build"]
-    payload_pipelines:
-      - "anaconda-tree"
-      - "efiboot-tree"
-      - "os"
-      - "bootiso-tree"
-      - "bootiso"
     exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     installer_config:
@@ -1682,8 +1641,6 @@ image_types:
     mime_type: "application/x-tar"
     image_func: "container"
     bootable: false
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "container"]
     exports: ["container"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
@@ -1755,8 +1712,6 @@ image_types:
     compression: "xz"
     mime_type: "application/x-tar"
     image_func: "tar"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "archive", "xz"]
     exports: ["xz"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
@@ -1864,15 +1819,6 @@ image_types:
     ostree:
       name: "fedora"
       remote_name: "fedora-iot"
-    build_pipelines: ["build"]
-    payload_pipelines:
-      - "ostree-deployment"
-      - "image"
-      - "xz"
-      - "coi-tree"
-      - "efiboot-tree"
-      - "bootiso-tree"
-      - "bootiso"
     exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     installer_config:

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -382,8 +382,8 @@ type ImageTypeYAML struct {
 	DefaultSize uint64 `yaml:"default_size"`
 	// the image func name: disk,container,live-installer,...
 	Image                  string            `yaml:"image_func"`
-	BuildPipelines         []string          `yaml:"build_pipelines"`
-	PayloadPipelines       []string          `yaml:"payload_pipelines"`
+	XXXUnused              []string          `yaml:"build_pipelines"`
+	XXXUnused2             []string          `yaml:"payload_pipelines"`
 	Exports                []string          `yaml:"exports"`
 	RequiredPartitionSizes map[string]uint64 `yaml:"required_partition_sizes"`
 

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -696,8 +696,8 @@ distros:
 	assert.Equal(t, "Workstation", imgType.ISOLabel)
 	assert.Equal(t, uint64(5*datasizes.GibiByte), imgType.DefaultSize)
 	assert.Equal(t, "disk", imgType.Image)
-	assert.Equal(t, []string{"build"}, imgType.BuildPipelines)
-	assert.Equal(t, []string{"os", "image", "qcow2"}, imgType.PayloadPipelines)
+	assert.Equal(t, []string{"build"}, imgType.XXXUnused)
+	assert.Equal(t, []string{"os", "image", "qcow2"}, imgType.XXXUnused2)
 	assert.Equal(t, []string{"qcow2"}, imgType.Exports)
 	assert.Equal(t, map[string]uint64{"/": 1_073_741_824}, imgType.RequiredPartitionSizes)
 	assert.Equal(t, []platform.PlatformConf{

--- a/pkg/distro/defs/rhel-10/distro.yaml
+++ b/pkg/distro/defs/rhel-10/distro.yaml
@@ -701,8 +701,6 @@ image_types:
     bootable: true
     default_size: 10_737_418_240  # 10 * datasizes.GibiByte
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "qcow2"]
     exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
@@ -806,8 +804,6 @@ image_types:
     bootable: true
     default_size: 10_737_418_240  # 10 * datasizes.GibiByte
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "vagrant", "archive"]
     exports: ["archive"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
@@ -850,7 +846,6 @@ image_types:
     filename: "disk.vhd"
     mime_type: "application/x-vhd"
     default_size: 4_294_967_296  # 4 * datasizes.GibiByte
-    payload_pipelines: ["os", "image", "vpc"]
     exports: ["vpc"]
     # note that unlike fedora no "environment.Azure" is used here for
     # unknown reasons
@@ -971,7 +966,6 @@ image_types:
 
   "azure-rhui": &azure_rhui
     <<: *vhd
-    payload_pipelines: ["os", "image", "vpc", "xz"]
     exports: ["xz"]
     compression: "xz"
     filename: "disk.vhd.xz"
@@ -1096,8 +1090,6 @@ image_types:
     filename: "root.tar.xz"
     mime_type: "application/x-tar"
     image_func: "tar"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "archive"]
     exports: ["archive"]
     package_sets:
       os:
@@ -1118,8 +1110,6 @@ image_types:
     bootable: true
     default_size: 4_294_967_296  # 4 * datasizes.GibiByte
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "vmdk"]
     exports: ["vmdk"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
@@ -1148,7 +1138,6 @@ image_types:
     <<: *vmdk
     filename: "image.ova"
     mime_type: "application/ovf"
-    payload_pipelines: ["os", "image", "vmdk", "ovf", "archive"]
     exports: ["archive"]
     platforms:
       - <<: *x86_64_bios_platform
@@ -1158,8 +1147,6 @@ image_types:
     filename: "image.raw"
     mime_type: "application/octet-stream"
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image"]
     exports: ["image"]
     bootable: true
     default_size: 10_737_418_240  # 10 * datasizes.GibiByte
@@ -1331,7 +1318,6 @@ image_types:
   # RHEL internal-only x86_64 EC2 image type
   ec2: &ec2
     <<: *ami
-    payload_pipelines: ["os", "image", "xz"]
     exports: ["xz"]
     filename: "image.raw.xz"
     compression: "xz"
@@ -1387,8 +1373,6 @@ image_types:
     filename: "image.wsl"
     mime_type: "application/x-tar"
     image_func: "tar"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "archive", "xz"]
     exports: ["xz"]
     compression: "xz"
     platforms:
@@ -1519,13 +1503,6 @@ image_types:
     image_func: "image_installer"
     # We don't know the variant of the OS pipeline being installed
     iso_label: "Unknown"
-    build_pipelines: ["build"]
-    payload_pipelines:
-      - "anaconda-tree"
-      - "efiboot-tree"
-      - "os"
-      - "bootiso-tree"
-      - "bootiso"
     exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     image_config:
@@ -1683,8 +1660,6 @@ image_types:
     filename: "image.tar.gz"
     mime_type: "application/gzip"
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "archive"]
     exports: ["archive"]
     bootable: true
     default_size: 21_474_836_480  # 20 * datasizes.GibiByte
@@ -1852,7 +1827,6 @@ image_types:
     <<: *vhd
     filename: "disk.vhd.xz"
     mime_type: "application/xz"
-    payload_pipelines: ["os", "image", "vpc", "xz"]
     exports: ["xz"]
     compression: "xz"
     default_size: 34_359_738_368  # 32 * datasizes.GibiByte

--- a/pkg/distro/defs/rhel-7/distro.yaml
+++ b/pkg/distro/defs/rhel-7/distro.yaml
@@ -262,8 +262,6 @@ image_types:
     mime_type: "application/xz"
     image_func: "disk"
     default_size: 68_719_476_736  # 64 * datasizes.GibiByte
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "vpc", "xz"]
     exports: ["xz"]
     compression: "xz"
     bootable: true
@@ -419,8 +417,6 @@ image_types:
     filename: "image.raw.xz"
     mime_type: "application/xz"
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "xz"]
     exports: ["xz"]
     compression: "xz"
     bootable: true
@@ -576,8 +572,6 @@ image_types:
     bootable: true
     default_size: 10_737_418_240  # 10 * datasizes.GibiByte
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "qcow2"]
     exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
     disk_image_part_tool: sgdisk

--- a/pkg/distro/defs/rhel-8/distro.yaml
+++ b/pkg/distro/defs/rhel-8/distro.yaml
@@ -1265,8 +1265,6 @@ image_types:
     filename: "image.raw"
     mime_type: "application/octet-stream"
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image"]
     exports: ["image"]
     bootable: true
     default_size: 10_737_418_240  # 10 * datasizes.GibiByte
@@ -1304,7 +1302,6 @@ image_types:
     filename: "image.raw.xz"
     mime_type: "application/xz"
     compression: "xz"
-    payload_pipelines: ["os", "image", "xz"]
     exports: ["xz"]
     image_config:
       <<: *ec2_image_config
@@ -1414,8 +1411,6 @@ image_types:
     bootable: true
     default_size: 10_737_418_240  # 10 * datasizes.GibiByte
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "qcow2"]
     exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
@@ -1462,8 +1457,6 @@ image_types:
     mime_type: "application/x-vhd"
     image_func: "disk"
     default_size: 4_294_967_296  # 4 * datasizes.GibiByte
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "vpc"]
     exports: ["vpc"]
     bootable: true
     # note that unlike fedora no "environment.Azure" is used here for
@@ -1623,8 +1616,6 @@ image_types:
     mime_type: "application/xz"
     image_func: "disk"
     default_size: 68_719_476_736  # 64 * datasizes.GibiByte
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "vpc", "xz"]
     exports: ["xz"]
     compression: "xz"
     bootable: true
@@ -1782,13 +1773,6 @@ image_types:
     image_func: "image_installer"
     # We don't know the variant of the OS pipeline being installed
     iso_label: "Unknown"
-    build_pipelines: ["build"]
-    payload_pipelines:
-      - "anaconda-tree"
-      - "efiboot-tree"
-      - "os"
-      - "bootiso-tree"
-      - "bootiso"
     exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     image_config:
@@ -1818,8 +1802,6 @@ image_types:
     filename: "root.tar.xz"
     mime_type: "application/x-tar"
     image_func: "tar"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "archive"]
     exports: ["archive"]
     platforms:
       - arch: "x86_64"
@@ -1840,8 +1822,6 @@ image_types:
     mime_type: "application/x-tar"
     rpm_ostree: true
     image_func: "iot_commit"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "ostree-commit", "commit-archive"]
     exports: ["commit-archive"]
     platforms:
       - *x86_64_bios_platform
@@ -2028,12 +2008,6 @@ image_types:
     variant: "edge"
     ostree:
       name: "rhel-edge"
-    build_pipelines: ["build"]
-    payload_pipelines:
-      - "anaconda-tree"
-      - "efiboot-tree"
-      - "bootiso-tree"
-      - "bootiso"
     exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     image_config:
@@ -2077,8 +2051,6 @@ image_types:
       name: "rhel-edge"
       remote_name: "rhel-edge"
     use_ostree_remotes: true
-    build_pipelines: ["build"]
-    payload_pipelines: ["ostree-deployment", "image", "xz"]
     exports: ["xz"]
     platforms:
       - <<: *x86_64_installer_platform
@@ -2116,15 +2088,6 @@ image_types:
       remote_name: "rhel-edge"
     # XXX: find better name
     use_ostree_remotes: true
-    build_pipelines: ["build"]
-    payload_pipelines:
-      - "ostree-deployment"
-      - "image"
-      - "xz"
-      - "coi-tree"
-      - "efiboot-tree"
-      - "bootiso-tree"
-      - "bootiso"
     exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     installer_config:
@@ -2213,8 +2176,6 @@ image_types:
     mime_type: "application/x-tar"
     rpm_ostree: true
     image_func: "iot_container"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "ostree-commit", "container-tree", "container"]
     exports: ["container"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
@@ -2232,8 +2193,6 @@ image_types:
     bootable: true
     default_size: 4_294_967_296  # 4 * datasizes.GibiByte
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "vmdk"]
     exports: ["vmdk"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
@@ -2263,7 +2222,6 @@ image_types:
     <<: *vmdk
     filename: "image.ova"
     mime_type: "application/ovf"
-    payload_pipelines: ["os", "image", "vmdk", "ovf", "archive"]
     exports: ["archive"]
     platforms:
       - <<: *x86_64_bios_platform
@@ -2273,8 +2231,6 @@ image_types:
     filename: "image.tar.gz"
     mime_type: "application/gzip"
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "archive"]
     exports: ["archive"]
     bootable: true
     default_size: 21_474_836_480  # 20 * datasizes.GibiByte
@@ -2433,8 +2389,6 @@ image_types:
     filename: "image.wsl"
     mime_type: "application/x-tar"
     image_func: "tar"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "archive", "xz"]
     exports: ["xz"]
     compression: "xz"
     platforms:
@@ -2559,8 +2513,6 @@ image_types:
     bootable: true
     default_size: 2_147_483_648  # 2 * datasizes.GibiByte
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "xz"]
     exports: ["xz"]
     required_partition_sizes: *default_required_dir_sizes
     image_config:

--- a/pkg/distro/defs/rhel-9/distro.yaml
+++ b/pkg/distro/defs/rhel-9/distro.yaml
@@ -1132,8 +1132,6 @@ image_types:
     bootable: true
     default_size: 10_737_418_240  # 10 * datasizes.GibiByte
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "qcow2"]
     exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
@@ -1246,7 +1244,6 @@ image_types:
     filename: "disk.vhd"
     mime_type: "application/x-vhd"
     default_size: 4_294_967_296  # 4 * datasizes.GibiByte
-    payload_pipelines: ["os", "image", "vpc"]
     exports: ["vpc"]
     platforms:
       - <<: *x86_64_bios_platform
@@ -1374,7 +1371,6 @@ image_types:
   "azure-rhui": &azure_rhui
     <<: *vhd
     mime_type: "application/xz"
-    payload_pipelines: ["os", "image", "vpc", "xz"]
     exports: ["xz"]
     compression: "xz"
     filename: "disk.vhd.xz"
@@ -1556,8 +1552,6 @@ image_types:
     filename: "root.tar.xz"
     mime_type: "application/x-tar"
     image_func: "tar"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "archive"]
     exports: ["archive"]
     platforms:
       - arch: "x86_64"
@@ -1578,8 +1572,6 @@ image_types:
     bootable: true
     default_size: 4_294_967_296  # 4 * datasizes.GibiByte
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "vmdk"]
     exports: ["vmdk"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
@@ -1608,7 +1600,6 @@ image_types:
     <<: *vmdk
     filename: "image.ova"
     mime_type: "application/ovf"
-    payload_pipelines: ["os", "image", "vmdk", "ovf", "archive"]
     exports: ["archive"]
     platforms:
       - <<: *x86_64_bios_platform
@@ -1617,8 +1608,6 @@ image_types:
   ec2: &ec2
     filename: "image.raw.xz"
     mime_type: "application/xz"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "xz"]
     exports: ["xz"]
     compression: "xz"
     image_func: "disk"
@@ -1765,7 +1754,6 @@ image_types:
     <<: *ec2
     mime_type: "application/octet-stream"
     filename: "image.raw"
-    payload_pipelines: ["os", "image"]
     exports: ["image"]
     compression: ""
 
@@ -1844,8 +1832,6 @@ image_types:
     filename: "image.wsl"
     mime_type: "application/x-tar"
     image_func: "tar"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "archive"]
     exports: ["xz"]
     compression: "xz"
     platforms:
@@ -1932,13 +1918,6 @@ image_types:
     image_func: "image_installer"
     # We don't know the variant of the OS pipeline being installed
     iso_label: "Unknown"
-    build_pipelines: ["build"]
-    payload_pipelines:
-      - "anaconda-tree"
-      - "efiboot-tree"
-      - "os"
-      - "bootiso-tree"
-      - "bootiso"
     exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
@@ -1964,8 +1943,6 @@ image_types:
     filename: "image.tar.gz"
     mime_type: "application/gzip"
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "archive"]
     exports: ["archive"]
     bootable: true
     default_size: 21_474_836_480  # 20 * datasizes.GibiByte
@@ -2124,8 +2101,6 @@ image_types:
     bootable: true
     default_size: 2_147_483_648  # 2 * datasizes.GibiByte
     image_func: "disk"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "image", "xz"]
     exports: ["xz"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
@@ -2268,8 +2243,6 @@ image_types:
     mime_type: "application/x-tar"
     rpm_ostree: true
     image_func: "iot_commit"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "ostree-commit", "commit-archive"]
     exports: ["commit-archive"]
     platforms:
       - *x86_64_bios_platform
@@ -2441,8 +2414,6 @@ image_types:
     mime_type: "application/x-tar"
     rpm_ostree: true
     image_func: "iot_container"
-    build_pipelines: ["build"]
-    payload_pipelines: ["os", "ostree-commit", "container-tree", "container"]
     exports: ["container"]
     <<: *edge_commit
 
@@ -2451,8 +2422,6 @@ image_types:
     filename: "image.raw.xz"
     compression: "xz"
     mime_type: "application/xz"
-    build_pipelines: ["build"]
-    payload_pipelines: ["ostree-deployment", "image", "xz"]
     exports: ["xz"]
     default_size: 10_737_418_240  # 10 * datasizes.GibiByte
     rpm_ostree: true
@@ -2511,12 +2480,6 @@ image_types:
     variant: "edge"
     ostree:
       name: "rhel-edge"
-    build_pipelines: ["build"]
-    payload_pipelines:
-      - "anaconda-tree"
-      - "efiboot-tree"
-      - "bootiso-tree"
-      - "bootiso"
     exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
@@ -2557,15 +2520,6 @@ image_types:
       remote_name: "rhel-edge"
     # XXX: find better name
     use_ostree_remotes: true
-    build_pipelines: ["build"]
-    payload_pipelines:
-      - "ostree-deployment"
-      - "image"
-      - "xz"
-      - "coi-tree"
-      - "efiboot-tree"
-      - "bootiso-tree"
-      - "bootiso"
     exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     installer_config:
@@ -2657,8 +2611,6 @@ image_types:
     filename: "image.raw"
     mime_type: "application/octet-stream"
     default_size: 10_737_418_240  # 10 * datasizes.GibiByte
-    build_pipelines: ["build"]
-    payload_pipelines: ["ostree-deployment", "image"]
     exports: ["image"]
     rpm_ostree: true
     bootable: true
@@ -2713,7 +2665,6 @@ image_types:
     <<: *edge_ami
     filename: "image.vmdk"
     mime_type: "application/x-vmdk"
-    payload_pipelines: ["ostree-deployment", "image", "vmdk"]
     exports: ["vmdk"]
     platforms:
       - <<: *x86_64_bios_platform
@@ -2740,7 +2691,6 @@ image_types:
     <<: *vhd
     filename: "disk.vhd.xz"
     mime_type: "application/xz"
-    payload_pipelines: ["os", "image", "vpc", "xz"]
     exports: ["xz"]
     compression: "xz"
     default_size: 34_359_738_368  # 32 * datasizes.GibiByte

--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -105,12 +105,6 @@ type ImageType interface {
 	// Returns the corresponding boot mode ("legacy", "uefi", "hybrid") or "none"
 	BootMode() platform.BootMode
 
-	// Returns the names of the pipelines that set up the build environment (buildroot).
-	BuildPipelines() []string
-
-	// Returns the names of the pipelines that create the image.
-	PayloadPipelines() []string
-
 	// Returns the package set names safe to install custom packages via custom repositories.
 	PayloadPackageSets() []string
 
@@ -146,13 +140,6 @@ type BasePartitionTableMap map[string]disk.PartitionTable
 // function from below.
 // Example: Exports() simply returns "assembler" for older image type
 // implementations that didn't produce v1 manifests that have named pipelines.
-func BuildPipelinesFallback() []string {
-	return []string{"build"}
-}
-
-func PayloadPipelinesFallback() []string {
-	return []string{"os", "assembler"}
-}
 
 func ExportsFallback() []string {
 	return []string{"assembler"}

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -209,17 +209,6 @@ func TestImageTypePipelineNames(t *testing.T) {
 					// This might change in the future, but for now, let's make
 					// sure they match.
 					assert.Equal(imageType.Exports()[0], pm.Pipelines[len(pm.Pipelines)-1].Name)
-
-					// The pipelines named in allPipelines must exist in the manifest, and in the
-					// order specified (eg. 'build' first) but it does not need to be an exact
-					// match. Only the pipelines with rpm or ostree metadata are required.
-					var order int
-					allPipelines := append(imageType.BuildPipelines(), imageType.PayloadPipelines()...)
-					for _, name := range allPipelines {
-						idx := slices.Index(pmNames, name)
-						assert.True(idx >= order, "%s not in order %v", name, pmNames)
-						order = idx
-					}
 				})
 			}
 		}

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -122,14 +122,6 @@ func (t *imageType) Size(size uint64) uint64 {
 	return size
 }
 
-func (t *imageType) BuildPipelines() []string {
-	return t.ImageTypeYAML.BuildPipelines
-}
-
-func (t *imageType) PayloadPipelines() []string {
-	return t.ImageTypeYAML.PayloadPipelines
-}
-
 func (t *imageType) PayloadPackageSets() []string {
 	return []string{blueprintPkgsKey}
 }

--- a/pkg/distro/test_distro/distro.go
+++ b/pkg/distro/test_distro/distro.go
@@ -220,14 +220,6 @@ func (t *TestImageType) BootMode() platform.BootMode {
 	return platform.BOOT_HYBRID
 }
 
-func (t *TestImageType) BuildPipelines() []string {
-	return distro.BuildPipelinesFallback()
-}
-
-func (t *TestImageType) PayloadPipelines() []string {
-	return distro.PayloadPipelinesFallback()
-}
-
 func (t *TestImageType) PayloadPackageSets() []string {
 	return []string{blueprintPkgsKey}
 }

--- a/pkg/manifestgen/manifestgen.go
+++ b/pkg/manifestgen/manifestgen.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/osbuild/images/pkg/blueprint"
@@ -194,10 +193,10 @@ func (mg *Generator) Generate(bp *blueprint.Blueprint, dist distro.Distro, imgTy
 		for plName, depsolvedPipeline := range depsolved {
 			pipelinePurpose := "unknown"
 			switch {
-			case slices.Contains(imgType.PayloadPipelines(), plName):
-				pipelinePurpose = "image"
-			case slices.Contains(imgType.BuildPipelines(), plName):
+			case plName == "build":
 				pipelinePurpose = "buildroot"
+			default:
+				pipelinePurpose = "image"
 			}
 			// XXX: sync with image-builder-cli:build.go name generation - can we have a shared helper?
 			imageName := fmt.Sprintf("%s-%s-%s", dist.Name(), imgType.Name(), a.Name())


### PR DESCRIPTION
[draft as this is obviously very controversial and also currently osbuild-composer uses the pipeline names to collect rpm metadata, however AFAICT composer could also just iterate over all pipelines and use "build" to identify the build pipeline name]

This started out from me investigating if we can inferre `[Build,Payload}Pipelines` and `Exports` when documenting the new YAML based image types. I think for `Exports` that is still something worth perusing but for 

All image types currently define the build and payload pipelines. But the build pipelines are the same (`["build"]`) for all images and the only place that uses it is the sbom writer so we can as well just use the static name there.

The payload pipelines are not used at all in the code AFAICT and osbuild just needs the export to know what pipelines it needs to run.

The extra complication is that the connection between the pipeline names and the code is quite loose and the pipelines are actually fully determined by the combination of the image function, platform and compression and could (probably) also be infered. But it AFAICT we don't need them at all so YAGNI.