### PR TITLE
test: ensure manifest from bib/images are identical

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,8 @@ jobs:
         run: sudo apt update
 
       # This is needed for the container resolver dependencies
-      - name: Install libgpgme devel package
+      - &apt_install_dependencies
+        name: Install libgpgme devel package
         run: sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev podman
 
       # We need to run the test as root, since we use the root
@@ -164,8 +165,7 @@ jobs:
         run: sudo apt install -y libkrb5-dev
 
       # This is needed for the container upload dependencies
-      - name: Install libgpgme devel package
-        run: sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev
+      - *apt_install_dependencies
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
@@ -264,3 +264,30 @@ jobs:
         # We only care about distro definitions for this check
         run: |
           find pkg/distro/defs "(" -iname "*.yaml" -or -iname "*.yml" ")" -exec yq . {} \+ > /dev/null
+
+  bib-manifest-diff:
+    name: "bib manifest diff validation"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - *apt_install_dependencies
+
+      - run: sudo apt install -y qemu-user-static
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Workaround podman issues in GH actions
+        run: |
+          # see https://github.com/osbuild/bootc-image-builder/issues/446
+          sudo rm -rf /var/lib/containers/storage
+          sudo mkdir -p /etc/containers
+          echo -e "[storage]\ndriver = \"overlay\"\nrunroot = \"/run/containers/storage\"\ngraphroot = \"/var/lib/containers/storage\"" | sudo tee /etc/containers/storage.conf
+
+      - name: Running manifest diff between images/bib
+        run: ./tools/gen-bootc-diff

--- a/pkg/distro/bootc/bootc.go
+++ b/pkg/distro/bootc/bootc.go
@@ -90,6 +90,10 @@ func (d *BootcDistro) SetDefaultFs(defaultFs string) error {
 	return nil
 }
 
+func (d *BootcDistro) DefaultFs() string {
+	return d.defaultFs
+}
+
 func (d *BootcDistro) Name() string {
 	return d.name
 }

--- a/tools/gen-bootc-diff
+++ b/tools/gen-bootc-diff
@@ -1,0 +1,121 @@
+#!/bin/bash
+#
+# This tool is meant as a temporary measure to ensure that we
+# produce identical manifests from the bootc integration of
+# images. We need it because we have no manifest checksums
+# for bootc based images (yet).
+
+set -e
+set -o pipefail
+
+(cd "$(dirname "$0")"/../cmd/gen-manifests && go build)
+
+# we only need to test a single type, all bootc disk manifests
+# contain all possible types by default
+TYPE=qcow2
+
+BPDIR=$(mktemp -d)
+trap 'rm -rf -- "$BPDIR"' EXIT
+BP_EMPTY="$BPDIR/empty.json"
+cat <<EOF > "$BP_EMPTY"
+{}
+EOF
+BP_FULL_FS="$BPDIR/full.json"
+cat <<EOF > "$BP_FULL_FS"
+{
+  "customizations": {
+    "filesystem": [
+      {
+        "mountpoint": "/",
+        "minsize": "10 GiB"
+      },
+      {
+        "mountpoint": "/var/data",
+        "minsize": "20 GiB"
+      }
+    ],
+    "user": [
+      {
+        "name": "alice",
+        "key": "ssh-rsa AAA ... user@email.com",
+        "groups": [
+          "wheel",
+          "admins"
+        ]
+      }
+    ],
+    "group": [
+      {
+        "name": "fancypants"
+      }
+    ]
+  }
+}
+EOF
+BP_LVM="$BPDIR/lvm.json"
+cat <<EOF > "$BP_LVM"
+{
+  "customizations": {
+    "disk": {
+      "partitions": [
+            {
+                "type": "lvm",
+                "minsize": "22 GiB",
+                "logical_volumes": [
+		    {
+			   "mountpoint": "/",
+			   "fs_type": "ext4",
+                           "minsize": "15 GiB"
+		    }
+                ]
+            }
+        ]
+    }
+  }
+}
+EOF
+
+
+for REF in quay.io/centos-bootc/centos-bootc:stream9 \
+	   quay.io/fedora/fedora-bootc:42;
+do
+    for ARCH in x86_64 aarch64; do
+	for BP in "$BP_FULL_FS" "$BP_LVM" "$BP_EMPTY"; do
+	    echo "Testing $REF;$ARCH;$(basename "$BP")"
+	    sudo podman pull -q --arch "$ARCH" "$REF"
+
+	    TMPDIR=$(mktemp -d)
+	    trap 'rm -rf -- "$TMPDIR"' EXIT
+
+	    ROOTFS=""
+	    if grep -q fedora <(echo "$REF"); then
+		ROOTFS="ext4"
+	    fi
+
+	    sudo go run github.com/osbuild/bootc-image-builder/bib/cmd/bootc-image-builder@main \
+		manifest -v "$REF" \
+		--config "$BP" \
+		--target-arch "$ARCH" \
+		--rootfs "$ROOTFS" \
+		--type "$TYPE" | jq > "$TMPDIR/bib.json"
+
+	    # oh well, we need to convert our blueprint into the
+	    # gen-manifests config :/
+	    echo '{"blueprint":' >  "$TMPDIR"/gm-conf.json
+	    cat "$BP" >> "$TMPDIR"/gm-conf.json
+	    echo '}' >>  "$TMPDIR"/gm-conf.json
+	    sudo ./cmd/gen-manifests/gen-manifests \
+		-types "$TYPE" \
+		-arches "$ARCH" \
+		-distros ignore \
+		-metadata=false \
+		-config "$TMPDIR"/gm-conf.json \
+		-bootc-refs "$REF" \
+		-output "$TMPDIR"
+
+	    # ensure manifests are identical (but skip uuid diffs)
+	    echo "Comparing images and bootc-image-builder generated manifests"
+	    diff -u <(grep -v uuid "$TMPDIR"/bootc_*.json) <(grep -v uuid "$TMPDIR"/bib.json)
+	done
+    done
+done

--- a/tools/gen-bootc-diff
+++ b/tools/gen-bootc-diff
@@ -8,7 +8,7 @@
 set -e
 set -o pipefail
 
-(cd "$(dirname "$0")"/../cmd/gen-manifests && go build)
+(cd "$(dirname "$0")"/../cmd/gen-manifests && go build -buildvcs=false)
 
 # we only need to test a single type, all bootc disk manifests
 # contain all possible types by default
@@ -92,7 +92,9 @@ do
 		ROOTFS="ext4"
 	    fi
 
-	    sudo go run github.com/osbuild/bootc-image-builder/bib/cmd/bootc-image-builder@main \
+	    sudo go run \
+		 -buildvcs=false \
+		 github.com/osbuild/bootc-image-builder/bib/cmd/bootc-image-builder@main \
 		manifest -v "$REF" \
 		--config "$BP" \
 		--target-arch "$ARCH" \


### PR DESCRIPTION
This is meant as a temporary measure to ensure that we
produce identical manifests from the bootc integration of
images. We need it because we have no manifest checksums
for bootc based images (yet).

So the idea is:
1. have this tool validate that the manifests are identical
2. create manifests checksums for bootc images (just like we
   do for regular images)
3. merge bib PR#1014 that switches disk generation to images
4. drop using the tool
5. add something like `test-integration-bib` that runs the bib tests with the latest images

Keep the tool in the backpocket because we will need it for
the ISO move to images too (c.f. https://github.com/osbuild/images/pull/1804)
