### PR TITLE
tools: run `-fake-bootc=true` in old manifest-gen too

### DIFF
--- a/tools/gen-manifests-diff
+++ b/tools/gen-manifests-diff
@@ -49,6 +49,7 @@ def run_gen_manifests(cmd, output_dir):
         "-metadata=false",
         "-containers=false",
         "-arches", ",".join(arches),
+        "-fake-bootc=true",
         "-output", output_dir,
     ], env=env, text=True, capture_output=True, check=False)
     if p.returncode != 0:


### PR DESCRIPTION
Now that the fake bootc manifest generation has landed we can also add this flag when we run gen-manifests from the main repository.