### PR TITLE
pkg/distro/test_distro: ensure Manifest.*Pipeline() works as expected

### DIFF
--- a/pkg/distro/test_distro/distro.go
+++ b/pkg/distro/test_distro/distro.go
@@ -18,9 +18,6 @@ import (
 const (
 	// package set names
 
-	// build package set name
-	buildPkgsKey = "build"
-
 	// main/common os image package set name
 	osPkgsKey = "os"
 
@@ -296,8 +293,8 @@ func (t *TestImageType) Manifest(b *blueprint.Blueprint, options distro.ImageOpt
 
 	m := &manifest.Manifest{}
 
-	manifest.NewContentTest(m, buildPkgsKey, buildPackages, nil, nil)
-	manifest.NewContentTest(m, osPkgsKey, osPackages, nil, ostreeSources)
+	build := manifest.NewContentTestBuild(m, buildPackages, nil, nil)
+	manifest.NewContentTest(osPkgsKey, build, osPackages, nil, ostreeSources)
 
 	return m, nil, nil
 }

--- a/pkg/distro/test_distro/distro_test.go
+++ b/pkg/distro/test_distro/distro_test.go
@@ -1,0 +1,36 @@
+package test_distro_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distro/test_distro"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTestDistroGetPipelines(t *testing.T) {
+	testDistro := test_distro.DistroFactory(test_distro.TestDistro1Name)
+	for _, testArchName := range testDistro.ListArches() {
+		testArch, err := testDistro.GetArch(testArchName)
+		require.NoError(t, err)
+
+		for _, testImageTypeName := range testArch.ListImageTypes() {
+			t.Run(fmt.Sprintf("%s/%s", testArchName, testImageTypeName), func(t *testing.T) {
+				testImageType, err := testArch.GetImageType(testImageTypeName)
+				require.NoError(t, err)
+				m, _, err := testImageType.Manifest(nil, distro.ImageOptions{}, nil, nil)
+				require.NoError(t, err)
+				require.NotNil(t, m)
+
+				buildPipelines := m.BuildPipelines()
+				require.Len(t, buildPipelines, 1)
+				require.Equal(t, buildPipelines[0], "build")
+
+				payloadPipelines := m.PayloadPipelines()
+				require.Len(t, payloadPipelines, 1)
+				require.Equal(t, payloadPipelines[0], "os")
+			})
+		}
+	}
+}


### PR DESCRIPTION
In the past, each image type has been defining a static list of its build and payload pipelines. This is now handled dynamically on the `Manifest` type level by iterating over all pipelines and picking the ones based on their type.

This however didn't work properly for the test_distro image types, which were returning a `Manifest` instance with two pipelines (build and os), but the build pipeline was not a proper `manifest.Build` type. Thus the Manifest.BuildPipelines() returned an empty list, while Manifest.PayloadPipelines() returned both pipelines.

To fix this, a new manifest.ContentTestBuild pipeline is added, which provides the means to create a testing build pipeline implementing the `manifest.Build` interface. Note that the manifest.ContentTest can't implement the `manifest.Build` interface, because then even non-build pipelines would be treated as build pipelines by
Manifest.BuildPipelines() method.

Modify the manifest.NewContentTest() to require a build pipeline, which is the case for all other pipeline implementations that are not used only for testing.

This change is needed in order to not break osbuild-composer API unit tests, which use the distro.TestDistro. Previously the API there was setting fallback values for pipeline names, which was a compatibility layer from 4 years ago when we migrated from v1 to v2 osbuild manifests. Removing the unneeded compatibility layer in osbuild-composer revealed the limitation of distro.TestDistro. See osbuild-composer PR#4875 [0] for more information.

[0] https://github.com/osbuild/osbuild-composer/pull/4875