### PR TITLE
distrodefs/fedora: add supported customizations for net installer

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -2169,3 +2169,5 @@ image_types:
       - *aarch64_installer_platform
     supported_blueprint_options:
       - "distro"
+      - "customizations.fips"
+      - "customizations.locale"

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -640,7 +640,7 @@ func TestDistro_ManifestFIPSWarning(t *testing.T) {
 						switch imgTypeName {
 						case "workstation-live-installer":
 							assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.fips: not supported", imgTypeName))
-						case "wsl", "iot-bootable-container", "container", "everything-netinst":
+						case "wsl", "iot-bootable-container", "container":
 							assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 						default:
 							assert.Equal(t, slices.Contains(warn, msg), !common.IsBuildHostFIPSEnabled(),

--- a/pkg/distro/generic/fedora_test.go
+++ b/pkg/distro/generic/fedora_test.go
@@ -508,13 +508,13 @@ func TestFedoraDistro_ManifestError(t *testing.T) {
 					switch imgTypeName {
 					case "iot-commit", "iot-container":
 						assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.kernel.append: not supported", imgTypeName))
-					case "minimal-installer", "iot-installer", "workstation-live-installer":
+					case "minimal-installer", "iot-installer", "workstation-live-installer", "everything-netinst":
 						assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.kernel: not supported", imgTypeName))
 					case "iot-simplified-installer":
 						assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.installation_device: required", imgTypeName))
 					case "iot-raw-xz", "iot-qcow2":
 						assert.EqualError(t, err, fmt.Sprintf("%s: ostree commit URL required", imgTypeName))
-					case "container", "wsl", "iot-bootable-container", "everything-netinst":
+					case "container", "wsl", "iot-bootable-container":
 						assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 					default:
 						assert.NoError(t, err)
@@ -719,9 +719,9 @@ func TestFedoraDistro_CustomFileSystemManifestError(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: maybeMakeOSTreeURL(imgTypeName)}, nil, nil)
 				switch imgTypeName {
-				case "minimal-installer", "iot-installer", "workstation-live-installer", "iot-simplified-installer", "iot-commit", "iot-container":
+				case "minimal-installer", "iot-installer", "workstation-live-installer", "iot-simplified-installer", "iot-commit", "iot-container", "everything-netinst":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "container", "wsl", "iot-bootable-container", "everything-netinst":
+				case "container", "wsl", "iot-bootable-container":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					// TODO: this error message is a bit clunky; bring it more in line with the other messages (remove "The following errors ...")
@@ -750,9 +750,9 @@ func TestFedoraDistro_TestRootMountPoint(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: maybeMakeOSTreeURL(imgTypeName)}, nil, nil)
 				switch imgTypeName {
-				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container":
+				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "everything-netinst":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "iot-bootable-container", "container", "everything-netinst":
+				case "wsl", "iot-bootable-container", "container":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					assert.NoError(t, err)
@@ -784,9 +784,9 @@ func TestFedoraDistro_CustomFileSystemSubDirectories(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: maybeMakeOSTreeURL(imgTypeName)}, nil, nil)
 				switch imgTypeName {
-				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container":
+				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "everything-netinst":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "iot-bootable-container", "container", "everything-netinst":
+				case "wsl", "iot-bootable-container", "container":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					assert.NoError(t, err)
@@ -826,9 +826,9 @@ func TestFedoraDistro_MountpointsWithArbitraryDepthAllowed(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: maybeMakeOSTreeURL(imgTypeName)}, nil, nil)
 				switch imgTypeName {
-				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container":
+				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "everything-netinst":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "iot-bootable-container", "container", "everything-netinst":
+				case "wsl", "iot-bootable-container", "container":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					assert.NoError(t, err)
@@ -864,9 +864,9 @@ func TestFedoraDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: maybeMakeOSTreeURL(imgTypeName)}, nil, nil)
 				switch imgTypeName {
-				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container":
+				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "everything-netinst":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "iot-bootable-container", "container", "everything-netinst":
+				case "wsl", "iot-bootable-container", "container":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					// TODO: this error message is a bit clunky; bring it more in line with the other messages (remove "The following errors ...")
@@ -898,9 +898,9 @@ func TestFedoraDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, options, nil, nil)
 				switch imgTypeName {
-				case "workstation-live-installer", "iot-container", "iot-commit", "iot-installer", "iot-simplified-installer", "minimal-installer":
+				case "workstation-live-installer", "iot-container", "iot-commit", "iot-installer", "iot-simplified-installer", "minimal-installer", "everything-netinst":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "iot-bootable-container", "container", "everything-netinst":
+				case "wsl", "iot-bootable-container", "container":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					assert.NoError(t, err)
@@ -942,9 +942,9 @@ func TestFedoraDistro_PartitioningConflict(t *testing.T) {
 				}
 				_, _, err := imgType.Manifest(&bp, options, nil, nil)
 				switch imgTypeName {
-				case "workstation-live-installer", "iot-container", "iot-commit", "iot-installer", "iot-simplified-installer", "minimal-installer":
+				case "workstation-live-installer", "iot-container", "iot-commit", "iot-installer", "iot-simplified-installer", "minimal-installer", "everything-netinst":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "iot-bootable-container", "container", "everything-netinst":
+				case "wsl", "iot-bootable-container", "container":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.disk cannot be used with customizations.filesystem", imgTypeName))


### PR DESCRIPTION
The net installer supports only FIPS and the locale.

https://github.com/osbuild/images/pull/1216#issuecomment-3189972728

~~Draft: Based on #1767~~