### PR TITLE
Update supported blueprint options for Fedora image types

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -1489,15 +1489,7 @@ image_types:
                 exclude:
                   - "perl"
                   - "perl-interpreter"
-    supported_blueprint_options:
-      # Only supporting a few basic options for now because we never tested any
-      # other customization with this image type
-      - "distro"
-      - "packages"
-      - "modules"
-      - "groups"
-      - "enabled_modules"
-      - "minimal"
+    supported_blueprint_options: *supported_options_ostree_commit
 
   "minimal-raw-xz": &minimal_raw_xz
     name_aliases: ["minimal-raw"]

--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -806,6 +806,27 @@
       - "customizations.services"
       - "customizations.timezone"
 
+    # supported options for container types (container and wsl)
+    supported_options_container: &supported_options_container
+      - "distro"
+      - "packages"
+      - "modules"
+      - "groups"
+      - "enabled_modules"
+      - "minimal"
+      - "containers"
+      - "customizations.directories"
+      - "customizations.files"
+      - "customizations.firewall"
+      - "customizations.user"
+      - "customizations.sshkey"
+      - "customizations.group"
+      - "customizations.hostname"
+      - "customizations.locale"
+      - "customizations.repositories"
+      - "customizations.services"
+      - "customizations.timezone"
+
     # options supported by ostree disk (deployment) image types
     supported_options_ostree_disk: &supported_options_ostree_disk
       - "distro"
@@ -1804,15 +1825,7 @@ image_types:
             - "trousers"
             - "whois-nls"
             - "xkeyboard-config"
-    supported_blueprint_options:
-      # Only supporting a few basic options for now because we never tested any
-      # other customization with this image type
-      - "distro"
-      - "packages"
-      - "modules"
-      - "groups"
-      - "enabled_modules"
-      - "minimal"
+    supported_blueprint_options: *supported_options_container
 
   wsl:
     # this is the eventual name, and `wsl` the alias but we've been
@@ -1918,15 +1931,7 @@ image_types:
               append:
                 exclude:
                   - "fuse-libs"
-    supported_blueprint_options:
-      # Only supporting a few basic options for now because we never tested any
-      # other customization with this image type
-      - "distro"
-      - "packages"
-      - "modules"
-      - "groups"
-      - "enabled_modules"
-      - "minimal"
+    supported_blueprint_options: *supported_options_container
 
   "iot-simplified-installer":
     <<: *rpm_ostree_imgtype_common

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -640,7 +640,7 @@ func TestDistro_ManifestFIPSWarning(t *testing.T) {
 						switch imgTypeName {
 						case "workstation-live-installer":
 							assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.fips: not supported", imgTypeName))
-						case "wsl", "iot-bootable-container", "container":
+						case "wsl", "container":
 							assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 						default:
 							assert.Equal(t, slices.Contains(warn, msg), !common.IsBuildHostFIPSEnabled(),

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -638,10 +638,8 @@ func TestDistro_ManifestFIPSWarning(t *testing.T) {
 						// functionality which produces different error
 						// messages. These will be added to RHEL as well soon.
 						switch imgTypeName {
-						case "workstation-live-installer":
+						case "workstation-live-installer", "container", "wsl":
 							assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.fips: not supported", imgTypeName))
-						case "wsl", "container":
-							assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 						default:
 							assert.Equal(t, slices.Contains(warn, msg), !common.IsBuildHostFIPSEnabled(),
 								"FIPS warning not shown for image: distro='%s', imgTypeName='%s', archName='%s', warn='%v'", distroName, imgTypeName, archName, warn)

--- a/pkg/distro/generic/fedora_test.go
+++ b/pkg/distro/generic/fedora_test.go
@@ -515,7 +515,7 @@ func TestFedoraDistro_ManifestError(t *testing.T) {
 					case "iot-raw-xz", "iot-qcow2":
 						assert.EqualError(t, err, fmt.Sprintf("options validation failed for image type %q: ostree.url: required", imgTypeName))
 					case "container", "wsl":
-						assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
+						assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.kernel: not supported", imgTypeName))
 					default:
 						assert.NoError(t, err)
 					}
@@ -719,10 +719,8 @@ func TestFedoraDistro_CustomFileSystemManifestError(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: maybeMakeOSTreeURL(imgTypeName)}, nil, nil)
 				switch imgTypeName {
-				case "minimal-installer", "iot-installer", "workstation-live-installer", "iot-simplified-installer", "iot-commit", "iot-container", "iot-bootable-container", "everything-netinst":
+				case "minimal-installer", "iot-installer", "workstation-live-installer", "iot-simplified-installer", "iot-commit", "iot-container", "iot-bootable-container", "everything-netinst", "container", "wsl":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "container", "wsl":
-					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					// TODO: this error message is a bit clunky; bring it more in line with the other messages (remove "The following errors ...")
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: The following custom mountpoints are not supported [\"/etc\"]", imgTypeName))
@@ -750,10 +748,8 @@ func TestFedoraDistro_TestRootMountPoint(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: maybeMakeOSTreeURL(imgTypeName)}, nil, nil)
 				switch imgTypeName {
-				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "iot-bootable-container", "everything-netinst":
+				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "iot-bootable-container", "everything-netinst", "container", "wsl":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "container":
-					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					assert.NoError(t, err)
 				}
@@ -784,10 +780,8 @@ func TestFedoraDistro_CustomFileSystemSubDirectories(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: maybeMakeOSTreeURL(imgTypeName)}, nil, nil)
 				switch imgTypeName {
-				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "iot-bootable-container", "everything-netinst":
+				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "iot-bootable-container", "everything-netinst", "container", "wsl":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "container":
-					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					assert.NoError(t, err)
 				}
@@ -826,10 +820,8 @@ func TestFedoraDistro_MountpointsWithArbitraryDepthAllowed(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: maybeMakeOSTreeURL(imgTypeName)}, nil, nil)
 				switch imgTypeName {
-				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "iot-bootable-container", "everything-netinst":
+				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "iot-bootable-container", "everything-netinst", "container", "wsl":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "container":
-					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					assert.NoError(t, err)
 				}
@@ -864,10 +856,8 @@ func TestFedoraDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: maybeMakeOSTreeURL(imgTypeName)}, nil, nil)
 				switch imgTypeName {
-				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "iot-bootable-container", "everything-netinst":
+				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "iot-bootable-container", "everything-netinst", "container", "wsl":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "container":
-					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					// TODO: this error message is a bit clunky; bring it more in line with the other messages (remove "The following errors ...")
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: The following custom mountpoints are not supported [\"//\" \"/var//\" \"/var//log/audit/\"]", imgTypeName))
@@ -898,10 +888,8 @@ func TestFedoraDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, options, nil, nil)
 				switch imgTypeName {
-				case "workstation-live-installer", "iot-container", "iot-commit", "iot-bootable-container", "iot-installer", "iot-simplified-installer", "minimal-installer", "everything-netinst":
+				case "workstation-live-installer", "iot-container", "iot-commit", "iot-bootable-container", "iot-installer", "iot-simplified-installer", "minimal-installer", "everything-netinst", "container", "wsl":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "container":
-					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					assert.NoError(t, err)
 				}
@@ -942,10 +930,8 @@ func TestFedoraDistro_PartitioningConflict(t *testing.T) {
 				}
 				_, _, err := imgType.Manifest(&bp, options, nil, nil)
 				switch imgTypeName {
-				case "workstation-live-installer", "iot-container", "iot-commit", "iot-bootable-container", "iot-installer", "iot-simplified-installer", "minimal-installer", "everything-netinst":
+				case "workstation-live-installer", "iot-container", "iot-commit", "iot-bootable-container", "iot-installer", "iot-simplified-installer", "minimal-installer", "everything-netinst", "container", "wsl":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "container":
-					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.disk cannot be used with customizations.filesystem", imgTypeName))
 				}

--- a/pkg/distro/generic/fedora_test.go
+++ b/pkg/distro/generic/fedora_test.go
@@ -506,7 +506,7 @@ func TestFedoraDistro_ManifestError(t *testing.T) {
 					}
 					_, _, err := imgType.Manifest(&bp, imgOpts, nil, nil)
 					switch imgTypeName {
-					case "iot-commit", "iot-container":
+					case "iot-commit", "iot-container", "iot-bootable-container":
 						assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.kernel.append: not supported", imgTypeName))
 					case "minimal-installer", "iot-installer", "workstation-live-installer", "everything-netinst":
 						assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.kernel: not supported", imgTypeName))
@@ -514,7 +514,7 @@ func TestFedoraDistro_ManifestError(t *testing.T) {
 						assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.installation_device: required", imgTypeName))
 					case "iot-raw-xz", "iot-qcow2":
 						assert.EqualError(t, err, fmt.Sprintf("options validation failed for image type %q: ostree.url: required", imgTypeName))
-					case "container", "wsl", "iot-bootable-container":
+					case "container", "wsl":
 						assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 					default:
 						assert.NoError(t, err)
@@ -719,9 +719,9 @@ func TestFedoraDistro_CustomFileSystemManifestError(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: maybeMakeOSTreeURL(imgTypeName)}, nil, nil)
 				switch imgTypeName {
-				case "minimal-installer", "iot-installer", "workstation-live-installer", "iot-simplified-installer", "iot-commit", "iot-container", "everything-netinst":
+				case "minimal-installer", "iot-installer", "workstation-live-installer", "iot-simplified-installer", "iot-commit", "iot-container", "iot-bootable-container", "everything-netinst":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "container", "wsl", "iot-bootable-container":
+				case "container", "wsl":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					// TODO: this error message is a bit clunky; bring it more in line with the other messages (remove "The following errors ...")
@@ -750,9 +750,9 @@ func TestFedoraDistro_TestRootMountPoint(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: maybeMakeOSTreeURL(imgTypeName)}, nil, nil)
 				switch imgTypeName {
-				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "everything-netinst":
+				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "iot-bootable-container", "everything-netinst":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "iot-bootable-container", "container":
+				case "wsl", "container":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					assert.NoError(t, err)
@@ -784,9 +784,9 @@ func TestFedoraDistro_CustomFileSystemSubDirectories(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: maybeMakeOSTreeURL(imgTypeName)}, nil, nil)
 				switch imgTypeName {
-				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "everything-netinst":
+				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "iot-bootable-container", "everything-netinst":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "iot-bootable-container", "container":
+				case "wsl", "container":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					assert.NoError(t, err)
@@ -826,9 +826,9 @@ func TestFedoraDistro_MountpointsWithArbitraryDepthAllowed(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: maybeMakeOSTreeURL(imgTypeName)}, nil, nil)
 				switch imgTypeName {
-				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "everything-netinst":
+				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "iot-bootable-container", "everything-netinst":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "iot-bootable-container", "container":
+				case "wsl", "container":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					assert.NoError(t, err)
@@ -864,9 +864,9 @@ func TestFedoraDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: maybeMakeOSTreeURL(imgTypeName)}, nil, nil)
 				switch imgTypeName {
-				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "everything-netinst":
+				case "minimal-installer", "workstation-live-installer", "iot-simplified-installer", "iot-installer", "iot-commit", "iot-container", "iot-bootable-container", "everything-netinst":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "iot-bootable-container", "container":
+				case "wsl", "container":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					// TODO: this error message is a bit clunky; bring it more in line with the other messages (remove "The following errors ...")
@@ -898,9 +898,9 @@ func TestFedoraDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 				imgType, _ := arch.GetImageType(imgTypeName)
 				_, _, err := imgType.Manifest(&bp, options, nil, nil)
 				switch imgTypeName {
-				case "workstation-live-installer", "iot-container", "iot-commit", "iot-installer", "iot-simplified-installer", "minimal-installer", "everything-netinst":
+				case "workstation-live-installer", "iot-container", "iot-commit", "iot-bootable-container", "iot-installer", "iot-simplified-installer", "minimal-installer", "everything-netinst":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "iot-bootable-container", "container":
+				case "wsl", "container":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					assert.NoError(t, err)
@@ -942,9 +942,9 @@ func TestFedoraDistro_PartitioningConflict(t *testing.T) {
 				}
 				_, _, err := imgType.Manifest(&bp, options, nil, nil)
 				switch imgTypeName {
-				case "workstation-live-installer", "iot-container", "iot-commit", "iot-installer", "iot-simplified-installer", "minimal-installer", "everything-netinst":
+				case "workstation-live-installer", "iot-container", "iot-commit", "iot-bootable-container", "iot-installer", "iot-simplified-installer", "minimal-installer", "everything-netinst":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.filesystem: not supported", imgTypeName))
-				case "wsl", "iot-bootable-container", "container":
+				case "wsl", "container":
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations: not supported", imgTypeName))
 				default:
 					assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.disk cannot be used with customizations.filesystem", imgTypeName))


### PR DESCRIPTION
Adding more supported blueprint options for some Fedora image types based on tests in osbuild-composer.

---

**distrodefs/fedora: support iot-commit options in iot-bootable-container**

In osbuild-composer, we were already testing the iot-bootable-container
with the same blueprint options as the iot-commit and iot-container.

---

**distrodefs/fedora: support customizations in container types**

Add support for customizations in container types (container and wsl).
These are tested in osbuild-composer.
These types also support embedding containers.

---
