### PR TITLE
distro: ensure correct bootc image type Filename() output

### DIFF
--- a/pkg/distro/bootc/bootc.go
+++ b/pkg/distro/bootc/bootc.go
@@ -56,6 +56,8 @@ type BootcImageType struct {
 
 	name   string
 	export string
+	// file extension
+	ext string
 }
 
 func (d *BootcDistro) SetBuildContainer(imgref string) (err error) {
@@ -194,7 +196,7 @@ func (t *BootcImageType) Arch() distro.Arch {
 }
 
 func (t *BootcImageType) Filename() string {
-	return "disk"
+	return fmt.Sprintf("disk.%s", t.ext)
 }
 
 func (t *BootcImageType) MIMEType() string {
@@ -402,30 +404,41 @@ func NewBootcDistro(imgref string) (bd *BootcDistro, err error) {
 			arch: common.Must(arch.FromString(archStr)),
 		}
 		// TODO: add iso image types, see bootc-image-builder
+		//
+		// Note that the file extension is hardcoded in
+		// pkg/image/bootc_disk.go, we have no way to access
+		// it here so we need to duplicate it
+		// XXX: find a way to avoid this duplication
 		ba.addImageTypes(
 			BootcImageType{
 				name:   "ami",
 				export: "image",
+				ext:    "raw",
 			},
 			BootcImageType{
 				name:   "qcow2",
 				export: "qcow2",
+				ext:    "qcow2",
 			},
 			BootcImageType{
 				name:   "raw",
 				export: "image",
+				ext:    "raw",
 			},
 			BootcImageType{
 				name:   "vmdk",
 				export: "vmdk",
+				ext:    "vmdk",
 			},
 			BootcImageType{
 				name:   "vhd",
 				export: "bpc",
+				ext:    "vhd",
 			},
 			BootcImageType{
 				name:   "gce",
 				export: "gce",
+				ext:    "tar.gz",
 			},
 		)
 		bd.addArches(ba)

--- a/pkg/distro/bootc/export_test.go
+++ b/pkg/distro/bootc/export_test.go
@@ -33,6 +33,7 @@ func NewTestBootcImageType() *BootcImageType {
 		arch:   a,
 		name:   "qcow2",
 		export: "qcow2",
+		ext:    "qcow2",
 	}
 	a.addImageTypes(*imgType)
 


### PR DESCRIPTION
[edit: this will unblock https://github.com/osbuild/image-builder-cli/pull/245]

This fixes a bug in the new bootc based imagetypes. The filename was not returned with the correct extension. The reason is that the the file extension is hardcoded in pkg/image/bootc_disk.go, we have no way to access this information the level when the image type is generated.

When the bootc imagetypes move into YAML the problem hopefully solves itself as will then set the filename in the YAML just like we do for the other image types (this will need changes to bootc_disk.go then too).

So this commit needs to duplicate it for now. No
explicit test as this is indirectly tested via ibcli and it will go away when moving into yaml based bootc definitions (see https://github.com/osbuild/images/pull/1656 for an outline what that might look like).

(fwiw with https://github.com/osbuild/images/pull/1039 this wouldn't be an issue for ibcli).