### PR TITLE
bootc disk: Copy /uar/lib/bootupd from target container to build cont…

### DIFF
--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -60,8 +60,8 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 
 		pipelineName := "target"
 		// files to copy have slash at end to copy directory contents, not directory itself
-		copyFiles := []string{"/usr/lib/bootc/install/", "/usr/lib/ostree/"}
-		ensureDirPaths := []string{"/usr/lib/bootc/install", "/usr/lib/ostree"}
+		copyFiles := []string{"/usr/lib/bootc/install/", "/usr/lib/ostree/", "/usr/lib/bootupd/"}
+		ensureDirPaths := []string{"/usr/lib/bootc/install", "/usr/lib/ostree", "/usr/lib/bootupd"}
 
 		copyFilesFrom = map[string][]string{pipelineName: copyFiles}
 		for _, path := range ensureDirPaths {


### PR DESCRIPTION
…ainer

/usr/lib/bootupd container target container specific details, and bootc install-to-filesystem will read it from the build container. So, if we're running bootc-image-builder with a different build container we need to copy this data to the build container just like we do the bootc install config files, etc.