### PR TITLE
defs: typo in RHEL-7 UBI URL

### DIFF
--- a/data/distrodefs/distros.yaml
+++ b/data/distrodefs/distros.yaml
@@ -366,6 +366,6 @@ distros:
         # Install python36 explicitly for RHEL 8.
         - "python36"
     bootstrap_containers:
-      x86_64: "registry.access.redhat.com/ubi{{.MajorVersion}}/ub i:latest"
+      x86_64: "registry.access.redhat.com/ubi{{.MajorVersion}}/ubi:latest"
       ppc64le: "registry.access.redhat.com/ubi{{.MajorVersion}}/ubi:latest"
       s390x: "registry.access.redhat.com/ubi{{.MajorVersion}}/ubi:latest"


### PR DESCRIPTION
Don't even know how I spotted this but I doubt there's actually a space in the URL?