### PR TITLE
[RFC] kernel arguments options support  for all installers

### DIFF
--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -541,6 +541,12 @@ func liveInstallerImage(imgTypeCustomizations manifest.OSCustomizations,
 
 	img := image.NewAnacondaLiveInstaller()
 
+	var err error
+	img.OSCustomizations, err = osCustomizations(t, packageSets[osPkgsKey], options, containers, bp.Customizations)
+	if err != nil {
+		return nil, err
+	}
+
 	img.Platform = t.platform
 	img.ImgTypeCustomizations = imgTypeCustomizations
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
@@ -553,7 +559,6 @@ func liveInstallerImage(imgTypeCustomizations manifest.OSCustomizations,
 	img.Release = fmt.Sprintf("%s %s", d.Product(), d.OsVersion())
 	img.Preview = d.DistroYAML.Preview
 
-	var err error
 	img.ISOLabel, err = t.ISOLabel()
 	if err != nil {
 		return nil, err

--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -986,6 +986,10 @@ func netinstImage(imgTypeCustomizations manifest.OSCustomizations,
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
 
 	var err error
+	img.OSCustomizations, err = osCustomizations(t, packageSets[osPkgsKey], options, containers, bp.Customizations)
+	if err != nil {
+		return nil, err
+	}
 
 	img.InstallerCustomizations, err = installerCustomizations(t, bp.Customizations)
 

--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -798,7 +798,10 @@ func iotInstallerImage(imgTypeCustomizations manifest.OSCustomizations,
 	img.Kickstart.Timezone, _ = customizations.GetTimezoneSettings()
 
 	img.InstallerCustomizations, err = installerCustomizations(t, bp.Customizations)
-
+	if err != nil {
+		return nil, err
+	}
+	img.OSCustomizations, err = osCustomizations(t, packageSets[osPkgsKey], options, containers, bp.Customizations)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -23,6 +23,7 @@ type AnacondaContainerInstaller struct {
 	Platform                platform.Platform
 	InstallerCustomizations manifest.InstallerCustomizations
 	ExtraBasePackages       rpmmd.PackageSet
+	OSCustomizations        manifest.OSCustomizations
 
 	RootfsCompression string
 
@@ -116,6 +117,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	if anacondaPipeline.InstallerCustomizations.FIPS {
 		bootTreePipeline.KernelOpts = append(bootTreePipeline.KernelOpts, "fips=1")
 	}
+	bootTreePipeline.KernelOpts = append(bootTreePipeline.KernelOpts, img.OSCustomizations.KernelOptionsAppend...)
 
 	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(buildPipeline, anacondaPipeline, rootfsImagePipeline, bootTreePipeline)
 	isoTreePipeline.PartitionTable = efiBootPartitionTable(rng)
@@ -134,6 +136,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	if anacondaPipeline.InstallerCustomizations.FIPS {
 		isoTreePipeline.KernelOpts = append(isoTreePipeline.KernelOpts, "fips=1")
 	}
+	isoTreePipeline.KernelOpts = append(isoTreePipeline.KernelOpts, img.OSCustomizations.KernelOptionsAppend...)
 
 	isoTreePipeline.InstallRootfsType = img.InstallRootfsType
 

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -20,6 +20,7 @@ type AnacondaLiveInstaller struct {
 	InstallerCustomizations manifest.InstallerCustomizations
 	Environment             environment.Environment
 	ImgTypeCustomizations   manifest.OSCustomizations
+	OSCustomizations        manifest.OSCustomizations
 
 	ExtraBasePackages rpmmd.PackageSet
 
@@ -101,6 +102,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	}
 
 	kernelOpts = append(kernelOpts, img.InstallerCustomizations.AdditionalKernelOpts...)
+	kernelOpts = append(kernelOpts, img.OSCustomizations.KernelOptionsAppend...)
 
 	bootTreePipeline.KernelOpts = kernelOpts
 

--- a/pkg/image/anaconda_net_installer.go
+++ b/pkg/image/anaconda_net_installer.go
@@ -21,6 +21,7 @@ type AnacondaNetInstaller struct {
 	InstallerCustomizations manifest.InstallerCustomizations
 	Environment             environment.Environment
 	ImgTypeCustomizations   manifest.OSCustomizations
+	OSCustomizations        manifest.OSCustomizations
 
 	ExtraBasePackages rpmmd.PackageSet
 
@@ -100,6 +101,7 @@ func (img *AnacondaNetInstaller) InstantiateManifest(m *manifest.Manifest,
 		kernelOpts = append(kernelOpts, "fips=1")
 	}
 	kernelOpts = append(kernelOpts, img.InstallerCustomizations.AdditionalKernelOpts...)
+	kernelOpts = append(kernelOpts, img.OSCustomizations.KernelOptionsAppend...)
 	bootTreePipeline.KernelOpts = kernelOpts
 
 	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(buildPipeline, anacondaPipeline, rootfsImagePipeline, bootTreePipeline)
@@ -111,6 +113,7 @@ func (img *AnacondaNetInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.RootfsType = img.InstallerCustomizations.ISORootfsType
 
 	isoTreePipeline.KernelOpts = img.InstallerCustomizations.AdditionalKernelOpts
+	isoTreePipeline.KernelOpts = append(isoTreePipeline.KernelOpts, img.OSCustomizations.KernelOptionsAppend...)
 	if anacondaPipeline.InstallerCustomizations.FIPS {
 		isoTreePipeline.KernelOpts = append(isoTreePipeline.KernelOpts, "fips=1")
 	}

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -22,6 +22,7 @@ type AnacondaOSTreeInstaller struct {
 	Base
 	Platform                platform.Platform
 	InstallerCustomizations manifest.InstallerCustomizations
+	OSCustomizations        manifest.OSCustomizations
 	ExtraBasePackages       rpmmd.PackageSet
 
 	Kickstart *kickstart.Options
@@ -119,6 +120,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	if anacondaPipeline.InstallerCustomizations.FIPS {
 		bootTreePipeline.KernelOpts = append(bootTreePipeline.KernelOpts, "fips=1")
 	}
+	bootTreePipeline.KernelOpts = append(bootTreePipeline.KernelOpts, img.OSCustomizations.KernelOptionsAppend...)
 
 	var subscriptionPipeline *manifest.Subscription
 	if img.Subscription != nil {
@@ -140,6 +142,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	if anacondaPipeline.InstallerCustomizations.FIPS {
 		isoTreePipeline.KernelOpts = append(isoTreePipeline.KernelOpts, "fips=1")
 	}
+	isoTreePipeline.KernelOpts = append(isoTreePipeline.KernelOpts, img.OSCustomizations.KernelOptionsAppend...)
 	isoTreePipeline.SubscriptionPipeline = subscriptionPipeline
 
 	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, img.ISOLabel)


### PR DESCRIPTION
When debugging a test failure of centos9 iso install I want to use the cool new feature by Simon to add kernel arguments to the installer (c.f. https://github.com/osbuild/images/pull/1727/files) test in bib via a blueprint kernel append.

I noticed then that its currently implemented for a subset of our installers, so I created this quick draft to see what it would take and it seems (beside the duplication) straightforward. Is there a reason not to support the kargs for the missing installers? If not I'm happy to flesh this one out more, it needs tests (obviously) but I did not want to write them before there is agreement that is what we want.

[edit/reminder: the AanacondaContainerInstaller needs a coresponding change in bib to fully work]