### PR TITLE
Add crc image types as image aliases (HMS-8730)

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -608,7 +608,7 @@ image_types:
         image_format: "vagrant_virtualbox"
 
   "server-qcow2": &server_qcow2
-    name_aliases: ["qcow2"]
+    name_aliases: ["qcow2", "guest-image"]
     filename: "disk.qcow2"
     mime_type: "application/x-qemu-disk"
     environment: *kvm_env
@@ -654,7 +654,7 @@ image_types:
 
   "server-ami":
     <<: *server_qcow2
-    name_aliases: ["ami"]
+    name_aliases: ["ami", "aws"]
     filename: "image.raw"
     mime_type: "application/octet-stream"
     payload_pipelines: ["os", "image"]
@@ -688,7 +688,7 @@ image_types:
 
   "server-vhd":
     <<: *server_qcow2
-    name_aliases: ["vhd"]
+    name_aliases: ["vhd", "azure"]
     filename: "disk.vhd"
     mime_type: "application/x-vhd"
     payload_pipelines: ["os", "image", "vpc"]
@@ -712,7 +712,7 @@ image_types:
             - "WALinuxAgent"
 
   "server-vmdk": &server_vmdk
-    name_aliases: ["vmdk"]
+    name_aliases: ["vmdk", "vsphere"]
     filename: "disk.vmdk"
     mime_type: "application/x-vmdk"
     bootable: true
@@ -765,7 +765,7 @@ image_types:
 
   "server-ova":
     <<: *server_vmdk
-    name_aliases: ["ova"]
+    name_aliases: ["ova", "vsphere-ova"]
     filename: "image.ova"
     mime_type: "application/ovf"
     payload_pipelines: ["os", "image", "vmdk", "ovf", "archive"]

--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -745,6 +745,7 @@ image_types:
                   - "subscription-manager-cockpit"
 
   qcow2: &qcow2
+    name_aliases: ["guest-image"]
     filename: "disk.qcow2"
     mime_type: "application/x-qemu-disk"
     # note that unlike fedora rhel does not use the environment.KVM
@@ -853,6 +854,9 @@ image_types:
 
   "vagrant-libvirt": &vagrant_libvirt
     <<: *qcow2
+    # we have to reset the aliases otherwise this type
+    # will inherit the name aliases causing a conflict
+    name_aliases: []
     filename: "vagrant-libvirt.box"
     mime_type: "application/x-tar"
     bootable: true
@@ -893,12 +897,18 @@ image_types:
 
   oci:
     <<: *qcow2
+    # we have to reset the aliases otherwise this type
+    # will inherit the name aliases causing a conflict
+    name_aliases: []
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "qcow2"
 
   vhd: &vhd
     <<: *qcow2
+    # we have to reset the aliases otherwise this type
+    # will inherit the name aliases causing a conflict
+    name_aliases: []
     filename: "disk.vhd"
     mime_type: "application/x-vhd"
     default_size: 4_294_967_296  # 4 * datasizes.GibiByte
@@ -1168,6 +1178,7 @@ image_types:
       - arch: "s390x"
 
   vmdk: &vmdk
+    name_aliases: ["vshpere"]
     filename: "disk.vmdk"
     mime_type: "application/x-vmdk"
     bootable: true
@@ -1201,6 +1212,7 @@ image_types:
 
   ova:
     <<: *vmdk
+    name_aliases: ["vsphere-ova"]
     filename: "image.ova"
     mime_type: "application/ovf"
     payload_pipelines: ["os", "image", "vmdk", "ovf", "archive"]
@@ -1210,6 +1222,7 @@ image_types:
         image_format: "ova"
 
   ami: &ami
+    name_aliases: ['aws']
     filename: "image.raw"
     mime_type: "application/octet-stream"
     image_func: "disk"
@@ -1391,6 +1404,9 @@ image_types:
   # RHEL internal-only x86_64 EC2 image type
   ec2: &ec2
     <<: *ami
+    # we have to reset the aliases otherwise this type
+    # will inherit the name aliases causing a conflict
+    name_aliases: []
     payload_pipelines: ["os", "image", "xz"]
     exports: ["xz"]
     filename: "image.raw.xz"
@@ -1732,6 +1748,9 @@ image_types:
                   - "dmidecode"
 
   gce:
+    # this image type is set to `gcp` in image-builder-crc
+    # & `osbuild-composer`, so set the alias here
+    name_aliases: ["gcp"]
     filename: "image.tar.gz"
     mime_type: "application/gzip"
     image_func: "disk"

--- a/data/distrodefs/rhel-8/imagetypes.yaml
+++ b/data/distrodefs/rhel-8/imagetypes.yaml
@@ -1311,6 +1311,9 @@ image_types:
 
   ec2: &ec2
     <<: *ami
+    # we have to reset the aliases otherwise this type
+    # will inherit the name aliases causing a conflict
+    name_aliases: []
     filename: "image.raw.xz"
     mime_type: "application/xz"
     compression: "xz"
@@ -1417,6 +1420,7 @@ image_types:
                   - "rh-amazon-rhui-client-sap-bundle"
 
   qcow2: &qcow2
+    name_aliases: ["guest-image"]
     filename: "disk.qcow2"
     mime_type: "application/x-qemu-disk"
     # note that unlike fedora rhel does not use the environment.KVM
@@ -1468,6 +1472,7 @@ image_types:
         - *qcow2_common_pkgset
 
   vhd:
+    name_aliases: ["azure"]
     filename: "disk.vhd"
     mime_type: "application/x-vhd"
     image_func: "disk"
@@ -2231,6 +2236,7 @@ image_types:
         - *edge_commit_pkgset
 
   vmdk: &vmdk
+    name_aliases: ["vsphere"]
     filename: "disk.vmdk"
     mime_type: "application/x-vmdk"
     bootable: true
@@ -2265,6 +2271,7 @@ image_types:
 
   ova:
     <<: *vmdk
+    name_aliases: ["vsphere-ova"]
     filename: "image.ova"
     mime_type: "application/ovf"
     payload_pipelines: ["os", "image", "vmdk", "ovf", "archive"]
@@ -2274,6 +2281,9 @@ image_types:
         image_format: "ova"
 
   gce: &gce
+    # this image type is set to `gcp` in image-builder-crc
+    # & `osbuild-composer`, so set the alias here
+    name_aliases: ["gcp"]
     filename: "image.tar.gz"
     mime_type: "application/gzip"
     image_func: "disk"
@@ -2377,6 +2387,9 @@ image_types:
 
   "gce-rhui":
     <<: *gce
+    # we have to reset the aliases otherwise this type
+    # will inherit the name aliases causing a conflict
+    name_aliases: []
     image_config:
       <<: *gce_image_config
       rhsm_config:
@@ -2400,6 +2413,9 @@ image_types:
 
   oci:
     <<: *qcow2
+    # we have to reset the aliases otherwise this type
+    # will inherit the name aliases causing a conflict
+    name_aliases: []
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "qcow2"
@@ -2407,6 +2423,9 @@ image_types:
 
   openstack:
     <<: *qcow2
+    # we have to reset the aliases otherwise this type
+    # will inherit the name aliases causing a conflict
+    name_aliases: []
     default_size: 4_294_967_296  # 4 * datasizes.GibiByte
     image_config:
       kernel_options:

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -1160,6 +1160,7 @@ image_types:
                   - "subscription-manager-cockpit"
 
   qcow2: &qcow2
+    name_aliases: ["guest-image"]
     filename: "disk.qcow2"
     mime_type: "application/x-qemu-disk"
     # note that unlike fedora rhel does not use the environment.KVM
@@ -1272,6 +1273,9 @@ image_types:
 
   "vagrant-libvirt": &vagrant_libvirt
     <<: *qcow2
+    # we have to reset the aliases otherwise this type
+    # will inherit the name aliases causing a conflict
+    name_aliases: []
     filename: "vagrant-libvirt.box"
     mime_type: "application/x-tar"
     bootable: true
@@ -1312,12 +1316,18 @@ image_types:
 
   oci:
     <<: *qcow2
+    # we have to reset the aliases otherwise this type
+    # will inherit the name aliases causing a conflict
+    name_aliases: []
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "qcow2"
 
   vhd: &vhd
     <<: *qcow2
+    # we have to reset the aliases otherwise this type
+    # will inherit the name aliases causing a conflict
+    name_aliases: []
     filename: "disk.vhd"
     mime_type: "application/x-vhd"
     default_size: 4_294_967_296  # 4 * datasizes.GibiByte
@@ -1651,6 +1661,7 @@ image_types:
             - "rng-tools"
 
   vmdk: &vmdk
+    name_aliases: ["vsphere"]
     filename: "disk.vmdk"
     mime_type: "application/x-vmdk"
     bootable: true
@@ -1684,6 +1695,7 @@ image_types:
 
   ova:
     <<: *vmdk
+    name_aliases: ["vsphere-ova"]
     filename: "image.ova"
     mime_type: "application/ovf"
     payload_pipelines: ["os", "image", "vmdk", "ovf", "archive"]
@@ -1841,6 +1853,7 @@ image_types:
 
   ami:
     <<: *ec2
+    name_aliases: ["aws"]
     mime_type: "application/octet-stream"
     filename: "image.raw"
     payload_pipelines: ["os", "image"]
@@ -2078,7 +2091,9 @@ image_types:
         - *anaconda_pkgset
 
   gce:
-    name_aliases: ["gce-rhui"]
+    # this image type is set to `gcp` in image-builder-crc
+    # & `osbuild-composer`, so set the alias here
+    name_aliases: ["gce-rhui", "gcp"]
     filename: "image.tar.gz"
     mime_type: "application/gzip"
     image_func: "disk"
@@ -2343,6 +2358,9 @@ image_types:
 
   openstack:
     <<: *qcow2
+    # we have to reset the aliases otherwise this type
+    # will inherit the name aliases causing a conflict
+    name_aliases: []
     default_size: 4_294_967_296  # 4 * datasizes.GibiByte
     platforms:
       - <<: *x86_64_bios_platform

--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -79,6 +79,9 @@ type ImageType interface {
 	// Returns the name of the image type.
 	Name() string
 
+	// Returns the aliases for the image type.
+	Aliases() []string
+
 	// Returns the parent architecture
 	Arch() Arch
 

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -79,6 +79,10 @@ func (t *imageType) Name() string {
 	return t.ImageTypeYAML.Name()
 }
 
+func (t *imageType) Aliases() []string {
+	return t.ImageTypeYAML.NameAliases
+}
+
 func (t *imageType) Arch() distro.Arch {
 	return t.arch
 }

--- a/pkg/distro/test_distro/distro.go
+++ b/pkg/distro/test_distro/distro.go
@@ -45,6 +45,7 @@ type TestArch struct {
 type TestImageType struct {
 	architecture *TestArch
 	name         string
+	aliases      []string
 }
 
 const (
@@ -176,6 +177,10 @@ func (a *TestArch) addImageTypes(imageTypes ...TestImageType) {
 
 func (t *TestImageType) Name() string {
 	return t.name
+}
+
+func (t *TestImageType) Aliases() []string {
+	return t.aliases
 }
 
 func (t *TestImageType) Arch() distro.Arch {
@@ -341,10 +346,16 @@ func newTestDistro(releasever string) *TestDistro {
 
 	it3 := TestImageType{
 		name: TestImageTypeAmi,
+		aliases: []string{
+			"aws",
+		},
 	}
 
 	it4 := TestImageType{
 		name: TestImageTypeVhd,
+		aliases: []string{
+			"azure",
+		},
 	}
 
 	it5 := TestImageType{
@@ -361,14 +372,23 @@ func newTestDistro(releasever string) *TestDistro {
 
 	it8 := TestImageType{
 		name: TestImageTypeQcow2,
+		aliases: []string{
+			"guest-image",
+		},
 	}
 
 	it9 := TestImageType{
 		name: TestImageTypeVmdk,
+		aliases: []string{
+			"vsphere",
+		},
 	}
 
 	it10 := TestImageType{
 		name: TestImageTypeGce,
+		aliases: []string{
+			"gcp",
+		},
 	}
 
 	it11 := TestImageType{

--- a/pkg/imagefilter/filter_test.go
+++ b/pkg/imagefilter/filter_test.go
@@ -37,6 +37,12 @@ func TestImageFilterFilter(t *testing.T) {
 		{[]string{"type:qcow2"}, "test-distro-1", "test_arch3", "qcow2", true},
 		{[]string{"type:qcow"}, "test-distro-1", "test_arch3", "qcow2", false},
 		{[]string{"type:qcow?"}, "test-distro-1", "test_arch3", "qcow2", true},
+		// type: alias tests
+		{[]string{"type:aws"}, "test-distro-3", "test_arch3", "ami", true},
+		{[]string{"type:guest-image"}, "test-distro-3", "test_arch3", "qcow2", true},
+		{[]string{"type:vsphere"}, "test-distro-3", "test_arch3", "vmdk", true},
+		{[]string{"type:gcp"}, "test-distro-3", "test_arch3", "gce", true},
+		{[]string{"type:non-existent-alias"}, "test-distro-3", "test_arch3", "qcow2", false},
 		// bootmode: prefix
 		{[]string{"bootmode:uefi"}, "test-distro-1", "test_arch3", "qcow2", false},
 		{[]string{"bootmode:hybrid"}, "test-distro-1", "test_arch3", "qcow2", true},


### PR DESCRIPTION
Since we support aliases for image definitions, we can add the image
types used in `image-builder-crc` to the alias of the corresponding
image type in the distro definitions.