### PR TITLE
Support setting what type of mount configuration to set in disk.yaml

### DIFF
--- a/pkg/bib/osinfo/osinfo.go
+++ b/pkg/bib/osinfo/osinfo.go
@@ -15,6 +15,7 @@ import (
 	"github.com/osbuild/images/pkg/bib/blueprintload"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/osbuild"
 )
 
 // XXX: use image-builder instead?
@@ -41,7 +42,8 @@ type Info struct {
 	ImageCustomization *blueprint.Customizations
 	KernelInfo         *KernelInfo
 
-	PartitionTable *disk.PartitionTable
+	MountConfiguration *osbuild.MountConfiguration
+	PartitionTable     *disk.PartitionTable
 }
 
 func validateOSRelease(osrelease map[string]string) error {
@@ -131,10 +133,11 @@ func readImageCustomization(root string) (*blueprint.Customizations, error) {
 }
 
 type diskYAML struct {
-	PartitionTable *disk.PartitionTable `json:"partition_table" yaml:"partition_table"`
+	MountConfiguration *osbuild.MountConfiguration `json:"mount_configuration" yaml:"mount_configuration"`
+	PartitionTable     *disk.PartitionTable        `json:"partition_table" yaml:"partition_table"`
 }
 
-func readPartitionTable(root string) (*disk.PartitionTable, error) {
+func readDiskYaml(root string) (*diskYAML, error) {
 	p := path.Join(root, bibPathPrefix, "disk.yaml")
 	var disk diskYAML
 	f, err := os.Open(p)
@@ -150,7 +153,7 @@ func readPartitionTable(root string) (*disk.PartitionTable, error) {
 		return nil, fmt.Errorf("cannot parse disk definitions from %q: %w", p, err)
 	}
 
-	return disk.PartitionTable, nil
+	return &disk, nil
 }
 
 func readKernelInfo(root string) (*KernelInfo, error) {
@@ -205,9 +208,15 @@ func Load(root string) (*Info, error) {
 		return nil, err
 	}
 
-	pt, err := readPartitionTable(root)
+	diskYaml, err := readDiskYaml(root)
 	if err != nil {
 		return nil, err
+	}
+	var mc *osbuild.MountConfiguration
+	var pt *disk.PartitionTable
+	if diskYaml != nil {
+		mc = diskYaml.MountConfiguration
+		pt = diskYaml.PartitionTable
 	}
 
 	kernelInfo, err := readKernelInfo(root)
@@ -239,6 +248,7 @@ func Load(root string) (*Info, error) {
 		SELinuxPolicy:      selinuxPolicy,
 		ImageCustomization: customization,
 		KernelInfo:         kernelInfo,
+		MountConfiguration: mc,
 		PartitionTable:     pt,
 	}, nil
 }

--- a/pkg/distro/bootc/bootc.go
+++ b/pkg/distro/bootc/bootc.go
@@ -313,6 +313,9 @@ func (t *BootcImageType) Manifest(bp *blueprint.Blueprint, options distro.ImageO
 	if t.arch.distro.buildSourceInfo != nil {
 		img.OSCustomizations.BuildSELinux = t.arch.distro.buildSourceInfo.SELinuxPolicy
 	}
+	if t.arch.distro.sourceInfo != nil && t.arch.distro.sourceInfo.MountConfiguration != nil {
+		img.OSCustomizations.MountConfiguration = *t.arch.distro.sourceInfo.MountConfiguration
+	}
 
 	img.OSCustomizations.KernelOptionsAppend = []string{
 		"rw",

--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -318,8 +318,8 @@ func osCustomizations(t *imageType, osPackageSet rpmmd.PackageSet, options distr
 		osc.MachineIdUninitialized = *imageConfig.MachineIdUninitialized
 	}
 
-	if imageConfig.MountUnits != nil {
-		osc.MountUnits = *imageConfig.MountUnits
+	if imageConfig.MountUnits != nil && *imageConfig.MountUnits {
+		osc.MountConfiguration = osbuild.MOUNT_CONFIGURATION_UNITS
 	}
 
 	osc.VersionlockPackages = imageConfig.VersionlockPackages

--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -30,6 +30,9 @@ func NewBootcDiskImage(platform platform.Platform, filename string, container co
 		Base:                 NewBase("bootc-raw-image", platform, filename),
 		ContainerSource:      &container,
 		BuildContainerSource: &buildContainer,
+		OSCustomizations: manifest.OSCustomizations{
+			MountConfiguration: osbuild.MOUNT_CONFIGURATION_UNITS, // default use mount units for bootc disk images
+		},
 	}
 }
 
@@ -110,7 +113,7 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 	rawImage.Directories = img.OSCustomizations.Directories
 	rawImage.KernelOptionsAppend = img.OSCustomizations.KernelOptionsAppend
 	rawImage.SELinux = img.OSCustomizations.SELinux
-	rawImage.MountUnits = true // always use mount units for bootc disk images
+	rawImage.MountConfiguration = img.OSCustomizations.MountConfiguration
 
 	// In BIB, we export multiple images from the same pipeline so we use the
 	// filename as the basename for each export and set the extensions based on

--- a/pkg/manifest/common.go
+++ b/pkg/manifest/common.go
@@ -1,6 +1,8 @@
 package manifest
 
 import (
+	"fmt"
+
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
 )
@@ -9,14 +11,19 @@ import (
 // collection of org.osbuild.systemd.unit.create stages for .mount and .swap
 // units (and an org.osbuild.systemd stage to enable them) depending on the
 // pipeline configuration.
-func filesystemConfigStages(pt *disk.PartitionTable, mountUnits bool) ([]*osbuild.Stage, error) {
-	if mountUnits {
+func filesystemConfigStages(pt *disk.PartitionTable, mountConfiguration osbuild.MountConfiguration) ([]*osbuild.Stage, error) {
+	switch mountConfiguration {
+	case osbuild.MOUNT_CONFIGURATION_UNITS:
 		return osbuild.GenSystemdMountStages(pt)
-	} else {
+	case osbuild.MOUNT_CONFIGURATION_FSTAB:
 		opts, err := osbuild.NewFSTabStageOptions(pt)
 		if err != nil {
 			return nil, err
 		}
 		return []*osbuild.Stage{osbuild.NewFSTabStage(opts)}, nil
+	case osbuild.MOUNT_CONFIGURATION_NONE:
+		return []*osbuild.Stage{}, nil
+	default:
+		panic(fmt.Sprintf("Unexpected mount configuration %d", mountConfiguration))
 	}
 }

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -182,9 +182,9 @@ type OSCustomizations struct {
 	// "ConditionFirstBoot" to work in systemd
 	MachineIdUninitialized bool
 
-	// MountUnits creates systemd .mount units to describe the filesystem
-	// instead of writing to /etc/fstab
-	MountUnits bool
+	// What type of mount configuration should we create, systemd units, fstab
+	// or none
+	MountConfiguration osbuild.MountConfiguration
 
 	// VersionlockPackges uses dnf versionlock to lock a package to the version
 	// that is installed during image build, preventing it from being updated.
@@ -738,7 +738,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 	}
 
 	if pt := p.PartitionTable; pt != nil {
-		rootUUID, kernelOptions, err := osbuild.GenImageKernelOptions(p.PartitionTable, p.OSCustomizations.MountUnits)
+		rootUUID, kernelOptions, err := osbuild.GenImageKernelOptions(p.PartitionTable, p.OSCustomizations.MountConfiguration)
 		if err != nil {
 			panic(err)
 		}
@@ -752,7 +752,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 			}))
 		}
 
-		fsCfgStages, err := filesystemConfigStages(pt, p.OSCustomizations.MountUnits)
+		fsCfgStages, err := filesystemConfigStages(pt, p.OSCustomizations.MountConfiguration)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -43,9 +43,9 @@ type OSTreeDeploymentCustomizations struct {
 	// user options in the build configuration.
 	LockRoot bool
 
-	// MountUnits creates systemd .mount units to describe the filesystem
-	// instead of writing to /etc/fstab
-	MountUnits bool
+	// What type of mount configuration should we create, systemd units, fstab
+	// or none
+	MountConfiguration osbuild.MountConfiguration
 }
 
 // OSTreeDeployment represents the filesystem tree of a target image based
@@ -300,7 +300,7 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 			},
 		},
 	}))
-	_, kernelOpts, err := osbuild.GenImageKernelOptions(p.PartitionTable, p.MountUnits)
+	_, kernelOpts, err := osbuild.GenImageKernelOptions(p.PartitionTable, p.MountConfiguration)
 	if err != nil {
 		panic(err)
 	}
@@ -343,7 +343,7 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 	configStage.MountOSTree(p.osName, ref, 0)
 	pipeline.AddStage(configStage)
 
-	fsCfgStages, err := filesystemConfigStages(p.PartitionTable, p.MountUnits)
+	fsCfgStages, err := filesystemConfigStages(p.PartitionTable, p.MountConfiguration)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/manifest/ostree_deployment_test.go
+++ b/pkg/manifest/ostree_deployment_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osbuild/images/internal/testdisk"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -45,8 +46,8 @@ func NewTestOSTreeDeployment() *manifest.OSTreeDeployment {
 func TestOSTreeDeploymentPipelineFStabStage(t *testing.T) {
 	pipeline := NewTestOSTreeDeployment()
 
-	pipeline.PartitionTable = testdisk.MakeFakePartitionTable("/") // PT specifics don't matter
-	pipeline.MountUnits = false                                    // set it explicitly just to be sure
+	pipeline.PartitionTable = testdisk.MakeFakePartitionTable("/")  // PT specifics don't matter
+	pipeline.MountConfiguration = osbuild.MOUNT_CONFIGURATION_FSTAB // set it explicitly just to be sure
 
 	checkStagesForFSTab(t, manifest.SerializeWith(pipeline, testCommitInputs()).Stages)
 }
@@ -56,9 +57,18 @@ func TestOSTreeDeploymentPipelineMountUnitStages(t *testing.T) {
 
 	expectedUnits := []string{"-.mount", "home.mount"}
 	pipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/home")
-	pipeline.MountUnits = true
+	pipeline.MountConfiguration = osbuild.MOUNT_CONFIGURATION_UNITS
 
 	checkStagesForMountUnits(t, manifest.SerializeWith(pipeline, testCommitInputs()).Stages, expectedUnits)
+}
+
+func TestOSTreeDeploymentPipelineNoMountUnitStages(t *testing.T) {
+	pipeline := NewTestOSTreeDeployment()
+
+	pipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/home")
+	pipeline.MountConfiguration = osbuild.MOUNT_CONFIGURATION_NONE
+
+	checkStagesForNoMounts(t, manifest.SerializeWith(pipeline, testCommitInputs()).Stages)
 }
 
 func TestAddInlineOSTreeDeployment(t *testing.T) {

--- a/pkg/manifest/raw_bootc.go
+++ b/pkg/manifest/raw_bootc.go
@@ -45,9 +45,9 @@ type RawBootcImage struct {
 	// selected profile
 	SELinux string
 
-	// MountUnits creates systemd .mount units to describe the filesystem
-	// instead of writing to /etc/fstab
-	MountUnits bool
+	// What type of mount configuration should we create, systemd units, fstab
+	// or none
+	MountConfiguration osbuild.MountConfiguration
 
 	// Source pipeline for files written to raw partitions
 	SourcePipeline string
@@ -176,7 +176,7 @@ func (p *RawBootcImage) serialize() osbuild.Pipeline {
 	mounts = append(mounts, *osbuild.NewOSTreeDeploymentMountDefault("ostree.deployment", osbuild.OSTreeMountSourceMount))
 	mounts = append(mounts, *osbuild.NewBindMount("bind-ostree-deployment-to-tree", "mount://", "tree://"))
 
-	fsCfgStages, err := filesystemConfigStages(pt, p.MountUnits)
+	fsCfgStages, err := filesystemConfigStages(pt, p.MountConfiguration)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/manifest/raw_bootc_test.go
+++ b/pkg/manifest/raw_bootc_test.go
@@ -348,7 +348,7 @@ func TestRawBootcPipelineFSTabStage(t *testing.T) {
 	pipeline := makeFakeRawBootcPipeline()
 
 	pipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/boot/efi") // PT requires /boot/efi
-	pipeline.MountUnits = false                                                 // set it explicitly just to be sure
+	pipeline.MountConfiguration = osbuild.MOUNT_CONFIGURATION_FSTAB             // set it explicitly just to be sure
 
 	checkStagesForFSTab(t, pipeline.Serialize().Stages)
 }
@@ -358,7 +358,16 @@ func TestRawBootcPipelineMountUnitStages(t *testing.T) {
 
 	expectedUnits := []string{"-.mount", "home.mount", "boot-efi.mount"}
 	pipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/home", "/boot/efi")
-	pipeline.MountUnits = true
+	pipeline.MountConfiguration = osbuild.MOUNT_CONFIGURATION_UNITS
 
 	checkStagesForMountUnits(t, pipeline.Serialize().Stages, expectedUnits)
+}
+
+func TestRawBootcPipelineNoMountsStages(t *testing.T) {
+	pipeline := makeFakeRawBootcPipeline()
+
+	pipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/home", "/boot/efi")
+	pipeline.MountConfiguration = osbuild.MOUNT_CONFIGURATION_NONE
+
+	checkStagesForNoMounts(t, pipeline.Serialize().Stages)
 }

--- a/pkg/osbuild/disk_test.go
+++ b/pkg/osbuild/disk_test.go
@@ -50,7 +50,7 @@ func TestGenImageKernelOptions(t *testing.T) {
 	uuids := collectUUIDs(pt)
 	assert.NotEmpty(uuids["/"], "Could not find root filesystem")
 	assert.NotEmpty(uuids["luks"], "Could not find LUKS container")
-	rootUUID, cmdline, err := GenImageKernelOptions(pt, false)
+	rootUUID, cmdline, err := GenImageKernelOptions(pt, MOUNT_CONFIGURATION_FSTAB)
 	assert.NoError(err)
 
 	assert.Equal(rootUUID, uuids["/"])
@@ -59,14 +59,14 @@ func TestGenImageKernelOptions(t *testing.T) {
 
 func TestGenImageKernelOptionsBtrfs(t *testing.T) {
 	pt := testdisk.MakeFakeBtrfsPartitionTable("/")
-	_, actual, err := GenImageKernelOptions(pt, false)
+	_, actual, err := GenImageKernelOptions(pt, MOUNT_CONFIGURATION_FSTAB)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"rootflags=subvol=root"}, actual)
 }
 
 func TestGenImageKernelOptionsBtrfsNotRootCmdlineGenerated(t *testing.T) {
 	pt := testdisk.MakeFakeBtrfsPartitionTable("/var")
-	_, kopts, err := GenImageKernelOptions(pt, false)
+	_, kopts, err := GenImageKernelOptions(pt, MOUNT_CONFIGURATION_FSTAB)
 	assert.EqualError(t, err, "root filesystem must be defined for kernel-cmdline stage, this is a programming error")
 	assert.Equal(t, len(kopts), 0)
 }
@@ -210,7 +210,7 @@ func TestGenImageKernelOptionsMountUnitsPlain(t *testing.T) {
 	uuids := collectUUIDs(pt)
 	assert.Len(uuids, 2)
 
-	rootUUID, cmdline, err := GenImageKernelOptions(pt, true)
+	rootUUID, cmdline, err := GenImageKernelOptions(pt, MOUNT_CONFIGURATION_UNITS)
 	assert.NoError(err)
 
 	assert.Equal(rootUUID, uuids["/"])
@@ -230,7 +230,7 @@ func TestGenImageKernelOptionsMountUnitsPlainWithUsr(t *testing.T) {
 	uuids := collectUUIDs(pt)
 	assert.Len(uuids, 3)
 
-	rootUUID, cmdline, err := GenImageKernelOptions(pt, true)
+	rootUUID, cmdline, err := GenImageKernelOptions(pt, MOUNT_CONFIGURATION_UNITS)
 	assert.NoError(err)
 
 	assert.Equal(rootUUID, uuids["/"])
@@ -248,7 +248,7 @@ func TestGenImageKernelOptionsMountUnitsBtrfs(t *testing.T) {
 	uuids := collectUUIDs(pt)
 	assert.Len(uuids, 2)
 
-	rootUUID, cmdline, err := GenImageKernelOptions(pt, true)
+	rootUUID, cmdline, err := GenImageKernelOptions(pt, MOUNT_CONFIGURATION_UNITS)
 	assert.NoError(err)
 
 	assert.Equal(rootUUID, uuids["/"])
@@ -270,7 +270,7 @@ func TestGenImageKernelOptionsMountUnitsBtrfsWithUsr(t *testing.T) {
 	uuids := collectUUIDs(pt)
 	assert.Len(uuids, 3)
 
-	rootUUID, cmdline, err := GenImageKernelOptions(pt, true)
+	rootUUID, cmdline, err := GenImageKernelOptions(pt, MOUNT_CONFIGURATION_UNITS)
 	assert.NoError(err)
 
 	assert.Equal(rootUUID, uuids["/"])
@@ -294,7 +294,7 @@ func TestGenImageKernelOptionsMountUnitsLVM(t *testing.T) {
 	uuids := collectUUIDs(pt)
 	assert.Len(uuids, 2)
 
-	rootUUID, cmdline, err := GenImageKernelOptions(pt, true)
+	rootUUID, cmdline, err := GenImageKernelOptions(pt, MOUNT_CONFIGURATION_UNITS)
 	assert.NoError(err)
 
 	assert.Equal(rootUUID, uuids["/"])
@@ -314,7 +314,7 @@ func TestGenImageKernelOptionsMountUnitsLVMWithUsr(t *testing.T) {
 	uuids := collectUUIDs(pt)
 	assert.Len(uuids, 3)
 
-	rootUUID, cmdline, err := GenImageKernelOptions(pt, true)
+	rootUUID, cmdline, err := GenImageKernelOptions(pt, MOUNT_CONFIGURATION_UNITS)
 	assert.NoError(err)
 
 	assert.Equal(rootUUID, uuids["/"])


### PR DESCRIPTION
This extends the current internal boolean mountUnits options to an enum that also allows to disable both fstab and mount units.

Additionally, it also adds the option "mount_configuration" to the bootc disk.yaml embedded config file, allowing bootc images to configure this.

For now, distro.ImageConfig still has MountUnits, because changing that would break the yaml format. However, this could be changed in the future.

MOUNT_CONFIGURATION_FSTAB has value 0, to make the default match the default for a mountUnit boolean (i.e. false).

Note: The previous MountUnits option also affected the generated kernel config options in some cases. We do the same now even if the option is set to none.