### PR TITLE
 bootc: add integration test for disk.yaml (HMS-9295) 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Run unit tests for bib container
         run: sudo go test ./pkg/bib/container/... --fail-if-podman-missing
 
+      - name: Run tests for bootc container
+        run: sudo go test ./pkg/distro/bootc/...
+
   unit-tests-cs:
     strategy:
       matrix:

--- a/pkg/distro/bootc/bootctest/bootctest.go
+++ b/pkg/distro/bootc/bootctest/bootctest.go
@@ -1,0 +1,118 @@
+package bootctest
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/internal/randutil"
+)
+
+func makeOsRelease(t *testing.T, buildDir string) {
+	osRelease := `
+NAME="bootc-fake-name"
+ID="bootc-fake"
+VERSION_ID="1"
+`
+
+	osReleasePath := filepath.Join(buildDir, "etc/os-release")
+	err := os.MkdirAll(filepath.Dir(osReleasePath), 0755)
+	require.NoError(t, err)
+	//nolint:gosec
+	err = os.WriteFile(osReleasePath, []byte(osRelease), 0644)
+	require.NoError(t, err)
+}
+
+func makeUsrBinInstall(t *testing.T, buildDir string) {
+	installToml := `
+[install]
+filesystem = [
+    { mountpoint = "/", type = "xfs", size = "10 GiB" },
+    { mountpoint = "/boot", type = "ext4", size = "1 GiB" },
+]
+`
+
+	installTomlPath := filepath.Join(buildDir, "usr/lib/bootc/install/99-fedora-install.toml")
+	err := os.MkdirAll(filepath.Dir(installTomlPath), 0755)
+	require.NoError(t, err)
+	//nolint:gosec
+	err = os.WriteFile(installTomlPath, []byte(installToml), 0644)
+	require.NoError(t, err)
+}
+
+func makeFakeBinaries(t *testing.T, buildDir string) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	currentDir := filepath.Dir(currentFile)
+
+	fakeBootcPath := filepath.Join(buildDir, "usr/bin/bootc")
+	err := os.MkdirAll(filepath.Dir(fakeBootcPath), 0755)
+	require.NoError(t, err)
+	cmd := exec.Command(
+		"go", "build",
+		"-o", fakeBootcPath,
+		filepath.Join(currentDir, "./exe"),
+	)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		require.NoError(t, err, string(output))
+	}
+
+	fakeSleepPath := filepath.Join(buildDir, "usr/bin/sleep")
+	err = os.Symlink("bootc", fakeSleepPath)
+	require.NoError(t, err)
+}
+
+func makeContainerfile(t *testing.T, buildDir string) {
+	var fakeBootcCnt = `
+FROM scratch
+COPY etc /etc
+COPY usr/bin /usr/bin
+COPY usr/lib/bootc/install /usr/lib/bootc/install 
+`
+
+	cntFilePath := filepath.Join(buildDir, "Containerfile")
+	//nolint:gosec
+	err := os.WriteFile(cntFilePath, []byte(fakeBootcCnt), 0644)
+	require.NoError(t, err)
+}
+
+func makeFakeContainerImage(t *testing.T, buildDir, purpose string) string {
+	imgTag := fmt.Sprintf("image-builder-test-%s-%s", purpose, randutil.String(10, randutil.AsciiLower))
+	//nolint:gosec
+	output, err := exec.Command(
+		"podman", "build",
+		"-f", filepath.Join(buildDir, "Containerfile"),
+		"-t", imgTag,
+	).CombinedOutput()
+	require.NoError(t, err, string(output))
+	// add cleanup
+	t.Cleanup(func() {
+		output, err := exec.Command("podman", "image", "rm", imgTag).CombinedOutput()
+		assert.NoError(t, err, string(output))
+	})
+
+	return fmt.Sprintf("localhost/%s", imgTag)
+}
+
+func NewFakeContainer(t *testing.T, purpose string) string {
+	t.Helper()
+
+	buildDir := t.TempDir()
+
+	// XXX: allow adding test specific content
+	makeContainerfile(t, buildDir)
+	makeFakeBinaries(t, buildDir)
+	// XXX: make os-release content configurable
+	makeOsRelease(t, buildDir)
+	makeUsrBinInstall(t, buildDir)
+
+	return makeFakeContainerImage(t, buildDir, purpose)
+}

--- a/pkg/distro/bootc/bootctest/bootctest.go
+++ b/pkg/distro/bootc/bootctest/bootctest.go
@@ -70,13 +70,22 @@ func makeFakeBinaries(t *testing.T, buildDir string) {
 	require.NoError(t, err)
 }
 
-func makeContainerfile(t *testing.T, buildDir string) {
+func makeContainerfile(t *testing.T, buildDir string, extraFiles map[string]string) {
 	var fakeBootcCnt = `
 FROM scratch
 COPY etc /etc
 COPY usr/bin /usr/bin
 COPY usr/lib/bootc/install /usr/lib/bootc/install 
 `
+	for path, content := range extraFiles {
+		fakeBootcCnt += fmt.Sprintf("COPY %s %s\n", path[1:], path)
+
+		err := os.MkdirAll(filepath.Join(buildDir, filepath.Dir(path)), 0755)
+		require.NoError(t, err)
+		//nolint:gosec
+		err = os.WriteFile(filepath.Join(buildDir, path), []byte(content), 0644)
+		require.NoError(t, err)
+	}
 
 	cntFilePath := filepath.Join(buildDir, "Containerfile")
 	//nolint:gosec
@@ -102,13 +111,13 @@ func makeFakeContainerImage(t *testing.T, buildDir, purpose string) string {
 	return fmt.Sprintf("localhost/%s", imgTag)
 }
 
-func NewFakeContainer(t *testing.T, purpose string) string {
+func NewFakeContainer(t *testing.T, purpose string, extraFiles map[string]string) string {
 	t.Helper()
 
 	buildDir := t.TempDir()
 
 	// XXX: allow adding test specific content
-	makeContainerfile(t, buildDir)
+	makeContainerfile(t, buildDir, extraFiles)
 	makeFakeBinaries(t, buildDir)
 	// XXX: make os-release content configurable
 	makeOsRelease(t, buildDir)

--- a/pkg/distro/bootc/bootctest/exe/bootc.go
+++ b/pkg/distro/bootc/bootctest/exe/bootc.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func fakeBootc() error {
+	if os.Args[1] != "install" || os.Args[2] != "print-configuration" {
+		return fmt.Errorf("unexpected bootc arguments %v", os.Args)
+	}
+	// print a sensible default configuration
+	fmt.Println(`{"filesystem": {"root": {"type": "ext4"}}}`)
+	return nil
+}
+
+func fakeSleep() error {
+	if os.Args[1] != "infinity" {
+		return fmt.Errorf("unexpected sleep arguments %v", os.Args)
+	}
+	time.Sleep(math.MaxInt64)
+	return nil
+}
+
+func main() {
+	var err error
+	switch filepath.Base(os.Args[0]) {
+	case "bootc":
+		err = fakeBootc()
+	case "sleep":
+		err = fakeSleep()
+	}
+	if err != nil {
+		println("error: ", err.Error())
+	}
+}

--- a/pkg/distro/bootc/integration_test.go
+++ b/pkg/distro/bootc/integration_test.go
@@ -1,0 +1,104 @@
+package bootc_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/blueprint/pkg/blueprint"
+
+	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distro/bootc"
+	"github.com/osbuild/images/pkg/distro/bootc/bootctest"
+	"github.com/osbuild/images/pkg/manifestgen"
+	"github.com/osbuild/images/pkg/osbuild/manifesttest"
+	"github.com/osbuild/images/pkg/rpmmd"
+)
+
+func canRunIntegration(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("test needs root")
+	}
+	if _, err := exec.LookPath("podman"); err != nil {
+		t.Skip("test needs installed podman")
+	}
+	if _, err := exec.LookPath("systemd-detect-virt"); err != nil {
+		t.Skip("test needs systemd-detect-virt")
+	}
+	// exit code "0" means the container is detected
+	if err := exec.Command("systemd-detect-virt", "-c", "-q").Run(); err == nil {
+		t.Skip("test cannot run inside a container")
+	}
+}
+
+func genManifest(t *testing.T, imgType distro.ImageType) string {
+	var bp blueprint.Blueprint
+
+	var manifestJson bytes.Buffer
+	mg, err := manifestgen.New(nil, &manifestgen.Options{
+		Output: &manifestJson,
+		OverrideRepos: []rpmmd.RepoConfig{
+			{Id: "not-used", BaseURLs: []string{"not-used"}},
+		},
+	})
+	assert.NoError(t, err)
+	err = mg.Generate(&bp, imgType.Arch().Distro(), imgType, imgType.Arch(), nil)
+	assert.NoError(t, err)
+
+	// XXX: it would be nice to return an *osbuild.Manifest here
+	// and do all of this more structed, however this is not
+	// working currently as osbuild.NewManifestsFromBytes() cannot
+	// unmarshal our manifests because of:
+	// "unexpected source name: org.osbuild.containers-storage"
+	return manifestJson.String()
+}
+
+func TestBuildContainerHandling(t *testing.T) {
+	canRunIntegration(t)
+
+	imgTag := bootctest.NewFakeContainer(t, "bootc")
+	buildImgTag := bootctest.NewFakeContainer(t, "build")
+
+	for _, withBuildContainer := range []bool{true, false} {
+		t.Run(fmt.Sprintf("build-cnt:%v", withBuildContainer), func(t *testing.T) {
+			distri, err := bootc.NewBootcDistro(imgTag)
+			require.NoError(t, err)
+			if withBuildContainer {
+				err = distri.SetBuildContainer(buildImgTag)
+				require.NoError(t, err)
+			}
+
+			archi, err := distri.GetArch(arch.Current().String())
+			require.NoError(t, err)
+			imgType, err := archi.GetImageType("qcow2")
+			assert.NoError(t, err)
+
+			manifestJson := genManifest(t, imgType)
+			pipelineNames, err := manifesttest.PipelineNamesFrom([]byte(manifestJson))
+			require.NoError(t, err)
+			buildStages, err := manifesttest.StagesForPipeline([]byte(manifestJson), "build")
+			require.NoError(t, err)
+			// the bootc container is always pulled
+			assert.Contains(t, manifestJson, imgTag)
+			if withBuildContainer {
+				assert.Contains(t, manifestJson, buildImgTag)
+				// validate that the usr/lib/bootc/install/ dir is copied
+				assert.Contains(t, manifestJson, "usr/lib/bootc/install/")
+				assert.Contains(t, buildStages, "org.osbuild.copy")
+				// validate that we have a "target" pipeline for raw content
+				assert.Contains(t, pipelineNames, "target")
+			} else {
+				assert.NotContains(t, manifestJson, buildImgTag)
+				assert.NotContains(t, manifestJson, "usr/lib/bootc/install/")
+				assert.NotContains(t, buildStages, "org.osbuild.copy")
+				assert.NotContains(t, pipelineNames, "target")
+			}
+		})
+	}
+}


### PR DESCRIPTION
[based on https://github.com/https://github.com/osbuild/images/pull/1828 ]

This commit adds support to test for disk.yaml

/jira-epic HMS-8839

JIRA: [HMS-9295](https://issues.redhat.com/browse/HMS-9295)
