### PR TITLE
distro: use `arch.Arch` instead of `archStr`

### DIFF
--- a/pkg/distro/generic/distro.go
+++ b/pkg/distro/generic/distro.go
@@ -8,6 +8,7 @@ import (
 	"text/template"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/platform"
@@ -95,7 +96,7 @@ func newDistro(nameVer string) (distro.Distro, error) {
 		for _, pl := range platforms {
 			ar, ok := rd.arches[pl.Arch.String()]
 			if !ok {
-				ar = newArchitecture(rd, pl.Arch.String())
+				ar = newArchitecture(rd, pl.Arch)
 				rd.arches[pl.Arch.String()] = ar
 			}
 			if distroYAML.SkipImageType(imgTypeYAML.Name(), pl.Arch.String()) {
@@ -161,22 +162,22 @@ var _ = distro.Arch(&architecture{})
 
 type architecture struct {
 	distro           *distribution
-	name             string
+	arch             arch.Arch
 	imageTypes       map[string]distro.ImageType
 	imageTypeAliases map[string]string
 }
 
-func newArchitecture(rd *distribution, name string) *architecture {
+func newArchitecture(rd *distribution, arch arch.Arch) *architecture {
 	return &architecture{
 		distro:           rd,
-		name:             name,
+		arch:             arch,
 		imageTypes:       make(map[string]distro.ImageType),
 		imageTypeAliases: make(map[string]string),
 	}
 }
 
 func (a *architecture) Name() string {
-	return a.name
+	return a.arch.String()
 }
 
 func (a *architecture) ListImageTypes() []string {

--- a/pkg/distro/generic/distro_test.go
+++ b/pkg/distro/generic/distro_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/distro/defs"
 	testrepos "github.com/osbuild/images/test/data/repositories"
 )
@@ -12,7 +14,7 @@ import (
 func TestISOLabel(t *testing.T) {
 	imgType := &imageType{
 		arch: &architecture{
-			name: "some-arch",
+			arch: common.Must(arch.FromString("s390x")),
 		},
 	}
 	d := &distribution{
@@ -24,7 +26,7 @@ func TestISOLabel(t *testing.T) {
 	}
 
 	isoLabelFunc := d.getISOLabelFunc("iso-label")
-	assert.Equal(t, "name:rhel,major:9,minor:1,product:some-product,arch:some-arch,iso-label:iso-label", isoLabelFunc(imgType))
+	assert.Equal(t, "name:rhel,major:9,minor:1,product:some-product,arch:s390x,iso-label:iso-label", isoLabelFunc(imgType))
 }
 
 func TestBootstrapContainers(t *testing.T) {

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/workload"
-	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/datasizes"
@@ -153,7 +152,7 @@ func (t *imageType) BootMode() platform.BootMode {
 }
 
 func (t *imageType) BasePartitionTable() (*disk.PartitionTable, error) {
-	return t.ImageTypeYAML.PartitionTable(t.arch.distro.ID, t.arch.name)
+	return t.ImageTypeYAML.PartitionTable(t.arch.distro.ID, t.arch.arch.String())
 }
 
 func (t *imageType) getPartitionTable(customizations *blueprint.Customizations, options distro.ImageOptions, rng *rand.Rand) (*disk.PartitionTable, error) {
@@ -191,7 +190,7 @@ func (t *imageType) getPartitionTable(customizations *blueprint.Customizations, 
 }
 
 func (t *imageType) getDefaultImageConfig() *distro.ImageConfig {
-	imageConfig := t.ImageConfig(t.arch.distro.ID, t.arch.name)
+	imageConfig := t.ImageConfig(t.arch.distro.ID, t.arch.arch.String())
 	return imageConfig.InheritFrom(t.arch.distro.ImageConfig())
 
 }
@@ -200,7 +199,7 @@ func (t *imageType) getDefaultInstallerConfig() (*distro.InstallerConfig, error)
 	if !t.ImageTypeYAML.BootISO {
 		return nil, fmt.Errorf("image type %q is not an ISO", t.Name())
 	}
-	return t.InstallerConfig(t.arch.distro.ID, t.arch.name), nil
+	return t.InstallerConfig(t.arch.distro.ID, t.arch.arch.String()), nil
 }
 
 func (t *imageType) PartitionType() disk.PartitionTableType {
@@ -232,7 +231,7 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 
 	// don't add any static packages if Minimal was selected
 	if !bp.Minimal {
-		pkgSets := t.ImageTypeYAML.PackageSets(t.arch.distro.ID, t.arch.name)
+		pkgSets := t.ImageTypeYAML.PackageSets(t.arch.distro.ID, t.arch.arch.String())
 		for name, pkgSet := range pkgSets {
 			staticPackageSets[name] = pkgSet
 		}
@@ -344,6 +343,5 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 }
 
 func bootstrapContainerFor(t *imageType) string {
-	a := common.Must(arch.FromString(t.arch.name))
-	return t.arch.distro.DistroYAML.BootstrapContainers[a]
+	return t.arch.distro.DistroYAML.BootstrapContainers[t.arch.arch]
 }


### PR DESCRIPTION
This commit adds a bit more type safety around the usage of the architecture. It currently uses strings in many places where its more appropriate to use our `arch.Arch` abstraction.