### PR TITLE
distro: Fix build container use in bootc distro

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -513,10 +513,22 @@ func main() {
 			}
 		}
 	}
-	for _, bootcRef := range bootcRefs {
+	for _, bootcRefTuple := range bootcRefs {
+		l := strings.SplitN(bootcRefTuple, "#", 2)
+		bootcRef := l[0]
+		var buildBootcRef string
+		if len(l) > 1 {
+			buildBootcRef = l[1]
+		}
+
 		distribution, err := bootc.NewBootcDistro(bootcRef)
 		if err != nil {
 			panic(err)
+		}
+		if buildBootcRef != "" {
+			if err := distribution.SetBuildContainer(buildBootcRef); err != nil {
+				panic(err)
+			}
 		}
 		// XXX: consider making this configurable but for now
 		// we just need diffable manifests

--- a/pkg/distro/bootc/bootc.go
+++ b/pkg/distro/bootc/bootc.go
@@ -397,10 +397,14 @@ func NewBootcDistro(imgref string) (bd *BootcDistro, err error) {
 		name:          nameVer,
 		releasever:    info.OSRelease.VersionID,
 		defaultFs:     defaultFs,
-		sourceInfo:    info,
 		rootfsMinSize: cntSize * containerSizeToDiskSizeMultiplier,
 
-		imgref: imgref,
+		imgref:     imgref,
+		sourceInfo: info,
+		// default buildref/info to regular container, this can
+		// be overriden with SetBuildContainer()
+		buildImgref:     imgref,
+		buildSourceInfo: info,
 	}
 
 	for _, archStr := range []string{"x86_64", "aarch64", "ppc64le", "s390x", "riscv64"} {

--- a/pkg/distro/bootc/bootc.go
+++ b/pkg/distro/bootc/bootc.go
@@ -77,6 +77,7 @@ func (d *BootcDistro) SetBuildContainer(imgref string) (err error) {
 	if err != nil {
 		return err
 	}
+	d.buildImgref = imgref
 	d.buildSourceInfo = info
 	return nil
 }
@@ -399,8 +400,7 @@ func NewBootcDistro(imgref string) (bd *BootcDistro, err error) {
 		sourceInfo:    info,
 		rootfsMinSize: cntSize * containerSizeToDiskSizeMultiplier,
 
-		imgref:      imgref,
-		buildImgref: imgref,
+		imgref: imgref,
 	}
 
 	for _, archStr := range []string{"x86_64", "aarch64", "ppc64le", "s390x", "riscv64"} {

--- a/tools/gen-bootc-diff
+++ b/tools/gen-bootc-diff
@@ -81,43 +81,49 @@ for REF in quay.io/centos-bootc/centos-bootc:stream9 \
 do
     for ARCH in x86_64 aarch64; do
 	for BP in "$BP_FULL_FS" "$BP_LVM" "$BP_EMPTY"; do
-	    echo "Testing $REF;$ARCH;$(basename "$BP")"
-	    sudo podman pull -q --arch "$ARCH" "$REF"
+	    for BUILD_REF in "" "quay.io/fedora/fedora-bootc:41"; do
+		echo "Testing $REF;$ARCH;$(basename "$BP")"
+		sudo podman pull -q --arch "$ARCH" "$REF"
+		if [ -n "$BUILD_REF" ]; then
+		    sudo podman pull -q --arch "$ARCH" "$BUILD_REF"
+		fi
 
-	    TMPDIR=$(mktemp -d)
-	    trap 'rm -rf -- "$TMPDIR"' EXIT
+		TMPDIR=$(mktemp -d)
+		trap 'rm -rf -- "$TMPDIR"' EXIT
 
-	    ROOTFS=""
-	    if grep -q fedora <(echo "$REF"); then
-		ROOTFS="ext4"
-	    fi
+		ROOTFS=""
+		if grep -q fedora <(echo "$REF"); then
+		    ROOTFS="ext4"
+		fi
 
-	    sudo go run \
-		 -buildvcs=false \
-		 github.com/osbuild/bootc-image-builder/bib/cmd/bootc-image-builder@main \
-		manifest -v "$REF" \
-		--config "$BP" \
-		--target-arch "$ARCH" \
-		--rootfs "$ROOTFS" \
-		--type "$TYPE" | jq > "$TMPDIR/bib.json"
+		sudo go run \
+		     -buildvcs=false \
+		     github.com/osbuild/bootc-image-builder/bib/cmd/bootc-image-builder@main \
+		    manifest -v "$REF" \
+		    --config "$BP" \
+		    --target-arch "$ARCH" \
+		    --rootfs "$ROOTFS" \
+		    --build-container "$BUILD_REF" \
+		    --type "$TYPE" | jq > "$TMPDIR/bib.json"
 
-	    # oh well, we need to convert our blueprint into the
-	    # gen-manifests config :/
-	    echo '{"blueprint":' >  "$TMPDIR"/gm-conf.json
-	    cat "$BP" >> "$TMPDIR"/gm-conf.json
-	    echo '}' >>  "$TMPDIR"/gm-conf.json
-	    sudo ./cmd/gen-manifests/gen-manifests \
-		-types "$TYPE" \
-		-arches "$ARCH" \
-		-distros ignore \
-		-metadata=false \
-		-config "$TMPDIR"/gm-conf.json \
-		-bootc-refs "$REF" \
-		-output "$TMPDIR"
+		# oh well, we need to convert our blueprint into the
+		# gen-manifests config :/
+		echo '{"blueprint":' >  "$TMPDIR"/gm-conf.json
+		cat "$BP" >> "$TMPDIR"/gm-conf.json
+		echo '}' >>  "$TMPDIR"/gm-conf.json
+		sudo ./cmd/gen-manifests/gen-manifests \
+		    -types "$TYPE" \
+		    -arches "$ARCH" \
+		    -distros ignore \
+		    -metadata=false \
+		    -config "$TMPDIR"/gm-conf.json \
+		    -bootc-refs "$REF#$BUILD_REF" \
+		    -output "$TMPDIR"
 
-	    # ensure manifests are identical (but skip uuid diffs)
-	    echo "Comparing images and bootc-image-builder generated manifests"
-	    diff -u <(grep -v uuid "$TMPDIR"/bootc_*.json) <(grep -v uuid "$TMPDIR"/bib.json)
+		# ensure manifests are identical (but skip uuid diffs)
+		echo "Comparing images and bootc-image-builder generated manifests"
+		diff -u <(grep -v uuid "$TMPDIR"/bootc_*.json) <(grep -v uuid "$TMPDIR"/bib.json)
+	    done
 	done
     done
 done


### PR DESCRIPTION
This fixes two things:
 1) If SetBuildContainer() is not called, buildImgRef is nil
 2) If it is called, buildImgRef is properly set to the value passed.

Without this, when using a build container, I got errors about a missing "target" pipeline when using https://github.com/osbuild/bootc-image-builder/pull/1014