### PR TITLE
allow boot mode selection through blueprint.DiskCustomization

### DIFF
--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -1304,6 +1304,12 @@ func NewCustomPartitionTable(customizations *blueprint.DiskCustomization, option
 	if customizations == nil {
 		customizations = &blueprint.DiskCustomization{}
 	}
+	if customizations.BootMode != "" {
+		bootMode, ok := platform.BootModeMap[customizations.BootMode]
+		if ok {
+			options.BootMode = bootMode
+		}
+	}
 
 	errPrefix := "error generating partition table:"
 

--- a/pkg/distro/bootc/partition.go
+++ b/pkg/distro/bootc/partition.go
@@ -144,13 +144,23 @@ func (t *BootcImageType) genPartitionTableDiskCust(basept *disk.PartitionTable, 
 	if err != nil {
 		return nil, err
 	}
+
+	// XXX: not setting/defaults will fail to boot with btrfs/lvm
+	bootMode := platform.BOOT_HYBRID
+
+	if diskCust.BootMode != "" {
+		customMode, ok := platform.BootModeMap[diskCust.BootMode]
+		if ok {
+			bootMode = customMode
+		}
+	}
+
 	partOptions := &disk.CustomPartitionTableOptions{
 		PartitionTableType: basept.Type,
-		// XXX: not setting/defaults will fail to boot with btrfs/lvm
-		BootMode:         platform.BOOT_HYBRID,
-		DefaultFSType:    defaultFSType,
-		RequiredMinSizes: requiredMinSizes,
-		Architecture:     t.arch.arch,
+		BootMode:           bootMode,
+		DefaultFSType:      defaultFSType,
+		RequiredMinSizes:   requiredMinSizes,
+		Architecture:       t.arch.arch,
 	}
 	return disk.NewCustomPartitionTable(diskCust, partOptions, rng)
 }

--- a/pkg/platform/bootmode.go
+++ b/pkg/platform/bootmode.go
@@ -23,3 +23,12 @@ func (m BootMode) String() string {
 		panic("invalid boot mode")
 	}
 }
+
+var BootModeMap = make(map[string]BootMode)
+
+func init() {
+	BootModeMap["none"] = BOOT_NONE
+	BootModeMap["legacy"] = BOOT_LEGACY
+	BootModeMap["uefi"] = BOOT_UEFI
+	BootModeMap["hybrid"] = BOOT_HYBRID
+}


### PR DESCRIPTION
When using the bootc-image-builder we found that when creating a bootc-based Fedora IoT image a 1 MiB bootable partition was inserted at the start of the disk image. For our Raspberry Pi-based project we desire a DOS MBR partition table where the first partition is large enough to hold the initial bootloader and the device tree overlays. Since this does not fit inside the 1 MiB partition, and the Raspberry Pi is unable to locate the boot loader and device tree overlays when they are located on the second partition of the disk, we designed a method for _optionally_ customizing the "boot mode" through the blueprint.

This pull request defines a way to customize the "boot mode" of a disk image through the blueprint. Another pull request is made to the blueprint repo[1] to parse the new option from the blueprint configuration.

[1]: https://github.com/osbuild/blueprint/pull/35