### PR TITLE
pkg/rpmmd: simplify package search in depsolved package list and `panic()` less (HMS-9310)

### DIFF
--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -190,8 +190,11 @@ func (p *AnacondaInstaller) serializeStart(inputs Inputs) error {
 	}
 	p.packageSpecs = inputs.Depsolved.Packages
 	if p.kernelName != "" {
-		// XXX: return error instead of panic
-		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.kernelName)
+		kernelPkg, err := rpmmd.GetPackage(p.packageSpecs, p.kernelName)
+		if err != nil {
+			return fmt.Errorf("AnacondaInstaller: failed to find kernel package %q in the depsolved packages", p.kernelName)
+		}
+		p.kernelVer = kernelPkg.GetEVRA()
 	}
 	p.repos = append(p.repos, inputs.Depsolved.Repos...)
 	return nil

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -183,15 +184,17 @@ func (p *AnacondaInstaller) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *AnacondaInstaller) serializeStart(inputs Inputs) {
+func (p *AnacondaInstaller) serializeStart(inputs Inputs) error {
 	if len(p.packageSpecs) > 0 {
-		panic("double call to serializeStart()")
+		return errors.New("AnacondaInstaller: double call to serializeStart()")
 	}
 	p.packageSpecs = inputs.Depsolved.Packages
 	if p.kernelName != "" {
+		// XXX: return error instead of panic
 		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.kernelName)
 	}
 	p.repos = append(p.repos, inputs.Depsolved.Repos...)
+	return nil
 }
 
 func (p *AnacondaInstaller) serializeEnd() {

--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -192,7 +192,7 @@ func (p *AnacondaInstaller) serializeStart(inputs Inputs) error {
 	if p.kernelName != "" {
 		kernelPkg, err := rpmmd.GetPackage(p.packageSpecs, p.kernelName)
 		if err != nil {
-			return fmt.Errorf("AnacondaInstaller: failed to find kernel package %q in the depsolved packages", p.kernelName)
+			return fmt.Errorf("AnacondaInstaller: %w", err)
 		}
 		p.kernelVer = kernelPkg.GetEVRA()
 	}

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -317,17 +318,17 @@ func (p *AnacondaInstallerISOTree) NewErofsStage() *osbuild.Stage {
 	return osbuild.NewErofsStage(&erofsOptions, p.anacondaPipeline.Name())
 }
 
-func (p *AnacondaInstallerISOTree) serializeStart(inputs Inputs) {
+func (p *AnacondaInstallerISOTree) serializeStart(inputs Inputs) error {
 	if p.ostreeCommitSpec != nil || p.containerSpec != nil {
-		panic("double call to serializeStart()")
+		return errors.New("AnacondaInstallerISOTree: double call to serializeStart()")
 	}
 
 	if len(inputs.Commits) > 1 {
-		panic("pipeline supports at most one ostree commit")
+		return errors.New("AnacondaInstallerISOTree: pipeline supports at most one ostree commit")
 	}
 
 	if len(inputs.Containers) > 1 {
-		panic("pipeline supports at most one container")
+		return errors.New("AnacondaInstallerISOTree: pipeline supports at most one container")
 	}
 
 	if len(inputs.Commits) > 0 {
@@ -337,6 +338,8 @@ func (p *AnacondaInstallerISOTree) serializeStart(inputs Inputs) {
 	if len(inputs.Containers) > 0 {
 		p.containerSpec = &inputs.Containers[0]
 	}
+
+	return nil
 }
 
 func (p *AnacondaInstallerISOTree) serializeEnd() {

--- a/pkg/manifest/anaconda_installer_test.go
+++ b/pkg/manifest/anaconda_installer_test.go
@@ -85,13 +85,14 @@ func TestAnacondaInstallerModules(t *testing.T) {
 		// Run each test case twice: once with activatable-modules and once with kickstart-modules.
 		// Remove this when we drop support for RHEL 8.
 		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
 			for _, legacy := range []bool{true, false} {
 				installerPipeline := newAnacondaInstaller()
 				installerPipeline.InstallerCustomizations.UseLegacyAnacondaConfig = legacy
 				installerPipeline.InstallerCustomizations.EnabledAnacondaModules = tc.enable
 				installerPipeline.InstallerCustomizations.DisabledAnacondaModules = tc.disable
-				pipeline := manifest.SerializeWith(installerPipeline, manifest.Inputs{Depsolved: depsolvednf.DepsolveResult{Packages: pkgs}})
-				require := require.New(t)
+				pipeline, err := manifest.SerializeWith(installerPipeline, manifest.Inputs{Depsolved: depsolvednf.DepsolveResult{Packages: pkgs}})
+				require.NoError(err)
 				require.NotNil(pipeline)
 				require.NotNil(pipeline.Stages)
 
@@ -133,10 +134,11 @@ func TestISOLocale(t *testing.T) {
 
 	for input, expected := range locales {
 		t.Run(input, func(t *testing.T) {
+			require := require.New(t)
 			installerPipeline := newAnacondaInstaller()
 			installerPipeline.Locale = input
-			pipeline := manifest.SerializeWith(installerPipeline, manifest.Inputs{Depsolved: depsolvednf.DepsolveResult{Packages: pkgs}})
-			require := require.New(t)
+			pipeline, err := manifest.SerializeWith(installerPipeline, manifest.Inputs{Depsolved: depsolvednf.DepsolveResult{Packages: pkgs}})
+			require.NoError(err)
 			require.NotNil(pipeline)
 			require.NotNil(pipeline.Stages)
 
@@ -160,13 +162,13 @@ func TestAnacondaInstallerDracutModulesAndDrivers(t *testing.T) {
 			Checksum: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
 		},
 	}
+	require := require.New(t)
 
 	installerPipeline := newAnacondaInstaller()
 	installerPipeline.InstallerCustomizations.AdditionalDracutModules = []string{"test-module"}
 	installerPipeline.InstallerCustomizations.AdditionalDrivers = []string{"test-driver"}
-	pipeline := manifest.SerializeWith(installerPipeline, manifest.Inputs{Depsolved: depsolvednf.DepsolveResult{Packages: pkgs}})
-
-	require := require.New(t)
+	pipeline, err := manifest.SerializeWith(installerPipeline, manifest.Inputs{Depsolved: depsolvednf.DepsolveResult{Packages: pkgs}})
+	require.NoError(err)
 	require.NotNil(pipeline)
 	require.NotNil(pipeline.Stages)
 

--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/osbuild/images/pkg/container"
@@ -149,12 +150,13 @@ func (p *BuildrootFromPackages) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *BuildrootFromPackages) serializeStart(inputs Inputs) {
+func (p *BuildrootFromPackages) serializeStart(inputs Inputs) error {
 	if len(p.packageSpecs) > 0 {
-		panic("double call to serializeStart()")
+		return errors.New("BuildrootFromPackages: double call to serializeStart()")
 	}
 	p.packageSpecs = inputs.Depsolved.Packages
 	p.repos = append(p.repos, inputs.Depsolved.Repos...)
+	return nil
 }
 
 func (p *BuildrootFromPackages) serializeEnd() {
@@ -264,11 +266,12 @@ func (p *BuildrootFromContainer) getContainerSpecs() []container.Spec {
 	return p.containerSpecs
 }
 
-func (p *BuildrootFromContainer) serializeStart(inputs Inputs) {
+func (p *BuildrootFromContainer) serializeStart(inputs Inputs) error {
 	if len(p.containerSpecs) > 0 {
-		panic("double call to serializeStart()")
+		return errors.New("BuildrootFromContainer: double call to serializeStart()")
 	}
 	p.containerSpecs = inputs.Containers
+	return nil
 }
 
 func (p *BuildrootFromContainer) serializeEnd() {

--- a/pkg/manifest/build_test.go
+++ b/pkg/manifest/build_test.go
@@ -111,7 +111,8 @@ func TestNewBuildFromContainerSpecs(t *testing.T) {
 
 	// containerSpecs is "nil" until serializeStart populates it
 	require.Nil(t, build.getContainerSpecs())
-	build.serializeStart(Inputs{Containers: fakeContainerSpecs})
+	err := build.serializeStart(Inputs{Containers: fakeContainerSpecs})
+	assert.NoError(t, err)
 	assert.Equal(t, build.getContainerSpecs(), fakeContainerSpecs)
 
 	osbuildPipeline := build.serialize()

--- a/pkg/manifest/commit_server_tree.go
+++ b/pkg/manifest/commit_server_tree.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"errors"
 	"path/filepath"
 
 	"github.com/osbuild/images/internal/common"
@@ -78,12 +79,13 @@ func (p *OSTreeCommitServer) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *OSTreeCommitServer) serializeStart(inputs Inputs) {
+func (p *OSTreeCommitServer) serializeStart(inputs Inputs) error {
 	if len(p.packageSpecs) > 0 {
-		panic("double call to serializeStart()")
+		return errors.New("OSTreeCommitServer: double call to serializeStart()")
 	}
 	p.packageSpecs = inputs.Depsolved.Packages
 	p.repos = append(p.repos, inputs.Depsolved.Repos...)
+	return nil
 }
 
 func (p *OSTreeCommitServer) serializeEnd() {

--- a/pkg/manifest/coreos_installer.go
+++ b/pkg/manifest/coreos_installer.go
@@ -144,7 +144,7 @@ func (p *CoreOSInstaller) serializeStart(inputs Inputs) error {
 	if p.kernelName != "" {
 		kernelPkg, err := rpmmd.GetPackage(p.packageSpecs, p.kernelName)
 		if err != nil {
-			return fmt.Errorf("CoreOSInstaller: failed to find kernel package %q in the depsolved packages", p.kernelName)
+			return fmt.Errorf("CoreOSInstaller: %w", err)
 		}
 		p.kernelVer = kernelPkg.GetEVRA()
 	}

--- a/pkg/manifest/coreos_installer.go
+++ b/pkg/manifest/coreos_installer.go
@@ -142,7 +142,11 @@ func (p *CoreOSInstaller) serializeStart(inputs Inputs) error {
 	}
 	p.packageSpecs = inputs.Depsolved.Packages
 	if p.kernelName != "" {
-		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.kernelName)
+		kernelPkg, err := rpmmd.GetPackage(p.packageSpecs, p.kernelName)
+		if err != nil {
+			return fmt.Errorf("CoreOSInstaller: failed to find kernel package %q in the depsolved packages", p.kernelName)
+		}
+		p.kernelVer = kernelPkg.GetEVRA()
 	}
 	p.repos = append(p.repos, inputs.Depsolved.Repos...)
 	return nil

--- a/pkg/manifest/coreos_installer.go
+++ b/pkg/manifest/coreos_installer.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/osbuild/images/pkg/arch"
@@ -135,15 +136,16 @@ func (p *CoreOSInstaller) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *CoreOSInstaller) serializeStart(inputs Inputs) {
+func (p *CoreOSInstaller) serializeStart(inputs Inputs) error {
 	if len(p.packageSpecs) > 0 {
-		panic("double call to serializeStart()")
+		return errors.New("CoreOSInstaller: double call to serializeStart()")
 	}
 	p.packageSpecs = inputs.Depsolved.Packages
 	if p.kernelName != "" {
 		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.kernelName)
 	}
 	p.repos = append(p.repos, inputs.Depsolved.Repos...)
+	return nil
 }
 
 func (p *CoreOSInstaller) getInline() []string {

--- a/pkg/manifest/coreos_installer_test.go
+++ b/pkg/manifest/coreos_installer_test.go
@@ -38,7 +38,8 @@ func TestCoreOSInstallerDracutModulesAndDrivers(t *testing.T) {
 	coiPipeline := newCoreOSInstaller()
 	coiPipeline.AdditionalDracutModules = []string{"test-module"}
 	coiPipeline.AdditionalDrivers = []string{"test-driver"}
-	coiPipeline.serializeStart(Inputs{Depsolved: depsolvednf.DepsolveResult{Packages: pkgs}})
+	err := coiPipeline.serializeStart(Inputs{Depsolved: depsolvednf.DepsolveResult{Packages: pkgs}})
+	require.NoError(t, err)
 	pipeline := coiPipeline.serialize()
 
 	require := require.New(t)

--- a/pkg/manifest/empty.go
+++ b/pkg/manifest/empty.go
@@ -1,6 +1,8 @@
 package manifest
 
 import (
+	"errors"
+
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
@@ -65,9 +67,9 @@ func (p *ContentTest) getOSTreeCommits() []ostree.CommitSpec {
 	return p.commitSpecs
 }
 
-func (p *ContentTest) serializeStart(inputs Inputs) {
+func (p *ContentTest) serializeStart(inputs Inputs) error {
 	if p.serializing {
-		panic("double call to serializeStart()")
+		return errors.New("ContentTest: double call to serializeStart()")
 	}
 	p.packageSpecs = inputs.Depsolved.Packages
 	p.containerSpecs = inputs.Containers
@@ -75,6 +77,7 @@ func (p *ContentTest) serializeStart(inputs Inputs) {
 	p.repos = inputs.Depsolved.Repos
 
 	p.serializing = true
+	return nil
 }
 
 func (p *ContentTest) serializeEnd() {

--- a/pkg/manifest/export_test.go
+++ b/pkg/manifest/export_test.go
@@ -55,9 +55,13 @@ func Serialize(p Pipeline) osbuild.Pipeline {
 	return p.serialize()
 }
 
-func SerializeWith(p Pipeline, inputs Inputs) osbuild.Pipeline {
-	p.serializeStart(inputs)
-	return p.serialize()
+func SerializeWith(p Pipeline, inputs Inputs) (osbuild.Pipeline, error) {
+	err := p.serializeStart(inputs)
+	if err != nil {
+		return osbuild.Pipeline{}, err
+	}
+	// XXX: we may want to return an error from the serialize() call too
+	return p.serialize(), nil
 }
 
 var MakeKickstartSudoersPost = makeKickstartSudoersPost
@@ -71,11 +75,15 @@ func (p *OS) Serialize() osbuild.Pipeline {
 	packages := []rpmmd.PackageSpec{
 		{Name: "pkg1", Checksum: "sha1:c02524e2bd19490f2a7167958f792262754c5f46"},
 	}
-	p.serializeStart(Inputs{
+	err := p.serializeStart(Inputs{
 		Depsolved: depsolvednf.DepsolveResult{
 			Packages: packages,
 			Repos:    repos,
 		},
 	})
+	if err != nil {
+		// XXX: we may want to return an error from this function instead of panicking
+		panic(err)
+	}
 	return p.serialize()
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -178,11 +178,14 @@ func (m Manifest) Serialize(depsolvedSets map[string]depsolvednf.DepsolveResult,
 	}
 
 	for _, pipeline := range m.pipelines {
-		pipeline.serializeStart(Inputs{
+		err := pipeline.serializeStart(Inputs{
 			Depsolved:  depsolvedSets[pipeline.Name()],
 			Containers: containerSpecs[pipeline.Name()],
 			Commits:    ostreeCommits[pipeline.Name()],
 		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var pipelines []osbuild.Pipeline

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -485,8 +485,11 @@ func (p *OS) serializeStart(inputs Inputs) error {
 	}
 
 	if p.OSCustomizations.KernelName != "" {
-		// XXX: return error instead of panicking
-		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.OSCustomizations.KernelName)
+		kernelPkg, err := rpmmd.GetPackage(p.packageSpecs, p.OSCustomizations.KernelName)
+		if err != nil {
+			return fmt.Errorf("OS: failed to find kernel package %q in the depsolved packages", p.OSCustomizations.KernelName)
+		}
+		p.kernelVer = kernelPkg.GetEVRA()
 	}
 
 	p.repos = append(p.repos, inputs.Depsolved.Repos...)

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"path/filepath"
@@ -468,9 +469,9 @@ func (p *OS) getContainerSpecs() []container.Spec {
 	return p.containerSpecs
 }
 
-func (p *OS) serializeStart(inputs Inputs) {
+func (p *OS) serializeStart(inputs Inputs) error {
 	if len(p.packageSpecs) > 0 {
-		panic("double call to serializeStart()")
+		return errors.New("OS: double call to serializeStart()")
 	}
 
 	p.packageSpecs = inputs.Depsolved.Packages
@@ -478,16 +479,18 @@ func (p *OS) serializeStart(inputs Inputs) {
 	p.containerSpecs = inputs.Containers
 	if len(inputs.Commits) > 0 {
 		if len(inputs.Commits) > 1 {
-			panic("pipeline supports at most one ostree commit")
+			return errors.New("OS: pipeline supports at most one ostree commit")
 		}
 		p.ostreeParentSpec = &inputs.Commits[0]
 	}
 
 	if p.OSCustomizations.KernelName != "" {
+		// XXX: return error instead of panicking
 		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.OSCustomizations.KernelName)
 	}
 
 	p.repos = append(p.repos, inputs.Depsolved.Repos...)
+	return nil
 }
 
 func (p *OS) serializeEnd() {

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -487,7 +487,7 @@ func (p *OS) serializeStart(inputs Inputs) error {
 	if p.OSCustomizations.KernelName != "" {
 		kernelPkg, err := rpmmd.GetPackage(p.packageSpecs, p.OSCustomizations.KernelName)
 		if err != nil {
-			return fmt.Errorf("OS: failed to find kernel package %q in the depsolved packages", p.OSCustomizations.KernelName)
+			return fmt.Errorf("OS: %w", err)
 		}
 		p.kernelVer = kernelPkg.GetEVRA()
 	}

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -1043,7 +1043,7 @@ func grubStage(p *OS, pt *disk.PartitionTable, kernelOptions []string) *osbuild.
 			Nick:    p.OSNick,
 		}
 
-		_, err := rpmmd.GetVerStrFromPackageSpecList(p.packageSpecs, "dracut-config-rescue")
+		_, err := rpmmd.GetPackage(p.packageSpecs, "dracut-config-rescue")
 		hasRescue := err == nil
 		return osbuild.NewGrub2LegacyStage(
 			osbuild.NewGrub2LegacyStageOptions(

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -254,7 +254,8 @@ func TestModularityIncludesConfigStage(t *testing.T) {
 				},
 			}},
 	}
-	pipeline := manifest.SerializeWith(os, inputs)
+	pipeline, err := manifest.SerializeWith(os, inputs)
+	require.NoError(t, err)
 	st := findStage("org.osbuild.dnf.module-config", pipeline.Stages)
 	require.NotNil(t, st)
 }
@@ -523,7 +524,9 @@ func TestHMACStageInclusion(t *testing.T) {
 		os := manifest.NewOS(build, platform, repos)
 		os.PartitionTable = &pt
 		os.OSCustomizations.KernelName = "test-kernel"
-		pipeline := manifest.SerializeWith(os, inputs)
+		pipeline, err := manifest.SerializeWith(os, inputs)
+		assert.NoError(t, err)
+		assert.NotNil(t, pipeline)
 
 		hmacStage := findStage("org.osbuild.hmac", pipeline.Stages)
 		assert.NotNil(t, hmacStage)
@@ -577,7 +580,9 @@ func TestHMACStageInclusion(t *testing.T) {
 		build := manifest.NewBuild(&m, runner, repos, nil)
 		os := manifest.NewOS(build, platform, repos)
 		os.PartitionTable = &pt
-		pipeline := manifest.SerializeWith(os, inputs)
+		pipeline, err := manifest.SerializeWith(os, inputs)
+		assert.NoError(t, err)
+		assert.NotNil(t, pipeline)
 
 		hmacStage := findStage("org.osbuild.hmac", pipeline.Stages)
 		assert.Nil(t, hmacStage)
@@ -656,7 +661,9 @@ func TestShimVersionLock(t *testing.T) {
 		},
 	}
 
-	pipeline := manifest.SerializeWith(os, inputs)
+	pipeline, err := manifest.SerializeWith(os, inputs)
+	assert.NoError(t, err)
+	assert.NotNil(t, pipeline)
 	versionlockStage := findStage("org.osbuild.dnf4.versionlock", pipeline.Stages)
 	assert.NotNil(t, versionlockStage)
 	stageOptions := versionlockStage.Options.(*osbuild.DNF4VersionlockOptions)

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -171,9 +172,9 @@ func (p *OSTreeDeployment) getContainerSources() []container.SourceSpec {
 	}
 }
 
-func (p *OSTreeDeployment) serializeStart(inputs Inputs) {
+func (p *OSTreeDeployment) serializeStart(inputs Inputs) error {
 	if p.ostreeSpec != nil || p.containerSpec != nil {
-		panic("double call to serializeStart()")
+		return errors.New("OSTreeDeployment: double call to serializeStart()")
 	}
 
 	switch {
@@ -182,8 +183,9 @@ func (p *OSTreeDeployment) serializeStart(inputs Inputs) {
 	case len(inputs.Containers) == 1:
 		p.containerSpec = &inputs.Containers[0]
 	default:
-		panic(fmt.Sprintf("pipeline %s requires exactly one ostree commit or one container (have commits: %v; containers: %v)", p.Name(), inputs.Commits, inputs.Containers))
+		return fmt.Errorf("OSTreeDeployment: pipeline %s requires exactly one ostree commit or one container (have commits: %v; containers: %v)", p.Name(), inputs.Commits, inputs.Containers)
 	}
+	return nil
 }
 
 func (p *OSTreeDeployment) serializeEnd() {

--- a/pkg/manifest/ostree_deployment_test.go
+++ b/pkg/manifest/ostree_deployment_test.go
@@ -49,7 +49,10 @@ func TestOSTreeDeploymentPipelineFStabStage(t *testing.T) {
 	pipeline.PartitionTable = testdisk.MakeFakePartitionTable("/")  // PT specifics don't matter
 	pipeline.MountConfiguration = osbuild.MOUNT_CONFIGURATION_FSTAB // set it explicitly just to be sure
 
-	checkStagesForFSTab(t, manifest.SerializeWith(pipeline, testCommitInputs()).Stages)
+	osbuildPipeline, err := manifest.SerializeWith(pipeline, testCommitInputs())
+	require.NoError(t, err)
+	require.NotNil(t, osbuildPipeline)
+	checkStagesForFSTab(t, osbuildPipeline.Stages)
 }
 
 func TestOSTreeDeploymentPipelineMountUnitStages(t *testing.T) {
@@ -59,7 +62,10 @@ func TestOSTreeDeploymentPipelineMountUnitStages(t *testing.T) {
 	pipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/home")
 	pipeline.MountConfiguration = osbuild.MOUNT_CONFIGURATION_UNITS
 
-	checkStagesForMountUnits(t, manifest.SerializeWith(pipeline, testCommitInputs()).Stages, expectedUnits)
+	osbuildPipeline, err := manifest.SerializeWith(pipeline, testCommitInputs())
+	require.NoError(t, err)
+	require.NotNil(t, osbuildPipeline)
+	checkStagesForMountUnits(t, osbuildPipeline.Stages, expectedUnits)
 }
 
 func TestOSTreeDeploymentPipelineNoMountUnitStages(t *testing.T) {
@@ -68,7 +74,10 @@ func TestOSTreeDeploymentPipelineNoMountUnitStages(t *testing.T) {
 	pipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/home")
 	pipeline.MountConfiguration = osbuild.MOUNT_CONFIGURATION_NONE
 
-	checkStagesForNoMounts(t, manifest.SerializeWith(pipeline, testCommitInputs()).Stages)
+	osbuildPipeline, err := manifest.SerializeWith(pipeline, testCommitInputs())
+	require.NoError(t, err)
+	require.NotNil(t, osbuildPipeline)
+	checkStagesForNoMounts(t, osbuildPipeline.Stages)
 }
 
 func TestAddInlineOSTreeDeployment(t *testing.T) {
@@ -91,7 +100,9 @@ func TestAddInlineOSTreeDeployment(t *testing.T) {
 
 	// the OSTreeDeployment pipeline *requires* a partition table
 	deployment.PartitionTable = testdisk.MakeFakeBtrfsPartitionTable("/")
-	pipeline := manifest.SerializeWith(deployment, testCommitInputs())
+	pipeline, err := manifest.SerializeWith(deployment, testCommitInputs())
+	require.NoError(err)
+	require.NotNil(pipeline)
 
 	destinationPaths := collectCopyDestinationPaths(pipeline.Stages)
 

--- a/pkg/manifest/pipeline.go
+++ b/pkg/manifest/pipeline.go
@@ -50,7 +50,7 @@ type Pipeline interface {
 	// its full Spec. See the ostree package for more details.
 	getOSTreeCommitSources() []ostree.SourceSpec
 
-	serializeStart(Inputs)
+	serializeStart(Inputs) error
 	serializeEnd()
 	serialize() osbuild.Pipeline
 
@@ -174,7 +174,9 @@ func NewBase(name string, build Build) Base {
 
 // serializeStart must be called exactly once before each call
 // to serialize().
-func (p Base) serializeStart(inputs Inputs) {
+func (p Base) serializeStart(inputs Inputs) error {
+	// XXX: we could do the "double call" check and other common mistakes here
+	return nil
 }
 
 // serializeEnd must be called exactly once after each call to

--- a/pkg/manifest/raw_bootc.go
+++ b/pkg/manifest/raw_bootc.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -82,11 +83,12 @@ func (p *RawBootcImage) getContainerSpecs() []container.Spec {
 	return p.containerSpecs
 }
 
-func (p *RawBootcImage) serializeStart(inputs Inputs) {
+func (p *RawBootcImage) serializeStart(inputs Inputs) error {
 	if len(p.containerSpecs) > 0 {
-		panic("double call to serializeStart()")
+		return errors.New("RawBootcImage: double call to serializeStart()")
 	}
 	p.containerSpecs = inputs.Containers
+	return nil
 }
 
 func (p *RawBootcImage) serializeEnd() {

--- a/pkg/manifest/raw_bootc_export_test.go
+++ b/pkg/manifest/raw_bootc_export_test.go
@@ -12,6 +12,6 @@ func (rbc *RawBootcImage) Serialize() osbuild.Pipeline {
 	return rbc.serialize()
 }
 
-func (rbc *RawBootcImage) SerializeStart(inputs Inputs) {
-	rbc.serializeStart(inputs)
+func (rbc *RawBootcImage) SerializeStart(inputs Inputs) error {
+	return rbc.serializeStart(inputs)
 }

--- a/pkg/manifest/raw_bootc_test.go
+++ b/pkg/manifest/raw_bootc_test.go
@@ -64,7 +64,8 @@ func TestRawBootcImageSerialize(t *testing.T) {
 	rawBootcPipeline.Users = []users.User{{Name: "root", Key: common.ToPtr("some-ssh-key")}}
 	rawBootcPipeline.KernelOptionsAppend = []string{"karg1", "karg2"}
 
-	rawBootcPipeline.SerializeStart(manifest.Inputs{Containers: []container.Spec{{Source: "foo"}}})
+	err := rawBootcPipeline.SerializeStart(manifest.Inputs{Containers: []container.Spec{{Source: "foo"}}})
+	assert.NoError(t, err)
 	imagePipeline := rawBootcPipeline.Serialize()
 	assert.Equal(t, "image", imagePipeline.Name)
 
@@ -90,7 +91,8 @@ func TestRawBootcImageSerializeMountsValidated(t *testing.T) {
 	rawBootcPipeline := manifest.NewRawBootcImage(build, nil, pf)
 	// note that we create a partition table without /boot here
 	rawBootcPipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/missing-boot")
-	rawBootcPipeline.SerializeStart(manifest.Inputs{Containers: []container.Spec{{Source: "foo"}}})
+	err := rawBootcPipeline.SerializeStart(manifest.Inputs{Containers: []container.Spec{{Source: "foo"}}})
+	assert.NoError(t, err)
 	assert.PanicsWithError(t, `required mounts for bootupd stage [/boot/efi] missing`, func() {
 		rawBootcPipeline.Serialize()
 	})
@@ -115,7 +117,10 @@ func makeFakeRawBootcPipeline() *manifest.RawBootcImage {
 	build := manifest.NewBuildFromContainer(&mani, runner, nil, nil)
 	rawBootcPipeline := manifest.NewRawBootcImage(build, nil, pf)
 	rawBootcPipeline.PartitionTable = testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
-	rawBootcPipeline.SerializeStart(manifest.Inputs{Containers: []container.Spec{{Source: "foo"}}})
+	err := rawBootcPipeline.SerializeStart(manifest.Inputs{Containers: []container.Spec{{Source: "foo"}}})
+	if err != nil {
+		panic(err)
+	}
 
 	return rawBootcPipeline
 }

--- a/pkg/rpmmd/repository.go
+++ b/pkg/rpmmd/repository.go
@@ -246,23 +246,6 @@ func GetPackage(pkgs []PackageSpec, packageName string) (PackageSpec, error) {
 	return PackageSpec{}, fmt.Errorf("package %q not found in the PackageSpec list", packageName)
 }
 
-func GetVerStrFromPackageSpecList(pkgs []PackageSpec, packageName string) (string, error) {
-	pkg, err := GetPackage(pkgs, packageName)
-	if err != nil {
-		return "", err
-	}
-
-	return pkg.GetEVRA(), nil
-}
-
-func GetVerStrFromPackageSpecListPanic(pkgs []PackageSpec, packageName string) string {
-	pkgVerStr, err := GetVerStrFromPackageSpecList(pkgs, packageName)
-	if err != nil {
-		panic(err)
-	}
-	return pkgVerStr
-}
-
 func LoadRepositoriesFromFile(filename string) (map[string][]RepoConfig, error) {
 	f, err := os.Open(filename)
 	if err != nil {

--- a/pkg/rpmmd/repository_test.go
+++ b/pkg/rpmmd/repository_test.go
@@ -80,15 +80,3 @@ func TestPackageSpecFull(t *testing.T) {
  "repo_id": "813859d10fe28ff54dbde44655a18b071c8adbaa849a551ec23cc415f0f7f1b0"
 }`)
 }
-
-func TestGetVerStrFromPackageSpecList(t *testing.T) {
-	assert := assert.New(t)
-
-	tmuxEvra, err := rpmmd.GetVerStrFromPackageSpecList(specs, "tmux")
-	assert.NoError(err)
-	assert.Equal("3.3a-3.fc38.x86_64", tmuxEvra)
-
-	grub2Evra, err := rpmmd.GetVerStrFromPackageSpecList(specs, "grub2")
-	assert.NoError(err)
-	assert.Equal("1:2.06-94.fc38.noarch", grub2Evra)
-}


### PR DESCRIPTION
Simplify the `rpmmd` implementation and reduce code that will need to be ported as part of the `rpmmd` data structures consolidation by deleting the `GetVerStrFromPackageSpecList*()` functions. Let's use `rpmmd.GetPackage()` everywhere and let the caller do whatever it needs with the returned `rpmmd.PackageSpec` instance.

I also used this opportunity to reduce the amount of `panic()` calls.

/jira-epic HMS-8910

JIRA: [HMS-9310](https://issues.redhat.com/browse/HMS-9310)