### PR TITLE
distrodefs: enable bsi oscap profile for RHEL-9.7 (HMS-9458)

### DIFF
--- a/data/distrodefs/distros.yaml
+++ b/data/distrodefs/distros.yaml
@@ -214,6 +214,7 @@ distros:
       - "xccdf_org.ssgproject.content_profile_anssi_bp28_high"
       - "xccdf_org.ssgproject.content_profile_anssi_bp28_intermediary"
       - "xccdf_org.ssgproject.content_profile_anssi_bp28_minimal"
+      - "xccdf_org.ssgproject.content_profile_bsi"
       - "xccdf_org.ssgproject.content_profile_ccn_advanced"
       - "xccdf_org.ssgproject.content_profile_ccn_basic"
       - "xccdf_org.ssgproject.content_profile_ccn_intermediate"


### PR DESCRIPTION
Enable the BSI OpenSCAP profile for RHEL9 & RHEL10. This change will need to be backported to RHEL-9.7