### PR TITLE
manifest: fix comment for OSCustomizations.BaseModules

### DIFF
--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -39,8 +39,7 @@ type OSCustomizations struct {
 	// These are the statically defined packages for the image type.
 	BasePackages []string
 
-	// Modules to install in addition to the ones required by the pipeline.
-	// These are the statically defined packages for the image type.
+	// Module streams to make available for installation.
 	BaseModules []string
 
 	// Packages to exclude from the base package set. This is useful in


### PR DESCRIPTION
This commit fixes an incorrect comment in the description of OSCustomizations.BaseModules.

Thanks to Thozza, c.f.
https://github.com/osbuild/images/pull/1770#discussion_r2289845280