### PR TITLE
github: run yaml checks on all yaml files

### DIFF
--- a/.github/workflows/test-ibcli-integration.yml
+++ b/.github/workflows/test-ibcli-integration.yml
@@ -2,7 +2,6 @@
 name: "ibcli integration"
 
 
-
 on:  # yamllint disable-line rule:truthy
   pull_request:
     branches:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -263,15 +263,13 @@ jobs:
           sudo apt install -y yamllint yq
 
       - name: YAML Lint
-        # We only care about distro definitions for this check
         run: |
-          find pkg/distro/defs "(" -iname "*.yaml" -or -iname "*.yml" ")" -exec yamllint --strict {} \+
+          find . "(" -iname "*.yaml" -or -iname "*.yml" ")" -exec yamllint --strict {} \+
 
       - name: Check YAML definitions with yq
         # yq will catch issues that yamllint will not, like duplicate anchros
-        # We only care about distro definitions for this check
         run: |
-          find pkg/distro/defs "(" -iname "*.yaml" -or -iname "*.yml" ")" -exec yq . {} \+ > /dev/null
+          find . "(" -iname "*.yaml" -or -iname "*.yml" ")" -exec yq . {} \+ > /dev/null
 
   bib-manifest-diff:
     name: "bib manifest diff validation"

--- a/.github/workflows/update-osbuild.yml
+++ b/.github/workflows/update-osbuild.yml
@@ -2,7 +2,7 @@
 ---
 name: "Update osbuild commit ID"
 
-on:
+on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
   schedule:
     # Every Sunday at 12:00


### PR DESCRIPTION
We recently changed the paths for the distro definitions, which meant
they weren't being linted.
Let's change the check to lint all yaml files in the repository.