### PR TITLE
github: run go test without verbose in integration tests

### DIFF
--- a/.github/workflows/test-osbuild-composer-integration.yml
+++ b/.github/workflows/test-osbuild-composer-integration.yml
@@ -102,7 +102,7 @@ jobs:
         # This step will not fail if the test fails, but it will write the
         # failure to GITHUB_OUTPUT
         run: |
-          if ./tools/prepare-source.sh && go test -v -race ./...; then
+          if ./tools/prepare-source.sh && go test -race ./...; then
             echo "base_test=1" >> $GITHUB_OUTPUT
           else
             echo "base_test=0" >> $GITHUB_OUTPUT
@@ -127,7 +127,7 @@ jobs:
         # This step will not fail if the test fails, but it will write the
         # failure to GITHUB_OUTPUT
         run: |
-          if ./tools/prepare-source.sh && go test -v -race ./...; then
+          if ./tools/prepare-source.sh && go test -race ./...; then
             echo "pr_test=1" >> $GITHUB_OUTPUT
           else
             echo "pr_test=0" >> $GITHUB_OUTPUT
@@ -214,7 +214,7 @@ jobs:
         # This step will not fail if the test fails, but it will write the
         # failure to GITHUB_OUTPUT
         run: |
-          if go mod tidy && go test -v -race ./...; then
+          if go mod tidy && go test -race ./...; then
             echo "base_test=1" >> $GITHUB_OUTPUT
           else
             echo "base_test=0" >> $GITHUB_OUTPUT
@@ -239,7 +239,7 @@ jobs:
         # This step will not fail if the test fails, but it will write the
         # failure to GITHUB_OUTPUT
         run: |
-          if go mod tidy && go test -v -race ./...; then
+          if go mod tidy && go test -race ./...; then
             echo "pr_test=1" >> $GITHUB_OUTPUT
           else
             echo "pr_test=0" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The verbosity makes it hard to pinpoint failures when needed.