### PR TITLE
Basic support for aboot support in bootc-image-builder

### DIFF
--- a/internal/testdisk/partition.go
+++ b/internal/testdisk/partition.go
@@ -398,6 +398,11 @@ func MakeFakePartitionTable(mntPoints ...string) *disk.PartitionTable {
 			}
 			swap.GenUUID(rng)
 			payload = swap
+		case "raw":
+			payload = &disk.Raw{
+				SourcePipeline: "build",
+				SourcePath:     "/usr/lib/modules/5.0/aboot.img",
+			}
 		default:
 			payload = &disk.Filesystem{
 				Type:       "ext4",

--- a/pkg/disk/raw.go
+++ b/pkg/disk/raw.go
@@ -1,0 +1,31 @@
+package disk
+
+import (
+	"reflect"
+)
+
+// Raw defines the payload for a raw partition. It's similar to a
+// [Filesystem] but with fewer fields. It is a [PayloadEntity].
+type Raw struct {
+	SourcePipeline string
+	SourcePath     string
+}
+
+func init() {
+	payloadEntityMap["raw"] = reflect.TypeOf(Raw{})
+}
+
+func (s *Raw) EntityName() string {
+	return "raw"
+}
+
+func (s *Raw) Clone() Entity {
+	if s == nil {
+		return nil
+	}
+
+	return &Raw{
+		SourcePipeline: s.SourcePipeline,
+		SourcePath:     s.SourcePath,
+	}
+}

--- a/pkg/disk/raw_test.go
+++ b/pkg/disk/raw_test.go
@@ -1,0 +1,11 @@
+package disk_test
+
+import (
+	"testing"
+
+	"github.com/osbuild/images/pkg/disk"
+)
+
+func TestImplementsInterfacesCompileTimeCheckRaw(t *testing.T) {
+	var _ = disk.PayloadEntity(&disk.Raw{})
+}

--- a/pkg/osbuild/bootupd_stage.go
+++ b/pkg/osbuild/bootupd_stage.go
@@ -118,13 +118,13 @@ func genMountsForBootupd(source string, pt *disk.PartitionTable) ([]Mount, error
 					}
 					mount.Source = lv.Name
 					mounts = append(mounts, *mount)
-				case *disk.Swap:
+				case *disk.Swap, *disk.Raw:
 					// nothing to do
 				default:
 					return nil, fmt.Errorf("expected LV payload %+[1]v to be mountable or swap, got %[1]T", lv.Payload)
 				}
 			}
-		case *disk.Swap:
+		case *disk.Swap, *disk.Raw:
 			// nothing to do
 		default:
 			return nil, fmt.Errorf("type %T not supported by bootupd handling yet", part.Payload)

--- a/pkg/osbuild/device.go
+++ b/pkg/osbuild/device.go
@@ -164,6 +164,8 @@ func deviceName(p disk.Entity) string {
 		return "btrfs-" + payload.UUID[:4]
 	case *disk.Swap:
 		return "swap-" + payload.UUID[:4]
+	case *disk.Raw:
+		return "raw-" + pathEscape(payload.SourcePath)
 	}
 	panic(fmt.Sprintf("unsupported device type in deviceName: '%T'", p))
 }

--- a/pkg/osbuild/write_device_stage.go
+++ b/pkg/osbuild/write_device_stage.go
@@ -1,0 +1,16 @@
+package osbuild
+
+type WriteDeviceStageOptions struct {
+	From string `json:"from"`
+}
+
+func (WriteDeviceStageOptions) isStageOptions() {}
+
+func NewWriteDeviceStage(options *WriteDeviceStageOptions, inputs Inputs, devices map[string]Device) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.write-device",
+		Options: options,
+		Inputs:  inputs,
+		Devices: devices,
+	}
+}


### PR DESCRIPTION
This adds required features for making bootc-image-builder support aboot images. 

The two features are:

Add support for Osinfo to find the kernel dir (/usr/lib/moduler/*) in the target container, and check if it contains an aboot.img. This will be used by bootc-image-builder to trigger the "aboot mode" for the image. This is similar to what was done for `bootc install` in https://github.com/bootc-dev/bootc/pull/1532.

Support adding a "disk.Raw" payload, that specifies a file from an earlier pipeline and writes it to a device. This uses the new org.ostree.write-device stage (added in v154).

The intent is that bootc-image-builder will detect that there is an aboot.img in the target image, and then find the correct partition in the partition table and add a disk.Raw  payload to the raw boot partition to initialize it from the file. The corresponding bc-i-b code is available here: https://github.com/alexlarsson/bootc-image-builder/tree/aboot-support for reading, but will later be a separate PR.

Note: The bc-i-b branch above doesn't build against this PR, because bc-i-b doesn't build against osbuild-images v0.178 due to API changes, but I tested it against v0.177, and it worked.
