### PR TITLE
manifest: add errors to package getters

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/osbuild/blueprint/pkg/blueprint"
 	"github.com/osbuild/images/internal/buildconfig"
 	"github.com/osbuild/images/internal/cmdutil"
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/bib/osinfo"
 	"github.com/osbuild/images/pkg/container"
@@ -272,7 +273,7 @@ func makeManifestJob(
 
 		var depsolvedSets map[string]depsolvednf.DepsolveResult
 		if content["packages"] {
-			depsolvedSets, err = manifestgen.DefaultDepsolver(cacheDir, os.Stderr, manifest.GetPackageSetChains(), distribution, archName)
+			depsolvedSets, err = manifestgen.DefaultDepsolver(cacheDir, os.Stderr, common.Must(manifest.GetPackageSetChains()), distribution, archName)
 			if err != nil {
 				err = fmt.Errorf("[%s] depsolve failed: %s", filename, err.Error())
 				return
@@ -284,7 +285,7 @@ func makeManifestJob(
 				}
 			}
 		} else {
-			depsolvedSets = manifestmock.Depsolve(manifest.GetPackageSetChains(), repos, archName)
+			depsolvedSets = manifestmock.Depsolve(common.Must(manifest.GetPackageSetChains()), repos, archName)
 		}
 
 		var containerSpecs map[string][]container.Spec

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/depsolvednf"
 	"github.com/osbuild/images/pkg/distro"
@@ -36,7 +37,7 @@ func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos
 	}
 
 	depsolvedSets := make(map[string]depsolvednf.DepsolveResult)
-	for name, chain := range manifest.GetPackageSetChains() {
+	for name, chain := range common.Must(manifest.GetPackageSetChains()) {
 		res, err := solver.Depsolve(chain, sbom.StandardTypeNone)
 		if err != nil {
 			panic(fmt.Sprintf("failed to depsolve for pipeline %s: %s\n", name, err.Error()))

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -113,7 +113,8 @@ func TestImageTypePipelineNames(t *testing.T) {
 					// for the image (or 'kernel' if it's not defined).
 					// Get the content and "fake resolve" it to pass to
 					// Serialize().
-					packageSets := m.GetPackageSetChains()
+					packageSets, err := m.GetPackageSetChains()
+					assert.NoError(err)
 					depsolvedSets := make(map[string]depsolvednf.DepsolveResult, len(packageSets))
 					for name, sets := range packageSets {
 						packages := make([]rpmmd.PackageSpec, 0)
@@ -476,7 +477,8 @@ func TestPipelineRepositories(t *testing.T) {
 							repos := tCase.repos
 							manifest, _, err := imageType.Manifest(&bp, options, repos, nil)
 							require.NoError(err)
-							packageSets := manifest.GetPackageSetChains()
+							packageSets, err := manifest.GetPackageSetChains()
+							assert.NoError(t, err)
 
 							var globals stringSet
 							if len(tCase.result["*"]) > 0 {

--- a/pkg/distro/distro_test_common/distro_test_common.go
+++ b/pkg/distro/distro_test_common/distro_test_common.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/osbuild/blueprint/pkg/blueprint"
+	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/ostree"
@@ -41,7 +42,7 @@ func kernelCount(imgType distro.ImageType, bp blueprint.Blueprint) int {
 	if err != nil {
 		panic(err)
 	}
-	sets := manifest.GetPackageSetChains()
+	sets := common.Must(manifest.GetPackageSetChains())
 
 	// Use a map to count unique kernels in a package set. If the same kernel
 	// name appears twice, it will only be installed once, so we only count it

--- a/pkg/distro/generic/fedora_test.go
+++ b/pkg/distro/generic/fedora_test.go
@@ -309,7 +309,9 @@ func TestFedoraImageType_BuildPackages(t *testing.T) {
 					}
 					manifest, _, err := itStruct.Manifest(&blueprint.Blueprint{}, distro.ImageOptions{}, nil, nil)
 					assert.NoError(t, err)
-					buildPkgs := manifest.GetPackageSetChains()["build"]
+					pkgSetChain, err := manifest.GetPackageSetChains()
+					assert.NoError(t, err)
+					buildPkgs := pkgSetChain["build"]
 					assert.NotNil(t, buildPkgs)
 					assert.Len(t, buildPkgs, 1)
 					assert.ElementsMatch(t, buildPackages[archLabel], buildPkgs[0].Include)

--- a/pkg/distro/generic/rhel10_test.go
+++ b/pkg/distro/generic/rhel10_test.go
@@ -164,7 +164,9 @@ func TestRH10ImageType_BuildPackages(t *testing.T) {
 					}
 					manifest, _, err := itStruct.Manifest(&blueprint.Blueprint{}, distro.ImageOptions{}, nil, nil)
 					assert.NoError(t, err)
-					buildPkgs := manifest.GetPackageSetChains()["build"]
+					pkgSetChain, err := manifest.GetPackageSetChains()
+					assert.NoError(t, err)
+					buildPkgs := pkgSetChain["build"]
 					assert.NotNil(t, buildPkgs)
 					assert.Len(t, buildPkgs, 1)
 					assert.ElementsMatch(t, buildPackages[archLabel], buildPkgs[0].Include)

--- a/pkg/distro/generic/rhel7_test.go
+++ b/pkg/distro/generic/rhel7_test.go
@@ -129,7 +129,9 @@ func TestRhel7ImageType_BuildPackages(t *testing.T) {
 					}
 					manifest, _, err := itStruct.Manifest(&blueprint.Blueprint{}, distro.ImageOptions{}, nil, nil)
 					assert.NoError(t, err)
-					buildPkgs := manifest.GetPackageSetChains()["build"]
+					pkgSetChain, err := manifest.GetPackageSetChains()
+					assert.NoError(t, err)
+					buildPkgs := pkgSetChain["build"]
 					assert.NotNil(t, buildPkgs)
 					assert.Len(t, buildPkgs, 1)
 					assert.ElementsMatch(t, buildPackages[archLabel], buildPkgs[0].Include)

--- a/pkg/distro/generic/rhel8_test.go
+++ b/pkg/distro/generic/rhel8_test.go
@@ -290,7 +290,9 @@ func TestRH8_ImageType_BuildPackages(t *testing.T) {
 					}
 					manifest, _, err := itStruct.Manifest(&blueprint.Blueprint{}, distro.ImageOptions{}, nil, nil)
 					assert.NoError(t, err)
-					buildPkgs := manifest.GetPackageSetChains()["build"]
+					pkgSetChain, err := manifest.GetPackageSetChains()
+					assert.NoError(t, err)
+					buildPkgs := pkgSetChain["build"]
 					assert.NotNil(t, buildPkgs)
 					assert.Len(t, buildPkgs, 1)
 					assert.ElementsMatch(t, buildPackages[archLabel], buildPkgs[0].Include)

--- a/pkg/distro/generic/rhel9_test.go
+++ b/pkg/distro/generic/rhel9_test.go
@@ -290,7 +290,9 @@ func TestRhel9_ImageType_BuildPackages(t *testing.T) {
 					}
 					manifest, _, err := itStruct.Manifest(&blueprint.Blueprint{}, distro.ImageOptions{}, nil, nil)
 					assert.NoError(t, err)
-					buildPkgs := manifest.GetPackageSetChains()["build"]
+					pkgSetChain, err := manifest.GetPackageSetChains()
+					assert.NoError(t, err)
+					buildPkgs := pkgSetChain["build"]
 					assert.NotNil(t, buildPkgs)
 					assert.Len(t, buildPkgs, 1)
 					assert.ElementsMatch(t, buildPackages[archLabel], buildPkgs[0].Include)

--- a/pkg/distro/imagetype_test.go
+++ b/pkg/distro/imagetype_test.go
@@ -37,7 +37,8 @@ func TestManifestRepositoryCustomization(t *testing.T) {
 				}
 				mani, _, err := imgType.Manifest(bp, options, repos, nil)
 				assert.NoError(t, err)
-				chains := mani.GetPackageSetChains()
+				chains, err := mani.GetPackageSetChains()
+				assert.NoError(t, err)
 				osChains := chains["os"]
 				baseChain := osChains[0]
 				assert.Contains(t, baseChain.Include, "kernel")

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -194,7 +194,7 @@ func (p *AnacondaInstallerISOTree) getInline() []string {
 
 	return inlineData
 }
-func (p *AnacondaInstallerISOTree) getBuildPackages(_ Distro) []string {
+func (p *AnacondaInstallerISOTree) getBuildPackages(_ Distro) ([]string, error) {
 	var packages []string
 	switch p.RootfsType {
 	case SquashfsExt4Rootfs, SquashfsRootfs:
@@ -202,6 +202,7 @@ func (p *AnacondaInstallerISOTree) getBuildPackages(_ Distro) []string {
 	case ErofsRootfs:
 		packages = []string{"erofs-utils"}
 	default:
+		return nil, fmt.Errorf("unknown rootfs type: %q", p.RootfsType)
 	}
 
 	if p.ISOBoot == Grub2ISOBoot {
@@ -221,7 +222,7 @@ func (p *AnacondaInstallerISOTree) getBuildPackages(_ Distro) []string {
 		packages = append(packages, "tar")
 	}
 
-	return packages
+	return packages, nil
 }
 
 // Exclude most of the /boot files inside the rootfs to save space

--- a/pkg/manifest/build_test.go
+++ b/pkg/manifest/build_test.go
@@ -203,7 +203,9 @@ func TestNewBuildOptionSELinuxPolicyBuildrootFromPackages(t *testing.T) {
 		require.Len(t, osbuildPipeline.Stages, 2)
 		assert.Equal(t, "org.osbuild.selinux", osbuildPipeline.Stages[1].Type)
 		assert.Equal(t, tc.expectedFileContext, osbuildPipeline.Stages[1].Options.(*osbuild.SELinuxStageOptions).FileContexts)
-		assert.Contains(t, build.getPackageSetChain(DISTRO_NULL)[0].Include, tc.expectedBuildPkg)
+		buildPackageSetChain, err := build.getPackageSetChain(DISTRO_NULL)
+		assert.NoError(t, err)
+		assert.Contains(t, buildPackageSetChain[0].Include, tc.expectedBuildPkg)
 	}
 }
 

--- a/pkg/manifest/commit.go
+++ b/pkg/manifest/commit.go
@@ -28,11 +28,11 @@ func NewOSTreeCommit(buildPipeline Build, treePipeline *OS, ref string) *OSTreeC
 	return p
 }
 
-func (p *OSTreeCommit) getBuildPackages(Distro) []string {
+func (p *OSTreeCommit) getBuildPackages(Distro) ([]string, error) {
 	packages := []string{
 		"rpm-ostree",
 	}
-	return packages
+	return packages, nil
 }
 
 func (p *OSTreeCommit) serialize() (osbuild.Pipeline, error) {

--- a/pkg/manifest/commit_server_tree.go
+++ b/pkg/manifest/commit_server_tree.go
@@ -56,7 +56,7 @@ func NewOSTreeCommitServer(buildPipeline Build,
 	return p
 }
 
-func (p *OSTreeCommitServer) getPackageSetChain(Distro) []rpmmd.PackageSet {
+func (p *OSTreeCommitServer) getPackageSetChain(Distro) ([]rpmmd.PackageSet, error) {
 	// FIXME: container package is defined here
 	packages := []string{"nginx"}
 	return []rpmmd.PackageSet{
@@ -65,15 +65,15 @@ func (p *OSTreeCommitServer) getPackageSetChain(Distro) []rpmmd.PackageSet {
 			Repositories:    append(p.repos, p.ExtraRepos...),
 			InstallWeakDeps: true,
 		},
-	}
+	}, nil
 }
 
-func (p *OSTreeCommitServer) getBuildPackages(Distro) []string {
+func (p *OSTreeCommitServer) getBuildPackages(Distro) ([]string, error) {
 	packages := []string{
 		"rpm",
 		"rpm-ostree",
 	}
-	return packages
+	return packages, nil
 }
 
 func (p *OSTreeCommitServer) getPackageSpecs() []rpmmd.PackageSpec {

--- a/pkg/manifest/empty.go
+++ b/pkg/manifest/empty.go
@@ -44,8 +44,8 @@ func NewContentTest(m *Manifest, name string, packageSets []rpmmd.PackageSet, co
 	return pipeline
 }
 
-func (p *ContentTest) getPackageSetChain(Distro) []rpmmd.PackageSet {
-	return p.packageSets
+func (p *ContentTest) getPackageSetChain(Distro) ([]rpmmd.PackageSet, error) {
+	return p.packageSets, nil
 }
 
 func (p *ContentTest) getContainerSources() []container.SourceSpec {

--- a/pkg/manifest/export_test.go
+++ b/pkg/manifest/export_test.go
@@ -15,11 +15,11 @@ var (
 	DISTRO_COUNT = _distro_count
 )
 
-func (p *OS) GetBuildPackages(d Distro) []string {
+func (p *OS) GetBuildPackages(d Distro) ([]string, error) {
 	return p.getBuildPackages(d)
 }
 
-func (p *OS) GetPackageSetChain(d Distro) []rpmmd.PackageSet {
+func (p *OS) GetPackageSetChain(d Distro) ([]rpmmd.PackageSet, error) {
 	return p.getPackageSetChain(d)
 }
 

--- a/pkg/manifest/export_test.go
+++ b/pkg/manifest/export_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/osbuild/images/pkg/runner"
 )
 
+var (
+	DistroNames  = distroNames
+	DISTRO_COUNT = _distro_count
+)
+
 func (p *OS) GetBuildPackages(d Distro) []string {
 	return p.getBuildPackages(d)
 }

--- a/pkg/manifest/gzip.go
+++ b/pkg/manifest/gzip.go
@@ -47,8 +47,8 @@ func (p *Gzip) serialize() (osbuild.Pipeline, error) {
 	return pipeline, nil
 }
 
-func (p *Gzip) getBuildPackages(Distro) []string {
-	return []string{"gzip"}
+func (p *Gzip) getBuildPackages(Distro) ([]string, error) {
+	return []string{"gzip"}, nil
 }
 
 func (p *Gzip) Export() *artifact.Artifact {

--- a/pkg/manifest/iso.go
+++ b/pkg/manifest/iso.go
@@ -35,11 +35,11 @@ func NewISO(buildPipeline Build, treePipeline Pipeline, isoLabel string) *ISO {
 	return p
 }
 
-func (p *ISO) getBuildPackages(Distro) []string {
+func (p *ISO) getBuildPackages(Distro) ([]string, error) {
 	return []string{
 		"isomd5sum",
 		"xorriso",
-	}
+	}, nil
 }
 
 func (p *ISO) serialize() (osbuild.Pipeline, error) {

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -33,23 +33,24 @@ const (
 	DISTRO_EL8
 	DISTRO_EL7
 	DISTRO_FEDORA
+	_distro_count
 )
 
+var distroNames = map[Distro]string{
+	DISTRO_NULL:   "unset",
+	DISTRO_EL10:   "rhel-10",
+	DISTRO_EL9:    "rhel-9",
+	DISTRO_EL8:    "rhel-8",
+	DISTRO_EL7:    "rhel-7",
+	DISTRO_FEDORA: "fedora",
+}
+
 func (d Distro) String() string {
-	switch d {
-	case DISTRO_EL10:
-		return "rhel-10"
-	case DISTRO_EL9:
-		return "rhel-9"
-	case DISTRO_EL8:
-		return "rhel-8"
-	case DISTRO_EL7:
-		return "rhel-7"
-	case DISTRO_FEDORA:
-		return "fedora"
-	default:
+	s, ok := distroNames[d]
+	if !ok {
 		panic(fmt.Errorf("unknown distro: %d", d))
 	}
+	return s
 }
 
 func (d *Distro) UnmarshalJSON(data []byte) error {
@@ -58,21 +59,13 @@ func (d *Distro) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	switch s {
-	case "rhel-10":
-		*d = DISTRO_EL10
-	case "rhel-9":
-		*d = DISTRO_EL9
-	case "rhel-8":
-		*d = DISTRO_EL8
-	case "rhel-7":
-		*d = DISTRO_EL7
-	case "fedora":
-		*d = DISTRO_FEDORA
-	default:
-		return fmt.Errorf("unknown distro: %q", s)
+	for distro, distroName := range distroNames {
+		if s == distroName {
+			*d = distro
+			return nil
+		}
 	}
-	return nil
+	return fmt.Errorf("unknown distro: %q", s)
 }
 
 func (d *Distro) UnmarshalYAML(unmarshal func(any) error) error {

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -140,16 +140,20 @@ func (m *Manifest) addPipeline(p Pipeline) {
 
 type PackageSelector func([]rpmmd.PackageSet) []rpmmd.PackageSet
 
-func (m Manifest) GetPackageSetChains() map[string][]rpmmd.PackageSet {
+func (m Manifest) GetPackageSetChains() (map[string][]rpmmd.PackageSet, error) {
 	chains := make(map[string][]rpmmd.PackageSet)
 
 	for _, pipeline := range m.pipelines {
-		if chain := pipeline.getPackageSetChain(m.Distro); chain != nil {
+		chain, err := pipeline.getPackageSetChain(m.Distro)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get package set chain for %q: %w", pipeline.Name(), err)
+		}
+		if chain != nil {
 			chains[pipeline.Name()] = chain
 		}
 	}
 
-	return chains
+	return chains, nil
 }
 
 func (m Manifest) GetContainerSourceSpecs() map[string][]container.SourceSpec {

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -27,13 +27,30 @@ import (
 type Distro uint64
 
 const (
-	DISTRO_NULL = iota
+	DISTRO_NULL Distro = iota
 	DISTRO_EL10
 	DISTRO_EL9
 	DISTRO_EL8
 	DISTRO_EL7
 	DISTRO_FEDORA
 )
+
+func (d Distro) String() string {
+	switch d {
+	case DISTRO_EL10:
+		return "rhel-10"
+	case DISTRO_EL9:
+		return "rhel-9"
+	case DISTRO_EL8:
+		return "rhel-8"
+	case DISTRO_EL7:
+		return "rhel-7"
+	case DISTRO_FEDORA:
+		return "fedora"
+	default:
+		panic(fmt.Errorf("unknown distro: %d", d))
+	}
+}
 
 func (d *Distro) UnmarshalJSON(data []byte) error {
 	var s string

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -37,6 +37,10 @@ func TestUnknownDistroPanic(t *testing.T) {
 	})
 }
 
+func TestAllDistrosHaveNames(t *testing.T) {
+	assert.Equal(t, len(manifest.DistroNames), int(manifest.DISTRO_COUNT))
+}
+
 func findStage(name string, stages []*osbuild.Stage) *osbuild.Stage {
 	for _, s := range stages {
 		if s.Type == name {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -1,6 +1,7 @@
 package manifest_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,7 +26,15 @@ func TestDistroUnmarshal(t *testing.T) {
 		err := distro.UnmarshalJSON([]byte(tc.inp))
 		assert.NoError(t, err)
 		assert.Equal(t, tc.expected, distro)
+		// and distro can be converted back to the same string
+		assert.Equal(t, tc.inp, fmt.Sprintf("%q", distro))
 	}
+}
+
+func TestUnknownDistroPanic(t *testing.T) {
+	assert.PanicsWithError(t, "unknown distro: 911", func() {
+		_ = manifest.Distro(911).String()
+	})
 }
 
 func findStage(name string, stages []*osbuild.Stage) *osbuild.Stage {

--- a/pkg/manifest/oci_container.go
+++ b/pkg/manifest/oci_container.go
@@ -55,8 +55,8 @@ func (p *OCIContainer) serialize() (osbuild.Pipeline, error) {
 	return pipeline, nil
 }
 
-func (p *OCIContainer) getBuildPackages(Distro) []string {
-	return []string{"tar"}
+func (p *OCIContainer) getBuildPackages(Distro) ([]string, error) {
+	return []string{"tar"}, nil
 }
 
 func (p *OCIContainer) Export() *artifact.Artifact {

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -127,7 +127,9 @@ func TestSubscriptionManagerPackages(t *testing.T) {
 		BaseUrl:       "http://cdn.redhat.com/",
 	}
 
-	CheckPkgSetInclude(t, os.GetPackageSetChain(manifest.DISTRO_NULL), []string{"subscription-manager"})
+	pkgSetChain, err := os.GetPackageSetChain(manifest.DISTRO_NULL)
+	assert.NoError(t, err)
+	CheckPkgSetInclude(t, pkgSetChain, []string{"subscription-manager"})
 }
 
 func TestSubscriptionManagerInsightsPackages(t *testing.T) {
@@ -139,7 +141,9 @@ func TestSubscriptionManagerInsightsPackages(t *testing.T) {
 		BaseUrl:       "http://cdn.redhat.com/",
 		Insights:      true,
 	}
-	CheckPkgSetInclude(t, os.GetPackageSetChain(manifest.DISTRO_NULL), []string{"subscription-manager", "insights-client"})
+	pkgSetChain, err := os.GetPackageSetChain(manifest.DISTRO_NULL)
+	assert.NoError(t, err)
+	CheckPkgSetInclude(t, pkgSetChain, []string{"subscription-manager", "insights-client"})
 }
 
 func TestRhcInsightsPackages(t *testing.T) {
@@ -152,7 +156,9 @@ func TestRhcInsightsPackages(t *testing.T) {
 		Insights:      false,
 		Rhc:           true,
 	}
-	CheckPkgSetInclude(t, os.GetPackageSetChain(manifest.DISTRO_NULL), []string{"rhc", "subscription-manager", "insights-client"})
+	pkgSetChain, err := os.GetPackageSetChain(manifest.DISTRO_NULL)
+	assert.NoError(t, err)
+	CheckPkgSetInclude(t, pkgSetChain, []string{"rhc", "subscription-manager", "insights-client"})
 }
 
 func TestBootupdStage(t *testing.T) {
@@ -183,7 +189,8 @@ func TestInsightsClientConfigStage(t *testing.T) {
 
 func TestTomlLibUsedNoneByDefault(t *testing.T) {
 	os := manifest.NewTestOS()
-	buildPkgs := os.GetBuildPackages(manifest.DISTRO_FEDORA)
+	buildPkgs, err := os.GetBuildPackages(manifest.DISTRO_FEDORA)
+	assert.NoError(t, err)
 	for _, pkg := range []string{"python3-pytoml", "python3-toml", "python3-tomli-w"} {
 		assert.NotContains(t, buildPkgs, pkg)
 	}
@@ -216,7 +223,8 @@ func testTomlPkgsFor(t *testing.T, os *manifest.OS) {
 		{manifest.DISTRO_EL10, "python3-tomli-w"},
 		{manifest.DISTRO_FEDORA, "python3-tomli-w"},
 	} {
-		buildPkgs := os.GetBuildPackages(tc.distro)
+		buildPkgs, err := os.GetBuildPackages(tc.distro)
+		assert.NoError(t, err)
 		assert.Contains(t, buildPkgs, tc.expectedTomlPkg)
 	}
 }

--- a/pkg/manifest/ostree_deployment.go
+++ b/pkg/manifest/ostree_deployment.go
@@ -128,7 +128,7 @@ func NewOSTreeContainerDeployment(buildPipeline Build,
 	return p
 }
 
-func (p *OSTreeDeployment) getBuildPackages(Distro) []string {
+func (p *OSTreeDeployment) getBuildPackages(Distro) ([]string, error) {
 	packages := []string{
 		"rpm-ostree",
 	}
@@ -137,7 +137,7 @@ func (p *OSTreeDeployment) getBuildPackages(Distro) []string {
 		packages = append(packages, "shadow-utils")
 	}
 
-	return packages
+	return packages, nil
 }
 
 func (p *OSTreeDeployment) getOSTreeCommits() []ostree.CommitSpec {

--- a/pkg/manifest/ostree_encapsulate.go
+++ b/pkg/manifest/ostree_encapsulate.go
@@ -45,11 +45,11 @@ func (p *OSTreeEncapsulate) serialize() (osbuild.Pipeline, error) {
 	return pipeline, nil
 }
 
-func (p *OSTreeEncapsulate) getBuildPackages(Distro) []string {
+func (p *OSTreeEncapsulate) getBuildPackages(Distro) ([]string, error) {
 	return []string{
 		"rpm-ostree",
 		"python3-pyyaml",
-	}
+	}, nil
 }
 
 func (p *OSTreeEncapsulate) Export() *artifact.Artifact {

--- a/pkg/manifest/ovf.go
+++ b/pkg/manifest/ovf.go
@@ -54,6 +54,6 @@ func (p *OVF) serialize() (osbuild.Pipeline, error) {
 	return pipeline, nil
 }
 
-func (p *OVF) getBuildPackages(Distro) []string {
-	return []string{"qemu-img"}
+func (p *OVF) getBuildPackages(Distro) ([]string, error) {
+	return []string{"qemu-img"}, nil
 }

--- a/pkg/manifest/pipeline.go
+++ b/pkg/manifest/pipeline.go
@@ -35,12 +35,12 @@ type Pipeline interface {
 
 	// getBuildPackages returns the list of packages required for the pipeline
 	// at build time.
-	getBuildPackages(Distro) []string
+	getBuildPackages(Distro) ([]string, error)
 	// getPackageSetChain returns the list of package names to be required by
 	// the pipeline. Each set should be depsolved sequentially to resolve
 	// dependencies and full package specs. See the depsolvednf package for more
 	// details.
-	getPackageSetChain(Distro) []rpmmd.PackageSet
+	getPackageSetChain(Distro) ([]rpmmd.PackageSet, error)
 	// getContainerSources returns the list of containers sources to be resolved and
 	// embedded by the pipeline. Each source should be resolved to its full
 	// Spec. See the container package for more details.
@@ -120,12 +120,12 @@ func (p *Base) setManifest(m *Manifest) {
 	p.manifest = m
 }
 
-func (p Base) getBuildPackages(Distro) []string {
-	return []string{}
+func (p Base) getBuildPackages(Distro) ([]string, error) {
+	return nil, nil
 }
 
-func (p Base) getPackageSetChain(Distro) []rpmmd.PackageSet {
-	return nil
+func (p Base) getPackageSetChain(Distro) ([]rpmmd.PackageSet, error) {
+	return nil, nil
 }
 
 func (p Base) getContainerSources() []container.SourceSpec {

--- a/pkg/manifest/pxetree.go
+++ b/pkg/manifest/pxetree.go
@@ -32,12 +32,12 @@ func NewPXETree(buildPipeline Build, osPipeline *OS) *PXETree {
 	return p
 }
 
-func (p *PXETree) getBuildPackages(Distro) []string {
+func (p *PXETree) getBuildPackages(Distro) ([]string, error) {
 	switch p.RootfsType {
 	case ErofsRootfs:
-		return []string{"erofs-utils"}
+		return []string{"erofs-utils"}, nil
 	default:
-		return []string{"squashfs-tools"}
+		return []string{"squashfs-tools"}, nil
 	}
 }
 

--- a/pkg/manifest/qcow2.go
+++ b/pkg/manifest/qcow2.go
@@ -58,8 +58,8 @@ func (p *QCOW2) serialize() (osbuild.Pipeline, error) {
 	return pipeline, nil
 }
 
-func (p *QCOW2) getBuildPackages(Distro) []string {
-	return []string{"qemu-img"}
+func (p *QCOW2) getBuildPackages(Distro) ([]string, error) {
+	return []string{"qemu-img"}, nil
 }
 
 func (p *QCOW2) Export() *artifact.Artifact {

--- a/pkg/manifest/raw.go
+++ b/pkg/manifest/raw.go
@@ -36,12 +36,15 @@ func NewRawImage(buildPipeline Build, treePipeline *OS) *RawImage {
 	return p
 }
 
-func (p *RawImage) getBuildPackages(d Distro) []string {
-	pkgs := p.treePipeline.getBuildPackages(d)
+func (p *RawImage) getBuildPackages(d Distro) ([]string, error) {
+	pkgs, err := p.treePipeline.getBuildPackages(d)
+	if err != nil {
+		return nil, fmt.Errorf("cannget get build packages from %q: %w", p.treePipeline.Name(), err)
+	}
 	if p.PartTool == osbuild.PTSgdisk {
 		pkgs = append(pkgs, "gdisk")
 	}
-	return pkgs
+	return pkgs, nil
 }
 
 func (p *RawImage) serialize() (osbuild.Pipeline, error) {

--- a/pkg/manifest/raw_ostree.go
+++ b/pkg/manifest/raw_ostree.go
@@ -36,7 +36,7 @@ func NewRawOStreeImage(buildPipeline Build, treePipeline *OSTreeDeployment, plat
 	return p
 }
 
-func (p *RawOSTreeImage) getBuildPackages(Distro) []string {
+func (p *RawOSTreeImage) getBuildPackages(Distro) ([]string, error) {
 	packages := p.platform.GetBuildPackages()
 	packages = append(packages, p.platform.GetPackages()...)
 	packages = append(packages, p.treePipeline.PartitionTable.GetBuildPackages()...)
@@ -47,7 +47,7 @@ func (p *RawOSTreeImage) getBuildPackages(Distro) []string {
 		"dracut-config-generic",
 		"efibootmgr",
 	)
-	return packages
+	return packages, nil
 }
 
 func (p *RawOSTreeImage) serialize() (osbuild.Pipeline, error) {

--- a/pkg/manifest/tar.go
+++ b/pkg/manifest/tar.go
@@ -71,8 +71,8 @@ func (p *Tar) serialize() (osbuild.Pipeline, error) {
 	return pipeline, nil
 }
 
-func (p *Tar) getBuildPackages(Distro) []string {
-	return []string{"tar"}
+func (p *Tar) getBuildPackages(Distro) ([]string, error) {
+	return []string{"tar"}, nil
 }
 
 func (p *Tar) Export() *artifact.Artifact {

--- a/pkg/manifest/vagrant.go
+++ b/pkg/manifest/vagrant.go
@@ -107,8 +107,8 @@ func (p *Vagrant) serialize() (osbuild.Pipeline, error) {
 	return pipeline, nil
 }
 
-func (p *Vagrant) getBuildPackages(Distro) []string {
-	return []string{"qemu-img"}
+func (p *Vagrant) getBuildPackages(Distro) ([]string, error) {
+	return []string{"qemu-img"}, nil
 }
 
 func (p *Vagrant) Export() *artifact.Artifact {

--- a/pkg/manifest/vmdk.go
+++ b/pkg/manifest/vmdk.go
@@ -56,8 +56,8 @@ func (p *VMDK) serialize() (osbuild.Pipeline, error) {
 	return pipeline, nil
 }
 
-func (p *VMDK) getBuildPackages(Distro) []string {
-	return []string{"qemu-img"}
+func (p *VMDK) getBuildPackages(Distro) ([]string, error) {
+	return []string{"qemu-img"}, nil
 }
 
 func (p *VMDK) Export() *artifact.Artifact {

--- a/pkg/manifest/vpc.go
+++ b/pkg/manifest/vpc.go
@@ -57,8 +57,8 @@ func (p *VPC) serialize() (osbuild.Pipeline, error) {
 	return pipeline, nil
 }
 
-func (p *VPC) getBuildPackages(Distro) []string {
-	return []string{"qemu-img"}
+func (p *VPC) getBuildPackages(Distro) ([]string, error) {
+	return []string{"qemu-img"}, nil
 }
 
 func (p *VPC) Export() *artifact.Artifact {

--- a/pkg/manifest/xz.go
+++ b/pkg/manifest/xz.go
@@ -47,8 +47,8 @@ func (p *XZ) serialize() (osbuild.Pipeline, error) {
 	return pipeline, nil
 }
 
-func (p *XZ) getBuildPackages(Distro) []string {
-	return []string{"xz"}
+func (p *XZ) getBuildPackages(Distro) ([]string, error) {
+	return []string{"xz"}, nil
 }
 
 func (p *XZ) Export() *artifact.Artifact {

--- a/pkg/manifest/zstd.go
+++ b/pkg/manifest/zstd.go
@@ -47,8 +47,8 @@ func (p *Zstd) serialize() (osbuild.Pipeline, error) {
 	return pipeline, nil
 }
 
-func (p *Zstd) getBuildPackages(Distro) []string {
-	return []string{"zstd"}
+func (p *Zstd) getBuildPackages(Distro) ([]string, error) {
+	return []string{"zstd"}, nil
 }
 
 func (p *Zstd) Export() *artifact.Artifact {

--- a/pkg/manifestgen/manifestgen.go
+++ b/pkg/manifestgen/manifestgen.go
@@ -166,7 +166,11 @@ func (mg *Generator) Generate(bp *blueprint.Blueprint, imgType distro.ImageType,
 			return nil, fmt.Errorf("Warnings during manifest creation:\n%v", warn)
 		}
 	}
-	depsolved, err := mg.depsolver(mg.cacheDir, mg.depsolveWarningsOutput, preManifest.GetPackageSetChains(), dist, a.Name())
+	pkgSetChains, err := preManifest.GetPackageSetChains()
+	if err != nil {
+		return nil, err
+	}
+	depsolved, err := mg.depsolver(mg.cacheDir, mg.depsolveWarningsOutput, pkgSetChains, dist, a.Name())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
With get{BuildPackages,PackageSetChain} and GetPackageSetChains() being able to return errors we can avoid some more panic()s.