### PR TITLE
tools: error in gen-manifest-checksums on failure

### DIFF
--- a/tools/gen-manifest-checksums.sh
+++ b/tools/gen-manifest-checksums.sh
@@ -41,6 +41,7 @@ if ! "${tmpdir}/bin/gen-manifests" \
     > /dev/null 2> "${tmpdir}/stderr"; then
 
     cat "${tmpdir}/stderr"
+    exit 1
 fi
 
 


### PR DESCRIPTION
If `gen-manifests` fails because of e.g. unsupported/invalid configuration error instead of just continuing and leaving missing manifest checksums behind.