### PR TITLE
Fixes for blueprint option validation in Fedora

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -789,6 +789,7 @@
       - "modules"
       - "groups"
       - "minimal"
+      - "containers"
       - "customizations.directories"
       - "customizations.files"
       - "customizations.fips"

--- a/pkg/distro/generic/fedora_test.go
+++ b/pkg/distro/generic/fedora_test.go
@@ -513,7 +513,7 @@ func TestFedoraDistro_ManifestError(t *testing.T) {
 					case "iot-simplified-installer":
 						assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.installation_device: required", imgTypeName))
 					case "iot-raw-xz", "iot-qcow2":
-						assert.EqualError(t, err, fmt.Sprintf("%s: ostree commit URL required", imgTypeName))
+						assert.EqualError(t, err, fmt.Sprintf("options validation failed for image type %q: ostree.url: required", imgTypeName))
 					case "container", "wsl", "iot-bootable-container":
 						assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 					default:

--- a/pkg/distro/generic/options.go
+++ b/pkg/distro/generic/options.go
@@ -542,7 +542,7 @@ func checkOptionsFedora(t *imageType, bp *blueprint.Blueprint, options distro.Im
 		}
 	}
 
-	if t.BootISO && t.RPMOSTree {
+	if (t.BootISO || t.Bootable) && t.RPMOSTree {
 		// ostree-based ISOs require a URL from which to pull a payload commit
 		if options.OSTree == nil || options.OSTree.URL == "" {
 			return warnings, fmt.Errorf("options validation failed for image type %q: ostree.url: required", t.Name())

--- a/pkg/distro/generic/options.go
+++ b/pkg/distro/generic/options.go
@@ -549,38 +549,34 @@ func checkOptionsFedora(t *imageType, bp *blueprint.Blueprint, options distro.Im
 		}
 	}
 
-	// BootISOs have limited support for customizations.
-	// TODO: Support kernel name selection for image-installer
-	if t.BootISO {
-		if t.Name() == "iot-simplified-installer" {
-			// FDO is optional, but when specified has some restrictions
-			if customizations.GetFDO() != nil {
-				if customizations.GetFDO().ManufacturingServerURL == "" {
-					return warnings, fmt.Errorf("%s: customizations.fdo.manufacturing_server_url: required when using fdo", errPrefix)
-				}
-				var diunSet int
-				if customizations.GetFDO().DiunPubKeyHash != "" {
-					diunSet++
-				}
-				if customizations.GetFDO().DiunPubKeyInsecure != "" {
-					diunSet++
-				}
-				if customizations.GetFDO().DiunPubKeyRootCerts != "" {
-					diunSet++
-				}
-				if diunSet != 1 {
-					return warnings, fmt.Errorf("%s: one of customizations.fdo.diun_pub_key_hash, customizations.fdo.diun_pub_key_insecure, customizations.fdo.diun_pub_key_root_certs: required when using fdo", errPrefix)
-				}
+	if t.Name() == "iot-simplified-installer" {
+		// FDO is optional, but when specified has some restrictions
+		if customizations.GetFDO() != nil {
+			if customizations.GetFDO().ManufacturingServerURL == "" {
+				return warnings, fmt.Errorf("%s: customizations.fdo.manufacturing_server_url: required when using fdo", errPrefix)
 			}
+			var diunSet int
+			if customizations.GetFDO().DiunPubKeyHash != "" {
+				diunSet++
+			}
+			if customizations.GetFDO().DiunPubKeyInsecure != "" {
+				diunSet++
+			}
+			if customizations.GetFDO().DiunPubKeyRootCerts != "" {
+				diunSet++
+			}
+			if diunSet != 1 {
+				return warnings, fmt.Errorf("%s: one of customizations.fdo.diun_pub_key_hash, customizations.fdo.diun_pub_key_insecure, customizations.fdo.diun_pub_key_root_certs: required when using fdo", errPrefix)
+			}
+		}
 
-			// ignition is optional, we might be using FDO
-			if customizations.GetIgnition() != nil {
-				if customizations.GetIgnition().Embedded != nil && customizations.GetIgnition().FirstBoot != nil {
-					return warnings, fmt.Errorf("%s: customizations.ignition.embedded cannot be used with customizations.ignition.firstboot", errPrefix)
-				}
-				if customizations.GetIgnition().FirstBoot != nil && customizations.GetIgnition().FirstBoot.ProvisioningURL == "" {
-					return warnings, fmt.Errorf("%s: customizations.ignition.firstboot requires customizations.ignition.firstboot.provisioning_url", errPrefix)
-				}
+		// ignition is optional, we might be using FDO
+		if customizations.GetIgnition() != nil {
+			if customizations.GetIgnition().Embedded != nil && customizations.GetIgnition().FirstBoot != nil {
+				return warnings, fmt.Errorf("%s: customizations.ignition.embedded cannot be used with customizations.ignition.firstboot", errPrefix)
+			}
+			if customizations.GetIgnition().FirstBoot != nil && customizations.GetIgnition().FirstBoot.ProvisioningURL == "" {
+				return warnings, fmt.Errorf("%s: customizations.ignition.firstboot requires customizations.ignition.firstboot.provisioning_url", errPrefix)
 			}
 		}
 	}

--- a/pkg/distro/generic/options_test.go
+++ b/pkg/distro/generic/options_test.go
@@ -58,6 +58,11 @@ func TestCheckOptions(t *testing.T) {
 		"f42/ostree-disk-supported": {
 			distro: "fedora-42",
 			it:     "iot-qcow2",
+			options: distro.ImageOptions{
+				OSTree: &ostree.ImageOptions{
+					URL: "https://example.org/repo",
+				},
+			},
 			bp: blueprint.Blueprint{
 				Customizations: &blueprint.Customizations{
 					User:  []blueprint.UserCustomization{{Name: "root"}},
@@ -75,7 +80,6 @@ func TestCheckOptions(t *testing.T) {
 					FIPS: common.ToPtr(true),
 				},
 			},
-			// NOTE: this should also require an ostree URL
 		},
 		"f42/ostree-disk-not-supported": {
 			distro: "fedora-42",
@@ -509,17 +513,15 @@ func TestCheckOptions(t *testing.T) {
 			expErr: "blueprint validation failed for image type \"server-vhd\": customizations.oscap.profile_id: required when using customizations.oscap",
 		},
 
-		// NOTE: the following tests verify the current behaviour of the
-		// function, but the behaviour itself is wrong
 		"f42/ostree-disk-requires-ostree-url": {
 			distro: "fedora-42",
 			it:     "iot-qcow2",
-			expErr: "", // NOTE: it should require a URL
+			expErr: "options validation failed for image type \"iot-qcow2\": ostree.url: required",
 		},
 		"f42/ostree-disk2-requires-ostree-url": {
 			distro: "fedora-42",
 			it:     "iot-raw-xz",
-			expErr: "", // NOTE: it should require a URL
+			expErr: "options validation failed for image type \"iot-raw-xz\": ostree.url: required",
 		},
 
 		"r8/ami-ok": {


### PR DESCRIPTION
Follow-up from #1216.  Fixing a couple of issues I found with the new blueprint option validation in Fedora while I was working on the RHEL images.