### PR TITLE
image: add platform/filename to image.New*()

### DIFF
--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -49,9 +49,11 @@ type AnacondaContainerInstaller struct {
 	InstallRootfsType disk.FSType
 }
 
-func NewAnacondaContainerInstaller(container container.SourceSpec, ref string) *AnacondaContainerInstaller {
+func NewAnacondaContainerInstaller(platform platform.Platform, filename string, container container.SourceSpec, ref string) *AnacondaContainerInstaller {
 	return &AnacondaContainerInstaller{
 		Base:            NewBase("container-installer"),
+		Platform:        platform,
+		Filename:        filename,
 		ContainerSource: container,
 		Ref:             ref,
 	}

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -16,7 +16,6 @@ import (
 
 type AnacondaLiveInstaller struct {
 	Base
-	Platform                platform.Platform
 	InstallerCustomizations manifest.InstallerCustomizations
 	Environment             environment.Environment
 
@@ -31,8 +30,6 @@ type AnacondaLiveInstaller struct {
 	Release   string
 	Preview   bool
 
-	Filename string
-
 	// Locale for the installer. This should be set to the same locale as the
 	// ISO OS payload, if known.
 	Locale string
@@ -43,9 +40,7 @@ type AnacondaLiveInstaller struct {
 
 func NewAnacondaLiveInstaller(platform platform.Platform, filename string) *AnacondaLiveInstaller {
 	return &AnacondaLiveInstaller{
-		Base:     NewBase("live-installer"),
-		Platform: platform,
-		Filename: filename,
+		Base: NewBase("live-installer", platform, filename),
 	}
 }
 
@@ -59,7 +54,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	livePipeline := manifest.NewAnacondaInstaller(
 		manifest.AnacondaInstallerTypeLive,
 		buildPipeline,
-		img.Platform,
+		img.platform,
 		repos,
 		"kernel",
 		img.Product,
@@ -71,7 +66,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	livePipeline.ExcludePackages = img.ExtraBasePackages.Exclude
 
 	livePipeline.Variant = img.Variant
-	livePipeline.Biosdevname = (img.Platform.GetArch() == arch.ARCH_X86_64)
+	livePipeline.Biosdevname = (img.platform.GetArch() == arch.ARCH_X86_64)
 	livePipeline.Locale = img.Locale
 	livePipeline.InstallerCustomizations = img.InstallerCustomizations
 
@@ -89,8 +84,8 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	}
 
 	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
-	bootTreePipeline.Platform = img.Platform
-	bootTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
+	bootTreePipeline.Platform = img.platform
+	bootTreePipeline.UEFIVendor = img.platform.GetUEFIVendor()
 	bootTreePipeline.ISOLabel = img.ISOLabel
 	bootTreePipeline.DefaultMenu = img.InstallerCustomizations.DefaultMenu
 
@@ -116,7 +111,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.RootfsType = img.InstallerCustomizations.ISORootfsType
 
 	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, img.ISOLabel)
-	isoPipeline.SetFilename(img.Filename)
+	isoPipeline.SetFilename(img.filename)
 	isoPipeline.ISOBoot = img.InstallerCustomizations.ISOBoot
 
 	artifact := isoPipeline.Export()

--- a/pkg/image/anaconda_live_installer.go
+++ b/pkg/image/anaconda_live_installer.go
@@ -41,9 +41,11 @@ type AnacondaLiveInstaller struct {
 	AdditionalDrivers       []string
 }
 
-func NewAnacondaLiveInstaller() *AnacondaLiveInstaller {
+func NewAnacondaLiveInstaller(platform platform.Platform, filename string) *AnacondaLiveInstaller {
 	return &AnacondaLiveInstaller{
-		Base: NewBase("live-installer"),
+		Base:     NewBase("live-installer"),
+		Platform: platform,
+		Filename: filename,
 	}
 }
 

--- a/pkg/image/anaconda_net_installer.go
+++ b/pkg/image/anaconda_net_installer.go
@@ -36,9 +36,11 @@ type AnacondaNetInstaller struct {
 	Language string
 }
 
-func NewAnacondaNetInstaller() *AnacondaNetInstaller {
+func NewAnacondaNetInstaller(platform platform.Platform, filename string) *AnacondaNetInstaller {
 	return &AnacondaNetInstaller{
-		Base: NewBase("netinst"),
+		Base:     NewBase("netinst"),
+		Platform: platform,
+		Filename: filename,
 	}
 }
 

--- a/pkg/image/anaconda_net_installer.go
+++ b/pkg/image/anaconda_net_installer.go
@@ -17,7 +17,6 @@ import (
 
 type AnacondaNetInstaller struct {
 	Base
-	Platform                platform.Platform
 	InstallerCustomizations manifest.InstallerCustomizations
 	Environment             environment.Environment
 
@@ -32,15 +31,12 @@ type AnacondaNetInstaller struct {
 	Release   string
 	Preview   bool
 
-	Filename string
 	Language string
 }
 
 func NewAnacondaNetInstaller(platform platform.Platform, filename string) *AnacondaNetInstaller {
 	return &AnacondaNetInstaller{
-		Base:     NewBase("netinst"),
-		Platform: platform,
-		Filename: filename,
+		Base: NewBase("netinst", platform, filename),
 	}
 }
 
@@ -55,7 +51,7 @@ func (img *AnacondaNetInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline := manifest.NewAnacondaInstaller(
 		installerType,
 		buildPipeline,
-		img.Platform,
+		img.platform,
 		repos,
 		"kernel",
 		img.Product,
@@ -67,7 +63,7 @@ func (img *AnacondaNetInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline.ExcludePackages = img.ExtraBasePackages.Exclude
 	anacondaPipeline.ExtraRepos = img.ExtraBasePackages.Repositories
 	anacondaPipeline.Variant = img.Variant
-	anacondaPipeline.Biosdevname = (img.Platform.GetArch() == arch.ARCH_X86_64)
+	anacondaPipeline.Biosdevname = (img.platform.GetArch() == arch.ARCH_X86_64)
 
 	anacondaPipeline.InstallerCustomizations = img.InstallerCustomizations
 
@@ -91,8 +87,8 @@ func (img *AnacondaNetInstaller) InstantiateManifest(m *manifest.Manifest,
 	}
 
 	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
-	bootTreePipeline.Platform = img.Platform
-	bootTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
+	bootTreePipeline.Platform = img.platform
+	bootTreePipeline.UEFIVendor = img.platform.GetUEFIVendor()
 	bootTreePipeline.ISOLabel = img.ISOLabel
 	bootTreePipeline.DefaultMenu = img.InstallerCustomizations.DefaultMenu
 
@@ -119,7 +115,7 @@ func (img *AnacondaNetInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.ISOBoot = img.InstallerCustomizations.ISOBoot
 
 	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, img.ISOLabel)
-	isoPipeline.SetFilename(img.Filename)
+	isoPipeline.SetFilename(img.filename)
 	isoPipeline.ISOBoot = img.InstallerCustomizations.ISOBoot
 
 	artifact := isoPipeline.Export()

--- a/pkg/image/anaconda_ostree_installer.go
+++ b/pkg/image/anaconda_ostree_installer.go
@@ -47,10 +47,12 @@ type AnacondaOSTreeInstaller struct {
 	Locale string
 }
 
-func NewAnacondaOSTreeInstaller(commit ostree.SourceSpec) *AnacondaOSTreeInstaller {
+func NewAnacondaOSTreeInstaller(platform platform.Platform, filename string, commit ostree.SourceSpec) *AnacondaOSTreeInstaller {
 	return &AnacondaOSTreeInstaller{
-		Base:   NewBase("ostree-installer"),
-		Commit: commit,
+		Base:     NewBase("ostree-installer"),
+		Platform: platform,
+		Filename: filename,
+		Commit:   commit,
 	}
 }
 

--- a/pkg/image/anaconda_tar_installer.go
+++ b/pkg/image/anaconda_tar_installer.go
@@ -59,9 +59,11 @@ type AnacondaTarInstaller struct {
 	Filename string
 }
 
-func NewAnacondaTarInstaller() *AnacondaTarInstaller {
+func NewAnacondaTarInstaller(platform platform.Platform, filename string) *AnacondaTarInstaller {
 	return &AnacondaTarInstaller{
-		Base: NewBase("image-installer"),
+		Base:     NewBase("image-installer"),
+		Platform: platform,
+		Filename: filename,
 	}
 }
 

--- a/pkg/image/archive.go
+++ b/pkg/image/archive.go
@@ -13,10 +13,8 @@ import (
 
 type Archive struct {
 	Base
-	Platform         platform.Platform
 	OSCustomizations manifest.OSCustomizations
 	Environment      environment.Environment
-	Filename         string
 	Compression      string
 
 	OSVersion string
@@ -24,9 +22,7 @@ type Archive struct {
 
 func NewArchive(platform platform.Platform, filename string) *Archive {
 	return &Archive{
-		Base:     NewBase("archive"),
-		Platform: platform,
-		Filename: filename,
+		Base: NewBase("archive", platform, filename),
 	}
 }
 
@@ -37,7 +33,7 @@ func (img *Archive) InstantiateManifest(m *manifest.Manifest,
 	buildPipeline := addBuildBootstrapPipelines(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
-	osPipeline := manifest.NewOS(buildPipeline, img.Platform, repos)
+	osPipeline := manifest.NewOS(buildPipeline, img.platform, repos)
 	osPipeline.OSCustomizations = img.OSCustomizations
 	osPipeline.Environment = img.Environment
 	osPipeline.OSVersion = img.OSVersion
@@ -45,7 +41,7 @@ func (img *Archive) InstantiateManifest(m *manifest.Manifest,
 	tarPipeline := manifest.NewTar(buildPipeline, osPipeline, "archive")
 
 	compressionPipeline := GetCompressionPipeline(img.Compression, buildPipeline, tarPipeline)
-	compressionPipeline.SetFilename(img.Filename)
+	compressionPipeline.SetFilename(img.filename)
 
 	return compressionPipeline.Export(), nil
 }

--- a/pkg/image/archive.go
+++ b/pkg/image/archive.go
@@ -22,9 +22,11 @@ type Archive struct {
 	OSVersion string
 }
 
-func NewArchive() *Archive {
+func NewArchive(platform platform.Platform, filename string) *Archive {
 	return &Archive{
-		Base: NewBase("archive"),
+		Base:     NewBase("archive"),
+		Platform: platform,
+		Filename: filename,
 	}
 }
 

--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -16,10 +16,7 @@ import (
 type BootcDiskImage struct {
 	Base
 
-	Platform       platform.Platform
 	PartitionTable *disk.PartitionTable
-
-	Filename string
 
 	ContainerSource      *container.SourceSpec
 	BuildContainerSource *container.SourceSpec
@@ -30,9 +27,7 @@ type BootcDiskImage struct {
 
 func NewBootcDiskImage(platform platform.Platform, filename string, container container.SourceSpec, buildContainer container.SourceSpec) *BootcDiskImage {
 	return &BootcDiskImage{
-		Base:                 NewBase("bootc-raw-image"),
-		Platform:             platform,
-		Filename:             filename,
+		Base:                 NewBase("bootc-raw-image", platform, filename),
 		ContainerSource:      &container,
 		BuildContainerSource: &buildContainer,
 	}
@@ -101,7 +96,7 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 	// this is signified by passing nil to the below pipelines.
 	var hostPipeline manifest.Build
 
-	rawImage := manifest.NewRawBootcImage(buildPipeline, containers, img.Platform)
+	rawImage := manifest.NewRawBootcImage(buildPipeline, containers, img.platform)
 	rawImage.PartitionTable = img.PartitionTable
 	rawImage.Users = img.OSCustomizations.Users
 	rawImage.Groups = img.OSCustomizations.Groups
@@ -114,11 +109,11 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 	// In BIB, we export multiple images from the same pipeline so we use the
 	// filename as the basename for each export and set the extensions based on
 	// each file format.
-	fileBasename := img.Filename
+	fileBasename := img.filename
 	rawImage.SetFilename(fmt.Sprintf("%s.raw", fileBasename))
 
 	qcow2Pipeline := manifest.NewQCOW2(hostPipeline, rawImage)
-	qcow2Pipeline.Compat = img.Platform.GetQCOW2Compat()
+	qcow2Pipeline.Compat = img.platform.GetQCOW2Compat()
 	qcow2Pipeline.SetFilename(fmt.Sprintf("%s.qcow2", fileBasename))
 
 	vmdkPipeline := manifest.NewVMDK(hostPipeline, rawImage)

--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -28,9 +28,11 @@ type BootcDiskImage struct {
 	OSCustomizations manifest.OSCustomizations
 }
 
-func NewBootcDiskImage(container container.SourceSpec, buildContainer container.SourceSpec) *BootcDiskImage {
+func NewBootcDiskImage(platform platform.Platform, filename string, container container.SourceSpec, buildContainer container.SourceSpec) *BootcDiskImage {
 	return &BootcDiskImage{
 		Base:                 NewBase("bootc-raw-image"),
+		Platform:             platform,
+		Filename:             filename,
 		ContainerSource:      &container,
 		BuildContainerSource: &buildContainer,
 	}

--- a/pkg/image/bootc_disk_legacy.go
+++ b/pkg/image/bootc_disk_legacy.go
@@ -37,12 +37,12 @@ func (img *BootcLegacyDiskImage) InstantiateManifestFromContainers(m *manifest.M
 	// XXX: hardcoded for now
 	ref := "ostree/1/1/0"
 	ostreeImg := &OSTreeDiskImage{
-		Base:            NewBase("bootc-raw-image"),
+		Base:            NewBase("bootc-raw-image", img.bootcImg.platform, img.bootcImg.filename),
 		ContainerSource: img.bootcImg.ContainerSource,
 		Ref:             ref,
 		OSName:          "default",
 	}
-	ostreeImg.Platform = img.bootcImg.Platform
+	ostreeImg.platform = img.bootcImg.platform
 	ostreeImg.PartitionTable = img.bootcImg.PartitionTable
 	ostreeImg.OSTreeDeploymentCustomizations.KernelOptionsAppend = img.bootcImg.OSCustomizations.KernelOptionsAppend
 	ostreeImg.OSTreeDeploymentCustomizations.Users = img.bootcImg.OSCustomizations.Users
@@ -57,7 +57,7 @@ func (img *BootcLegacyDiskImage) InstantiateManifestFromContainers(m *manifest.M
 
 	opts := &baseRawOstreeImageOpts{useBootupd: true}
 
-	fileBasename := img.bootcImg.Filename
+	fileBasename := img.bootcImg.filename
 
 	// In BIB, we export multiple images from the same pipeline so we use the
 	// filename as the basename for each export and set the extensions based on
@@ -66,7 +66,7 @@ func (img *BootcLegacyDiskImage) InstantiateManifestFromContainers(m *manifest.M
 	baseImage.SetFilename(fmt.Sprintf("%s.raw", fileBasename))
 
 	qcow2Pipeline := manifest.NewQCOW2(hostPipeline, baseImage)
-	qcow2Pipeline.Compat = ostreeImg.Platform.GetQCOW2Compat()
+	qcow2Pipeline.Compat = ostreeImg.platform.GetQCOW2Compat()
 	qcow2Pipeline.SetFilename(fmt.Sprintf("%s.qcow2", fileBasename))
 
 	vmdkPipeline := manifest.NewVMDK(hostPipeline, baseImage)

--- a/pkg/image/bootc_disk_test.go
+++ b/pkg/image/bootc_disk_test.go
@@ -26,7 +26,7 @@ func TestBootcDiskImageNew(t *testing.T) {
 		Name:   "name",
 	}
 
-	img := image.NewBootcDiskImage(containerSource, containerSource)
+	img := image.NewBootcDiskImage(testPlatform, "filename", containerSource, containerSource)
 	require.NotNil(t, img)
 	assert.Equal(t, img.Base.Name(), "bootc-raw-image")
 }
@@ -74,10 +74,8 @@ func makeBootcDiskImageOsbuildManifest(t *testing.T, opts *bootcDiskImageTestOpt
 	}
 	containers := []container.SourceSpec{containerSource}
 
-	img := image.NewBootcDiskImage(containerSource, containerSource)
-	img.Filename = "fake-disk"
+	img := image.NewBootcDiskImage(makeFakePlatform(opts), "fake-disk", containerSource, containerSource)
 	require.NotNil(t, img)
-	img.Platform = makeFakePlatform(opts)
 	img.PartitionTable = testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
 	img.OSCustomizations.KernelOptionsAppend = opts.KernelOptionsAppend
 	img.OSCustomizations.Users = opts.Users

--- a/pkg/image/container.go
+++ b/pkg/image/container.go
@@ -19,9 +19,11 @@ type BaseContainer struct {
 	Filename         string
 }
 
-func NewBaseContainer() *BaseContainer {
+func NewBaseContainer(platform platform.Platform, filename string) *BaseContainer {
 	return &BaseContainer{
-		Base: NewBase("base-container"),
+		Base:     NewBase("base-container"),
+		Platform: platform,
+		Filename: filename,
 	}
 }
 

--- a/pkg/image/container.go
+++ b/pkg/image/container.go
@@ -13,17 +13,13 @@ import (
 
 type BaseContainer struct {
 	Base
-	Platform         platform.Platform
 	OSCustomizations manifest.OSCustomizations
 	Environment      environment.Environment
-	Filename         string
 }
 
 func NewBaseContainer(platform platform.Platform, filename string) *BaseContainer {
 	return &BaseContainer{
-		Base:     NewBase("base-container"),
-		Platform: platform,
-		Filename: filename,
+		Base: NewBase("base-container", platform, filename),
 	}
 }
 
@@ -34,12 +30,12 @@ func (img *BaseContainer) InstantiateManifest(m *manifest.Manifest,
 	buildPipeline := addBuildBootstrapPipelines(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
-	osPipeline := manifest.NewOS(buildPipeline, img.Platform, repos)
+	osPipeline := manifest.NewOS(buildPipeline, img.platform, repos)
 	osPipeline.OSCustomizations = img.OSCustomizations
 	osPipeline.Environment = img.Environment
 
 	ociPipeline := manifest.NewOCIContainer(buildPipeline, osPipeline)
-	ociPipeline.SetFilename(img.Filename)
+	ociPipeline.SetFilename(img.filename)
 	artifact := ociPipeline.Export()
 
 	return artifact, nil

--- a/pkg/image/disk.go
+++ b/pkg/image/disk.go
@@ -35,9 +35,11 @@ type DiskImage struct {
 	OSNick    string
 }
 
-func NewDiskImage() *DiskImage {
+func NewDiskImage(platform platform.Platform, filename string) *DiskImage {
 	return &DiskImage{
 		Base:     NewBase("disk"),
+		Platform: platform,
+		Filename: filename,
 		PartTool: osbuild.PTSfdisk,
 	}
 }

--- a/pkg/image/disk.go
+++ b/pkg/image/disk.go
@@ -18,11 +18,10 @@ import (
 
 type DiskImage struct {
 	Base
-	Platform         platform.Platform
+
 	PartitionTable   *disk.PartitionTable
 	OSCustomizations manifest.OSCustomizations
 	Environment      environment.Environment
-	Filename         string
 	Compression      string
 
 	// Control the VPC subformat use of force_size
@@ -37,9 +36,7 @@ type DiskImage struct {
 
 func NewDiskImage(platform platform.Platform, filename string) *DiskImage {
 	return &DiskImage{
-		Base:     NewBase("disk"),
-		Platform: platform,
-		Filename: filename,
+		Base:     NewBase("disk", platform, filename),
 		PartTool: osbuild.PTSfdisk,
 	}
 }
@@ -52,7 +49,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 	buildPipeline := addBuildBootstrapPipelines(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
-	osPipeline := manifest.NewOS(buildPipeline, img.Platform, repos)
+	osPipeline := manifest.NewOS(buildPipeline, img.platform, repos)
 	osPipeline.PartitionTable = img.PartitionTable
 	osPipeline.OSCustomizations = img.OSCustomizations
 	osPipeline.Environment = img.Environment
@@ -64,16 +61,16 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 	rawImagePipeline.PartTool = img.PartTool
 
 	var imagePipeline manifest.FilePipeline
-	switch img.Platform.GetImageFormat() {
+	switch img.platform.GetImageFormat() {
 	case platform.FORMAT_RAW:
 		imagePipeline = rawImagePipeline
 	case platform.FORMAT_QCOW2:
 		qcow2Pipeline := manifest.NewQCOW2(buildPipeline, rawImagePipeline)
-		qcow2Pipeline.Compat = img.Platform.GetQCOW2Compat()
+		qcow2Pipeline.Compat = img.platform.GetQCOW2Compat()
 		imagePipeline = qcow2Pipeline
 	case platform.FORMAT_VAGRANT_LIBVIRT:
 		qcow2Pipeline := manifest.NewQCOW2(buildPipeline, rawImagePipeline)
-		qcow2Pipeline.Compat = img.Platform.GetQCOW2Compat()
+		qcow2Pipeline.Compat = img.platform.GetQCOW2Compat()
 
 		vagrantPipeline := manifest.NewVagrant(buildPipeline, qcow2Pipeline, osbuild.VagrantProviderLibvirt, rng)
 
@@ -89,7 +86,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 
 		tarPipeline := manifest.NewTar(buildPipeline, vagrantPipeline, "archive")
 		tarPipeline.Format = osbuild.TarArchiveFormatUstar
-		tarPipeline.SetFilename(img.Filename)
+		tarPipeline.SetFilename(img.filename)
 
 		imagePipeline = tarPipeline
 	case platform.FORMAT_VHD:
@@ -103,8 +100,8 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 		ovfPipeline := manifest.NewOVF(buildPipeline, vmdkPipeline)
 		tarPipeline := manifest.NewTar(buildPipeline, ovfPipeline, "archive")
 		tarPipeline.Format = osbuild.TarArchiveFormatUstar
-		tarPipeline.SetFilename(img.Filename)
-		extLess := strings.TrimSuffix(img.Filename, filepath.Ext(img.Filename))
+		tarPipeline.SetFilename(img.filename)
+		extLess := strings.TrimSuffix(img.filename, filepath.Ext(img.filename))
 		// The .ovf descriptor needs to be the first file in the archive
 		tarPipeline.Paths = []string{
 			fmt.Sprintf("%s.ovf", extLess),
@@ -123,7 +120,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 	}
 
 	compressionPipeline := GetCompressionPipeline(img.Compression, buildPipeline, imagePipeline)
-	compressionPipeline.SetFilename(img.Filename)
+	compressionPipeline.SetFilename(img.filename)
 
 	return compressionPipeline.Export(), nil
 }

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/osbuild/images/pkg/artifact"
 	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/runner"
 )
@@ -16,16 +17,20 @@ type ImageKind interface {
 }
 
 type Base struct {
-	name string
+	name     string
+	platform platform.Platform
+	filename string
 }
 
 func (img Base) Name() string {
 	return img.name
 }
 
-func NewBase(name string) Base {
+func NewBase(name string, platform platform.Platform, filename string) Base {
 	return Base{
-		name: name,
+		name:     name,
+		platform: platform,
+		filename: filename,
 	}
 }
 

--- a/pkg/image/installer_image_test.go
+++ b/pkg/image/installer_image_test.go
@@ -87,7 +87,7 @@ const (
 )
 
 func TestContainerInstallerUnsetKSOptions(t *testing.T) {
-	img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+	img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -100,7 +100,7 @@ func TestContainerInstallerUnsetKSOptions(t *testing.T) {
 }
 
 func TestContainerInstallerUnsetKSPath(t *testing.T) {
-	img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+	img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -115,7 +115,7 @@ func TestContainerInstallerUnsetKSPath(t *testing.T) {
 }
 
 func TestContainerInstallerSetKSPath(t *testing.T) {
-	img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+	img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -132,7 +132,7 @@ func TestContainerInstallerSetKSPath(t *testing.T) {
 }
 
 func TestContainerInstallerExt4Rootfs(t *testing.T) {
-	img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+	img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -148,7 +148,7 @@ func TestContainerInstallerExt4Rootfs(t *testing.T) {
 }
 
 func TestContainerInstallerSquashfsRootfs(t *testing.T) {
-	img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+	img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -165,7 +165,7 @@ func TestContainerInstallerSquashfsRootfs(t *testing.T) {
 }
 
 func TestOSTreeInstallerUnsetKSPath(t *testing.T) {
-	img := image.NewAnacondaOSTreeInstaller(ostree.SourceSpec{})
+	img := image.NewAnacondaOSTreeInstaller(testPlatform, "filename", ostree.SourceSpec{})
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -182,7 +182,7 @@ func TestOSTreeInstallerUnsetKSPath(t *testing.T) {
 }
 
 func TestOSTreeInstallerSetKSPath(t *testing.T) {
-	img := image.NewAnacondaOSTreeInstaller(ostree.SourceSpec{})
+	img := image.NewAnacondaOSTreeInstaller(testPlatform, "filename", ostree.SourceSpec{})
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -201,7 +201,7 @@ func TestOSTreeInstallerSetKSPath(t *testing.T) {
 }
 
 func TestOSTreeInstallerExt4Rootfs(t *testing.T) {
-	img := image.NewAnacondaOSTreeInstaller(ostree.SourceSpec{})
+	img := image.NewAnacondaOSTreeInstaller(testPlatform, "filename", ostree.SourceSpec{})
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -221,7 +221,7 @@ func TestOSTreeInstallerExt4Rootfs(t *testing.T) {
 }
 
 func TestOSTreeInstallerSquashfsRootfs(t *testing.T) {
-	img := image.NewAnacondaOSTreeInstaller(ostree.SourceSpec{})
+	img := image.NewAnacondaOSTreeInstaller(testPlatform, "filename", ostree.SourceSpec{})
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -242,7 +242,7 @@ func TestOSTreeInstallerSquashfsRootfs(t *testing.T) {
 }
 
 func TestTarInstallerUnsetKSOptions(t *testing.T) {
-	img := image.NewAnacondaTarInstaller()
+	img := image.NewAnacondaTarInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -257,7 +257,7 @@ func TestTarInstallerUnsetKSOptions(t *testing.T) {
 }
 
 func TestTarInstallerUnsetKSPath(t *testing.T) {
-	img := image.NewAnacondaTarInstaller()
+	img := image.NewAnacondaTarInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -273,7 +273,7 @@ func TestTarInstallerUnsetKSPath(t *testing.T) {
 }
 
 func TestTarInstallerSetKSPath(t *testing.T) {
-	img := image.NewAnacondaTarInstaller()
+	img := image.NewAnacondaTarInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -292,7 +292,7 @@ func TestTarInstallerSetKSPath(t *testing.T) {
 }
 
 func TestTarInstallerExt4Rootfs(t *testing.T) {
-	img := image.NewAnacondaTarInstaller()
+	img := image.NewAnacondaTarInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -307,7 +307,7 @@ func TestTarInstallerExt4Rootfs(t *testing.T) {
 }
 
 func TestTarInstallerSquashfsRootfs(t *testing.T) {
-	img := image.NewAnacondaTarInstaller()
+	img := image.NewAnacondaTarInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -323,7 +323,7 @@ func TestTarInstallerSquashfsRootfs(t *testing.T) {
 }
 
 func TestLiveInstallerExt4Rootfs(t *testing.T) {
-	img := image.NewAnacondaLiveInstaller()
+	img := image.NewAnacondaLiveInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -338,7 +338,7 @@ func TestLiveInstallerExt4Rootfs(t *testing.T) {
 }
 
 func TestLiveInstallerSquashfsRootfs(t *testing.T) {
-	img := image.NewAnacondaLiveInstaller()
+	img := image.NewAnacondaLiveInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -379,7 +379,7 @@ func instantiateAndSerialize(t *testing.T, img image.ImageKind, depsolved map[st
 
 func TestContainerInstallerPanics(t *testing.T) {
 	assert := assert.New(t)
-	img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+	img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
 	img.Platform = testPlatform
 	assert.PanicsWithError("org.osbuild.grub2.iso: product.name option is required", func() { instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil) })
 	img.Product = product
@@ -390,7 +390,7 @@ func TestContainerInstallerPanics(t *testing.T) {
 
 func TestOSTreeInstallerPanics(t *testing.T) {
 	assert := assert.New(t)
-	img := image.NewAnacondaOSTreeInstaller(ostree.SourceSpec{})
+	img := image.NewAnacondaOSTreeInstaller(testPlatform, "filename", ostree.SourceSpec{})
 	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{
 		// the ostree options must be non-nil
@@ -411,8 +411,7 @@ func TestOSTreeInstallerPanics(t *testing.T) {
 
 func TestTarInstallerPanics(t *testing.T) {
 	assert := assert.New(t)
-	img := image.NewAnacondaTarInstaller()
-	img.Platform = testPlatform
+	img := image.NewAnacondaTarInstaller(testPlatform, "filename")
 
 	assert.PanicsWithError("org.osbuild.grub2.iso: product.name option is required",
 		func() { instantiateAndSerialize(t, img, mockPackageSets(), nil, nil) })
@@ -493,7 +492,7 @@ func TestContainerInstallerModules(t *testing.T) {
 		// Remove this when we drop support for RHEL 8.
 		for _, legacy := range []bool{true, false} {
 			t.Run(name, func(t *testing.T) {
-				img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+				img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
 				img.Product = product
 				img.OSVersion = osversion
 				img.ISOLabel = isolabel
@@ -520,7 +519,7 @@ func TestOSTreeInstallerModules(t *testing.T) {
 		// Remove this when we drop support for RHEL 8.
 		for _, legacy := range []bool{true, false} {
 			t.Run(name, func(t *testing.T) {
-				img := image.NewAnacondaOSTreeInstaller(ostree.SourceSpec{})
+				img := image.NewAnacondaOSTreeInstaller(testPlatform, "filename", ostree.SourceSpec{})
 				img.Product = product
 				img.OSVersion = osversion
 				img.ISOLabel = isolabel
@@ -551,7 +550,7 @@ func TestTarInstallerModules(t *testing.T) {
 		// Remove this when we drop support for RHEL 8.
 		for _, legacy := range []bool{true, false} {
 			t.Run(name, func(t *testing.T) {
-				img := image.NewAnacondaTarInstaller()
+				img := image.NewAnacondaTarInstaller(testPlatform, "filename")
 				img.Product = product
 				img.OSVersion = osversion
 				img.ISOLabel = isolabel
@@ -593,7 +592,7 @@ func TestInstallerLocales(t *testing.T) {
 
 	for input, expected := range locales {
 		{ // Container
-			img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+			img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
 			assert.NotNil(t, img)
 
 			img.Product = product
@@ -609,7 +608,7 @@ func TestInstallerLocales(t *testing.T) {
 		}
 
 		{ // OSTree
-			img := image.NewAnacondaOSTreeInstaller(ostree.SourceSpec{})
+			img := image.NewAnacondaOSTreeInstaller(testPlatform, "filename", ostree.SourceSpec{})
 			assert.NotNil(t, img)
 
 			img.Product = product
@@ -629,7 +628,7 @@ func TestInstallerLocales(t *testing.T) {
 		}
 
 		{ // Tar
-			img := image.NewAnacondaTarInstaller()
+			img := image.NewAnacondaTarInstaller(testPlatform, "filename")
 			assert.NotNil(t, img)
 
 			img.Product = product
@@ -645,7 +644,7 @@ func TestInstallerLocales(t *testing.T) {
 		}
 
 		{ // Net
-			img := image.NewAnacondaNetInstaller()
+			img := image.NewAnacondaNetInstaller(testPlatform, "filename")
 			assert.NotNil(t, img)
 
 			img.Product = product
@@ -661,7 +660,7 @@ func TestInstallerLocales(t *testing.T) {
 		}
 
 		{ // Live
-			img := image.NewAnacondaLiveInstaller()
+			img := image.NewAnacondaLiveInstaller(testPlatform, "filename")
 			assert.NotNil(t, img)
 
 			img.Product = product
@@ -729,7 +728,7 @@ func findGrub2IsoStageOptions(t *testing.T, mf manifest.OSBuildManifest, pipelin
 }
 
 func TestContainerInstallerDracut(t *testing.T) {
-	img := image.NewAnacondaContainerInstaller(container.SourceSpec{}, "")
+	img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
@@ -754,7 +753,7 @@ func TestContainerInstallerDracut(t *testing.T) {
 }
 
 func TestOSTreeInstallerDracut(t *testing.T) {
-	img := image.NewAnacondaOSTreeInstaller(ostree.SourceSpec{})
+	img := image.NewAnacondaOSTreeInstaller(testPlatform, "filename", ostree.SourceSpec{})
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
@@ -783,7 +782,7 @@ func TestOSTreeInstallerDracut(t *testing.T) {
 }
 
 func TestTarInstallerDracut(t *testing.T) {
-	img := image.NewAnacondaTarInstaller()
+	img := image.NewAnacondaTarInstaller(testPlatform, "filename")
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
@@ -808,7 +807,7 @@ func TestTarInstallerDracut(t *testing.T) {
 }
 
 func TestTarInstallerKernelOpts(t *testing.T) {
-	img := image.NewAnacondaTarInstaller()
+	img := image.NewAnacondaTarInstaller(testPlatform, "filename")
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
@@ -828,7 +827,7 @@ func TestTarInstallerKernelOpts(t *testing.T) {
 }
 
 func TestNetInstallerExt4Rootfs(t *testing.T) {
-	img := image.NewAnacondaNetInstaller()
+	img := image.NewAnacondaNetInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -843,7 +842,7 @@ func TestNetInstallerExt4Rootfs(t *testing.T) {
 }
 
 func TestNetInstallerSquashfsRootfs(t *testing.T) {
-	img := image.NewAnacondaNetInstaller()
+	img := image.NewAnacondaNetInstaller(testPlatform, "filename")
 	assert.NotNil(t, img)
 
 	img.Product = product
@@ -859,7 +858,7 @@ func TestNetInstallerSquashfsRootfs(t *testing.T) {
 }
 
 func TestNetInstallerDracut(t *testing.T) {
-	img := image.NewAnacondaNetInstaller()
+	img := image.NewAnacondaNetInstaller(testPlatform, "filename")
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel

--- a/pkg/image/installer_image_test.go
+++ b/pkg/image/installer_image_test.go
@@ -93,7 +93,6 @@ func TestContainerInstallerUnsetKSOptions(t *testing.T) {
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-	img.Platform = testPlatform
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil)
 	assert.Contains(t, mfs, fmt.Sprintf(`"inst.ks=hd:LABEL=%s:/osbuild.ks"`, isolabel))
@@ -106,7 +105,6 @@ func TestContainerInstallerUnsetKSPath(t *testing.T) {
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-	img.Platform = testPlatform
 	// set empty kickstart options (no path)
 	img.Kickstart = &kickstart.Options{}
 
@@ -121,7 +119,6 @@ func TestContainerInstallerSetKSPath(t *testing.T) {
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{
 		Path: "/test.ks",
 	}
@@ -138,7 +135,6 @@ func TestContainerInstallerExt4Rootfs(t *testing.T) {
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-	img.Platform = testPlatform
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil)
 
@@ -155,7 +151,6 @@ func TestContainerInstallerSquashfsRootfs(t *testing.T) {
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
 	img.InstallerCustomizations.ISORootfsType = manifest.SquashfsRootfs
-	img.Platform = testPlatform
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil)
 
@@ -171,7 +166,6 @@ func TestOSTreeInstallerUnsetKSPath(t *testing.T) {
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{
 		// the ostree options must be non-nil
 		OSTree: &kickstart.OSTree{},
@@ -188,7 +182,6 @@ func TestOSTreeInstallerSetKSPath(t *testing.T) {
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{
 		// the ostree options must be non-nil
 		OSTree: &kickstart.OSTree{},
@@ -207,7 +200,6 @@ func TestOSTreeInstallerExt4Rootfs(t *testing.T) {
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{
 		// the ostree options must be non-nil
 		OSTree: &kickstart.OSTree{},
@@ -228,7 +220,6 @@ func TestOSTreeInstallerSquashfsRootfs(t *testing.T) {
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
 	img.InstallerCustomizations.ISORootfsType = manifest.SquashfsRootfs
-	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{
 		// the ostree options must be non-nil
 		OSTree: &kickstart.OSTree{},
@@ -248,7 +239,6 @@ func TestTarInstallerUnsetKSOptions(t *testing.T) {
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-	img.Platform = testPlatform
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
 
@@ -263,7 +253,6 @@ func TestTarInstallerUnsetKSPath(t *testing.T) {
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{}
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
@@ -279,7 +268,6 @@ func TestTarInstallerSetKSPath(t *testing.T) {
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{
 		Path: "/test.ks",
 	}
@@ -298,7 +286,6 @@ func TestTarInstallerExt4Rootfs(t *testing.T) {
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-	img.Platform = testPlatform
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
 	// Confirm that it includes the rootfs-image pipeline that makes the ext4 rootfs
@@ -314,7 +301,6 @@ func TestTarInstallerSquashfsRootfs(t *testing.T) {
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
 	img.InstallerCustomizations.ISORootfsType = manifest.SquashfsRootfs
-	img.Platform = testPlatform
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
 	// Confirm that it does not include rootfs-image pipeline
@@ -329,7 +315,6 @@ func TestLiveInstallerExt4Rootfs(t *testing.T) {
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-	img.Platform = testPlatform
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
 	// Confirm that it includes the rootfs-image pipeline that makes the ext4 rootfs
@@ -345,7 +330,6 @@ func TestLiveInstallerSquashfsRootfs(t *testing.T) {
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
 	img.InstallerCustomizations.ISORootfsType = manifest.SquashfsRootfs
-	img.Platform = testPlatform
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
 	// Confirm that it does not include rootfs-image pipeline
@@ -380,7 +364,6 @@ func instantiateAndSerialize(t *testing.T, img image.ImageKind, depsolved map[st
 func TestContainerInstallerPanics(t *testing.T) {
 	assert := assert.New(t)
 	img := image.NewAnacondaContainerInstaller(testPlatform, "filename", container.SourceSpec{}, "")
-	img.Platform = testPlatform
 	assert.PanicsWithError("org.osbuild.grub2.iso: product.name option is required", func() { instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil) })
 	img.Product = product
 	assert.PanicsWithError("org.osbuild.grub2.iso: product.version option is required", func() { instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil) })
@@ -391,7 +374,6 @@ func TestContainerInstallerPanics(t *testing.T) {
 func TestOSTreeInstallerPanics(t *testing.T) {
 	assert := assert.New(t)
 	img := image.NewAnacondaOSTreeInstaller(testPlatform, "filename", ostree.SourceSpec{})
-	img.Platform = testPlatform
 	img.Kickstart = &kickstart.Options{
 		// the ostree options must be non-nil
 		OSTree: &kickstart.OSTree{},
@@ -502,7 +484,6 @@ func TestContainerInstallerModules(t *testing.T) {
 				img.InstallerCustomizations.DisabledAnacondaModules = tc.disable
 
 				assert.NotNil(t, img)
-				img.Platform = testPlatform
 				mfs := instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil)
 				modules := findAnacondaStageModules(t, manifest.OSBuildManifest(mfs), legacy)
 				assert.NotNil(t, modules)
@@ -533,7 +514,6 @@ func TestOSTreeInstallerModules(t *testing.T) {
 				img.InstallerCustomizations.DisabledAnacondaModules = tc.disable
 
 				assert.NotNil(t, img)
-				img.Platform = testPlatform
 				mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, mockOSTreeCommitSpecs())
 				modules := findAnacondaStageModules(t, manifest.OSBuildManifest(mfs), legacy)
 				assert.NotNil(t, modules)
@@ -560,7 +540,6 @@ func TestTarInstallerModules(t *testing.T) {
 				img.InstallerCustomizations.DisabledAnacondaModules = tc.disable
 
 				assert.NotNil(t, img)
-				img.Platform = testPlatform
 				mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
 				modules := findAnacondaStageModules(t, manifest.OSBuildManifest(mfs), legacy)
 				assert.NotNil(t, modules)
@@ -598,7 +577,6 @@ func TestInstallerLocales(t *testing.T) {
 			img.Product = product
 			img.OSVersion = osversion
 			img.ISOLabel = isolabel
-			img.Platform = testPlatform
 			img.Locale = input
 
 			mfs := instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil)
@@ -614,7 +592,6 @@ func TestInstallerLocales(t *testing.T) {
 			img.Product = product
 			img.OSVersion = osversion
 			img.ISOLabel = isolabel
-			img.Platform = testPlatform
 			img.Kickstart = &kickstart.Options{
 				// the ostree options must be non-nil
 				OSTree: &kickstart.OSTree{},
@@ -634,7 +611,6 @@ func TestInstallerLocales(t *testing.T) {
 			img.Product = product
 			img.OSVersion = osversion
 			img.ISOLabel = isolabel
-			img.Platform = testPlatform
 			img.OSCustomizations.Language = input
 
 			mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
@@ -650,7 +626,6 @@ func TestInstallerLocales(t *testing.T) {
 			img.Product = product
 			img.OSVersion = osversion
 			img.ISOLabel = isolabel
-			img.Platform = testPlatform
 			img.Language = input
 
 			mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
@@ -666,7 +641,6 @@ func TestInstallerLocales(t *testing.T) {
 			img.Product = product
 			img.OSVersion = osversion
 			img.ISOLabel = isolabel
-			img.Platform = testPlatform
 			img.Locale = input
 
 			mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
@@ -740,7 +714,6 @@ func TestContainerInstallerDracut(t *testing.T) {
 	img.InstallerCustomizations.AdditionalDrivers = testDrivers
 
 	assert.NotNil(t, img)
-	img.Platform = testPlatform
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), mockContainerSpecs(), nil)
 	modules, addModules, drivers, addDrivers := findDracutStageOptions(t, manifest.OSBuildManifest(mfs), "anaconda-tree")
 	assert.Nil(t, modules)
@@ -769,7 +742,6 @@ func TestOSTreeInstallerDracut(t *testing.T) {
 	img.InstallerCustomizations.AdditionalDrivers = testDrivers
 
 	assert.NotNil(t, img)
-	img.Platform = testPlatform
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, mockOSTreeCommitSpecs())
 	modules, addModules, drivers, addDrivers := findDracutStageOptions(t, manifest.OSBuildManifest(mfs), "anaconda-tree")
 	assert.Nil(t, modules)
@@ -794,7 +766,6 @@ func TestTarInstallerDracut(t *testing.T) {
 	img.InstallerCustomizations.AdditionalDrivers = testDrivers
 
 	assert.NotNil(t, img)
-	img.Platform = testPlatform
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
 	modules, addModules, drivers, addDrivers := findDracutStageOptions(t, manifest.OSBuildManifest(mfs), "anaconda-tree")
 	assert.Nil(t, modules)
@@ -817,7 +788,6 @@ func TestTarInstallerKernelOpts(t *testing.T) {
 	img.InstallerCustomizations.AdditionalKernelOpts = testOpts
 
 	assert.NotNil(t, img)
-	img.Platform = testPlatform
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
 
 	opts := findGrub2IsoStageOptions(t, manifest.OSBuildManifest(mfs), "efiboot-tree")
@@ -833,7 +803,6 @@ func TestNetInstallerExt4Rootfs(t *testing.T) {
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
-	img.Platform = testPlatform
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
 	// Confirm that it includes the rootfs-image pipeline that makes the ext4 rootfs
@@ -849,7 +818,6 @@ func TestNetInstallerSquashfsRootfs(t *testing.T) {
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel
 	img.InstallerCustomizations.ISORootfsType = manifest.SquashfsRootfs
-	img.Platform = testPlatform
 
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
 	// Confirm that it does not include rootfs-image pipeline
@@ -869,7 +837,6 @@ func TestNetInstallerDracut(t *testing.T) {
 	img.InstallerCustomizations.AdditionalDrivers = testDrivers
 
 	assert.NotNil(t, img)
-	img.Platform = testPlatform
 	mfs := instantiateAndSerialize(t, img, mockPackageSets(), nil, nil)
 	modules, addModules, drivers, addDrivers := findDracutStageOptions(t, manifest.OSBuildManifest(mfs), "anaconda-tree")
 	assert.Nil(t, modules)

--- a/pkg/image/ostree_archive.go
+++ b/pkg/image/ostree_archive.go
@@ -15,7 +15,6 @@ import (
 
 type OSTreeArchive struct {
 	Base
-	Platform         platform.Platform
 	OSCustomizations manifest.OSCustomizations
 	Environment      environment.Environment
 
@@ -27,7 +26,6 @@ type OSTreeArchive struct {
 	OSTreeRef string
 
 	OSVersion string
-	Filename  string
 
 	InstallWeakDeps bool
 
@@ -41,9 +39,7 @@ type OSTreeArchive struct {
 
 func NewOSTreeArchive(platform platform.Platform, filename string, ref string) *OSTreeArchive {
 	return &OSTreeArchive{
-		Base:            NewBase("ostree-archive"),
-		Platform:        platform,
-		Filename:        filename,
+		Base:            NewBase("ostree-archive", platform, filename),
 		OSTreeRef:       ref,
 		InstallWeakDeps: true,
 	}
@@ -56,7 +52,7 @@ func (img *OSTreeArchive) InstantiateManifest(m *manifest.Manifest,
 	buildPipeline := addBuildBootstrapPipelines(m, runner, repos, nil)
 	buildPipeline.Checkpoint()
 
-	osPipeline := manifest.NewOS(buildPipeline, img.Platform, repos)
+	osPipeline := manifest.NewOS(buildPipeline, img.platform, repos)
 	osPipeline.OSCustomizations = img.OSCustomizations
 	osPipeline.Environment = img.Environment
 	osPipeline.OSTreeParent = img.OSTreeParent
@@ -71,11 +67,11 @@ func (img *OSTreeArchive) InstantiateManifest(m *manifest.Manifest,
 		osPipeline.Bootupd = true
 		osPipeline.BootcConfig = img.BootcConfig
 		encapsulatePipeline := manifest.NewOSTreeEncapsulate(buildPipeline, ostreeCommitPipeline, "ostree-encapsulate")
-		encapsulatePipeline.SetFilename(img.Filename)
+		encapsulatePipeline.SetFilename(img.filename)
 		artifact = encapsulatePipeline.Export()
 	} else {
 		tarPipeline := manifest.NewTar(buildPipeline, ostreeCommitPipeline, "commit-archive")
-		tarPipeline.SetFilename(img.Filename)
+		tarPipeline.SetFilename(img.filename)
 		artifact = tarPipeline.Export()
 	}
 

--- a/pkg/image/ostree_archive.go
+++ b/pkg/image/ostree_archive.go
@@ -39,9 +39,11 @@ type OSTreeArchive struct {
 	BootcConfig *bootc.Config
 }
 
-func NewOSTreeArchive(ref string) *OSTreeArchive {
+func NewOSTreeArchive(platform platform.Platform, filename string, ref string) *OSTreeArchive {
 	return &OSTreeArchive{
 		Base:            NewBase("ostree-archive"),
+		Platform:        platform,
+		Filename:        filename,
 		OSTreeRef:       ref,
 		InstallWeakDeps: true,
 	}

--- a/pkg/image/ostree_container.go
+++ b/pkg/image/ostree_container.go
@@ -31,9 +31,12 @@ type OSTreeContainer struct {
 	Filename               string
 }
 
-func NewOSTreeContainer(ref string) *OSTreeContainer {
+func NewOSTreeContainer(platform platform.Platform, filename string, ref string) *OSTreeContainer {
 	return &OSTreeContainer{
-		Base:      NewBase("ostree-container"),
+		Base:     NewBase("ostree-container"),
+		Platform: platform,
+		Filename: filename,
+
 		OSTreeRef: ref,
 	}
 }

--- a/pkg/image/ostree_disk.go
+++ b/pkg/image/ostree_disk.go
@@ -39,16 +39,21 @@ type OSTreeDiskImage struct {
 	ContainerBuildable bool
 }
 
-func NewOSTreeDiskImageFromCommit(commit ostree.SourceSpec) *OSTreeDiskImage {
+func NewOSTreeDiskImageFromCommit(platform platform.Platform, filename string, commit ostree.SourceSpec) *OSTreeDiskImage {
 	return &OSTreeDiskImage{
-		Base:         NewBase("ostree-raw-image"),
+		Base:     NewBase("ostree-raw-image"),
+		Platform: platform,
+		Filename: filename,
+
 		CommitSource: &commit,
 	}
 }
 
-func NewOSTreeDiskImageFromContainer(container container.SourceSpec, ref string) *OSTreeDiskImage {
+func NewOSTreeDiskImageFromContainer(platform platform.Platform, filename string, container container.SourceSpec, ref string) *OSTreeDiskImage {
 	return &OSTreeDiskImage{
 		Base:            NewBase("ostree-raw-image"),
+		Platform:        platform,
+		Filename:        filename,
 		ContainerSource: &container,
 		Ref:             ref,
 	}

--- a/pkg/image/ostree_disk_test.go
+++ b/pkg/image/ostree_disk_test.go
@@ -38,7 +38,7 @@ func TestOSTreeDiskImageManifestSetsContainerBuildable(t *testing.T) {
 		buildOpts = nil
 
 		mf := manifest.New()
-		img := image.NewOSTreeDiskImageFromContainer(containerSource, ref)
+		img := image.NewOSTreeDiskImageFromContainer(testPlatform, "filename", containerSource, ref)
 		require.NotNil(t, img)
 		img.Platform = &platform.Data{
 			ImageFormat: platform.FORMAT_QCOW2,

--- a/pkg/image/ostree_disk_test.go
+++ b/pkg/image/ostree_disk_test.go
@@ -6,11 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/image"
 	"github.com/osbuild/images/pkg/manifest"
-	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/runner"
 )
@@ -40,13 +38,6 @@ func TestOSTreeDiskImageManifestSetsContainerBuildable(t *testing.T) {
 		mf := manifest.New()
 		img := image.NewOSTreeDiskImageFromContainer(testPlatform, "filename", containerSource, ref)
 		require.NotNil(t, img)
-		img.Platform = &platform.Data{
-			ImageFormat: platform.FORMAT_QCOW2,
-
-			Arch:         arch.ARCH_X86_64,
-			BIOSPlatform: "i386-pc",
-			UEFIVendor:   "fedora",
-		}
 		img.OSName = "osname"
 		img.ContainerBuildable = containerBuildable
 

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -21,7 +21,6 @@ type OSTreeSimplifiedInstaller struct {
 	// Raw image that will be created and embedded
 	rawImage *OSTreeDiskImage
 
-	Platform         platform.Platform
 	OSCustomizations manifest.OSCustomizations
 	Environment      environment.Environment
 
@@ -46,8 +45,6 @@ type OSTreeSimplifiedInstaller struct {
 
 	installDevice string
 
-	Filename string
-
 	FDO *fdo.Options
 
 	// Ignition firstboot configuration options
@@ -62,10 +59,7 @@ type OSTreeSimplifiedInstaller struct {
 
 func NewOSTreeSimplifiedInstaller(platform platform.Platform, filename string, rawImage *OSTreeDiskImage, installDevice string) *OSTreeSimplifiedInstaller {
 	return &OSTreeSimplifiedInstaller{
-		Base:     NewBase("ostree-simplified-installer"),
-		Platform: platform,
-		Filename: filename,
-
+		Base:          NewBase("ostree-simplified-installer", platform, filename),
 		rawImage:      rawImage,
 		installDevice: installDevice,
 	}
@@ -86,7 +80,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	coiPipeline := manifest.NewCoreOSInstaller(
 		buildPipeline,
-		img.Platform,
+		img.platform,
 		repos,
 		"kernel",
 		img.Product,
@@ -97,7 +91,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	coiPipeline.ExtraRepos = img.ExtraBasePackages.Repositories
 	coiPipeline.FDO = img.FDO
 	coiPipeline.Ignition = img.IgnitionEmbedded
-	coiPipeline.Biosdevname = (img.Platform.GetArch() == arch.ARCH_X86_64)
+	coiPipeline.Biosdevname = (img.platform.GetArch() == arch.ARCH_X86_64)
 	coiPipeline.Variant = img.Variant
 	coiPipeline.AdditionalDracutModules = img.AdditionalDracutModules
 	coiPipeline.AdditionalDrivers = img.AdditionalDrivers
@@ -108,12 +102,12 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 		isoLabel = img.ISOLabel
 	} else {
 		// TODO: replace isoLabelTmpl with more high-level properties
-		isoLabel = fmt.Sprintf(img.ISOLabelTmpl, img.Platform.GetArch())
+		isoLabel = fmt.Sprintf(img.ISOLabelTmpl, img.platform.GetArch())
 	}
 
 	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
-	bootTreePipeline.Platform = img.Platform
-	bootTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
+	bootTreePipeline.Platform = img.platform
+	bootTreePipeline.UEFIVendor = img.platform.GetUEFIVendor()
 	bootTreePipeline.ISOLabel = isoLabel
 
 	// kernel options for EFI boot tree grub stage
@@ -146,7 +140,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	bootTreePipeline.KernelOpts = kernelOpts
 
 	// enable ISOLinux on x86_64 only
-	isoLinuxEnabled := img.Platform.GetArch() == arch.ARCH_X86_64
+	isoLinuxEnabled := img.platform.GetArch() == arch.ARCH_X86_64
 
 	isoTreePipeline := manifest.NewCoreOSISOTree(buildPipeline, compressedImage, coiPipeline, bootTreePipeline)
 	isoTreePipeline.KernelOpts = kernelOpts
@@ -156,7 +150,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.ISOLinux = isoLinuxEnabled
 
 	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, isoLabel)
-	isoPipeline.SetFilename(img.Filename)
+	isoPipeline.SetFilename(img.filename)
 	if isoLinuxEnabled {
 		isoPipeline.ISOBoot = manifest.SyslinuxISOBoot
 	}

--- a/pkg/image/ostree_simplified_installer.go
+++ b/pkg/image/ostree_simplified_installer.go
@@ -60,9 +60,12 @@ type OSTreeSimplifiedInstaller struct {
 	AdditionalDrivers       []string
 }
 
-func NewOSTreeSimplifiedInstaller(rawImage *OSTreeDiskImage, installDevice string) *OSTreeSimplifiedInstaller {
+func NewOSTreeSimplifiedInstaller(platform platform.Platform, filename string, rawImage *OSTreeDiskImage, installDevice string) *OSTreeSimplifiedInstaller {
 	return &OSTreeSimplifiedInstaller{
-		Base:          NewBase("ostree-simplified-installer"),
+		Base:     NewBase("ostree-simplified-installer"),
+		Platform: platform,
+		Filename: filename,
+
 		rawImage:      rawImage,
 		installDevice: installDevice,
 	}

--- a/pkg/image/ostree_simplified_installer_test.go
+++ b/pkg/image/ostree_simplified_installer_test.go
@@ -3,20 +3,21 @@ package image_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/osbuild/images/internal/testdisk"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/image"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSimplifiedInstallerDracut(t *testing.T) {
 	commit := ostree.SourceSpec{}
-	ostreeDiskImage := image.NewOSTreeDiskImageFromCommit(testPlatform, "filename", commit)
+	platform := &platform.Data{Arch: arch.ARCH_X86_64}
+	ostreeDiskImage := image.NewOSTreeDiskImageFromCommit(platform, "filename", commit)
 	ostreeDiskImage.PartitionTable = testdisk.MakeFakePartitionTable("/")
-	ostreeDiskImage.Platform = &platform.Data{Arch: arch.ARCH_X86_64}
 	img := image.NewOSTreeSimplifiedInstaller(testPlatform, "filename", ostreeDiskImage, "")
 	img.Product = product
 	img.OSVersion = osversion
@@ -41,7 +42,6 @@ func TestSimplifiedInstallerDracut(t *testing.T) {
 	packageSets["coi-tree"] = packageSets["os"]
 
 	assert.NotNil(t, img)
-	img.Platform = testPlatform
 	mfs := instantiateAndSerialize(t, img, packageSets, nil, commitSpec)
 	modules, addModules, drivers, addDrivers := findDracutStageOptions(t, manifest.OSBuildManifest(mfs), "coi-tree")
 	assert.NotNil(t, modules)

--- a/pkg/image/ostree_simplified_installer_test.go
+++ b/pkg/image/ostree_simplified_installer_test.go
@@ -14,10 +14,10 @@ import (
 
 func TestSimplifiedInstallerDracut(t *testing.T) {
 	commit := ostree.SourceSpec{}
-	ostreeDiskImage := image.NewOSTreeDiskImageFromCommit(commit)
+	ostreeDiskImage := image.NewOSTreeDiskImageFromCommit(testPlatform, "filename", commit)
 	ostreeDiskImage.PartitionTable = testdisk.MakeFakePartitionTable("/")
 	ostreeDiskImage.Platform = &platform.Data{Arch: arch.ARCH_X86_64}
-	img := image.NewOSTreeSimplifiedInstaller(ostreeDiskImage, "")
+	img := image.NewOSTreeSimplifiedInstaller(testPlatform, "filename", ostreeDiskImage, "")
 	img.Product = product
 	img.OSVersion = osversion
 	img.ISOLabel = isolabel


### PR DESCRIPTION
image: add platform/filename to image.New*()

We require a platform and a filename for all images we create
so instead of setting it as the first thing after New*() make
it required. This ensures that its not missed.

---

image: make platform/filename part of image.Base and unexport

Every image we use has a platform and a filename so make it
part of `image.Base` instead of duplicating it everywhere.

