### PR TITLE
distro: turn all errors from distro.ValidateConfig() into warnings (HMS-9444)

### DIFF
--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -629,10 +629,12 @@ func TestDistro_ManifestFIPSWarning(t *testing.T) {
 					if strings.HasSuffix(imgTypeName, "simplified-installer") {
 						bp.Customizations.InstallationDevice = "/dev/dummy"
 					}
-					_, warn, err := imgType.Manifest(&bp, imgOpts, nil, nil)
+					_, warn, _ := imgType.Manifest(&bp, imgOpts, nil, nil)
 					switch imgTypeName {
 					case "workstation-live-installer", "container", "wsl", "tar":
-						assert.EqualError(t, err, fmt.Sprintf("blueprint validation failed for image type %q: customizations.fips: not supported", imgTypeName))
+						// NOTE (validation-warnings): blueprint validation errors have temporarily been converted to warnings
+						assert.Contains(t, warn, fmt.Sprintf("blueprint validation failed for image type %q: customizations.fips: not supported", imgTypeName))
+						assert.Equal(t, slices.Contains(warn, msg), !common.IsBuildHostFIPSEnabled(), "FIPS warning not shown for image: distro='%s', imgTypeName='%s', archName='%s', warn='%v'", distroName, imgTypeName, archName, warn)
 					default:
 						assert.Equal(t, slices.Contains(warn, msg), !common.IsBuildHostFIPSEnabled(),
 							"FIPS warning not shown for image: distro='%s', imgTypeName='%s', archName='%s', warn='%v'", distroName, imgTypeName, archName, warn)

--- a/pkg/distro/generic/options.go
+++ b/pkg/distro/generic/options.go
@@ -28,7 +28,10 @@ func checkOptionsCommon(t *imageType, bp *blueprint.Blueprint, options distro.Im
 	errPrefix := fmt.Sprintf("blueprint validation failed for image type %q", t.Name())
 
 	if err := distro.ValidateConfig(t, *bp); err != nil {
-		return warnings, fmt.Errorf("%s: %w", errPrefix, err)
+		// NOTE (validation-warnings): appending to warnings now, because this
+		// is breaking a lot of things the service
+		errAsWarning := fmt.Errorf("%s: %w", errPrefix, err)
+		warnings = append(warnings, errAsWarning.Error())
 	}
 
 	if options.OSTree != nil {


### PR DESCRIPTION
The stricter blueprint validation is causing a lot of issues in the service and frontend where customizations that were previously silently ignored are causing errors.  This is causing issues because some error cases aren't being reported to users and it appears that the service is simply not responding to a build request.

Relax the blueprint validation errors for now, turning them into warnings.  We should turn them back into errors when consumers of the library have adapted to handle the new error conditions.