### PR TITLE
Add support to set partition GPT attributes in yaml format

### DIFF
--- a/pkg/disk/partition.go
+++ b/pkg/disk/partition.go
@@ -3,6 +3,7 @@ package disk
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/datasizes"
@@ -27,6 +28,9 @@ type Partition struct {
 
 	// If nil, the partition is raw; It doesn't contain a payload.
 	Payload PayloadEntity `json:"payload,omitempty" yaml:"payload,omitempty"`
+
+	// Partition GPT attribute flags to set
+	Attrs []uint `json:"attrs,omitempty" yaml:"attrs,omitempty"`
 }
 
 func (p *Partition) Clone() Entity {
@@ -41,6 +45,7 @@ func (p *Partition) Clone() Entity {
 		Bootable: p.Bootable,
 		UUID:     p.UUID,
 		Label:    p.Label,
+		Attrs:    slices.Clone(p.Attrs),
 	}
 
 	if p.Payload != nil {

--- a/pkg/disk/partition_test.go
+++ b/pkg/disk/partition_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/types"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -199,4 +200,22 @@ func TestIsBIOSBoot(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestPartitionClone(t *testing.T) {
+	p1 := &disk.Partition{
+		Start:    123,
+		Size:     456,
+		Type:     "0x83",
+		Bootable: true,
+		UUID:     "7a23f22e-3da3-4b3c-a1b7-cc3ebb995307",
+		Label:    "part-label",
+		Payload:  &disk.Raw{SourcePath: "/source/path"},
+		Attrs:    []uint{7, 8, 9},
+	}
+	p2 := p1.Clone().(*disk.Partition)
+	assert.Equal(t, p1, p2)
+	// payload/attrs got cloned as well
+	assert.False(t, reflect.ValueOf(p1.Payload).Pointer() == reflect.ValueOf(p2.Payload).Pointer())
+	assert.False(t, reflect.ValueOf(p1.Attrs).Pointer() == reflect.ValueOf(p2.Attrs).Pointer())
 }

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -230,6 +230,9 @@ image_types:
         partitions:
           - size: 1_048_576
             bootable: true
+            attrs:
+              - 50
+              - 51
           - payload_type: filesystem
             size: 209_715_200
             payload:
@@ -273,6 +276,7 @@ image_types:
 			{
 				Size:     1048576,
 				Bootable: true,
+				Attrs:    []uint{50, 51},
 			},
 			{
 				Size: 209_715_200,

--- a/pkg/osbuild/disk.go
+++ b/pkg/osbuild/disk.go
@@ -20,6 +20,7 @@ func sfdiskStageOptions(pt *disk.PartitionTable) *SfdiskStageOptions {
 			Type:     p.Type,
 			UUID:     p.UUID,
 			Name:     p.Label,
+			Attrs:    p.Attrs,
 		}
 	}
 	stageOptions := &SfdiskStageOptions{
@@ -42,6 +43,7 @@ func sgdiskStageOptions(pt *disk.PartitionTable) *SgdiskStageOptions {
 			Size:     pt.BytesToSectors(p.Size),
 			Type:     p.Type,
 			Name:     p.Label,
+			Attrs:    p.Attrs,
 		}
 
 		if p.UUID != "" {

--- a/pkg/osbuild/sfdisk_stage.go
+++ b/pkg/osbuild/sfdisk_stage.go
@@ -40,6 +40,9 @@ type SfdiskPartition struct {
 
 	// UUID of the partition (GPT)
 	UUID string `json:"uuid,omitempty"`
+
+	// Partition attribute flags to set (GPT)
+	Attrs []uint `json:"attrs,omitempty"`
 }
 
 func (o SfdiskStageOptions) validate() error {

--- a/pkg/osbuild/sfdisk_stage_test.go
+++ b/pkg/osbuild/sfdisk_stage_test.go
@@ -40,6 +40,11 @@ func TestNewSfdiskStage(t *testing.T) {
 	options.Label = "dos"
 	actualStageDOS := NewSfdiskStage(&options, device)
 	assert.Equal(t, expectedStage, actualStageDOS)
+
+	// test with attributes
+	options.Partitions[0].Attrs = []uint{50, 51}
+	actualStageAttr := NewSfdiskStage(&options, device)
+	assert.Equal(t, expectedStage, actualStageAttr)
 }
 
 func TestNewSfdiskStageInvalid(t *testing.T) {

--- a/pkg/osbuild/sgdisk_stage.go
+++ b/pkg/osbuild/sgdisk_stage.go
@@ -35,6 +35,9 @@ type SgdiskPartition struct {
 
 	// UUID of the partition
 	UUID *uuid.UUID `json:"uuid,omitempty"`
+
+	// Partition attribute flags to set (GPT)
+	Attrs []uint `json:"attrs,omitempty"`
 }
 
 func NewSgdiskStage(options *SgdiskStageOptions, device *Device) *Stage {

--- a/pkg/osbuild/sgdisk_stage_test.go
+++ b/pkg/osbuild/sgdisk_stage_test.go
@@ -35,4 +35,9 @@ func TestNewSgdiskStage(t *testing.T) {
 
 	actualStage := NewSgdiskStage(&options, device)
 	assert.Equal(t, expectedStage, actualStage)
+
+	// test with attributes
+	options.Partitions[0].Attrs = []uint{50, 51}
+	actualStageAttr := NewSgdiskStage(&options, device)
+	assert.Equal(t, expectedStage, actualStageAttr)
 }


### PR DESCRIPTION
This is going to be necessary for automotive to set up aboot partitions.