### PR TITLE
test: skip running null child pipelines

### DIFF
--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -65,6 +65,8 @@ NullBuild:
   script: "true"
   tags:
     - "shell"
+  rules:
+    - when: never
 """
 
 


### PR DESCRIPTION
Based on [this comment](https://gitlab.com/gitlab-org/gitlab/-/issues/331816#note_2722942139) and if I'm reading [the docs](https://docs.gitlab.com/ci/yaml/#workflowrules) correctly, this should work and make our "null" child pipelines a proper no-op, instead of starting a shell runner that does nothing.

---

Null child pipelines are needed because a completely empty pipeline is invalid.  This change makes it so that the pipeline isn't run at all, instead of simply running `true` and exiting.  This should save us some time from starting the shell running and exiting.