### PR TITLE
distro: fix bug in variable substitution for static distros

### DIFF
--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -210,16 +210,17 @@ func NewDistroYAML(nameVer string) (*DistroYAML, error) {
 			return nil, err
 		}
 		if found != "" {
-			if err := distro.runTemplates(found); err != nil {
-				return nil, err
-			}
-
 			foundDistro = &distro
+			// nameVer must be replaced with normalized name
+			nameVer = found
 			break
 		}
 	}
 	if foundDistro == nil {
 		return nil, nil
+	}
+	if err := foundDistro.runTemplates(nameVer); err != nil {
+		return nil, err
 	}
 
 	// load imageTypes

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -795,7 +795,7 @@ distros:
       name: org.osbuild.fedora43
       build_packages: ["glibc"]
     bootstrap_containers:
-      x86_64: "registry.fedoraproject.org/fedora-toolbox:43"
+      x86_64: "registry.fedoraproject.org/fedora-toolbox:{{.MajorVersion}}"
     oscap_profiles_allowlist:
       - "xccdf_org.ssgproject.content_profile_ospp"
 


### PR DESCRIPTION
This fixes a bug that when a distro is not found via the `match` mechanism but with an exact `name` match the variables where not substituted. This caused an error in image-builder-clis build.

We also need a reverse dependency test for ibcli in images but that should be its own commit.