### PR TITLE
distro: fix openscap version check for rhel8

### DIFF
--- a/pkg/distro/generic/options.go
+++ b/pkg/distro/generic/options.go
@@ -407,7 +407,8 @@ func checkOptionsRhel8(t *imageType, bp *blueprint.Blueprint, options distro.Ima
 	}
 
 	if osc := customizations.GetOpenSCAP(); osc != nil {
-		if t.Arch().Distro().OsVersion() == "9.0" {
+		// only add support for RHEL 8.7 and above.
+		if common.VersionLessThan(t.Arch().Distro().OsVersion(), "8.7") {
 			return warnings, fmt.Errorf("OpenSCAP unsupported os version: %s", t.Arch().Distro().OsVersion())
 		}
 		if !oscap.IsProfileAllowed(osc.ProfileID, t.arch.distro.DistroYAML.OscapProfilesAllowList) {


### PR DESCRIPTION
This commit partly reverts `e0182a9f93` which changed some ostree validation but also changed in the rhel8 checkOptions() code:
```
pkg/distro/rhel8/imagetype.go:

-		if common.VersionLessThan(t.arch.distro.osVersion, "8.7") {
+		if t.arch.distro.osVersion == "9.0" {
```
(c.f. https://github.com/osbuild/images/pull/91/files#diff-041430a8039876cfa501c6018f198eb7e7bc03fe206e5422112d43241f8b22b2L377)

It looks like a copy/paste mistake, it also is here for a while so maybe its not important. Stumbled over this while reviewing the (excellent) checkOptions tests PR#1701.