### PR TITLE
github: disable unit tests on distros without osbuild rpms

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,11 +22,12 @@ jobs:
             version: 41
           - name: current
             version: 42
-          - name: branched
-            version: 43
-          - name: rawhide
-            version: rawhide
-            continue-on-error: true
+        # Enable these when we get osbuild rpm builds for each distro version
+        # - name: branched
+        #   version: 43
+        # - name: rawhide
+        #   version: rawhide
+        #   continue-on-error: true
       fail-fast: false  # if one fails, keep the other(s) running
     name: "🛃 Unit tests (Fedora ${{ matrix.fedora_version.name }})"
     runs-on: ubuntu-24.04


### PR DESCRIPTION
We don't have test runners yet to build RPMs for Fedora 43 and 44. Disable the unit tests until we get these.