### PR TITLE
distro: fix issues with yaml distro definitions and enable yaml checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -239,3 +239,28 @@ jobs:
         run: |
           python3 -m pylint --version
           python3 -m pylint $(grep -l "/usr/bin/env python3" -r test/scripts) test/scripts/*.py
+
+  yaml-checks:
+    name: "YAML checks"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install checkers
+        run: |
+          sudo apt update
+          sudo apt install -y yamllint yq
+
+      - name: YAML Lint
+        # We only care about distro definitions for this check
+        run: |
+          find pkg/distro/defs "(" -iname "*.yaml" -or -iname "*.yml" ")" -exec yamllint --strict {} \+
+
+      - name: Check YAML definitions with yq
+        # yq will catch issues that yamllint will not, like duplicate anchros
+        # We only care about distro definitions for this check
+        run: |
+          find pkg/distro/defs "(" -iname "*.yaml" -or -iname "*.yml" ")" -exec yq . {} \+ > /dev/null

--- a/pkg/distro/defs/distros.yaml
+++ b/pkg/distro/defs/distros.yaml
@@ -1,3 +1,4 @@
+---
 distros:
   - &fedora_rawhide
     name: fedora-43
@@ -29,17 +30,19 @@ distros:
       # XXX: remove once fedora containers are part of the upstream
       # fedora registry (and can be validated via tls)
       riscv64: "ghcr.io/mvo5/fedora-buildroot:43"
-    # XXX: add repos here too, that requires some churn, see
-    # https://github.com/osbuild/images/compare/main...mvo5:yaml-distroconfig?expand=1
-    # and we will also need to think about backward compat, as currently
-    # dropping "$distro-$ver.json" files into
-    # /etc/osbuild-composer/repositories will define what distros are
-    # available via images and we will need to provide compatibility for
-    # that.
-    #
-    # Having the repos separated means when a new fedora release is out
-    # we will need to update two places which is clearly a regression from
-    # before.
+
+      # XXX: add repos here too, that requires some churn, see
+      # https://github.com/osbuild/images/compare/main...mvo5:yaml-distroconfig?expand=1
+      # and we will also need to think about backward compat, as currently
+      # dropping "$distro-$ver.json" files into
+      # /etc/osbuild-composer/repositories will define what distros are
+      # available via images and we will need to provide compatibility for
+      # that.
+      #
+      # Having the repos separated means when a new fedora release is out
+      # we will need to update two places which is clearly a regression from
+      # before.
+
   - &fedora_stable
     <<: *fedora_rawhide
     name: "fedora-{{.MajorVersion}}"

--- a/pkg/distro/defs/rhel-8/distro.yaml
+++ b/pkg/distro/defs/rhel-8/distro.yaml
@@ -1278,7 +1278,7 @@ image_types:
       - <<: *aarch64_platform
         image_format: "raw"
     platforms_override:
-      conditions: &platform_override_conditions_ami
+      conditions:
         "Keep the RHEL EC2 x86_64 images before 8.9 BIOS-only":
           when:
             # Keep the RHEL EC2 x86_64 images before 8.9 BIOS-only for backward compatibility.
@@ -1330,7 +1330,7 @@ image_types:
       - <<: *x86_64_bios_platform
         image_format: "raw"
     platforms_override:
-      conditions: &platform_override_conditions_ami
+      conditions:
         # XXX: duplicated with "ami" but drops "aarch64", I cannot
         # find a better way to express this complex condition in YAML
         "Keep the RHEL EC2 x86_64 images before 8.9 BIOS-only":
@@ -1358,7 +1358,7 @@ image_types:
       - <<: *x86_64_bios_platform
         image_format: "raw"
     platforms_override:
-      conditions: &platform_override_conditions_ami
+      conditions:
         # XXX: duplicated with "ami" but drops "aarch64", I cannot
         # find a better way to express this complex condition in YAML
         "Keep the RHEL EC2 x86_64 images before 8.9 BIOS-only":

--- a/pkg/distro/defs/rhel-9/distro.yaml
+++ b/pkg/distro/defs/rhel-9/distro.yaml
@@ -1682,7 +1682,7 @@ image_types:
       - <<: *aarch64_platform
         image_format: "raw"
     platforms_override:
-      conditions: &platform_override_conditions_ami
+      conditions:
         "Keep the RHEL EC2 x86_64 images before 9.3 BIOS-only":
           when:
             distro_name: "rhel"
@@ -1826,7 +1826,7 @@ image_types:
       - <<: *x86_64_bios_platform
         image_format: "raw"
     platforms_override:
-      conditions: &platform_override_conditions_ami
+      conditions:
         # XXX: duplicated with "ec2" but drops "aarch64", I cannot
         # find a better way to express this complex condition in YAML
         "Keep the RHEL EC2 x86_64 images before 9.3 BIOS-only":
@@ -1851,7 +1851,7 @@ image_types:
       - <<: *x86_64_bios_platform
         image_format: "raw"
     platforms_override:
-      conditions: &platform_override_conditions_ami
+      conditions:
         # XXX: duplicated with "ec2" but drops "aarch64", I cannot
         # find a better way to express this complex condition in YAML
         "Keep the RHEL EC2 x86_64 images before 9.3 BIOS-only":
@@ -2248,25 +2248,15 @@ image_types:
             type: *xboot_ldr_partition_guid
             uuid: *data_partition_uuid
             payload_type: "filesystem"
-            payload: &default_partition_table_part_boot_payload
-              type: "xfs"
-              mountpoint: "/boot"
-              label: "boot"
-              fstab_options: "defaults"
-              fstab_freq: 0
-              fstab_passno: 0
+            payload:
+              <<: *default_partition_table_part_boot_payload
           - &minimal_raw_partition_table_part_root
             size: "2 GiB"
             type: *filesystem_data_guid
             uuid: *root_partition_uuid
             payload_type: "filesystem"
-            payload: &default_partition_table_part_root_payload
-              type: "xfs"
-              label: "root"
-              mountpoint: "/"
-              fstab_options: "defaults"
-              fstab_freq: 0
-              fstab_passno: 0
+            payload:
+              <<: *default_partition_table_part_root_payload
       aarch64: &partition_table_minimal_raw_aarch64
         <<: *partition_table_minimal_raw_x86_64
     partition_tables_override:


### PR DESCRIPTION
**distro/rhel9: remove duplicate anchors from yaml definitions**

I've been using `yq` a lot to get a flattened view of our yaml
definitions, with all references resolved.  While `yamllint` doesn't
seem to mind duplicated anchors, `yq` fails when they are found.

Duplicate anchors create ambiguity.  Remove them.

- platform_override_conditions_ami: never referenced, so it is
  unnecessary.
- default_partition_table_part_boot_payload: defined three times with
  the same body.  Convert the two extra anchors to references.

---

**distro/rhel8: remove duplicate anchors from yaml definitions**

platform_override_conditions_ami is never referenced, so it is
unnecessary.

---

**distro/defs: fix up issues in distros.yaml**

Fix issues caught by yamllint on distros.yaml:
- Document start marker (---).
- Comment indentation level.

---

**github: run yamllint and yq on distro definitions**

Check our yaml distro definitions for errors and warnings.

yamllint is run with `--strict` to convert warnings to errors.  Let's be
as clean as possible.
yq is also used because it will fail when a file has multiple anchors
with the same name.

---
