### PR TITLE
github: enable validate checksums on the merge queue

### DIFF
--- a/.github/workflows/validate-checksums.yml
+++ b/.github/workflows/validate-checksums.yml
@@ -4,6 +4,8 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches:
       - "*"
+  # for merge queue
+  merge_group:
 
 jobs:
   manifest-checksums:


### PR DESCRIPTION
Enable the validate checksums test on the merge queue. We will begin requiring it for merging.