### PR TITLE
manifest: remove most panics()

### DIFF
--- a/pkg/manifest/anaconda_installer_iso_tree_test.go
+++ b/pkg/manifest/anaconda_installer_iso_tree_test.go
@@ -446,8 +446,8 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 			},
 		}
 		pipeline.ISOBoot = manifest.SyslinuxISOBoot
-		// XXX: we should check the error instead
-		assert.Panics(t, func() { _, _ = manifest.SerializeWith(pipeline, manifest.Inputs{}) })
+		_, err := manifest.SerializeWith(pipeline, manifest.Inputs{})
+		assert.EqualError(t, err, "cannot create ostree container stages: cannot create kickstart stages: kickstart unattended options are not compatible with user-supplied kickstart content")
 	})
 
 	t.Run("unhappy/user-kickstart-with-sudo-bits", func(t *testing.T) {
@@ -462,8 +462,8 @@ func TestAnacondaISOTreeSerializeWithOS(t *testing.T) {
 			},
 		}
 		pipeline.ISOBoot = manifest.SyslinuxISOBoot
-		// XXX: we should check the error instead
-		assert.Panics(t, func() { _, _ = manifest.SerializeWith(pipeline, manifest.Inputs{}) })
+		_, err := manifest.SerializeWith(pipeline, manifest.Inputs{})
+		assert.EqualError(t, err, "cannot create ostree container stages: cannot create kickstart stages: kickstart sudo nopasswd drop-in file creation is not compatible with user-supplied kickstart content")
 	})
 
 	t.Run("plain+squashfs-rootfs", func(t *testing.T) {
@@ -583,10 +583,8 @@ func TestAnacondaISOTreeSerializeWithOSTree(t *testing.T) {
 			OSTree: &kickstart.OSTree{},
 		}
 		pipeline.ISOBoot = manifest.SyslinuxISOBoot
-		// XXX: we should check the error instead
-		assert.Panics(t, func() {
-			_, _ = manifest.SerializeWith(pipeline, manifest.Inputs{Commits: []ostree.CommitSpec{ostreeCommit}})
-		})
+		_, err := manifest.SerializeWith(pipeline, manifest.Inputs{Commits: []ostree.CommitSpec{ostreeCommit}})
+		assert.EqualError(t, err, "cannot create ostree commit stages: cannot create kickstart stages: kickstart unattended options are not compatible with user-supplied kickstart content")
 	})
 
 	t.Run("unhappy/user-kickstart-with-sudo-bits", func(t *testing.T) {
@@ -602,10 +600,8 @@ func TestAnacondaISOTreeSerializeWithOSTree(t *testing.T) {
 			OSTree:       &kickstart.OSTree{},
 		}
 		pipeline.ISOBoot = manifest.SyslinuxISOBoot
-		// XXX: we should check the error instead
-		assert.Panics(t, func() {
-			_, _ = manifest.SerializeWith(pipeline, manifest.Inputs{Commits: []ostree.CommitSpec{ostreeCommit}})
-		})
+		_, err := manifest.SerializeWith(pipeline, manifest.Inputs{Commits: []ostree.CommitSpec{ostreeCommit}})
+		assert.EqualError(t, err, "cannot create ostree commit stages: cannot create kickstart stages: kickstart sudo nopasswd drop-in file creation is not compatible with user-supplied kickstart content")
 	})
 
 	t.Run("plain+squashfs-rootfs", func(t *testing.T) {

--- a/pkg/manifest/common.go
+++ b/pkg/manifest/common.go
@@ -24,6 +24,6 @@ func filesystemConfigStages(pt *disk.PartitionTable, mountConfiguration osbuild.
 	case osbuild.MOUNT_CONFIGURATION_NONE:
 		return []*osbuild.Stage{}, nil
 	default:
-		panic(fmt.Sprintf("Unexpected mount configuration %d", mountConfiguration))
+		return nil, fmt.Errorf("Unexpected mount configuration %d", mountConfiguration)
 	}
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -201,7 +201,11 @@ func (m Manifest) Serialize(depsolvedSets map[string]depsolvednf.DepsolveResult,
 		mergedInputs.Depsolved.Repos = append(mergedInputs.Depsolved.Repos, depsolvedSets[pipeline.Name()].Repos...)
 		mergedInputs.Containers = append(mergedInputs.Containers, pipeline.getContainerSpecs()...)
 		mergedInputs.InlineData = append(mergedInputs.InlineData, pipeline.getInline()...)
-		mergedInputs.FileRefs = append(mergedInputs.FileRefs, pipeline.fileRefs()...)
+		fileRefs, err := pipeline.fileRefs()
+		if err != nil {
+			return nil, fmt.Errorf("cannot get files ref from %q: %w", pipeline.Name(), err)
+		}
+		mergedInputs.FileRefs = append(mergedInputs.FileRefs, fileRefs...)
 	}
 	for _, pipeline := range m.pipelines {
 		pipeline.serializeEnd()

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -1220,24 +1220,24 @@ func (p *OS) addStagesForAllFilesAndInlineData(pipeline *osbuild.Pipeline, files
 // (e.g. via the "uri" key in customizations) are added to the manifests "sources"
 //
 // Note that the actual copy/chmod/... stages are generated via addStagesForAllFilesAndInlineData
-func (p *OS) fileRefs() []string {
+func (p *OS) fileRefs() ([]string, error) {
 	var fileRefs []string
 
 	for _, file := range p.OSCustomizations.Files {
 		if uriStr := file.URI(); uriStr != "" {
 			uri, err := url.Parse(uriStr)
 			if err != nil {
-				panic(fmt.Errorf("internal error: file customizations is not a valid URL: %w", err))
+				return nil, fmt.Errorf("internal error: file customizations is not a valid URL: %w", err)
 			}
 
 			switch uri.Scheme {
 			case "", "file":
 				fileRefs = append(fileRefs, uri.Path)
 			default:
-				panic(fmt.Errorf("internal error: unsupported schema for OSCustomizations.Files: %v", uriStr))
+				return nil, fmt.Errorf("internal error: unsupported schema for OSCustomizations.Files: %v", uriStr)
 			}
 		}
 	}
 
-	return fileRefs
+	return fileRefs, nil
 }

--- a/pkg/manifest/pipeline.go
+++ b/pkg/manifest/pipeline.go
@@ -68,7 +68,7 @@ type Pipeline interface {
 	getInline() []string
 
 	// files generated from url references
-	fileRefs() []string
+	fileRefs() ([]string, error)
 }
 
 // ExportingPipeline is a pipeline that can export an artifact
@@ -152,8 +152,8 @@ func (p Base) getInline() []string {
 	return []string{}
 }
 
-func (p Base) fileRefs() []string {
-	return nil
+func (p Base) fileRefs() ([]string, error) {
+	return nil, nil
 }
 
 // NewBase returns a generic Pipeline object. The name is mandatory, immutable and must


### PR DESCRIPTION
With https://github.com/osbuild/images/pull/1882 we can not return errors in more places and need to panic less. This PR contains some followups to eliminate more panics. With it merged we go from 95 panics() in pkg/manifest to just 20 (most in serializeEnd, the rest in things like `getBuildPackages()` which can be caused by unsupported architecutures, see https://github.com/osbuild/images/blob/v0.193.0/pkg/manifest/anaconda_installer.go#L127)