### PR TITLE
many: drop `Exports()` from imagetypes and use the manifest

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -124,7 +124,8 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("[ERROR] manifest generator creation failed: %w", err)
 	}
-	if err := mg.Generate(config.Blueprint, distribution, imgType, arch, &config.Options); err != nil {
+	exports, err := mg.Generate(config.Blueprint, distribution, imgType, arch, &config.Options)
+	if err != nil {
 		return fmt.Errorf("[ERROR] manifest generation failed: %w", err)
 	}
 	fmt.Print("DONE\n")
@@ -138,7 +139,7 @@ func run() error {
 	fmt.Printf("Building manifest: %s\n", manifestPath)
 
 	jobOutput := filepath.Join(outputDir, buildName)
-	_, err = osbuild.RunOSBuild(mf.Bytes(), osbuildStore, jobOutput, imgType.Exports(), checkpoints, nil, false, os.Stderr)
+	_, err = osbuild.RunOSBuild(mf.Bytes(), osbuildStore, jobOutput, exports, checkpoints, nil, false, os.Stderr)
 	if err != nil {
 		return err
 	}

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -56,7 +56,7 @@ func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos
 
 	store := path.Join(state_dir, "osbuild-store")
 
-	_, err = osbuild.RunOSBuild(bytes, store, "./", manifest.GetExports(), manifest.GetCheckpoints(), nil, false, os.Stdout)
+	_, err = osbuild.RunOSBuild(bytes, store, "./", manifest.Exports(), manifest.GetCheckpoints(), nil, false, os.Stdout)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not run osbuild: %s", err.Error())
 	}

--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -551,7 +551,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "vagrant", "archive"]
-    exports: ["archive"]
     required_partition_sizes: *default_required_dir_sizes
     image_config: &image_config_vagrant
       conditions:
@@ -613,7 +612,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "qcow2"]
-    exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
     image_config: &image_config_qcow2
       default_target: "multi-user.target"
@@ -654,7 +652,6 @@ image_types:
     filename: "image.raw"
     mime_type: "application/octet-stream"
     payload_pipelines: ["os", "image"]
-    exports: ["image"]
     environment: *ec2_env
     platforms:
       - <<: *x86_64_bios_platform
@@ -688,7 +685,6 @@ image_types:
     filename: "disk.vhd"
     mime_type: "application/x-vhd"
     payload_pipelines: ["os", "image", "vpc"]
-    exports: ["vpc"]
     environment: *azure_env
     platforms:
       - <<: *x86_64_bios_platform
@@ -716,7 +712,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "vmdk"]
-    exports: ["vmdk"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_bios_platform
@@ -765,7 +760,6 @@ image_types:
     filename: "image.ova"
     mime_type: "application/ovf"
     payload_pipelines: ["os", "image", "vmdk", "ovf", "archive"]
-    exports: ["archive"]
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "ova"
@@ -780,7 +774,6 @@ image_types:
     image_func: "iot_commit"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "ostree-commit", "commit-archive"]
-    exports: ["commit-archive"]
     required_partition_sizes: *default_required_dir_sizes
     image_config: &image_config_iot_commit
       <<: *image_config_iot_enabled_services
@@ -941,7 +934,6 @@ image_types:
     image_func: "iot_container"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "ostree-commit", "container-tree", "container"]
-    exports: ["container"]
     required_partition_sizes: *default_required_dir_sizes
     image_config:
       <<: *image_config_iot_commit
@@ -964,7 +956,6 @@ image_types:
       remote_name: "fedora-iot"
     build_pipelines: ["build"]
     payload_pipelines: ["ostree-deployment", "image", "xz"]
-    exports: ["xz"]
     # Passing an empty map into the required partition sizes disables the
     # default partition sizes normally set so our `basePartitionTables` can
     # override them (and make them smaller, in this case).
@@ -1043,7 +1034,6 @@ image_types:
       remote_name: "fedora-iot"
     build_pipelines: ["build"]
     payload_pipelines: ["ostree-deployment", "image", "qcow2"]
-    exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
     image_config:
       <<: *image_config_iot
@@ -1066,7 +1056,6 @@ image_types:
     image_func: "bootable_container"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "ostree-commit", "ostree-encapsulate"]
-    exports: ["ostree-encapsulate"]
     required_partition_sizes: *default_required_dir_sizes
     image_config:
       machine_id_uninitialized: false
@@ -1217,7 +1206,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "xz"]
-    exports: ["xz"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_uefi_platform
@@ -1307,7 +1295,6 @@ image_types:
     filename: "disk.raw.zst"
     compression: zstd
     payload_pipelines: ["os", "image", "zstd"]
-    exports: ["zstd"]
 
   installer:
     package_sets:
@@ -1514,7 +1501,6 @@ image_types:
       - "efiboot-tree"
       - "bootiso-tree"
       - "bootiso"
-    exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     installer_config: *default_installer_config
     image_config:
@@ -1555,7 +1541,6 @@ image_types:
       - "efiboot-tree"
       - "bootiso-tree"
       - "bootiso"
-    exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     installer_config: *default_installer_config
     image_config:
@@ -1630,7 +1615,6 @@ image_types:
       - "os"
       - "bootiso-tree"
       - "bootiso"
-    exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     installer_config:
       additional_dracut_modules:
@@ -1684,7 +1668,6 @@ image_types:
     bootable: false
     build_pipelines: ["build"]
     payload_pipelines: ["os", "container"]
-    exports: ["container"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - arch: "x86_64"
@@ -1757,7 +1740,6 @@ image_types:
     image_func: "tar"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "archive", "xz"]
-    exports: ["xz"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - arch: "x86_64"
@@ -1873,7 +1855,6 @@ image_types:
       - "efiboot-tree"
       - "bootiso-tree"
       - "bootiso"
-    exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     installer_config:
       <<: *default_installer_config

--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -739,7 +739,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "qcow2"]
-    exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_bios_platform
@@ -845,7 +844,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "vagrant", "archive"]
-    exports: ["archive"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_bios_platform
@@ -888,7 +886,6 @@ image_types:
     mime_type: "application/x-vhd"
     default_size: 4_294_967_296  # 4 * datasizes.GibiByte
     payload_pipelines: ["os", "image", "vpc"]
-    exports: ["vpc"]
     # note that unlike fedora no "environment.Azure" is used here for
     # unknown reasons
     platforms:
@@ -1009,7 +1006,6 @@ image_types:
   "azure": &azure
     <<: *vhd
     payload_pipelines: ["os", "image", "vpc", "xz"]
-    exports: ["xz"]
     compression: "xz"
     filename: "disk.vhd.xz"
     partition_table:
@@ -1138,7 +1134,6 @@ image_types:
     image_func: "tar"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "archive"]
-    exports: ["archive"]
     package_sets:
       os:
         - include:
@@ -1160,7 +1155,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "vmdk"]
-    exports: ["vmdk"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_bios_platform
@@ -1189,7 +1183,6 @@ image_types:
     filename: "image.ova"
     mime_type: "application/ovf"
     payload_pipelines: ["os", "image", "vmdk", "ovf", "archive"]
-    exports: ["archive"]
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "ova"
@@ -1200,7 +1193,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image"]
-    exports: ["image"]
     bootable: true
     default_size: 10_737_418_240  # 10 * datasizes.GibiByte
     required_partition_sizes: *default_required_dir_sizes
@@ -1377,7 +1369,6 @@ image_types:
   ec2: &ec2
     <<: *ami
     payload_pipelines: ["os", "image", "xz"]
-    exports: ["xz"]
     filename: "image.raw.xz"
     compression: "xz"
 
@@ -1434,7 +1425,6 @@ image_types:
     image_func: "tar"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "archive", "xz"]
-    exports: ["xz"]
     compression: "xz"
     platforms:
       - arch: "x86_64"
@@ -1571,7 +1561,6 @@ image_types:
       - "os"
       - "bootiso-tree"
       - "bootiso"
-    exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     image_config:
       iso_rootfs_type: "squashfs"
@@ -1730,7 +1719,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "archive"]
-    exports: ["archive"]
     bootable: true
     default_size: 21_474_836_480  # 20 * datasizes.GibiByte
     required_partition_sizes: *default_required_dir_sizes
@@ -1903,7 +1891,6 @@ image_types:
     filename: "disk.vhd.xz"
     mime_type: "application/xz"
     payload_pipelines: ["os", "image", "vpc", "xz"]
-    exports: ["xz"]
     compression: "xz"
     default_size: 34_359_738_368  # 32 * datasizes.GibiByte
     platforms:

--- a/data/distrodefs/rhel-7/imagetypes.yaml
+++ b/data/distrodefs/rhel-7/imagetypes.yaml
@@ -264,7 +264,6 @@ image_types:
     default_size: 68_719_476_736  # 64 * datasizes.GibiByte
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "vpc", "xz"]
-    exports: ["xz"]
     compression: "xz"
     bootable: true
     # RHEL 7 qemu vpc subformat does not support force_size
@@ -421,7 +420,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "xz"]
-    exports: ["xz"]
     compression: "xz"
     bootable: true
     default_size: 10_737_418_240  # 10 * datasizes.GibiByte
@@ -578,7 +576,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "qcow2"]
-    exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
     disk_image_part_tool: sgdisk
     platforms:

--- a/data/distrodefs/rhel-8/imagetypes.yaml
+++ b/data/distrodefs/rhel-8/imagetypes.yaml
@@ -1268,7 +1268,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image"]
-    exports: ["image"]
     bootable: true
     default_size: 10_737_418_240  # 10 * datasizes.GibiByte
     required_partition_sizes: *default_required_dir_sizes
@@ -1306,7 +1305,6 @@ image_types:
     mime_type: "application/xz"
     compression: "xz"
     payload_pipelines: ["os", "image", "xz"]
-    exports: ["xz"]
     image_config:
       <<: *ec2_image_config
     package_sets:
@@ -1417,7 +1415,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "qcow2"]
-    exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_bios_platform
@@ -1465,7 +1462,6 @@ image_types:
     default_size: 4_294_967_296  # 4 * datasizes.GibiByte
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "vpc"]
-    exports: ["vpc"]
     bootable: true
     # note that unlike fedora no "environment.Azure" is used here for
     # unknown reasons
@@ -1626,7 +1622,6 @@ image_types:
     default_size: 68_719_476_736  # 64 * datasizes.GibiByte
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "vpc", "xz"]
-    exports: ["xz"]
     compression: "xz"
     bootable: true
     platforms:
@@ -1790,7 +1785,6 @@ image_types:
       - "os"
       - "bootiso-tree"
       - "bootiso"
-    exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     image_config:
       iso_rootfs_type: "squashfs-ext4"
@@ -1821,7 +1815,6 @@ image_types:
     image_func: "tar"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "archive"]
-    exports: ["archive"]
     platforms:
       - arch: "x86_64"
       - arch: "aarch64"
@@ -1843,7 +1836,6 @@ image_types:
     image_func: "iot_commit"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "ostree-commit", "commit-archive"]
-    exports: ["commit-archive"]
     platforms:
       - *x86_64_bios_platform
       - *aarch64_platform
@@ -2035,7 +2027,6 @@ image_types:
       - "efiboot-tree"
       - "bootiso-tree"
       - "bootiso"
-    exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     image_config:
       iso_rootfs_type: "squashfs-ext4"
@@ -2080,7 +2071,6 @@ image_types:
     use_ostree_remotes: true
     build_pipelines: ["build"]
     payload_pipelines: ["ostree-deployment", "image", "xz"]
-    exports: ["xz"]
     platforms:
       - <<: *x86_64_installer_platform
         image_format: "raw"
@@ -2126,7 +2116,6 @@ image_types:
       - "efiboot-tree"
       - "bootiso-tree"
       - "bootiso"
-    exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     installer_config:
       additional_dracut_modules:
@@ -2216,7 +2205,6 @@ image_types:
     image_func: "iot_container"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "ostree-commit", "container-tree", "container"]
-    exports: ["container"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - *x86_64_bios_platform
@@ -2235,7 +2223,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "vmdk"]
-    exports: ["vmdk"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_bios_platform
@@ -2265,7 +2252,6 @@ image_types:
     filename: "image.ova"
     mime_type: "application/ovf"
     payload_pipelines: ["os", "image", "vmdk", "ovf", "archive"]
-    exports: ["archive"]
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "ova"
@@ -2276,7 +2262,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "archive"]
-    exports: ["archive"]
     bootable: true
     default_size: 21_474_836_480  # 20 * datasizes.GibiByte
     # The configuration for non-RHUI images does not touch the RHSM configuration at all.
@@ -2436,7 +2421,6 @@ image_types:
     image_func: "tar"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "archive", "xz"]
-    exports: ["xz"]
     compression: "xz"
     platforms:
       - arch: "x86_64"
@@ -2562,7 +2546,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "xz"]
-    exports: ["xz"]
     required_partition_sizes: *default_required_dir_sizes
     image_config:
       enabled_services:

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -1164,7 +1164,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "qcow2"]
-    exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_bios_platform
@@ -1274,7 +1273,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "vagrant", "archive"]
-    exports: ["archive"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_bios_platform
@@ -1317,7 +1315,6 @@ image_types:
     mime_type: "application/x-vhd"
     default_size: 4_294_967_296  # 4 * datasizes.GibiByte
     payload_pipelines: ["os", "image", "vpc"]
-    exports: ["vpc"]
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "vhd"
@@ -1445,7 +1442,6 @@ image_types:
     <<: *vhd
     mime_type: "application/xz"
     payload_pipelines: ["os", "image", "vpc", "xz"]
-    exports: ["xz"]
     compression: "xz"
     filename: "disk.vhd.xz"
     partition_table: &partition_table_azure_internal
@@ -1631,7 +1627,6 @@ image_types:
     image_func: "tar"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "archive"]
-    exports: ["archive"]
     platforms:
       - arch: "x86_64"
       - arch: "aarch64"
@@ -1653,7 +1648,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "vmdk"]
-    exports: ["vmdk"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_bios_platform
@@ -1682,7 +1676,6 @@ image_types:
     filename: "image.ova"
     mime_type: "application/ovf"
     payload_pipelines: ["os", "image", "vmdk", "ovf", "archive"]
-    exports: ["archive"]
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "ova"
@@ -1692,7 +1685,6 @@ image_types:
     mime_type: "application/xz"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "xz"]
-    exports: ["xz"]
     compression: "xz"
     image_func: "disk"
     bootable: true
@@ -1839,7 +1831,6 @@ image_types:
     mime_type: "application/octet-stream"
     filename: "image.raw"
     payload_pipelines: ["os", "image"]
-    exports: ["image"]
     compression: ""
 
   "ec2-ha":
@@ -1919,7 +1910,6 @@ image_types:
     image_func: "tar"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "archive"]
-    exports: ["xz"]
     compression: "xz"
     platforms:
       - arch: "x86_64"
@@ -2052,7 +2042,6 @@ image_types:
       - "os"
       - "bootiso-tree"
       - "bootiso"
-    exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - *x86_64_installer_platform
@@ -2079,7 +2068,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "archive"]
-    exports: ["archive"]
     bootable: true
     default_size: 21_474_836_480  # 20 * datasizes.GibiByte
     required_partition_sizes: *default_required_dir_sizes
@@ -2239,7 +2227,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "xz"]
-    exports: ["xz"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_uefi_platform
@@ -2373,7 +2360,6 @@ image_types:
     image_func: "iot_commit"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "ostree-commit", "commit-archive"]
-    exports: ["commit-archive"]
     platforms:
       - *x86_64_bios_platform
       - *aarch64_platform
@@ -2546,7 +2532,6 @@ image_types:
     image_func: "iot_container"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "ostree-commit", "container-tree", "container"]
-    exports: ["container"]
     <<: *edge_commit
 
   "edge-raw-image":
@@ -2556,7 +2541,6 @@ image_types:
     mime_type: "application/xz"
     build_pipelines: ["build"]
     payload_pipelines: ["ostree-deployment", "image", "xz"]
-    exports: ["xz"]
     default_size: 10_737_418_240  # 10 * datasizes.GibiByte
     rpm_ostree: true
     bootable: true
@@ -2620,7 +2604,6 @@ image_types:
       - "efiboot-tree"
       - "bootiso-tree"
       - "bootiso"
-    exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - *x86_64_uefi_platform
@@ -2669,7 +2652,6 @@ image_types:
       - "efiboot-tree"
       - "bootiso-tree"
       - "bootiso"
-    exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     installer_config:
       additional_dracut_modules:
@@ -2762,7 +2744,6 @@ image_types:
     default_size: 10_737_418_240  # 10 * datasizes.GibiByte
     build_pipelines: ["build"]
     payload_pipelines: ["ostree-deployment", "image"]
-    exports: ["image"]
     rpm_ostree: true
     bootable: true
     image_func: "iot"
@@ -2817,7 +2798,6 @@ image_types:
     filename: "image.vmdk"
     mime_type: "application/x-vmdk"
     payload_pipelines: ["ostree-deployment", "image", "vmdk"]
-    exports: ["vmdk"]
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "vmdk"
@@ -2844,7 +2824,6 @@ image_types:
     filename: "disk.vhd.xz"
     mime_type: "application/xz"
     payload_pipelines: ["os", "image", "vpc", "xz"]
-    exports: ["xz"]
     compression: "xz"
     default_size: 34_359_738_368  # 32 * datasizes.GibiByte
     platforms:

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -373,7 +373,6 @@ type ImageTypeYAML struct {
 	Image                  string            `yaml:"image_func"`
 	BuildPipelines         []string          `yaml:"build_pipelines"`
 	PayloadPipelines       []string          `yaml:"payload_pipelines"`
-	Exports                []string          `yaml:"exports"`
 	RequiredPartitionSizes map[string]uint64 `yaml:"required_partition_sizes"`
 
 	InternalPlatforms []platform.PlatformConf `yaml:"platforms"`

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -621,7 +621,6 @@ image_types:
     image_func: "disk"
     build_pipelines: ["build"]
     payload_pipelines: ["os", "image", "qcow2"]
-    exports: ["qcow2"]
     required_partition_sizes:
       "/": 1_073_741_824  # 1 * datasizes.GiB
     platforms:
@@ -655,7 +654,6 @@ image_types:
 	assert.Equal(t, "disk", imgType.Image)
 	assert.Equal(t, []string{"build"}, imgType.BuildPipelines)
 	assert.Equal(t, []string{"os", "image", "qcow2"}, imgType.PayloadPipelines)
-	assert.Equal(t, []string{"qcow2"}, imgType.Exports)
 	assert.Equal(t, map[string]uint64{"/": 1_073_741_824}, imgType.RequiredPartitionSizes)
 	assert.Equal(t, []platform.PlatformConf{
 		{
@@ -928,14 +926,12 @@ image_types:
   ec2:
     filename: "disk.raw"
     image_func: "disk"
-    exports: ["image"]
     platforms:
       - arch: x86_64
         uefi_vendor: "some-uefi-vendor"
   container:
     filename: "container.tar.gz"
     image_func: "container"
-    exports: ["archive"]
     platforms:
       - arch: x86_64
 `
@@ -1014,7 +1010,6 @@ func TestImageTypesPlatformOverrides(t *testing.T) {
 image_types:
   server-qcow2:
     filename: "disk.qcow2"
-    exports: ["qcow2"]
     platforms_override:
       conditions:
         "test platform override, simulate old distro is bios only":
@@ -1071,7 +1066,6 @@ func TestImageTypesPlatformOverridesMultiMarchError(t *testing.T) {
 image_types:
   test_type:
     filename: "disk.qcow2"
-    exports: ["qcow2"]
     platforms:
       - arch: x86_64
     platforms_override:

--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -119,9 +119,6 @@ type ImageType interface {
 	// Returns the package set names safe to install custom packages via custom repositories.
 	PayloadPackageSets() []string
 
-	// Returns the names of the stages that will produce the build output.
-	Exports() []string
-
 	// Returns an osbuild manifest, containing the sources and pipeline necessary
 	// to build an image, given output format with all packages and customizations
 	// specified in the given blueprint; it also returns any warnings (e.g.

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -208,7 +208,7 @@ func TestImageTypePipelineNames(t *testing.T) {
 					// The last pipeline should match the export pipeline.
 					// This might change in the future, but for now, let's make
 					// sure they match.
-					assert.Equal(imageType.Exports()[0], pm.Pipelines[len(pm.Pipelines)-1].Name)
+					assert.Equal(m.GetExports()[0], pm.Pipelines[len(pm.Pipelines)-1].Name)
 
 					// The pipelines named in allPipelines must exist in the manifest, and in the
 					// order specified (eg. 'build' first) but it does not need to be an exact

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -208,7 +208,7 @@ func TestImageTypePipelineNames(t *testing.T) {
 					// The last pipeline should match the export pipeline.
 					// This might change in the future, but for now, let's make
 					// sure they match.
-					assert.Equal(m.GetExports()[0], pm.Pipelines[len(pm.Pipelines)-1].Name)
+					assert.Equal(m.Exports()[0], pm.Pipelines[len(pm.Pipelines)-1].Name)
 
 					// The pipelines named in allPipelines must exist in the manifest, and in the
 					// order specified (eg. 'build' first) but it does not need to be an exact

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -133,13 +133,6 @@ func (t *imageType) PayloadPackageSets() []string {
 	return []string{blueprintPkgsKey}
 }
 
-func (t *imageType) Exports() []string {
-	if len(t.ImageTypeYAML.Exports) > 0 {
-		return t.ImageTypeYAML.Exports
-	}
-	return []string{"assembler"}
-}
-
 func (t *imageType) BootMode() platform.BootMode {
 	if t.platform.GetUEFIVendor() != "" && t.platform.GetBIOSPlatform() != "" {
 		return platform.BOOT_HYBRID

--- a/pkg/manifest/gzip.go
+++ b/pkg/manifest/gzip.go
@@ -38,7 +38,7 @@ func (p *Gzip) serialize() osbuild.Pipeline {
 
 	pipeline.AddStage(osbuild.NewGzipStage(
 		osbuild.NewGzipStageOptions(p.Filename()),
-		osbuild.NewGzipStageInputs(osbuild.NewFilesInputPipelineObjectRef(p.imgPipeline.Name(), p.imgPipeline.Export().Filename(), nil)),
+		osbuild.NewGzipStageInputs(osbuild.NewFilesInputPipelineObjectRef(p.imgPipeline.Name(), p.imgPipeline.Filename(), nil)),
 	))
 
 	return pipeline

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -224,7 +224,7 @@ func (m Manifest) GetCheckpoints() []string {
 	return checkpoints
 }
 
-func (m Manifest) GetExports() []string {
+func (m Manifest) Exports() []string {
 	exports := []string{}
 	for _, p := range m.pipelines {
 		if p.getExport() {

--- a/pkg/manifest/ovf.go
+++ b/pkg/manifest/ovf.go
@@ -36,7 +36,7 @@ func (p *OVF) serialize() osbuild.Pipeline {
 		&osbuild.CopyStageOptions{
 			Paths: []osbuild.CopyStagePath{
 				{
-					From: fmt.Sprintf("input://%s/%s", inputName, p.imgPipeline.Export().Filename()),
+					From: fmt.Sprintf("input://%s/%s", inputName, p.imgPipeline.Filename()),
 					To:   "tree:///",
 				},
 			},

--- a/pkg/manifest/vagrant.go
+++ b/pkg/manifest/vagrant.go
@@ -73,7 +73,7 @@ func (p *Vagrant) serialize() osbuild.Pipeline {
 			&osbuild.CopyStageOptions{
 				Paths: []osbuild.CopyStagePath{
 					{
-						From: fmt.Sprintf("input://%s/%s", inputName, p.imgPipeline.Export().Filename()),
+						From: fmt.Sprintf("input://%s/%s", inputName, p.imgPipeline.Filename()),
 						To:   "tree:///",
 					},
 				},

--- a/pkg/manifest/vmdk.go
+++ b/pkg/manifest/vmdk.go
@@ -10,7 +10,7 @@ type VMDK struct {
 	Base
 	filename string
 
-	imgPipeline Pipeline
+	imgPipeline FilePipeline
 }
 
 func (p VMDK) Filename() string {
@@ -47,7 +47,7 @@ func (p *VMDK) serialize() osbuild.Pipeline {
 		osbuild.NewQEMUStageOptions(p.Filename(), osbuild.QEMUFormatVMDK, osbuild.VMDKOptions{
 			Subformat: osbuild.VMDKSubformatStreamOptimized,
 		}),
-		osbuild.NewQemuStagePipelineFilesInputs(p.imgPipeline.Name(), p.imgPipeline.Export().Filename()),
+		osbuild.NewQemuStagePipelineFilesInputs(p.imgPipeline.Name(), p.imgPipeline.Filename()),
 	))
 
 	return pipeline

--- a/pkg/manifest/xz.go
+++ b/pkg/manifest/xz.go
@@ -38,7 +38,7 @@ func (p *XZ) serialize() osbuild.Pipeline {
 
 	pipeline.AddStage(osbuild.NewXzStage(
 		osbuild.NewXzStageOptions(p.Filename()),
-		osbuild.NewXzStageInputs(osbuild.NewFilesInputPipelineObjectRef(p.imgPipeline.Name(), p.imgPipeline.Export().Filename(), nil)),
+		osbuild.NewXzStageInputs(osbuild.NewFilesInputPipelineObjectRef(p.imgPipeline.Name(), p.imgPipeline.Filename(), nil)),
 	))
 
 	return pipeline

--- a/pkg/manifest/zstd.go
+++ b/pkg/manifest/zstd.go
@@ -38,7 +38,7 @@ func (p *Zstd) serialize() osbuild.Pipeline {
 
 	pipeline.AddStage(osbuild.NewZstdStage(
 		osbuild.NewZstdStageOptions(p.Filename()),
-		osbuild.NewZstdStageInputs(osbuild.NewFilesInputPipelineObjectRef(p.imgPipeline.Name(), p.imgPipeline.Export().Filename(), nil)),
+		osbuild.NewZstdStageInputs(osbuild.NewFilesInputPipelineObjectRef(p.imgPipeline.Name(), p.imgPipeline.Filename(), nil)),
 	))
 
 	return pipeline

--- a/pkg/manifestgen/manifestgen.go
+++ b/pkg/manifestgen/manifestgen.go
@@ -214,7 +214,7 @@ func (mg *Generator) Generate(bp *blueprint.Blueprint, dist distro.Distro, imgTy
 		}
 	}
 
-	return preManifest.GetExports(), nil
+	return preManifest.Exports(), nil
 }
 
 func xdgCacheHome() (string, error) {

--- a/pkg/manifestgen/manifestgen_test.go
+++ b/pkg/manifestgen/manifestgen_test.go
@@ -65,7 +65,7 @@ func TestManifestGeneratorDepsolve(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, mg)
 			var bp blueprint.Blueprint
-			err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+			_, err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
 			require.NoError(t, err)
 
 			pipelineNames, err := manifesttest.PipelineNamesFrom(osbuildManifest.Bytes())
@@ -113,7 +113,7 @@ func TestManifestGeneratorWithOstreeCommit(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, mg)
 	var bp blueprint.Blueprint
-	err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, imageOpts)
+	_, err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, imageOpts)
 	assert.NoError(t, err)
 
 	pipelineNames, err := manifesttest.PipelineNamesFrom(osbuildManifest.Bytes())
@@ -237,7 +237,7 @@ func TestManifestGeneratorContainers(t *testing.T) {
 			},
 		},
 	}
-	err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+	_, err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
 	assert.NoError(t, err)
 
 	// container is included
@@ -276,7 +276,7 @@ func TestManifestGeneratorDepsolveWithSbomWriter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, mg)
 	var bp blueprint.Blueprint
-	err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+	_, err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
 	require.NoError(t, err)
 
 	assert.Contains(t, generatedSboms, "centos-9-qcow2-x86_64.buildroot-build.spdx.json")
@@ -314,7 +314,7 @@ func TestManifestGeneratorSeed(t *testing.T) {
 		assert.NoError(t, err)
 
 		var bp blueprint.Blueprint
-		err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+		_, err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
 		assert.NoError(t, err)
 
 		// with the customSeed we always get a predicatable uuid for
@@ -351,7 +351,7 @@ func TestManifestGeneratorDepsolveOutput(t *testing.T) {
 	assert.NoError(t, err)
 
 	var bp blueprint.Blueprint
-	err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+	_, err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []byte("fake depsolve output"), depsolveWarningsOutput.Bytes())
@@ -388,7 +388,7 @@ func TestManifestGeneratorOverrideRepos(t *testing.T) {
 			assert.NoError(t, err)
 
 			var bp blueprint.Blueprint
-			err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+			_, err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
 			assert.NoError(t, err)
 			if withOverrideRepos {
 				assert.Contains(t, osbuildManifest.String(), "http://example.com/overriden-repo/kernel.rpm")
@@ -424,7 +424,7 @@ func TestManifestGeneratorUseBootstrapContainer(t *testing.T) {
 			assert.NoError(t, err)
 
 			var bp blueprint.Blueprint
-			err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+			_, err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
 			assert.NoError(t, err)
 			pipelines, err := manifesttest.PipelineNamesFrom(osbuildManifest.Bytes())
 			assert.NoError(t, err)


### PR DESCRIPTION
[draft as it needs consensus first and also needs updates to ibcli/composer, based on the excellent suggestion from @achilleas-k - there is also the question how this will fit with bootc/bib, see https://github.com/osbuild/images/pull/1736 which has exports for all of raw/qcow2/etc currently, this side also needs tweaks probably a selector in the images function]

This PR removes the `distro.ImageType.Exports()` method and replaces it with the `manifest.Exports()`.
