### PR TITLE
imagefilter: include repos in filter result

### DIFF
--- a/pkg/imagefilter/formatter_test.go
+++ b/pkg/imagefilter/formatter_test.go
@@ -29,7 +29,7 @@ func newFakeResult(t *testing.T, resultSpec string) imagefilter.Result {
 	require.NoError(t, err)
 	im, err := ar.GetImageType(l[1])
 	require.NoError(t, err)
-	return imagefilter.Result{di, ar, im}
+	return imagefilter.Result{di, ar, im, nil}
 }
 
 func TestResultsFormatter(t *testing.T) {

--- a/pkg/imagefilter/imagefilter.go
+++ b/pkg/imagefilter/imagefilter.go
@@ -6,10 +6,12 @@ import (
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distrofactory"
 	"github.com/osbuild/images/pkg/distrosort"
+	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-type DistroLister interface {
+type MinimalRepoRegistry interface {
 	ListDistros() []string
+	ReposByImageTypeName(distro, arch, imageType string) ([]rpmmd.RepoConfig, error)
 }
 
 // Result contains a result from a imagefilter.Filter run
@@ -17,17 +19,18 @@ type Result struct {
 	Distro  distro.Distro
 	Arch    distro.Arch
 	ImgType distro.ImageType
+	Repos   []rpmmd.RepoConfig
 }
 
 // ImageFilter is an a flexible way to filter the available images.
 type ImageFilter struct {
 	fac   *distrofactory.Factory
-	repos DistroLister
+	repos MinimalRepoRegistry
 }
 
 // New creates a new ImageFilter that can be used to filter the list
 // of available images
-func New(fac *distrofactory.Factory, repos DistroLister) (*ImageFilter, error) {
+func New(fac *distrofactory.Factory, repos MinimalRepoRegistry) (*ImageFilter, error) {
 	if fac == nil {
 		return nil, fmt.Errorf("cannot create ImageFilter without a valid distrofactory")
 	}
@@ -80,7 +83,11 @@ func (i *ImageFilter) Filter(searchTerms ...string) ([]Result, error) {
 					return nil, err
 				}
 				if filter.Matches(distro, a, imgType) {
-					res = append(res, Result{distro, a, imgType})
+					repos, err := i.repos.ReposByImageTypeName(distroName, archName, imgTypeName)
+					if err != nil {
+						return nil, err
+					}
+					res = append(res, Result{distro, a, imgType, repos})
 				}
 			}
 		}


### PR DESCRIPTION
[draft as this needs tests but is otherwise good to go I think]

When returning the results of the image filter include the repositories too. To re-create an image we need the distro and the matching repositories, as they are currently only loosely connected we need to tie them a bit more together here. This will be needed by image-builder-cli for the pkgsearch command.

This will be needed for
* pkgSearch as the search needs to know what repos the image type has available, c.f. https://github.com/osbuild/image-builder-cli/pull/268 
* bootc support in images as the ISO will need to know what repositories are available from the container so that is can setup the mTLS config, c.f. https://github.com/osbuild/images/compare/main...mvo5:images:distro-bootc-with-iso and https://github.com/osbuild/bootc-image-builder/blob/main/bib/cmd/bootc-image-builder/mtls.go#L20)