### PR TITLE
github: use git status to verify checksum changes

### DIFF
--- a/.github/workflows/validate-checksums.yml
+++ b/.github/workflows/validate-checksums.yml
@@ -62,10 +62,14 @@ jobs:
               exit 1
           fi
 
-      # Run the manifest checksum generator on the HEAD (merge group temporary
-      # branch) and fail if there are changes.
-      - name: Validate manifest checksums (merge queue)
+      # Run the manifest checksum generator on the HEAD (which also works for
+      # the merge group temporary branch) and fail if there are changes.
+      - name: Validate manifest checksums (HEAD)
         if: ${{ github.event_name == 'merge_group' }}
         run: |
            ./tools/gen-manifest-checksums.sh
-           git diff --exit-code
+           if [ -n "$(git status --porcelain)" ]; then
+             echo "Manifest checksum differences detected"
+             git status -vv
+             exit 1
+           fi


### PR DESCRIPTION
When testing the head of the merge queue for manifest checksum changes, use 'git status --porcelain' instead of 'git diff --exit-code'.  Using diff does not exit with an error if there are untracked files in the tree, which we want to catch.

The "Validate manifest checksums for every commit in the PR" will still not catch file additions, because the rebase is not interrupted when untracked files introduced in the tree.  To make sure we don't fail on the merge queue when the PR is green, lets also run the "Validate manifest checksums (HEAD)" check (which uses 'git status') on PRs.

Noticed in #1802 that we merged #1812 without the manifests being added, because the addition of files was not caught.