### PR TITLE
manifest: move more tests outside the base package

### DIFF
--- a/pkg/manifest/anaconda_installer_test.go
+++ b/pkg/manifest/anaconda_installer_test.go
@@ -1,4 +1,4 @@
-package manifest
+package manifest_test
 
 import (
 	"testing"
@@ -7,16 +7,17 @@ import (
 
 	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/dnfjson"
+	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/runner"
 )
 
-func newAnacondaInstaller() *AnacondaInstaller {
-	m := &Manifest{}
+func newAnacondaInstaller() *manifest.AnacondaInstaller {
+	m := &manifest.Manifest{}
 	runner := &runner.Linux{}
-	build := NewBuild(m, runner, nil, nil)
+	build := manifest.NewBuild(m, runner, nil, nil)
 
 	x86plat := &platform.X86{}
 
@@ -25,7 +26,7 @@ func newAnacondaInstaller() *AnacondaInstaller {
 
 	preview := false
 
-	installer := NewAnacondaInstaller(AnacondaInstallerTypePayload, build, x86plat, nil, "kernel", product, osversion, preview)
+	installer := manifest.NewAnacondaInstaller(manifest.AnacondaInstallerTypePayload, build, x86plat, nil, "kernel", product, osversion, preview)
 	return installer
 }
 
@@ -83,9 +84,7 @@ func TestAnacondaInstallerModules(t *testing.T) {
 				installerPipeline.UseLegacyAnacondaConfig = legacy
 				installerPipeline.EnabledAnacondaModules = tc.enable
 				installerPipeline.DisabledAnacondaModules = tc.disable
-				installerPipeline.serializeStart(Inputs{Depsolved: dnfjson.DepsolveResult{Packages: pkgs}})
-				pipeline := installerPipeline.serialize()
-
+				pipeline := manifest.SerializeWith(installerPipeline, manifest.Inputs{Depsolved: dnfjson.DepsolveResult{Packages: pkgs}})
 				require := require.New(t)
 				require.NotNil(pipeline)
 				require.NotNil(pipeline.Stages)
@@ -130,9 +129,7 @@ func TestISOLocale(t *testing.T) {
 		t.Run(input, func(t *testing.T) {
 			installerPipeline := newAnacondaInstaller()
 			installerPipeline.Locale = input
-			installerPipeline.serializeStart(Inputs{Depsolved: dnfjson.DepsolveResult{Packages: pkgs}})
-			pipeline := installerPipeline.serialize()
-
+			pipeline := manifest.SerializeWith(installerPipeline, manifest.Inputs{Depsolved: dnfjson.DepsolveResult{Packages: pkgs}})
 			require := require.New(t)
 			require.NotNil(pipeline)
 			require.NotNil(pipeline.Stages)
@@ -161,8 +158,7 @@ func TestAnacondaInstallerDracutModulesAndDrivers(t *testing.T) {
 	installerPipeline := newAnacondaInstaller()
 	installerPipeline.AdditionalDracutModules = []string{"test-module"}
 	installerPipeline.AdditionalDrivers = []string{"test-driver"}
-	installerPipeline.serializeStart(Inputs{Depsolved: dnfjson.DepsolveResult{Packages: pkgs}})
-	pipeline := installerPipeline.serialize()
+	pipeline := manifest.SerializeWith(installerPipeline, manifest.Inputs{Depsolved: dnfjson.DepsolveResult{Packages: pkgs}})
 
 	require := require.New(t)
 	require.NotNil(pipeline)

--- a/pkg/manifest/export_test.go
+++ b/pkg/manifest/export_test.go
@@ -4,56 +4,10 @@ import (
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/dnfjson"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/runner"
 )
-
-// findStage is used in both internal and external package tests.
-// TODO: make all tests external and define this only in the manifest_test
-// package.
-func findStage(name string, stages []*osbuild.Stage) *osbuild.Stage {
-	for _, s := range stages {
-		if s.Type == name {
-			return s
-		}
-	}
-	return nil
-}
-
-var FindStage = findStage
-
-func (p *Tar) Serialize() osbuild.Pipeline {
-	return p.serialize()
-}
-
-func (p *Gzip) Serialize() osbuild.Pipeline {
-	return p.serialize()
-}
-
-func (p *Zstd) Serialize() osbuild.Pipeline {
-	return p.serialize()
-}
-
-func (p *OS) Serialize() osbuild.Pipeline {
-	repos := []rpmmd.RepoConfig{}
-	packages := []rpmmd.PackageSpec{
-		{Name: "pkg1", Checksum: "sha1:c02524e2bd19490f2a7167958f792262754c5f46"},
-	}
-	p.serializeStart(Inputs{
-		Depsolved: dnfjson.DepsolveResult{
-			Packages: packages,
-			Repos:    repos,
-		},
-	})
-	return p.serialize()
-}
-
-func (p *OS) SerializeWith(inputs Inputs) osbuild.Pipeline {
-	p.serializeStart(inputs)
-	return p.serialize()
-}
 
 func (p *OS) GetBuildPackages(d Distro) []string {
 	return p.getBuildPackages(d)
@@ -65,10 +19,6 @@ func (p *OS) GetPackageSetChain(d Distro) []rpmmd.PackageSet {
 
 func (p *OS) AddStagesForAllFilesAndInlineData(pipeline *osbuild.Pipeline, files []*fsnode.File) {
 	p.addStagesForAllFilesAndInlineData(pipeline, files)
-}
-
-func (p *OS) GetInline() []string {
-	return p.getInline()
 }
 
 // NewTestOS is used in both internal and external package tests.
@@ -91,21 +41,39 @@ func NewTestOS() *OS {
 	return os
 }
 
-func (p *OSTreeDeployment) Serialize() osbuild.Pipeline {
-	p.serializeStart(Inputs{
-		Commits: []ostree.CommitSpec{{}},
-	})
-	return p.serialize()
-}
-
 func (p *OSTreeDeployment) AddStagesForAllFilesAndInlineData(pipeline *osbuild.Pipeline, files []*fsnode.File) {
 	p.addStagesForAllFilesAndInlineData(pipeline, files, "ostree/ref")
 }
 
-func (p *OSTreeDeployment) GetInline() []string {
+func (p *Vagrant) GetMacAddress() string {
+	return p.macAddress
+}
+
+func Serialize(p Pipeline) osbuild.Pipeline {
+	return p.serialize()
+}
+
+func SerializeWith(p Pipeline, inputs Inputs) osbuild.Pipeline {
+	p.serializeStart(inputs)
+	return p.serialize()
+}
+
+var MakeKickstartSudoersPost = makeKickstartSudoersPost
+
+func GetInline(p Pipeline) []string {
 	return p.getInline()
 }
 
-func (p *Vagrant) GetMacAddress() string {
-	return p.macAddress
+func (p *OS) Serialize() osbuild.Pipeline {
+	repos := []rpmmd.RepoConfig{}
+	packages := []rpmmd.PackageSpec{
+		{Name: "pkg1", Checksum: "sha1:c02524e2bd19490f2a7167958f792262754c5f46"},
+	}
+	p.serializeStart(Inputs{
+		Depsolved: dnfjson.DepsolveResult{
+			Packages: packages,
+			Repos:    repos,
+		},
+	})
+	return p.serialize()
 }

--- a/pkg/manifest/gzip_test.go
+++ b/pkg/manifest/gzip_test.go
@@ -21,7 +21,7 @@ func TestGzipSerialize(t *testing.T) {
 	gzipPipeline.SetFilename("filename.gz")
 
 	// run
-	osbuildPipeline := gzipPipeline.Serialize()
+	osbuildPipeline := manifest.Serialize(gzipPipeline)
 
 	// assert
 	assert.Equal(t, "gzip", osbuildPipeline.Name)

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/osbuild"
 )
 
 func TestDistroUnmarshal(t *testing.T) {
@@ -25,4 +26,23 @@ func TestDistroUnmarshal(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, tc.expected, distro)
 	}
+}
+
+func findStage(name string, stages []*osbuild.Stage) *osbuild.Stage {
+	for _, s := range stages {
+		if s.Type == name {
+			return s
+		}
+	}
+	return nil
+}
+
+func findStages(name string, stages []*osbuild.Stage) []*osbuild.Stage {
+	var foundStages []*osbuild.Stage
+	for _, s := range stages {
+		if s.Type == name {
+			foundStages = append(foundStages, s)
+		}
+	}
+	return foundStages
 }

--- a/pkg/manifest/raw_bootc_test.go
+++ b/pkg/manifest/raw_bootc_test.go
@@ -67,7 +67,7 @@ func TestRawBootcImageSerialize(t *testing.T) {
 	imagePipeline := rawBootcPipeline.Serialize()
 	assert.Equal(t, "image", imagePipeline.Name)
 
-	bootcInst := manifest.FindStage("org.osbuild.bootc.install-to-filesystem", imagePipeline.Stages)
+	bootcInst := findStage("org.osbuild.bootc.install-to-filesystem", imagePipeline.Stages)
 	require.NotNil(t, bootcInst)
 	opts := bootcInst.Options.(*osbuild.BootcInstallToFilesystemOptions)
 	// Note that the root account is customized via the "users" stage
@@ -134,7 +134,7 @@ func TestRawBootcImageSerializeCreateUsersOptions(t *testing.T) {
 		rawBootcPipeline.Users = tc.users
 
 		pipeline := rawBootcPipeline.Serialize()
-		usersStage := manifest.FindStage("org.osbuild.users", pipeline.Stages)
+		usersStage := findStage("org.osbuild.users", pipeline.Stages)
 		if tc.expectedUsersStage {
 			// ensure options got passed
 			require.NotNil(t, usersStage)
@@ -176,7 +176,7 @@ func TestRawBootcImageSerializeMkdirOptions(t *testing.T) {
 		rawBootcPipeline.Users = tc.users
 
 		pipeline := rawBootcPipeline.Serialize()
-		mkdirStage := manifest.FindStage("org.osbuild.mkdir", pipeline.Stages)
+		mkdirStage := findStage("org.osbuild.mkdir", pipeline.Stages)
 		if len(tc.expectedMkdirPaths) > 0 {
 			// ensure options got passed
 			require.NotNil(t, mkdirStage)
@@ -203,7 +203,7 @@ func TestRawBootcImageSerializeCreateGroupOptions(t *testing.T) {
 		rawBootcPipeline.Groups = tc.groups
 
 		pipeline := rawBootcPipeline.Serialize()
-		groupsStage := manifest.FindStage("org.osbuild.groups", pipeline.Stages)
+		groupsStage := findStage("org.osbuild.groups", pipeline.Stages)
 		if tc.expectedGroupsStage {
 			// ensure options got passed
 			require.NotNil(t, groupsStage)
@@ -248,7 +248,7 @@ func TestRawBootcImageSerializeCustomizationGenCorrectStages(t *testing.T) {
 
 		pipeline := rawBootcPipeline.Serialize()
 		for _, expectedStage := range tc.expectedStages {
-			stage := manifest.FindStage(expectedStage, pipeline.Stages)
+			stage := findStage(expectedStage, pipeline.Stages)
 			assert.NotNil(t, stage)
 			assertBootcDeploymentAndBindMount(t, stage)
 		}
@@ -279,7 +279,7 @@ func RawBootcImageSerializeFstabPipelineHasBootcMounts(t *testing.T) {
 	rawBootcPipeline := makeFakeRawBootcPipeline()
 	pipeline := rawBootcPipeline.Serialize()
 
-	stage := manifest.FindStage("org.osbuild.fstab", pipeline.Stages)
+	stage := findStage("org.osbuild.fstab", pipeline.Stages)
 	assert.NotNil(t, stage)
 	assertBootcDeploymentAndBindMount(t, stage)
 }
@@ -309,7 +309,7 @@ func TestRawBootcImageSerializeCreateFilesDirs(t *testing.T) {
 			pipeline := rawBootcPipeline.Serialize()
 
 			// check dirs
-			mkdirStage := manifest.FindStage("org.osbuild.mkdir", pipeline.Stages)
+			mkdirStage := findStage("org.osbuild.mkdir", pipeline.Stages)
 			if len(tc.dirs) > 0 {
 				// ensure options got passed
 				require.NotNil(t, mkdirStage)
@@ -321,7 +321,7 @@ func TestRawBootcImageSerializeCreateFilesDirs(t *testing.T) {
 			}
 
 			// check files
-			copyStage := manifest.FindStage("org.osbuild.copy", pipeline.Stages)
+			copyStage := findStage("org.osbuild.copy", pipeline.Stages)
 			if len(tc.files) > 0 {
 				// ensure options got passed
 				require.NotNil(t, copyStage)
@@ -332,7 +332,7 @@ func TestRawBootcImageSerializeCreateFilesDirs(t *testing.T) {
 				assert.Nil(t, copyStage)
 			}
 
-			selinuxStage := manifest.FindStage("org.osbuild.selinux", pipeline.Stages)
+			selinuxStage := findStage("org.osbuild.selinux", pipeline.Stages)
 
 			assert.NotNil(t, selinuxStage)
 

--- a/pkg/manifest/tar_test.go
+++ b/pkg/manifest/tar_test.go
@@ -23,7 +23,7 @@ func TestTarSerialize(t *testing.T) {
 	tarPipeline.Compression = osbuild.TarArchiveCompressionZstd
 
 	// run
-	osbuildPipeline := tarPipeline.Serialize()
+	osbuildPipeline := manifest.Serialize(tarPipeline)
 
 	// assert
 	assert.Equal(t, "tar-pipeline", osbuildPipeline.Name)

--- a/pkg/manifest/zstd_test.go
+++ b/pkg/manifest/zstd_test.go
@@ -21,7 +21,7 @@ func TestZstdSerialize(t *testing.T) {
 	zstdPipeline.SetFilename("filename.zst")
 
 	// run
-	osbuildPipeline := zstdPipeline.Serialize()
+	osbuildPipeline := manifest.Serialize(zstdPipeline)
 
 	// assert
 	assert.Equal(t, "zstd", osbuildPipeline.Name)


### PR DESCRIPTION
I wanted to write some manifest generation tests for some cases we don't yet cover and as a first step I decided to clean up some of the tests under `pkg/manifest/`.  This is the result of that initial cleanup.

---

Move more tests outside the manifest package and into manifest_test.

The findStage() was previously defined in the manifest package and exported through export_test.go to be used in the manifest_test package. Now it is only defined in manifest_test.

The findStages() function has been moved from os_test.go to manifest_test.go.  Currently it's only used in os_test.go but it fits in the general file as a test utility function.

One major change in this commit is the exported serialization functions in export_test.go.  Previously, we had exported Serialize() methods defined, which we wrappers around the private serialize() method of specific pipelines.  Now these have been replaced with functions that take a Pipeline interface as first argument.  Two serialization functions are defined: one that takes inputs (SerializeWith(), which calls pipeline.serializeStart(inputs) and pipeline.serialize()) and one that does not (Serialize(), which only calls pipeline.serialize()).