### PR TITLE
github: avoid single person code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 *               @osbuild/osbuild-reviewers
 
 # Package-specific reviewers
-/pkg/disk/      @achilleas-k
+/pkg/disk/      @achilleas-k @osbuild/osbuild-reviewers
 
 # Test scripts
-/test/scripts   @achilleas-k @thozza
+/test/scripts   @achilleas-k @thozza @osbuild/osbuild-reviewers


### PR DESCRIPTION
When a single person is listed as a code owner for a path, a PR that modifies files in that path *requires* that person to approve before merging, which can be a problem when that person is away.  Add osbuild-reviewers to the pkg/disk/ package so that I'm not the only person that can approve PRs that modify files in that path. Similarly, add osbuild-reviewers to the test scripts.

Since Tomáš and I are already members of osbuild-reviewers, the effect of those line now is that we will always be automatically assigned as reviewrs of PRs that modify files in those paths, and the rest of the reviewers are selected randomly from reviewers team.