### PR TITLE
distro/validator: treat empty slices as unset [HMS-9437]

### DIFF
--- a/pkg/distro/validator_test.go
+++ b/pkg/distro/validator_test.go
@@ -566,6 +566,13 @@ func TestValidateConfig(t *testing.T) {
 			},
 			err: `customizations.user[1].name: required`,
 		},
+		"empty-slices-cause-errors": {
+			// TODO: this should not be an error
+			bp: blueprint.Blueprint{
+				Packages: []blueprint.Package{},
+			},
+			err: `packages: not supported`,
+		},
 	}
 
 	for name := range testCases {
@@ -847,6 +854,13 @@ func TestValidateSupportedConfig(t *testing.T) {
 				},
 			},
 			expErr: "customizations.embed.name: not supported",
+		},
+		"empty-slices-cause-errors": {
+			// TODO: this should not be an error
+			config: testConfigType{
+				Packages: []pkg{},
+			},
+			expErr: "packages: not supported",
 		},
 	}
 	for name, tc := range testCases {

--- a/pkg/distro/validator_test.go
+++ b/pkg/distro/validator_test.go
@@ -566,12 +566,10 @@ func TestValidateConfig(t *testing.T) {
 			},
 			err: `customizations.user[1].name: required`,
 		},
-		"empty-slices-cause-errors": {
-			// TODO: this should not be an error
+		"empty-slices-are-unset": {
 			bp: blueprint.Blueprint{
 				Packages: []blueprint.Package{},
 			},
-			err: `packages: not supported`,
 		},
 	}
 
@@ -855,12 +853,10 @@ func TestValidateSupportedConfig(t *testing.T) {
 			},
 			expErr: "customizations.embed.name: not supported",
 		},
-		"empty-slices-cause-errors": {
-			// TODO: this should not be an error
+		"empty-slices-are-unset": {
 			config: testConfigType{
 				Packages: []pkg{},
 			},
-			expErr: "packages: not supported",
 		},
 	}
 	for name, tc := range testCases {


### PR DESCRIPTION
Configs (Blueprints) can have initialised empty slices.  This can happen if a user specifies the field but doesn't add any elements.  It can also happen if an API is generating a request and initialises empty slices even when they're not used, or serialises a request without (the equivalent of) `omitempty` on a slice.  We should treat empty slices as unset to avoid causing issues in such cases.

This can cause issues in the service, which creates blueprints with empty slices.  Building an iot-simplified installer in the Fedora service is now blocked, because the request always contains an empty packages slice.
