### PR TITLE
bootc: add support for /usr/lib/bootc-image-builder/disk.yaml

### DIFF
--- a/pkg/distro/bootc/export_test.go
+++ b/pkg/distro/bootc/export_test.go
@@ -16,6 +16,8 @@ var (
 	UpdateFilesystemSizes         = updateFilesystemSizes
 	CreateRand                    = createRand
 	CalcRequiredDirectorySizes    = calcRequiredDirectorySizes
+
+	TestDiskContainers = diskContainers
 )
 
 func NewTestBootcImageType() *BootcImageType {
@@ -38,6 +40,10 @@ func NewTestBootcImageType() *BootcImageType {
 	a.addImageTypes(*imgType)
 
 	return imgType
+}
+
+func (t *BootcImageType) SetSourceInfoPartitionTable(basept *disk.PartitionTable) {
+	t.arch.distro.sourceInfo.PartitionTable = basept
 }
 
 func (t *BootcImageType) GenPartitionTable(customizations *blueprint.Customizations, rootfsMinSize uint64, rng *rand.Rand) (*disk.PartitionTable, error) {


### PR DESCRIPTION
Once we do this we need to consider this part of the YAML
an API. This should be fine as its pretty stable already
(and we need a test that has all possible YAML values ideally
as a regression test).

Ideally also this would be used by anaconda/bootc install to-disk
itself as it contains important information about the image
and ideally it would just need to encoded in a single place
in the bootc container.

---

osinfo: add support for /u/l/bootc-image-builder/disk.yaml

This commit implements reading of a custom per-container
partition table in `/usr/lib/bootc-image-builder/disk.yaml`.

The format is:
```yaml
partition_table:
  type: "gpt"
  partitions:
    - &bios_boot_partition
      size: "1 MiB"
      bootable: true
      type: *bios_boot_partition_guid
      # "type: raw" is a planned feature, it does not exit yet
      payload:
        type: raw
        source: /usr/lib/firwmware/some-file.bin
    - &default_partition_table_part_efi
      size: "200 MiB"
      type: *efi_system_partition_guid
      payload_type: "filesystem"
      payload:
        type: vfat
...
```
i.e. the low-level disk package YAML.

---

distro: read partition table from bootc container

Read the partition table from the container via the osinfo
functionality. This will read the `disk.yaml` from the
previous commit and apply it if set as the default base
partition table.

