### PR TITLE
manifestgen,imagefilter: simplify the API

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -124,7 +124,7 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("[ERROR] manifest generator creation failed: %w", err)
 	}
-	if err := mg.Generate(config.Blueprint, distribution, imgType, arch, &config.Options); err != nil {
+	if err := mg.Generate(config.Blueprint, imgType, &config.Options); err != nil {
 		return fmt.Errorf("[ERROR] manifest generation failed: %w", err)
 	}
 	fmt.Print("DONE\n")

--- a/pkg/distro/bootc/integration_test.go
+++ b/pkg/distro/bootc/integration_test.go
@@ -1,7 +1,6 @@
 package bootc_test
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -42,15 +41,13 @@ func canRunIntegration(t *testing.T) {
 func genManifest(t *testing.T, imgType distro.ImageType) string {
 	var bp blueprint.Blueprint
 
-	var manifestJson bytes.Buffer
 	mg, err := manifestgen.New(nil, &manifestgen.Options{
-		Output: &manifestJson,
 		OverrideRepos: []rpmmd.RepoConfig{
 			{Id: "not-used", BaseURLs: []string{"not-used"}},
 		},
 	})
 	assert.NoError(t, err)
-	err = mg.Generate(&bp, imgType.Arch().Distro(), imgType, imgType.Arch(), nil)
+	manifestJson, err := mg.Generate(&bp, imgType, nil)
 	assert.NoError(t, err)
 
 	// XXX: it would be nice to return an *osbuild.Manifest here
@@ -58,7 +55,7 @@ func genManifest(t *testing.T, imgType distro.ImageType) string {
 	// working currently as osbuild.NewManifestsFromBytes() cannot
 	// unmarshal our manifests because of:
 	// "unexpected source name: org.osbuild.containers-storage"
-	return manifestJson.String()
+	return string(manifestJson)
 }
 
 func TestBuildContainerHandling(t *testing.T) {

--- a/pkg/imagefilter/formatter.go
+++ b/pkg/imagefilter/formatter.go
@@ -63,7 +63,9 @@ func (*textResultsFormatter) Output(w io.Writer, all []Result) error {
 		// cmdline should support:
 		//   image-builder manifest centos-9 type:qcow2 arch:s390
 		//   image-builder build centos-9 type:qcow2 arch:x86_64
-		if _, err := fmt.Fprintf(w, "%s type:%s arch:%s\n", res.Distro.Name(), res.ImgType.Name(), res.Arch.Name()); err != nil {
+		arch := res.ImgType.Arch()
+		distro := arch.Distro()
+		if _, err := fmt.Fprintf(w, "%s type:%s arch:%s\n", distro.Name(), res.ImgType.Name(), arch.Name()); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -80,10 +82,12 @@ func (*shellResultsFormatter) Output(w io.Writer, all []Result) error {
 	var errs []error
 
 	for _, res := range all {
+		arch := res.ImgType.Arch()
+		distro := arch.Distro()
 		if _, err := fmt.Fprintf(w, "%s --distro %s --arch %s\n",
 			res.ImgType.Name(),
-			res.Distro.Name(),
-			res.Arch.Name()); err != nil {
+			distro.Name(),
+			arch.Name()); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -101,10 +105,12 @@ func (*textShortResultsFormatter) Output(w io.Writer, all []Result) error {
 
 	outputMap := make(map[string]map[string][]string)
 	for _, res := range all {
-		if _, ok := outputMap[res.Distro.Name()]; !ok {
-			outputMap[res.Distro.Name()] = make(map[string][]string)
+		arch := res.ImgType.Arch()
+		distro := arch.Distro()
+		if _, ok := outputMap[distro.Name()]; !ok {
+			outputMap[distro.Name()] = make(map[string][]string)
 		}
-		outputMap[res.Distro.Name()][res.ImgType.Name()] = append(outputMap[res.Distro.Name()][res.ImgType.Name()], res.Arch.Name())
+		outputMap[distro.Name()][res.ImgType.Name()] = append(outputMap[distro.Name()][res.ImgType.Name()], arch.Name())
 	}
 
 	// Sort and prepare output
@@ -165,12 +171,14 @@ func (*jsonResultsFormatter) Output(w io.Writer, all []Result) error {
 	var out []filteredResultJSON
 
 	for _, res := range all {
+		arch := res.ImgType.Arch()
+		distro := arch.Distro()
 		out = append(out, filteredResultJSON{
 			Distro: distroResultJSON{
-				Name: res.Distro.Name(),
+				Name: distro.Name(),
 			},
 			Arch: archResultJSON{
-				Name: res.Arch.Name(),
+				Name: arch.Name(),
 			},
 			ImgType: imgTypeResultJSON{
 				Name: res.ImgType.Name(),

--- a/pkg/imagefilter/formatter_test.go
+++ b/pkg/imagefilter/formatter_test.go
@@ -29,7 +29,7 @@ func newFakeResult(t *testing.T, resultSpec string) imagefilter.Result {
 	require.NoError(t, err)
 	im, err := ar.GetImageType(l[1])
 	require.NoError(t, err)
-	return imagefilter.Result{di, ar, im, nil}
+	return imagefilter.Result{im, nil}
 }
 
 func TestResultsFormatter(t *testing.T) {

--- a/pkg/imagefilter/imagefilter.go
+++ b/pkg/imagefilter/imagefilter.go
@@ -18,8 +18,6 @@ type MinimalRepoRegistry interface {
 
 // Result contains a result from a imagefilter.Filter run
 type Result struct {
-	Distro  distro.Distro
-	Arch    distro.Arch
 	ImgType distro.ImageType
 	Repos   []rpmmd.RepoConfig
 }
@@ -93,7 +91,7 @@ func (i *ImageFilter) Filter(searchTerms ...string) ([]Result, error) {
 					if err != nil {
 						return nil, err
 					}
-					res = append(res, Result{distro, a, imgType, repos})
+					res = append(res, Result{imgType, repos})
 				}
 			}
 		}

--- a/pkg/imagefilter/imagefilter_test.go
+++ b/pkg/imagefilter/imagefilter_test.go
@@ -36,8 +36,8 @@ func TestImageFilterSpecificResult(t *testing.T) {
 	res, err := imgFilter.Filter("distro:centos-9", "arch:x86_64", "type:qcow2")
 	require.NoError(t, err)
 	assert.Len(t, res, 1)
-	assert.Equal(t, "centos-9", res[0].Distro.Name())
-	assert.Equal(t, "x86_64", res[0].Arch.Name())
+	assert.Equal(t, "centos-9", res[0].ImgType.Arch().Distro().Name())
+	assert.Equal(t, "x86_64", res[0].ImgType.Arch().Name())
 	assert.Equal(t, "qcow2", res[0].ImgType.Name())
 	assert.True(t, len(res[0].Repos) > 0)
 	assert.True(t, slices.IndexFunc(res[0].Repos, func(r rpmmd.RepoConfig) bool {

--- a/pkg/manifestgen/manifestgen.go
+++ b/pkg/manifestgen/manifestgen.go
@@ -140,11 +140,13 @@ func New(reporegistry *reporegistry.RepoRegistry, opts *Options) (*Generator, er
 
 // Generate will generate a new manifest for the given distro/imageType/arch
 // combination.
-func (mg *Generator) Generate(bp *blueprint.Blueprint, dist distro.Distro, imgType distro.ImageType, a distro.Arch, imgOpts *distro.ImageOptions) (err error) {
+func (mg *Generator) Generate(bp *blueprint.Blueprint, imgType distro.ImageType, imgOpts *distro.ImageOptions) (err error) {
 	if imgOpts == nil {
 		imgOpts = &distro.ImageOptions{}
 	}
 	imgOpts.UseBootstrapContainer = mg.useBootstrapContainer
+	a := imgType.Arch()
+	dist := a.Distro()
 
 	var repos []rpmmd.RepoConfig
 	if mg.overrideRepos != nil {

--- a/pkg/manifestgen/manifestgen_test.go
+++ b/pkg/manifestgen/manifestgen_test.go
@@ -67,7 +67,7 @@ func TestManifestGeneratorDepsolve(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, mg)
 			var bp blueprint.Blueprint
-			err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+			err = mg.Generate(&bp, res[0].ImgType, nil)
 			require.NoError(t, err)
 
 			pipelineNames, err := manifesttest.PipelineNamesFrom(osbuildManifest.Bytes())
@@ -115,7 +115,7 @@ func TestManifestGeneratorWithOstreeCommit(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, mg)
 	var bp blueprint.Blueprint
-	err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, imageOpts)
+	err = mg.Generate(&bp, res[0].ImgType, imageOpts)
 	assert.NoError(t, err)
 
 	pipelineNames, err := manifesttest.PipelineNamesFrom(osbuildManifest.Bytes())
@@ -240,7 +240,7 @@ func TestManifestGeneratorContainers(t *testing.T) {
 			},
 		},
 	}
-	err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+	err = mg.Generate(&bp, res[0].ImgType, nil)
 	assert.NoError(t, err)
 
 	// container is included
@@ -279,7 +279,7 @@ func TestManifestGeneratorDepsolveWithSbomWriter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, mg)
 	var bp blueprint.Blueprint
-	err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+	err = mg.Generate(&bp, res[0].ImgType, nil)
 	require.NoError(t, err)
 
 	assert.Contains(t, generatedSboms, "centos-9-qcow2-x86_64.buildroot-build.spdx.json")
@@ -317,7 +317,7 @@ func TestManifestGeneratorSeed(t *testing.T) {
 		assert.NoError(t, err)
 
 		var bp blueprint.Blueprint
-		err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+		err = mg.Generate(&bp, res[0].ImgType, nil)
 		assert.NoError(t, err)
 
 		// with the customSeed we always get a predicatable uuid for
@@ -354,7 +354,7 @@ func TestManifestGeneratorDepsolveOutput(t *testing.T) {
 	assert.NoError(t, err)
 
 	var bp blueprint.Blueprint
-	err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+	err = mg.Generate(&bp, res[0].ImgType, nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []byte("fake depsolve output"), depsolveWarningsOutput.Bytes())
@@ -391,7 +391,7 @@ func TestManifestGeneratorOverrideRepos(t *testing.T) {
 			assert.NoError(t, err)
 
 			var bp blueprint.Blueprint
-			err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+			err = mg.Generate(&bp, res[0].ImgType, nil)
 			assert.NoError(t, err)
 			if withOverrideRepos {
 				assert.Contains(t, osbuildManifest.String(), "http://example.com/overriden-repo/kernel.rpm")
@@ -427,7 +427,7 @@ func TestManifestGeneratorUseBootstrapContainer(t *testing.T) {
 			assert.NoError(t, err)
 
 			var bp blueprint.Blueprint
-			err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+			err = mg.Generate(&bp, res[0].ImgType, nil)
 			assert.NoError(t, err)
 			pipelines, err := manifesttest.PipelineNamesFrom(osbuildManifest.Bytes())
 			assert.NoError(t, err)


### PR DESCRIPTION
manifestgen: return manifest via Generator.Generate()

Simplify the way to use manifestgen to just return the
osbuild manifest bytes from `manifestgen.Generator.Generate()`
instead of the previous (indirect) way via `Options.Output`.

The previous way way was a bit too indirect and cumbersome
and this approach is more inline with what the existing
Serialize() is doing.

This will require updates in bib/ibcli.

---

manifestgen: simplify Generate() to only take imageType

We used to require to pass distro,arch as well but that
is entirely unnecessary (and actually arguably dangerous)
as the image type that is already passed has references
to its architecture and distro already.

---

imagefilter: simplify result and just return imageType

The imagefilter was returning the tuple (distro,arch,imgtype)
but that is unnecessary. The image type already has references
to the matching arch and distro. So just drop that.
