### PR TITLE
distro: add bootc riscv partition table

### DIFF
--- a/pkg/distro/bootc/partition_tables.go
+++ b/pkg/distro/bootc/partition_tables.go
@@ -127,4 +127,13 @@ var partitionTables = distro.BasePartitionTableMap{
 			rootPartition,
 		},
 	},
+	arch.ARCH_RISCV64.String(): disk.PartitionTable{
+		UUID: diskUuidOfUnknownOrigin,
+		Type: disk.PT_GPT,
+		Partitions: []disk.Partition{
+			efiPartition,
+			bootPartition,
+			rootPartition,
+		},
+	},
 }


### PR DESCRIPTION
This adds the partition table from
https://github.com/osbuild/bootc-image-builder/pull/963/files

The architecure support does no longer need to be explicit as arch/uefi vendor will come from the container/sourceinfo.