### PR TITLE
bootc: UEFI for aarch64

### DIFF
--- a/pkg/distro/bootc/bootc.go
+++ b/pkg/distro/bootc/bootc.go
@@ -246,6 +246,13 @@ func (t *BootcImageType) BasePartitionTable() (*disk.PartitionTable, error) {
 }
 
 func (t *BootcImageType) BootMode() platform.BootMode {
+	// We really never want HYBRID or LEGACY on aarch64 platforms. In the future
+	// it might be much nicer to take the same apporach as `Bootmode()` in the
+	// generic distro but that's a bit more involved. Let's start here.
+	if t.arch.arch == arch.ARCH_AARCH64 {
+		return platform.BOOT_UEFI
+	}
+
 	return platform.BOOT_HYBRID
 }
 


### PR DESCRIPTION
Currently we hard code the boot mode to LEGACY. This means that both a BIOSBOOT and an ESP partition are required/created when missing. On aarch64 this is always wrong and the BIOSBOOT should *not* be there.

This is a quick bandaid. In the future we want to share more and move this into the same idiom as is being used for generic partitions.

---

This fixes the immediate issue reason for which #1923 was created. We can discuss there if the blueprint customization is still necessary after this merges.