### PR TITLE
distro: `hidden` image types (HMS-9375)

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -1378,6 +1378,7 @@ image_types:
   "iot-bootable-container":
     <<: *rpm_ostree_imgtype_common
     filename: "iot-bootable-container.tar"
+    hidden: true
     mime_type: "application/x-tar"
     image_func: "bootable_container"
     exports: ["ostree-encapsulate"]

--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -1187,6 +1187,7 @@ image_types:
 
   "azure-rhui": &azure_rhui
     <<: *azure
+    hidden: true
     supported_blueprint_options: *supported_options_disk
 
   "azure-sap-rhui":
@@ -1484,6 +1485,7 @@ image_types:
   # RHEL internal-only x86_64 EC2 image type
   ec2: &ec2
     <<: *ami
+    hidden: true
     # we have to reset the aliases otherwise this type
     # will inherit the name aliases causing a conflict
     name_aliases: []

--- a/data/distrodefs/rhel-7/imagetypes.yaml
+++ b/data/distrodefs/rhel-7/imagetypes.yaml
@@ -282,6 +282,7 @@ image_config:
 
 image_types:
   "azure-rhui":
+    hidden: true
     filename: "disk.vhd.xz"
     mime_type: "application/xz"
     image_func: "disk"

--- a/data/distrodefs/rhel-8/imagetypes.yaml
+++ b/data/distrodefs/rhel-8/imagetypes.yaml
@@ -1455,6 +1455,7 @@ image_types:
 
   ec2: &ec2
     <<: *ami
+    hidden: true
     # we have to reset the aliases otherwise this type
     # will inherit the name aliases causing a conflict
     name_aliases: []
@@ -1778,6 +1779,7 @@ image_types:
     supported_blueprint_options: *supported_options_disk
 
   "azure-rhui": &azure_rhui
+    hidden: true
     filename: "disk.vhd.xz"
     mime_type: "application/xz"
     image_func: "disk"

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -1771,6 +1771,7 @@ image_types:
 
   "azure-rhui": &azure_rhui
     <<: *azure
+    hidden: true
     supported_blueprint_options: *supported_options_disk
 
   "azure-sap-rhui":
@@ -1887,6 +1888,7 @@ image_types:
     supported_blueprint_options: *supported_options_disk
 
   ec2: &ec2
+    hidden: true
     filename: "image.raw.xz"
     mime_type: "application/xz"
     exports: ["xz"]

--- a/pkg/distro/bootc/bootc.go
+++ b/pkg/distro/bootc/bootc.go
@@ -208,6 +208,10 @@ func (t *BootcImageType) Aliases() []string {
 	return nil
 }
 
+func (t *BootcImageType) Hidden() bool {
+	return false
+}
+
 func (t *BootcImageType) Arch() distro.Arch {
 	return t.arch
 }

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -395,6 +395,12 @@ type ImageTypeYAML struct {
 	SupportedBlueprintOptions []string `yaml:"supported_blueprint_options"`
 	RequiredBlueprintOptions  []string `yaml:"required_blueprint_options"`
 
+	// Determines if an image should be included by default in image type listings, note
+	// that this does not prevent the image type from being selected directly. This is useful
+	// for image types that are not supposed to be built by end-users. For example image types
+	// that are non-official, or image types that are only built by build systems.
+	Hidden bool `yaml:"hidden"`
+
 	// name is set by the loader
 	name string
 }

--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -82,6 +82,9 @@ type ImageType interface {
 	// Returns the aliases for the image type.
 	Aliases() []string
 
+	// Returns the hidden flag for the image type
+	Hidden() bool
+
 	// Returns the parent architecture
 	Arch() Arch
 

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -84,6 +84,10 @@ func (t *imageType) Aliases() []string {
 	return t.ImageTypeYAML.NameAliases
 }
 
+func (t *imageType) Hidden() bool {
+	return t.ImageTypeYAML.Hidden
+}
+
 func (t *imageType) Arch() distro.Arch {
 	return t.arch
 }

--- a/pkg/distro/test_distro/distro.go
+++ b/pkg/distro/test_distro/distro.go
@@ -183,6 +183,10 @@ func (t *TestImageType) Aliases() []string {
 	return t.aliases
 }
 
+func (t *TestImageType) Hidden() bool {
+	return false
+}
+
 func (t *TestImageType) Arch() distro.Arch {
 	return t.architecture
 }

--- a/pkg/imagefilter/imagefilter_test.go
+++ b/pkg/imagefilter/imagefilter_test.go
@@ -18,7 +18,7 @@ func TestImageFilterSmoke(t *testing.T) {
 	repos, err := testrepos.New()
 	require.NoError(t, err)
 
-	imgFilter, err := imagefilter.New(fac, repos)
+	imgFilter, err := imagefilter.New(fac, repos, nil)
 	require.NoError(t, err)
 	res, err := imgFilter.Filter("*")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestImageFilterSpecificResult(t *testing.T) {
 	repos, err := testrepos.New()
 	require.NoError(t, err)
 
-	imgFilter, err := imagefilter.New(fac, repos)
+	imgFilter, err := imagefilter.New(fac, repos, nil)
 	require.NoError(t, err)
 
 	res, err := imgFilter.Filter("distro:centos-9", "arch:x86_64", "type:qcow2")
@@ -50,45 +50,51 @@ func TestImageFilterFilter(t *testing.T) {
 	repos, err := testrepos.New()
 	require.NoError(t, err)
 
-	imgFilter, err := imagefilter.New(fac, repos)
-	require.NoError(t, err)
-
 	for _, tc := range []struct {
 		searchExpr   []string
+		showHidden   bool
 		expectsMatch bool
 	}{
 		// no prefix is a "fuzzy" filter and will check distro/arch/imgType
-		{[]string{"foo"}, false},
-		{[]string{"rhel-9.6"}, true},
-		{[]string{"rhel*"}, true},
-		{[]string{"x86_64"}, true},
-		{[]string{"qcow2"}, true},
+		{[]string{"foo"}, false, false},
+		{[]string{"rhel-9.6"}, false, true},
+		{[]string{"rhel*"}, false, true},
+		{[]string{"x86_64"}, false, true},
+		{[]string{"qcow2"}, false, true},
 		// distro: prefix
-		{[]string{"distro:foo"}, false},
-		{[]string{"distro:centos-9"}, true},
-		{[]string{"distro:centos*"}, true},
-		{[]string{"distro:centos"}, false},
+		{[]string{"distro:foo"}, false, false},
+		{[]string{"distro:centos-9"}, false, true},
+		{[]string{"distro:centos*"}, false, true},
+		{[]string{"distro:centos"}, false, false},
 		// arch: prefix
-		{[]string{"arch:foo"}, false},
-		{[]string{"arch:x86_64"}, true},
-		{[]string{"arch:x86*"}, true},
-		{[]string{"arch:x86"}, false},
+		{[]string{"arch:foo"}, false, false},
+		{[]string{"arch:x86_64"}, false, true},
+		{[]string{"arch:x86*"}, false, true},
+		{[]string{"arch:x86"}, false, false},
 		// type: prefix
-		{[]string{"type:foo"}, false},
-		{[]string{"type:qcow2"}, true},
-		{[]string{"type:qcow?"}, true},
-		{[]string{"type:qcow"}, false},
+		{[]string{"type:foo"}, false, false},
+		{[]string{"type:qcow2"}, false, true},
+		{[]string{"type:qcow?"}, false, true},
+		{[]string{"type:qcow"}, false, false},
 		// bootmode: prefix
-		{[]string{"bootmode:foo"}, false},
-		{[]string{"bootmode:hybrid"}, true},
+		{[]string{"bootmode:foo"}, false, false},
+		{[]string{"bootmode:hybrid"}, false, true},
 		// multiple filters are AND
-		{[]string{"distro:centos-9", "type:foo"}, false},
-		{[]string{"distro:centos-9", "type:qcow2"}, true},
-		{[]string{"distro:centos-9", "arch:foo", "type:qcow2"}, false},
+		{[]string{"distro:centos-9", "type:foo"}, false, false},
+		{[]string{"distro:centos-9", "type:qcow2"}, false, true},
+		{[]string{"distro:centos-9", "arch:foo", "type:qcow2"}, false, false},
+		// hidden image types
+		{[]string{"type:iot-bootable-container", "distro:fedora-44"}, false, false},
+		{[]string{"type:iot-bootable-container", "distro:fedora-44"}, true, true},
+		{[]string{"type:ec2", "distro:rhel-10.0"}, false, false},
+		{[]string{"type:ec2", "distro:rhel-10.0"}, true, true},
 	} {
-
 		t.Run(tc.searchExpr[0], func(t *testing.T) {
 			t.Parallel()
+
+			imgFilter, err := imagefilter.New(fac, repos, &imagefilter.FilterOptions{ShowHidden: tc.showHidden})
+			require.NoError(t, err)
+
 			matches, err := imgFilter.Filter(tc.searchExpr...)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectsMatch, len(matches) > 0, tc)

--- a/pkg/manifestgen/manifestgen_test.go
+++ b/pkg/manifestgen/manifestgen_test.go
@@ -41,7 +41,7 @@ func TestManifestGeneratorDepsolve(t *testing.T) {
 	assert.NoError(t, err)
 	fac := distrofactory.NewDefault()
 
-	filter, err := imagefilter.New(fac, repos)
+	filter, err := imagefilter.New(fac, repos, nil)
 	assert.NoError(t, err)
 	res, err := filter.Filter("distro:centos-9", "type:qcow2", "arch:x86_64")
 	assert.NoError(t, err)
@@ -93,7 +93,7 @@ func TestManifestGeneratorWithOstreeCommit(t *testing.T) {
 	assert.NoError(t, err)
 
 	fac := distrofactory.NewDefault()
-	filter, err := imagefilter.New(fac, repos)
+	filter, err := imagefilter.New(fac, repos, nil)
 	assert.NoError(t, err)
 	res, err := filter.Filter("distro:centos-9", "type:edge-ami", "arch:x86_64")
 	assert.NoError(t, err)
@@ -216,7 +216,7 @@ func TestManifestGeneratorContainers(t *testing.T) {
 	assert.NoError(t, err)
 	fac := distrofactory.NewDefault()
 
-	filter, err := imagefilter.New(fac, repos)
+	filter, err := imagefilter.New(fac, repos, nil)
 	assert.NoError(t, err)
 	res, err := filter.Filter("distro:centos-9", "type:qcow2", "arch:x86_64")
 	assert.NoError(t, err)
@@ -252,7 +252,7 @@ func TestManifestGeneratorDepsolveWithSbomWriter(t *testing.T) {
 	assert.NoError(t, err)
 	fac := distrofactory.NewDefault()
 
-	filter, err := imagefilter.New(fac, repos)
+	filter, err := imagefilter.New(fac, repos, nil)
 	assert.NoError(t, err)
 	res, err := filter.Filter("distro:centos-9", "type:qcow2", "arch:x86_64")
 	assert.NoError(t, err)
@@ -296,7 +296,7 @@ func TestManifestGeneratorSeed(t *testing.T) {
 	assert.NoError(t, err)
 	fac := distrofactory.NewDefault()
 
-	filter, err := imagefilter.New(fac, repos)
+	filter, err := imagefilter.New(fac, repos, nil)
 	assert.NoError(t, err)
 	res, err := filter.Filter("distro:centos-9", "type:qcow2", "arch:x86_64")
 	assert.NoError(t, err)
@@ -336,7 +336,7 @@ func TestManifestGeneratorDepsolveOutput(t *testing.T) {
 	assert.NoError(t, err)
 	fac := distrofactory.NewDefault()
 
-	filter, err := imagefilter.New(fac, repos)
+	filter, err := imagefilter.New(fac, repos, nil)
 	assert.NoError(t, err)
 	res, err := filter.Filter("distro:centos-9", "type:qcow2", "arch:x86_64")
 	assert.NoError(t, err)
@@ -365,7 +365,7 @@ func TestManifestGeneratorOverrideRepos(t *testing.T) {
 	assert.NoError(t, err)
 	fac := distrofactory.NewDefault()
 
-	filter, err := imagefilter.New(fac, repos)
+	filter, err := imagefilter.New(fac, repos, nil)
 	assert.NoError(t, err)
 	res, err := filter.Filter("distro:centos-9", "type:qcow2", "arch:x86_64")
 	assert.NoError(t, err)
@@ -407,7 +407,7 @@ func TestManifestGeneratorUseBootstrapContainer(t *testing.T) {
 	assert.NoError(t, err)
 	fac := distrofactory.NewDefault()
 
-	filter, err := imagefilter.New(fac, repos)
+	filter, err := imagefilter.New(fac, repos, nil)
 	assert.NoError(t, err)
 	res, err := filter.Filter("distro:centos-9", "type:qcow2", "arch:x86_64")
 	assert.NoError(t, err)


### PR DESCRIPTION
Some of our image types are 'internal use only', in `osbuild-composer` we explicitly exclude them [1].

Instead of this information living in the executables this PR introduces the ability to have it be determined by the library (if `imagefilter` is being used to list images). We can still allow an `--all` option in, for example, `image-builder`.

Note that this PR doesn't yet mark any images as hidden; I'd like to keep that part of the discussion separate from the implementation.

[1]: https://github.com/osbuild/osbuild-composer/blob/main/cmd/osbuild-composer/config.go#L110-L117