### PR TITLE
defs/centos: cross-arch for s390x, ppc64le

### DIFF
--- a/data/distrodefs/distros.yaml
+++ b/data/distrodefs/distros.yaml
@@ -154,6 +154,8 @@ distros:
       # mount util
       x86_64: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
       aarch64: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
+      s390x: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
+      ppc64le: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
 
   - <<: *centos10
     name: "almalinux_kitten-10"
@@ -254,6 +256,8 @@ distros:
       # mount util
       x86_64: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
       aarch64: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
+      s390x: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
+      ppc64le: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
 
   - &rhel8
     name: "rhel-{{.MajorVersion}}.{{.MinorVersion}}"


### PR DESCRIPTION
I noticed that we were missing cross-arch bootstrap roots for CentOS 9 and 10 due to lacking toolbx containers. There's now a PR pending [1] to enable these additional architectures. The containers should appear at [2].

[1]: https://github.com/toolbx-images/images/pull/158
[2]: https://quay.io/repository/toolbx-images/centos-toolbox

---

Draft as the containers need to appear before we should merge this.