### PR TITLE
distro: add support for `default_size` to be a string

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -894,7 +894,7 @@ image_types:
     mime_type: "application/x-tar"
     environment: *kvm_env
     bootable: true
-    default_size: 5_368_709_120  # 5 * datasizes.GibiByte
+    default_size: "5 GiB"
     image_func: "disk"
     exports: ["archive"]
     required_partition_sizes: *default_required_dir_sizes
@@ -955,7 +955,7 @@ image_types:
     mime_type: "application/x-qemu-disk"
     environment: *kvm_env
     bootable: true
-    default_size: 5_368_709_120  # 5 * datasizes.GibiByte
+    default_size: "5 GiB"
     image_func: "disk"
     exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
@@ -1055,7 +1055,7 @@ image_types:
     filename: "disk.vmdk"
     mime_type: "application/x-vmdk"
     bootable: true
-    default_size: 2_147_483_648  # 2 * datasizes.GibiByte
+    default_size: "2 GiB"
     image_func: "disk"
     exports: ["vmdk"]
     required_partition_sizes: *default_required_dir_sizes
@@ -1304,7 +1304,7 @@ image_types:
     filename: "image.raw.xz"
     compression: "xz"
     mime_type: "application/xz"
-    default_size: 6_442_450_944  # 6 * datasizes.GibiByte
+    default_size: "6 GiB"
     bootable: true
     image_func: "iot"
     ostree:
@@ -1382,7 +1382,7 @@ image_types:
     name_aliases: ["iot-qcow2-image"]
     filename: "image.qcow2"
     mime_type: "application/x-qemu-disk"
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     bootable: true
     image_func: "iot"
     ostree:
@@ -1558,7 +1558,7 @@ image_types:
     compression: "xz"
     mime_type: "application/xz"
     bootable: true
-    default_size: 2_147_483_648  # 2 * datasizes.GibiByte
+    default_size: "2 GiB"
     image_func: "disk"
     exports: ["xz"]
     required_partition_sizes: *default_required_dir_sizes
@@ -2036,7 +2036,7 @@ image_types:
     mime_type: "application/x-iso9660-image"
     bootable: true
     boot_iso: true
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     image_func: "iot_simplified_installer"
     iso_label: "IoT"
     variant: "IoT"

--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -918,7 +918,7 @@ image_types:
     # note that unlike fedora rhel does not use the environment.KVM
     # for unknown reasons
     bootable: true
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     image_func: "disk"
     exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
@@ -1026,7 +1026,7 @@ image_types:
     filename: "vagrant-libvirt.box"
     mime_type: "application/x-tar"
     bootable: true
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     image_func: "disk"
     exports: ["archive"]
     required_partition_sizes: *default_required_dir_sizes
@@ -1077,7 +1077,7 @@ image_types:
     name_aliases: []
     filename: "disk.vhd"
     mime_type: "application/x-vhd"
-    default_size: 4_294_967_296  # 4 * datasizes.GibiByte
+    default_size: "4 GiB"
     exports: ["vpc"]
     # note that unlike fedora no "environment.Azure" is used here for
     # unknown reasons
@@ -1296,7 +1296,7 @@ image_types:
     filename: "disk.vmdk"
     mime_type: "application/x-vmdk"
     bootable: true
-    default_size: 4_294_967_296  # 4 * datasizes.GibiByte
+    default_size: "4 GiB"
     image_func: "disk"
     exports: ["vmdk"]
     required_partition_sizes: *default_required_dir_sizes
@@ -1341,7 +1341,7 @@ image_types:
     image_func: "disk"
     exports: ["image"]
     bootable: true
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_bios_platform
@@ -1910,7 +1910,7 @@ image_types:
     image_func: "disk"
     exports: ["archive"]
     bootable: true
-    default_size: 21_474_836_480  # 20 * datasizes.GibiByte
+    default_size: "20 GiB"
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_uefi_platform
@@ -2066,7 +2066,7 @@ image_types:
     mime_type: "application/xz"
     exports: ["xz"]
     compression: "xz"
-    default_size: 34_359_738_368  # 32 * datasizes.GibiByte
+    default_size: "32 GiB"
     platforms:
       - arch: "x86_64"
         bootloader: "uki"

--- a/data/distrodefs/rhel-7/imagetypes.yaml
+++ b/data/distrodefs/rhel-7/imagetypes.yaml
@@ -285,7 +285,7 @@ image_types:
     filename: "disk.vhd.xz"
     mime_type: "application/xz"
     image_func: "disk"
-    default_size: 68_719_476_736  # 64 * datasizes.GibiByte
+    default_size: "64 GiB"
     exports: ["xz"]
     compression: "xz"
     bootable: true
@@ -445,7 +445,7 @@ image_types:
     exports: ["xz"]
     compression: "xz"
     bootable: true
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_bios_platform
@@ -596,7 +596,7 @@ image_types:
     filename: "disk.qcow2"
     mime_type: "application/x-qemu-disk"
     bootable: true
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     image_func: "disk"
     exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes

--- a/data/distrodefs/rhel-8/imagetypes.yaml
+++ b/data/distrodefs/rhel-8/imagetypes.yaml
@@ -1428,7 +1428,7 @@ image_types:
     image_func: "disk"
     exports: ["image"]
     bootable: true
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_bios_platform
@@ -1578,7 +1578,7 @@ image_types:
     # note that unlike fedora rhel does not use the environment.KVM
     # for unknown reasons
     bootable: true
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     image_func: "disk"
     exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
@@ -1626,7 +1626,7 @@ image_types:
     filename: "disk.vhd"
     mime_type: "application/x-vhd"
     image_func: "disk"
-    default_size: 4_294_967_296  # 4 * datasizes.GibiByte
+    default_size: "4 GiB"
     exports: ["vpc"]
     bootable: true
     # note that unlike fedora no "environment.Azure" is used here for
@@ -1786,7 +1786,7 @@ image_types:
     filename: "disk.vhd.xz"
     mime_type: "application/xz"
     image_func: "disk"
-    default_size: 68_719_476_736  # 64 * datasizes.GibiByte
+    default_size: "64 GiB"
     exports: ["xz"]
     compression: "xz"
     bootable: true
@@ -2278,7 +2278,7 @@ image_types:
     filename: "image.raw.xz"
     compression: "xz"
     mime_type: "application/xz"
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     rpm_ostree: true
     bootable: true
     image_func: "iot"
@@ -2315,7 +2315,7 @@ image_types:
     use_syslinux: true
     # NOTE: RHEL 8 only supports the older Anaconda configs
     use_legacy_anaconda_config: true
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     image_func: "iot_simplified_installer"
     iso_label: "edge"
     variant: "edge"
@@ -2445,7 +2445,7 @@ image_types:
     filename: "disk.vmdk"
     mime_type: "application/x-vmdk"
     bootable: true
-    default_size: 4_294_967_296  # 4 * datasizes.GibiByte
+    default_size: "4 GiB"
     image_func: "disk"
     exports: ["vmdk"]
     required_partition_sizes: *default_required_dir_sizes
@@ -2493,7 +2493,7 @@ image_types:
     image_func: "disk"
     exports: ["archive"]
     bootable: true
-    default_size: 21_474_836_480  # 20 * datasizes.GibiByte
+    default_size: "20 GiB"
     # The configuration for non-RHUI images does not touch the RHSM configuration at all.
     # https://issues.redhat.com/browse/COMPOSER-2157
     image_config: &gce_image_config
@@ -2630,7 +2630,7 @@ image_types:
     # we have to reset the aliases otherwise this type
     # will inherit the name aliases causing a conflict
     name_aliases: []
-    default_size: 4_294_967_296  # 4 * datasizes.GibiByte
+    default_size: "4 GiB"
     image_config:
       kernel_options:
         - "ro"
@@ -2803,7 +2803,7 @@ image_types:
     mime_type: "application/xz"
     compression: "xz"
     bootable: true
-    default_size: 2_147_483_648  # 2 * datasizes.GibiByte
+    default_size: "2 GiB"
     image_func: "disk"
     exports: ["xz"]
     required_partition_sizes: *default_required_dir_sizes

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -1435,7 +1435,7 @@ image_types:
     # note that unlike fedora rhel does not use the environment.KVM
     # for unknown reasons
     bootable: true
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     image_func: "disk"
     exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
@@ -1546,7 +1546,7 @@ image_types:
     filename: "vagrant-libvirt.box"
     mime_type: "application/x-tar"
     bootable: true
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     image_func: "disk"
     exports: ["archive"]
     required_partition_sizes: *default_required_dir_sizes
@@ -1598,7 +1598,7 @@ image_types:
     name_aliases: []
     filename: "disk.vhd"
     mime_type: "application/x-vhd"
-    default_size: 4_294_967_296  # 4 * datasizes.GibiByte
+    default_size: "4 GiB"
     exports: ["vpc"]
     platforms:
       - <<: *x86_64_bios_platform
@@ -1823,7 +1823,7 @@ image_types:
     filename: "disk.vmdk"
     mime_type: "application/x-vmdk"
     bootable: true
-    default_size: 4_294_967_296  # 4 * datasizes.GibiByte
+    default_size: "4 GiB"
     image_func: "disk"
     exports: ["vmdk"]
     required_partition_sizes: *default_required_dir_sizes
@@ -1868,7 +1868,7 @@ image_types:
     compression: "xz"
     image_func: "disk"
     bootable: true
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_bios_platform
@@ -2328,7 +2328,7 @@ image_types:
     image_func: "disk"
     exports: ["archive"]
     bootable: true
-    default_size: 21_474_836_480  # 20 * datasizes.GibiByte
+    default_size: "20 GiB"
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_uefi_platform
@@ -2482,7 +2482,7 @@ image_types:
     mime_type: "application/xz"
     compression: "xz"
     bootable: true
-    default_size: 2_147_483_648  # 2 * datasizes.GibiByte
+    default_size: "2 GiB"
     image_func: "disk"
     exports: ["xz"]
     required_partition_sizes: *default_required_dir_sizes
@@ -2587,7 +2587,7 @@ image_types:
     # we have to reset the aliases otherwise this type
     # will inherit the name aliases causing a conflict
     name_aliases: []
-    default_size: 4_294_967_296  # 4 * datasizes.GibiByte
+    default_size: "4 GiB"
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "qcow2"
@@ -2803,7 +2803,7 @@ image_types:
     compression: "xz"
     mime_type: "application/xz"
     exports: ["xz"]
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     rpm_ostree: true
     bootable: true
     image_func: "iot"
@@ -2897,7 +2897,7 @@ image_types:
     use_syslinux: true
     # NOTE: RHEL 8 only supports the older Anaconda configs
     use_legacy_anaconda_config: true
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     image_func: "iot_simplified_installer"
     iso_label: "edge"
     variant: "edge"
@@ -3012,7 +3012,7 @@ image_types:
   "edge-ami": &edge_ami
     filename: "image.raw"
     mime_type: "application/octet-stream"
-    default_size: 10_737_418_240  # 10 * datasizes.GibiByte
+    default_size: "10 GiB"
     exports: ["image"]
     rpm_ostree: true
     bootable: true
@@ -3097,7 +3097,7 @@ image_types:
     mime_type: "application/xz"
     exports: ["xz"]
     compression: "xz"
-    default_size: 34_359_738_368  # 32 * datasizes.GibiByte
+    default_size: "32 GiB"
     platforms:
       - arch: "x86_64"
         bootloader: "uki"

--- a/pkg/datasizes/size.go
+++ b/pkg/datasizes/size.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+
+	"github.com/osbuild/images/internal/common"
 )
 
 // Size is a wrapper around uint64 with support for reading from string
@@ -43,6 +45,10 @@ func (si *Size) UnmarshalJSON(data []byte) error {
 	}
 	*si = Size(i)
 	return nil
+}
+
+func (si *Size) UnmarshalYAML(unmarshal func(any) error) error {
+	return common.UnmarshalYAMLviaJSON(si, unmarshal)
 }
 
 // decodeSize takes an integer or string representing a data size (with a data

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -19,6 +19,7 @@ import (
 	"github.com/osbuild/images/internal/environment"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/oscap"
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/disk/partition"
 	"github.com/osbuild/images/pkg/distro"
@@ -372,7 +373,7 @@ type ImageTypeYAML struct {
 	// XXX: rhel-8 uses this
 	UseOstreeRemotes bool `yaml:"use_ostree_remotes"`
 
-	DefaultSize uint64 `yaml:"default_size"`
+	DefaultSize datasizes.Size `yaml:"default_size"`
 	// the image func name: disk,container,live-installer,...
 	Image                  string            `yaml:"image_func"`
 	Exports                []string          `yaml:"exports"`

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -775,7 +775,7 @@ image_types:
 	assert.Equal(t, true, imgType.BootISO)
 	assert.Equal(t, false, imgType.RPMOSTree)
 	assert.Equal(t, "Workstation", imgType.ISOLabel)
-	assert.Equal(t, uint64(5*datasizes.GibiByte), imgType.DefaultSize)
+	assert.Equal(t, datasizes.Size(5*datasizes.GibiByte), imgType.DefaultSize)
 	assert.Equal(t, "disk", imgType.Image)
 	assert.Equal(t, []string{"qcow2"}, imgType.Exports)
 	assert.Equal(t, map[string]uint64{"/": 1_073_741_824}, imgType.RequiredPartitionSizes)

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -123,7 +123,7 @@ func (t *imageType) Size(size uint64) uint64 {
 		size = (size/datasizes.MebiByte + 1) * datasizes.MebiByte
 	}
 	if size == 0 {
-		size = t.ImageTypeYAML.DefaultSize
+		size = t.ImageTypeYAML.DefaultSize.Uint64()
 	}
 	return size
 }


### PR DESCRIPTION
distro: add support for `default_size` to be a string

Make `default_size` a datasizes.Size type which means
it can be written as `size: 1234` or `size: 1 Kb` etc.

This also converts all existing image types to use
the simpler string format for the default_size.

Closes: https://github.com/osbuild/images/issues/1920

---

datasizes: add support for YAML unmarshal of datasizes

Add support to unmarshal YAML based datasizes just like we
support TOML and JSON. This is extremly simple and just
reuses the existing `common.UnmarshalYAMLviaJSON()`.
