### PR TITLE
distro: improve bootc architecture mismatch error

### DIFF
--- a/pkg/distro/bootc/bootc.go
+++ b/pkg/distro/bootc/bootc.go
@@ -3,7 +3,9 @@ package bootc
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"math/rand"
+	"slices"
 	"sort"
 	"strings"
 
@@ -147,7 +149,7 @@ func (d *BootcDistro) ListArches() []string {
 func (d *BootcDistro) GetArch(arch string) (distro.Arch, error) {
 	a, exists := d.arches[arch]
 	if !exists {
-		return nil, errors.New("invalid arch: " + arch)
+		return nil, fmt.Errorf("requested bootc arch %q does not match available arches %v", arch, slices.Collect(maps.Keys(d.arches)))
 	}
 	return a, nil
 }

--- a/pkg/distro/bootc/bootc_test.go
+++ b/pkg/distro/bootc/bootc_test.go
@@ -236,3 +236,15 @@ func TestManifestSerialization(t *testing.T) {
 		})
 	}
 }
+
+func TestBootcDistroGetArch(t *testing.T) {
+	imgType := NewTestBootcImageType()
+	distro := imgType.Arch().Distro()
+
+	arch, err := distro.GetArch("x86_64")
+	assert.NoError(t, err)
+	assert.Equal(t, arch, imgType.Arch())
+
+	_, err = distro.GetArch("aarch64")
+	assert.EqualError(t, err, `requested bootc arch "aarch64" does not match available arches [x86_64]`)
+}

--- a/pkg/distro/bootc/export_test.go
+++ b/pkg/distro/bootc/export_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/bib/osinfo"
 	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/distro"
 )
 
 var (
@@ -30,6 +31,10 @@ func NewTestBootcImageType() *BootcImageType {
 		defaultFs: "xfs",
 	}
 	a := &BootcArch{distro: d, arch: arch.ARCH_X86_64}
+	d.arches = map[string]distro.Arch{
+		"x86_64": a,
+	}
+
 	imgType := &BootcImageType{
 		arch:   a,
 		name:   "qcow2",


### PR DESCRIPTION
This is the outcome of inspecting the failure:
https://github.com/osbuild/bootc-image-builder/pull/1052#issuecomment-3296464137

The error message for bootc with architecture mismatches is not great. This commit makes it better.