### PR TITLE
image,manifest: move installer metadata into InstallerCustomiaztions

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -1634,6 +1634,7 @@ image_types:
     boot_iso: true
     image_func: "live_installer"
     iso_label: "Workstation"
+    variant: "Workstation"
     exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
     installer_config:

--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -564,8 +564,6 @@ func liveInstallerImage(t *imageType,
 	if err != nil {
 		return nil, err
 	}
-	// XXX: get from yaml
-	img.InstallerCustomizations.Variant = "Workstation"
 
 	return img, nil
 }

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -62,18 +62,14 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 		img.platform,
 		repos,
 		"kernel",
-		img.InstallerCustomizations.Product,
-		img.InstallerCustomizations.OSVersion,
-		img.InstallerCustomizations.Preview,
+		img.InstallerCustomizations,
 	)
 
 	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include
 	anacondaPipeline.ExcludePackages = img.ExtraBasePackages.Exclude
 	anacondaPipeline.ExtraRepos = img.ExtraBasePackages.Repositories
-	anacondaPipeline.Variant = img.InstallerCustomizations.Variant
 	anacondaPipeline.Biosdevname = (img.platform.GetArch() == arch.ARCH_X86_64)
 	anacondaPipeline.Checkpoint()
-	anacondaPipeline.InstallerCustomizations = img.InstallerCustomizations
 
 	if anacondaPipeline.InstallerCustomizations.FIPS {
 		anacondaPipeline.InstallerCustomizations.EnabledAnacondaModules = append(

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -50,19 +50,14 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 		img.platform,
 		repos,
 		"kernel",
-		img.InstallerCustomizations.Product,
-		img.InstallerCustomizations.OSVersion,
-		img.InstallerCustomizations.Preview,
+		img.InstallerCustomizations,
 	)
 
 	livePipeline.ExtraPackages = img.ExtraBasePackages.Include
 	livePipeline.ExcludePackages = img.ExtraBasePackages.Exclude
 
-	livePipeline.Variant = img.InstallerCustomizations.Variant
 	livePipeline.Biosdevname = (img.platform.GetArch() == arch.ARCH_X86_64)
-
 	livePipeline.Locale = img.Locale
-	livePipeline.InstallerCustomizations = img.InstallerCustomizations
 
 	// The live installer has SELinux enabled and targeted
 	livePipeline.SELinux = "targeted"

--- a/pkg/image/anaconda_net_installer.go
+++ b/pkg/image/anaconda_net_installer.go
@@ -47,18 +47,13 @@ func (img *AnacondaNetInstaller) InstantiateManifest(m *manifest.Manifest,
 		img.platform,
 		repos,
 		"kernel",
-		img.InstallerCustomizations.Product,
-		img.InstallerCustomizations.OSVersion,
-		img.InstallerCustomizations.Preview,
+		img.InstallerCustomizations,
 	)
 
 	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include
 	anacondaPipeline.ExcludePackages = img.ExtraBasePackages.Exclude
 	anacondaPipeline.ExtraRepos = img.ExtraBasePackages.Repositories
-	anacondaPipeline.Variant = img.InstallerCustomizations.Variant
 	anacondaPipeline.Biosdevname = (img.platform.GetArch() == arch.ARCH_X86_64)
-
-	anacondaPipeline.InstallerCustomizations = img.InstallerCustomizations
 
 	if anacondaPipeline.InstallerCustomizations.FIPS {
 		anacondaPipeline.InstallerCustomizations.EnabledAnacondaModules = append(

--- a/pkg/image/anaconda_net_installer.go
+++ b/pkg/image/anaconda_net_installer.go
@@ -24,13 +24,6 @@ type AnacondaNetInstaller struct {
 
 	RootfsCompression string
 
-	ISOLabel  string
-	Product   string
-	Variant   string
-	OSVersion string
-	Release   string
-	Preview   bool
-
 	Language string
 }
 
@@ -54,15 +47,15 @@ func (img *AnacondaNetInstaller) InstantiateManifest(m *manifest.Manifest,
 		img.platform,
 		repos,
 		"kernel",
-		img.Product,
-		img.OSVersion,
-		img.Preview,
+		img.InstallerCustomizations.Product,
+		img.InstallerCustomizations.OSVersion,
+		img.InstallerCustomizations.Preview,
 	)
 
 	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include
 	anacondaPipeline.ExcludePackages = img.ExtraBasePackages.Exclude
 	anacondaPipeline.ExtraRepos = img.ExtraBasePackages.Repositories
-	anacondaPipeline.Variant = img.Variant
+	anacondaPipeline.Variant = img.InstallerCustomizations.Variant
 	anacondaPipeline.Biosdevname = (img.platform.GetArch() == arch.ARCH_X86_64)
 
 	anacondaPipeline.InstallerCustomizations = img.InstallerCustomizations
@@ -86,13 +79,13 @@ func (img *AnacondaNetInstaller) InstantiateManifest(m *manifest.Manifest,
 	default:
 	}
 
-	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
+	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.InstallerCustomizations.Product, img.InstallerCustomizations.OSVersion)
 	bootTreePipeline.Platform = img.platform
 	bootTreePipeline.UEFIVendor = img.platform.GetUEFIVendor()
-	bootTreePipeline.ISOLabel = img.ISOLabel
+	bootTreePipeline.ISOLabel = img.InstallerCustomizations.ISOLabel
 	bootTreePipeline.DefaultMenu = img.InstallerCustomizations.DefaultMenu
 
-	kernelOpts := []string{fmt.Sprintf("inst.stage2=hd:LABEL=%s", img.ISOLabel)}
+	kernelOpts := []string{fmt.Sprintf("inst.stage2=hd:LABEL=%s", img.InstallerCustomizations.ISOLabel)}
 	if anacondaPipeline.InstallerCustomizations.FIPS {
 		kernelOpts = append(kernelOpts, "fips=1")
 	}
@@ -102,7 +95,7 @@ func (img *AnacondaNetInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(buildPipeline, anacondaPipeline, rootfsImagePipeline, bootTreePipeline)
 	// TODO: the partition table is required - make it a ctor arg or set a default one in the pipeline
 	isoTreePipeline.PartitionTable = efiBootPartitionTable(rng)
-	isoTreePipeline.Release = img.Release
+	isoTreePipeline.Release = img.InstallerCustomizations.Release
 
 	isoTreePipeline.RootfsCompression = img.RootfsCompression
 	isoTreePipeline.RootfsType = img.InstallerCustomizations.ISORootfsType
@@ -114,7 +107,7 @@ func (img *AnacondaNetInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	isoTreePipeline.ISOBoot = img.InstallerCustomizations.ISOBoot
 
-	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, img.ISOLabel)
+	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, img.InstallerCustomizations.ISOLabel)
 	isoPipeline.SetFilename(img.filename)
 	isoPipeline.ISOBoot = img.InstallerCustomizations.ISOBoot
 

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -57,9 +57,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 		img.platform,
 		repos,
 		"kernel",
-		img.InstallerCustomizations.Product,
-		img.InstallerCustomizations.OSVersion,
-		img.InstallerCustomizations.Preview,
+		img.InstallerCustomizations,
 	)
 	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include
 	anacondaPipeline.ExcludePackages = img.ExtraBasePackages.Exclude
@@ -70,11 +68,8 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 			Groups: img.Kickstart.Groups,
 		}
 	}
-	anacondaPipeline.Variant = img.InstallerCustomizations.Variant
 	anacondaPipeline.Biosdevname = (img.platform.GetArch() == arch.ARCH_X86_64)
 	anacondaPipeline.Checkpoint()
-
-	anacondaPipeline.InstallerCustomizations = img.InstallerCustomizations
 
 	if anacondaPipeline.InstallerCustomizations.FIPS {
 		anacondaPipeline.InstallerCustomizations.EnabledAnacondaModules = append(

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -47,13 +47,6 @@ type AnacondaTarInstaller struct {
 	Kickstart *kickstart.Options
 
 	RootfsCompression string
-
-	ISOLabel  string
-	Product   string
-	Variant   string
-	OSVersion string
-	Release   string
-	Preview   bool
 }
 
 func NewAnacondaTarInstaller(platform platform.Platform, filename string) *AnacondaTarInstaller {
@@ -83,9 +76,9 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 		img.platform,
 		repos,
 		"kernel",
-		img.Product,
-		img.OSVersion,
-		img.Preview,
+		img.InstallerCustomizations.Product,
+		img.InstallerCustomizations.OSVersion,
+		img.InstallerCustomizations.Preview,
 	)
 
 	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include
@@ -97,7 +90,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 			Groups: img.Kickstart.Groups,
 		}
 	}
-	anacondaPipeline.Variant = img.Variant
+	anacondaPipeline.Variant = img.InstallerCustomizations.Variant
 	anacondaPipeline.Biosdevname = (img.platform.GetArch() == arch.ARCH_X86_64)
 
 	anacondaPipeline.InstallerCustomizations = img.InstallerCustomizations
@@ -123,15 +116,15 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	default:
 	}
 
-	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
+	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.InstallerCustomizations.Product, img.InstallerCustomizations.OSVersion)
 	bootTreePipeline.Platform = img.platform
 	bootTreePipeline.UEFIVendor = img.platform.GetUEFIVendor()
-	bootTreePipeline.ISOLabel = img.ISOLabel
+	bootTreePipeline.ISOLabel = img.InstallerCustomizations.ISOLabel
 	bootTreePipeline.DefaultMenu = img.InstallerCustomizations.DefaultMenu
 
 	kernelOpts := []string{
-		fmt.Sprintf("inst.stage2=hd:LABEL=%s", img.ISOLabel),
-		fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", img.ISOLabel, img.Kickstart.Path),
+		fmt.Sprintf("inst.stage2=hd:LABEL=%s", img.InstallerCustomizations.ISOLabel),
+		fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", img.InstallerCustomizations.ISOLabel, img.Kickstart.Path),
 	}
 
 	if img.OSCustomizations.FIPS {
@@ -148,7 +141,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline := manifest.NewAnacondaInstallerISOTree(buildPipeline, anacondaPipeline, rootfsImagePipeline, bootTreePipeline)
 	// TODO: the partition table is required - make it a ctor arg or set a default one in the pipeline
 	isoTreePipeline.PartitionTable = efiBootPartitionTable(rng)
-	isoTreePipeline.Release = img.Release
+	isoTreePipeline.Release = img.InstallerCustomizations.Release
 	isoTreePipeline.Kickstart = img.Kickstart
 	isoTreePipeline.PayloadPath = tarPath
 	isoTreePipeline.Kickstart.Path = img.Kickstart.Path
@@ -165,7 +158,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	isoTreePipeline.ISOBoot = img.InstallerCustomizations.ISOBoot
 
-	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, img.ISOLabel)
+	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, img.InstallerCustomizations.ISOLabel)
 	isoPipeline.SetFilename(img.filename)
 	isoPipeline.ISOBoot = img.InstallerCustomizations.ISOBoot
 

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -76,9 +76,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 		img.platform,
 		repos,
 		"kernel",
-		img.InstallerCustomizations.Product,
-		img.InstallerCustomizations.OSVersion,
-		img.InstallerCustomizations.Preview,
+		img.InstallerCustomizations,
 	)
 
 	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include
@@ -90,10 +88,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 			Groups: img.Kickstart.Groups,
 		}
 	}
-	anacondaPipeline.Variant = img.InstallerCustomizations.Variant
 	anacondaPipeline.Biosdevname = (img.platform.GetArch() == arch.ARCH_X86_64)
-
-	anacondaPipeline.InstallerCustomizations = img.InstallerCustomizations
 
 	if img.OSCustomizations.FIPS {
 		anacondaPipeline.InstallerCustomizations.EnabledAnacondaModules = append(

--- a/pkg/image/installer_image_test.go
+++ b/pkg/image/installer_image_test.go
@@ -90,9 +90,9 @@ func TestContainerInstallerUnsetKSOptions(t *testing.T) {
 	img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil)
 	assert.Contains(t, mfs, fmt.Sprintf(`"inst.ks=hd:LABEL=%s:/osbuild.ks"`, isolabel))
@@ -102,9 +102,9 @@ func TestContainerInstallerUnsetKSPath(t *testing.T) {
 	img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 	// set empty kickstart options (no path)
 	img.Kickstart = &kickstart.Options{}
 
@@ -116,9 +116,9 @@ func TestContainerInstallerSetKSPath(t *testing.T) {
 	img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 	img.Kickstart = &kickstart.Options{
 		Path: "/test.ks",
 	}
@@ -132,9 +132,9 @@ func TestContainerInstallerExt4Rootfs(t *testing.T) {
 	img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil)
 
@@ -147,9 +147,9 @@ func TestContainerInstallerSquashfsRootfs(t *testing.T) {
 	img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 	img.InstallerCustomizations.ISORootfsType = manifest.SquashfsRootfs
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil)
@@ -163,9 +163,9 @@ func TestOSTreeInstallerUnsetKSPath(t *testing.T) {
 	img := image.NewAnacondaOSTreeInstaller(testPlatform, "filename", ostree.SourceSpec{})
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 	img.Kickstart = &kickstart.Options{
 		// the ostree options must be non-nil
 		OSTree: &kickstart.OSTree{},
@@ -179,9 +179,9 @@ func TestOSTreeInstallerSetKSPath(t *testing.T) {
 	img := image.NewAnacondaOSTreeInstaller(testPlatform, "filename", ostree.SourceSpec{})
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 	img.Kickstart = &kickstart.Options{
 		// the ostree options must be non-nil
 		OSTree: &kickstart.OSTree{},
@@ -197,9 +197,9 @@ func TestOSTreeInstallerExt4Rootfs(t *testing.T) {
 	img := image.NewAnacondaOSTreeInstaller(testPlatform, "filename", ostree.SourceSpec{})
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 	img.Kickstart = &kickstart.Options{
 		// the ostree options must be non-nil
 		OSTree: &kickstart.OSTree{},
@@ -216,9 +216,9 @@ func TestOSTreeInstallerSquashfsRootfs(t *testing.T) {
 	img := image.NewAnacondaOSTreeInstaller(testPlatform, "filename", ostree.SourceSpec{})
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 	img.InstallerCustomizations.ISORootfsType = manifest.SquashfsRootfs
 	img.Kickstart = &kickstart.Options{
 		// the ostree options must be non-nil
@@ -236,9 +236,9 @@ func TestTarInstallerUnsetKSOptions(t *testing.T) {
 	img := image.NewAnacondaTarInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
 
@@ -250,9 +250,9 @@ func TestTarInstallerUnsetKSPath(t *testing.T) {
 	img := image.NewAnacondaTarInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 	img.Kickstart = &kickstart.Options{}
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
@@ -265,9 +265,9 @@ func TestTarInstallerSetKSPath(t *testing.T) {
 	img := image.NewAnacondaTarInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 	img.Kickstart = &kickstart.Options{
 		Path: "/test.ks",
 	}
@@ -283,9 +283,9 @@ func TestTarInstallerExt4Rootfs(t *testing.T) {
 	img := image.NewAnacondaTarInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
 	// Confirm that it includes the rootfs-image pipeline that makes the ext4 rootfs
@@ -297,9 +297,9 @@ func TestTarInstallerSquashfsRootfs(t *testing.T) {
 	img := image.NewAnacondaTarInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 	img.InstallerCustomizations.ISORootfsType = manifest.SquashfsRootfs
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
@@ -312,9 +312,9 @@ func TestLiveInstallerExt4Rootfs(t *testing.T) {
 	img := image.NewAnacondaLiveInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
 	// Confirm that it includes the rootfs-image pipeline that makes the ext4 rootfs
@@ -326,9 +326,9 @@ func TestLiveInstallerSquashfsRootfs(t *testing.T) {
 	img := image.NewAnacondaLiveInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 	img.InstallerCustomizations.ISORootfsType = manifest.SquashfsRootfs
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
@@ -365,9 +365,9 @@ func TestContainerInstallerPanics(t *testing.T) {
 	assert := assert.New(t)
 	img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
 	assert.PanicsWithError("org.osbuild.grub2.iso: product.name option is required", func() { instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil) })
-	img.Product = product
+	img.InstallerCustomizations.Product = product
 	assert.PanicsWithError("org.osbuild.grub2.iso: product.version option is required", func() { instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil) })
-	img.OSVersion = osversion
+	img.InstallerCustomizations.OSVersion = osversion
 	assert.PanicsWithError("org.osbuild.grub2.iso: isolabel option is required", func() { instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil) })
 }
 
@@ -382,11 +382,11 @@ func TestOSTreeInstallerPanics(t *testing.T) {
 	assert.PanicsWithError("org.osbuild.grub2.iso: product.name option is required",
 		func() { instantiateAndSerialize(t, img, mockPackageSets(), nil, mockOSTreeCommitSpecs()) })
 
-	img.Product = product
+	img.InstallerCustomizations.Product = product
 	assert.PanicsWithError("org.osbuild.grub2.iso: product.version option is required",
 		func() { instantiateAndSerialize(t, img, mockPackageSets(), nil, mockOSTreeCommitSpecs()) })
 
-	img.OSVersion = osversion
+	img.InstallerCustomizations.OSVersion = osversion
 	assert.PanicsWithError("org.osbuild.grub2.iso: isolabel option is required",
 		func() { instantiateAndSerialize(t, img, mockPackageSets(), nil, mockOSTreeCommitSpecs()) })
 }
@@ -398,11 +398,11 @@ func TestTarInstallerPanics(t *testing.T) {
 	assert.PanicsWithError("org.osbuild.grub2.iso: product.name option is required",
 		func() { instantiateAndSerialize(t, img, mockPackageSets(), nil, nil) })
 
-	img.Product = product
+	img.InstallerCustomizations.Product = product
 	assert.PanicsWithError("org.osbuild.grub2.iso: product.version option is required",
 		func() { instantiateAndSerialize(t, img, mockPackageSets(), nil, nil) })
 
-	img.OSVersion = osversion
+	img.InstallerCustomizations.OSVersion = osversion
 	assert.PanicsWithError("org.osbuild.grub2.iso: isolabel option is required",
 		func() { instantiateAndSerialize(t, img, mockPackageSets(), nil, nil) })
 }
@@ -475,9 +475,9 @@ func TestContainerInstallerModules(t *testing.T) {
 		for _, legacy := range []bool{true, false} {
 			t.Run(name, func(t *testing.T) {
 				img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
-				img.Product = product
-				img.OSVersion = osversion
-				img.ISOLabel = isolabel
+				img.InstallerCustomizations.Product = product
+				img.InstallerCustomizations.OSVersion = osversion
+				img.InstallerCustomizations.ISOLabel = isolabel
 
 				img.InstallerCustomizations.UseLegacyAnacondaConfig = legacy
 				img.InstallerCustomizations.EnabledAnacondaModules = tc.enable
@@ -501,9 +501,9 @@ func TestOSTreeInstallerModules(t *testing.T) {
 		for _, legacy := range []bool{true, false} {
 			t.Run(name, func(t *testing.T) {
 				img := image.NewAnacondaOSTreeInstaller(testPlatform, "filename", ostree.SourceSpec{})
-				img.Product = product
-				img.OSVersion = osversion
-				img.ISOLabel = isolabel
+				img.InstallerCustomizations.Product = product
+				img.InstallerCustomizations.OSVersion = osversion
+				img.InstallerCustomizations.ISOLabel = isolabel
 				img.Kickstart = &kickstart.Options{
 					// the ostree options must be non-nil
 					OSTree: &kickstart.OSTree{},
@@ -531,10 +531,9 @@ func TestTarInstallerModules(t *testing.T) {
 		for _, legacy := range []bool{true, false} {
 			t.Run(name, func(t *testing.T) {
 				img := image.NewAnacondaTarInstaller(testPlatform, "filename")
-				img.Product = product
-				img.OSVersion = osversion
-				img.ISOLabel = isolabel
-
+				img.InstallerCustomizations.Product = product
+				img.InstallerCustomizations.OSVersion = osversion
+				img.InstallerCustomizations.ISOLabel = isolabel
 				img.InstallerCustomizations.UseLegacyAnacondaConfig = legacy
 				img.InstallerCustomizations.EnabledAnacondaModules = tc.enable
 				img.InstallerCustomizations.DisabledAnacondaModules = tc.disable
@@ -574,9 +573,9 @@ func TestInstallerLocales(t *testing.T) {
 			img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
 			assert.NotNil(t, img)
 
-			img.Product = product
-			img.OSVersion = osversion
-			img.ISOLabel = isolabel
+			img.InstallerCustomizations.Product = product
+			img.InstallerCustomizations.OSVersion = osversion
+			img.InstallerCustomizations.ISOLabel = isolabel
 			img.Locale = input
 
 			mfs := instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil)
@@ -589,9 +588,9 @@ func TestInstallerLocales(t *testing.T) {
 			img := image.NewAnacondaOSTreeInstaller(testPlatform, "filename", ostree.SourceSpec{})
 			assert.NotNil(t, img)
 
-			img.Product = product
-			img.OSVersion = osversion
-			img.ISOLabel = isolabel
+			img.InstallerCustomizations.Product = product
+			img.InstallerCustomizations.OSVersion = osversion
+			img.InstallerCustomizations.ISOLabel = isolabel
 			img.Kickstart = &kickstart.Options{
 				// the ostree options must be non-nil
 				OSTree: &kickstart.OSTree{},
@@ -608,9 +607,9 @@ func TestInstallerLocales(t *testing.T) {
 			img := image.NewAnacondaTarInstaller(testPlatform, "filename")
 			assert.NotNil(t, img)
 
-			img.Product = product
-			img.OSVersion = osversion
-			img.ISOLabel = isolabel
+			img.InstallerCustomizations.Product = product
+			img.InstallerCustomizations.OSVersion = osversion
+			img.InstallerCustomizations.ISOLabel = isolabel
 			img.OSCustomizations.Language = input
 
 			mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
@@ -623,9 +622,9 @@ func TestInstallerLocales(t *testing.T) {
 			img := image.NewAnacondaNetInstaller(testPlatform, "filename")
 			assert.NotNil(t, img)
 
-			img.Product = product
-			img.OSVersion = osversion
-			img.ISOLabel = isolabel
+			img.InstallerCustomizations.Product = product
+			img.InstallerCustomizations.OSVersion = osversion
+			img.InstallerCustomizations.ISOLabel = isolabel
 			img.Language = input
 
 			mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
@@ -638,9 +637,9 @@ func TestInstallerLocales(t *testing.T) {
 			img := image.NewAnacondaLiveInstaller(testPlatform, "filename")
 			assert.NotNil(t, img)
 
-			img.Product = product
-			img.OSVersion = osversion
-			img.ISOLabel = isolabel
+			img.InstallerCustomizations.Product = product
+			img.InstallerCustomizations.OSVersion = osversion
+			img.InstallerCustomizations.ISOLabel = isolabel
 			img.Locale = input
 
 			mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
@@ -703,9 +702,9 @@ func findGrub2IsoStageOptions(t *testing.T, mf manifest.OSBuildManifest, pipelin
 
 func TestContainerInstallerDracut(t *testing.T) {
 	img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 
 	testModules := []string{"test-module"}
 	testDrivers := []string{"test-driver"}
@@ -727,9 +726,10 @@ func TestContainerInstallerDracut(t *testing.T) {
 
 func TestOSTreeInstallerDracut(t *testing.T) {
 	img := image.NewAnacondaOSTreeInstaller(testPlatform, "filename", ostree.SourceSpec{})
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
+
 	img.Kickstart = &kickstart.Options{
 		// the ostree options must be non-nil
 		OSTree: &kickstart.OSTree{},
@@ -755,9 +755,9 @@ func TestOSTreeInstallerDracut(t *testing.T) {
 
 func TestTarInstallerDracut(t *testing.T) {
 	img := image.NewAnacondaTarInstaller(testPlatform, "filename")
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 
 	testModules := []string{"test-module"}
 	testDrivers := []string{"test-driver"}
@@ -779,9 +779,9 @@ func TestTarInstallerDracut(t *testing.T) {
 
 func TestTarInstallerKernelOpts(t *testing.T) {
 	img := image.NewAnacondaTarInstaller(testPlatform, "filename")
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 
 	testOpts := []string{"foo=1", "bar=2"}
 
@@ -800,9 +800,9 @@ func TestNetInstallerExt4Rootfs(t *testing.T) {
 	img := image.NewAnacondaNetInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
 	// Confirm that it includes the rootfs-image pipeline that makes the ext4 rootfs
@@ -814,9 +814,9 @@ func TestNetInstallerSquashfsRootfs(t *testing.T) {
 	img := image.NewAnacondaNetInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 	img.InstallerCustomizations.ISORootfsType = manifest.SquashfsRootfs
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
@@ -827,9 +827,9 @@ func TestNetInstallerSquashfsRootfs(t *testing.T) {
 
 func TestNetInstallerDracut(t *testing.T) {
 	img := image.NewAnacondaNetInstaller(testPlatform, "filename")
-	img.Product = product
-	img.OSVersion = osversion
-	img.ISOLabel = isolabel
+	img.InstallerCustomizations.Product = product
+	img.InstallerCustomizations.OSVersion = osversion
+	img.InstallerCustomizations.ISOLabel = isolabel
 	testModules := []string{"test-module"}
 	testDrivers := []string{"test-driver"}
 

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -438,8 +438,8 @@ func (p *AnacondaInstallerISOTree) serialize() osbuild.Pipeline {
 	case SyslinuxISOBoot:
 		options := &osbuild.ISOLinuxStageOptions{
 			Product: osbuild.ISOLinuxProduct{
-				Name:    p.anacondaPipeline.product,
-				Version: p.anacondaPipeline.version,
+				Name:    p.anacondaPipeline.InstallerCustomizations.Product,
+				Version: p.anacondaPipeline.InstallerCustomizations.OSVersion,
 			},
 			Kernel: osbuild.ISOLinuxKernel{
 				Dir:  "/images/pxeboot",
@@ -459,8 +459,8 @@ func (p *AnacondaInstallerISOTree) serialize() osbuild.Pipeline {
 		}
 		options := &osbuild.Grub2ISOLegacyStageOptions{
 			Product: osbuild.Product{
-				Name:    p.anacondaPipeline.product,
-				Version: p.anacondaPipeline.version,
+				Name:    p.anacondaPipeline.InstallerCustomizations.Product,
+				Version: p.anacondaPipeline.InstallerCustomizations.OSVersion,
 			},
 			Kernel: osbuild.ISOKernel{
 				Dir:  "/images/pxeboot",

--- a/pkg/manifest/anaconda_installer_iso_tree_test.go
+++ b/pkg/manifest/anaconda_installer_iso_tree_test.go
@@ -50,9 +50,11 @@ func newTestAnacondaISOTree() *manifest.AnacondaInstallerISOTree {
 		x86plat,
 		nil,
 		"kernel",
-		product,
-		osversion,
-		preview,
+		manifest.InstallerCustomizations{
+			Product:   product,
+			OSVersion: osversion,
+			Preview:   preview,
+		},
 	)
 	rootfsImagePipeline := manifest.NewISORootfsImg(build, anacondaPipeline)
 	bootTreePipeline := manifest.NewEFIBootTree(build, product, osversion)

--- a/pkg/manifest/anaconda_installer_test.go
+++ b/pkg/manifest/anaconda_installer_test.go
@@ -27,7 +27,12 @@ func newAnacondaInstaller() *manifest.AnacondaInstaller {
 
 	preview := false
 
-	installer := manifest.NewAnacondaInstaller(manifest.AnacondaInstallerTypePayload, build, x86plat, nil, "kernel", product, osversion, preview)
+	instCust := manifest.InstallerCustomizations{
+		Product:   product,
+		OSVersion: osversion,
+		Preview:   preview,
+	}
+	installer := manifest.NewAnacondaInstaller(manifest.AnacondaInstallerTypePayload, build, x86plat, nil, "kernel", instCust)
 	return installer
 }
 

--- a/pkg/manifest/installer.go
+++ b/pkg/manifest/installer.go
@@ -24,4 +24,11 @@ type InstallerCustomizations struct {
 	ISOBoot       ISOBootType
 
 	DefaultMenu int
+
+	ISOLabel  string
+	Product   string
+	Variant   string
+	OSVersion string
+	Release   string
+	Preview   bool
 }


### PR DESCRIPTION
Some pretty mechanical refactor to avoid some duplication. Originally I planned multiple PRs but maybe this is straightforward enough for a single PR(?). In any case, happy to split it up if desired.

---

distro: move variant for live installer into YAML

We have a lot of duplicated extraction to get the installer product, isoLabel etc. This commit consolidates it into the InstallerCustomizations.

---

image,manifest: pass InstallerCustomizations in NewAnaconda*

By passing the InstallerCustomiations into the various
image.NewAnaconda*() function we can simplify the code by
only passing a single struct (that is part of the anaconda
structs anyway).

This also means we can use the product/preview etc values
from the customizations and don't need to carry an extra
copy. So this is dropped too.
