### PR TITLE
many: make `required_partition_sizes` take datasize.Size

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -480,8 +480,8 @@
 
   disk_sizes:
     default_required_partition_sizes: &default_required_dir_sizes
-      "/": 1_073_741_824     # 1 * datasizes.GiB
-      "/usr": 2_147_483_648  # 2 * datasizes.GiB
+      "/": "1 GiB"
+      "/usr": "2 GiB"
 
   partitioning:
     ids:

--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -32,8 +32,8 @@
 
   disk_sizes:
     default_required_partition_sizes: &default_required_dir_sizes
-      "/": 1_073_741_824     # 1 * datasizes.GiB
-      "/usr": 2_147_483_648  # 2 * datasizes.GiB
+      "/": "1 GiB"
+      "/usr": "2 GiB"
 
   platforms:
     x86_64_uefi_platform: &x86_64_uefi_platform

--- a/data/distrodefs/rhel-7/imagetypes.yaml
+++ b/data/distrodefs/rhel-7/imagetypes.yaml
@@ -191,8 +191,8 @@
 
   disk_sizes:
     default_required_partition_sizes: &default_required_dir_sizes
-      "/": 1_073_741_824     # 1 * datasizes.GiB
-      "/usr": 2_147_483_648  # 2 * datasizes.GiB
+      "/": "1 GiB"
+      "/usr": "2 GiB"
 
   platforms:
     x86_64_bios_platform: &x86_64_bios_platform

--- a/data/distrodefs/rhel-8/imagetypes.yaml
+++ b/data/distrodefs/rhel-8/imagetypes.yaml
@@ -767,8 +767,8 @@
 
   disk_sizes:
     default_required_partition_sizes: &default_required_dir_sizes
-      "/": 1_073_741_824     # 1 * datasizes.GiB
-      "/usr": 2_147_483_648  # 2 * datasizes.GiB
+      "/": "1 GiB"
+      "/usr": "2 GiB"
 
   platforms:
     x86_64_uefi_platform: &x86_64_uefi_platform

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -32,8 +32,8 @@
 
   disk_sizes:
     default_required_partition_sizes: &default_required_dir_sizes
-      "/": 1_073_741_824     # 1 * datasizes.GiB
-      "/usr": 2_147_483_648  # 2 * datasizes.GiB
+      "/": "1 GiB"
+      "/usr": "2 GiB"
 
   platforms:
     x86_64_uefi_platform: &x86_64_uefi_platform

--- a/pkg/disk/disk_test.go
+++ b/pkg/disk/disk_test.go
@@ -729,17 +729,17 @@ func TestFindDirectoryPartition(t *testing.T) {
 func TestEnsureDirectorySizes(t *testing.T) {
 	assert := assert.New(t)
 
-	varSizes := map[string]uint64{
-		"/var/lib":         uint64(3 * GiB),
-		"/var/cache":       uint64(2 * GiB),
-		"/var/log/journal": uint64(2 * GiB),
+	varSizes := map[string]datasizes.Size{
+		"/var/lib":         datasizes.Size(3 * GiB),
+		"/var/cache":       datasizes.Size(2 * GiB),
+		"/var/log/journal": datasizes.Size(2 * GiB),
 	}
 
-	varAndHomeSizes := map[string]uint64{
-		"/var/lib":         uint64(3 * GiB),
-		"/var/cache":       uint64(2 * GiB),
-		"/var/log/journal": uint64(2 * GiB),
-		"/home/user/data":  uint64(10 * GiB),
+	varAndHomeSizes := map[string]datasizes.Size{
+		"/var/lib":         datasizes.Size(3 * GiB),
+		"/var/cache":       datasizes.Size(2 * GiB),
+		"/var/log/journal": datasizes.Size(2 * GiB),
+		"/home/user/data":  datasizes.Size(10 * GiB),
 	}
 
 	partitionTables := testdisk.TestPartitionTables()
@@ -765,7 +765,7 @@ func TestEnsureDirectorySizes(t *testing.T) {
 			assert.Equal(uint64(7*GiB), rootPart.Size)
 
 			// invalid
-			assert.Panics(func() { pt.EnsureDirectorySizes(map[string]uint64{"invalid": uint64(300)}) })
+			assert.Panics(func() { pt.EnsureDirectorySizes(map[string]datasizes.Size{"invalid": datasizes.Size(300)}) })
 		}
 	}
 
@@ -804,7 +804,7 @@ func TestEnsureDirectorySizes(t *testing.T) {
 			assert.Equal(uint64(10*GiB), homeLV.Size)
 
 			// invalid
-			assert.Panics(func() { pt.EnsureDirectorySizes(map[string]uint64{"invalid": uint64(300)}) })
+			assert.Panics(func() { pt.EnsureDirectorySizes(map[string]datasizes.Size{"invalid": datasizes.Size(300)}) })
 		}
 	}
 
@@ -831,7 +831,7 @@ func TestEnsureDirectorySizes(t *testing.T) {
 			assert.Equal(uint64(7*GiB), rootPayload.Subvolumes[1].Size)
 
 			// invalid
-			assert.Panics(func() { pt.EnsureDirectorySizes(map[string]uint64{"invalid": uint64(300)}) })
+			assert.Panics(func() { pt.EnsureDirectorySizes(map[string]datasizes.Size{"invalid": datasizes.Size(300)}) })
 		}
 	}
 
@@ -847,7 +847,7 @@ func TestMinimumSizesWithRequiredSizes(t *testing.T) {
 
 	type testCase struct {
 		Blueprint        []blueprint.FilesystemCustomization
-		ExpectedMinSizes map[string]uint64
+		ExpectedMinSizes map[string]datasizes.Size
 	}
 
 	testCases := []testCase{
@@ -858,7 +858,7 @@ func TestMinimumSizesWithRequiredSizes(t *testing.T) {
 					MinSize:    1 * MiB,
 				},
 			},
-			ExpectedMinSizes: map[string]uint64{
+			ExpectedMinSizes: map[string]datasizes.Size{
 				"/usr": 3 * GiB,
 				"/":    1 * GiB,
 			},
@@ -874,7 +874,7 @@ func TestMinimumSizesWithRequiredSizes(t *testing.T) {
 					MinSize:    1 * KiB,
 				},
 			},
-			ExpectedMinSizes: map[string]uint64{
+			ExpectedMinSizes: map[string]datasizes.Size{
 				"/usr": 3 * GiB,
 				"/":    1 * GiB,
 			},
@@ -886,7 +886,7 @@ func TestMinimumSizesWithRequiredSizes(t *testing.T) {
 					MinSize:    10 * GiB,
 				},
 			},
-			ExpectedMinSizes: map[string]uint64{
+			ExpectedMinSizes: map[string]datasizes.Size{
 				"/usr": 10 * GiB,
 				"/":    1 * GiB,
 			},
@@ -902,7 +902,7 @@ func TestMinimumSizesWithRequiredSizes(t *testing.T) {
 					MinSize:    1 * MiB,
 				},
 			},
-			ExpectedMinSizes: map[string]uint64{
+			ExpectedMinSizes: map[string]datasizes.Size{
 				"/":     10 * GiB,
 				"/home": 1 * GiB,
 			},
@@ -914,7 +914,7 @@ func TestMinimumSizesWithRequiredSizes(t *testing.T) {
 					MinSize:    10 * GiB,
 				},
 			},
-			ExpectedMinSizes: map[string]uint64{
+			ExpectedMinSizes: map[string]datasizes.Size{
 				"/opt": 10 * GiB,
 				"/":    4 * GiB,
 			},
@@ -923,7 +923,7 @@ func TestMinimumSizesWithRequiredSizes(t *testing.T) {
 
 	for idx, tc := range testCases {
 		{ // without LVM
-			mpt, err := disk.NewPartitionTable(&pt, tc.Blueprint, uint64(3*GiB), partition.RawPartitioningMode, arch.ARCH_AARCH64, map[string]uint64{"/": 1 * GiB, "/usr": 3 * GiB}, "", rng)
+			mpt, err := disk.NewPartitionTable(&pt, tc.Blueprint, uint64(3*GiB), partition.RawPartitioningMode, arch.ARCH_AARCH64, map[string]datasizes.Size{"/": 1 * GiB, "/usr": 3 * GiB}, "", rng)
 			assert.NoError(err)
 			for mnt, minSize := range tc.ExpectedMinSizes {
 				path := disk.EntityPath(mpt, mnt)
@@ -937,7 +937,7 @@ func TestMinimumSizesWithRequiredSizes(t *testing.T) {
 		}
 
 		{ // with LVM
-			mpt, err := disk.NewPartitionTable(&pt, tc.Blueprint, uint64(3*GiB), partition.AutoLVMPartitioningMode, arch.ARCH_AARCH64, map[string]uint64{"/": 1 * GiB, "/usr": 3 * GiB}, "", rng)
+			mpt, err := disk.NewPartitionTable(&pt, tc.Blueprint, uint64(3*GiB), partition.AutoLVMPartitioningMode, arch.ARCH_AARCH64, map[string]datasizes.Size{"/": 1 * GiB, "/usr": 3 * GiB}, "", rng)
 			assert.NoError(err)
 			for mnt, minSize := range tc.ExpectedMinSizes {
 				path := disk.EntityPath(mpt, mnt)

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -1707,7 +1707,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 			options: &disk.CustomPartitionTableOptions{
 				DefaultFSType:      disk.FS_XFS,
 				BootMode:           platform.BOOT_HYBRID,
-				RequiredMinSizes:   map[string]uint64{"/": 1 * datasizes.GiB, "/usr": 2 * datasizes.GiB}, // the default for our distro definitions
+				RequiredMinSizes:   map[string]datasizes.Size{"/": 1 * datasizes.GiB, "/usr": 2 * datasizes.GiB}, // the default for our distro definitions
 				PartitionTableType: disk.PT_DOS,
 			},
 			expected: &disk.PartitionTable{
@@ -1805,7 +1805,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				DefaultFSType:      disk.FS_EXT4,
 				BootMode:           platform.BOOT_HYBRID,
 				PartitionTableType: disk.PT_DOS,
-				RequiredMinSizes:   map[string]uint64{"/": 3 * datasizes.GiB},
+				RequiredMinSizes:   map[string]datasizes.Size{"/": 3 * datasizes.GiB},
 				Architecture:       arch.ARCH_S390X,
 			},
 			expected: &disk.PartitionTable{
@@ -1878,7 +1878,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				DefaultFSType:      disk.FS_EXT4,
 				BootMode:           platform.BOOT_HYBRID,
 				PartitionTableType: disk.PT_DOS,
-				RequiredMinSizes:   map[string]uint64{"/": 3 * datasizes.GiB},
+				RequiredMinSizes:   map[string]datasizes.Size{"/": 3 * datasizes.GiB},
 				Architecture:       arch.ARCH_PPC64LE,
 			},
 			expected: &disk.PartitionTable{
@@ -1930,7 +1930,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				DefaultFSType:      disk.FS_EXT4,
 				BootMode:           platform.BOOT_HYBRID,
 				PartitionTableType: disk.PT_DOS,
-				RequiredMinSizes:   map[string]uint64{"/": 3 * datasizes.GiB},
+				RequiredMinSizes:   map[string]datasizes.Size{"/": 3 * datasizes.GiB},
 				Architecture:       arch.ARCH_PPC64LE,
 			},
 			expected: &disk.PartitionTable{
@@ -2316,7 +2316,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 			options: &disk.CustomPartitionTableOptions{
 				DefaultFSType:    disk.FS_EXT4,
 				BootMode:         platform.BOOT_HYBRID,
-				RequiredMinSizes: map[string]uint64{"/": 3 * datasizes.GiB},
+				RequiredMinSizes: map[string]datasizes.Size{"/": 3 * datasizes.GiB},
 			},
 			expected: &disk.PartitionTable{
 				Type: disk.PT_GPT, // default when unspecified

--- a/pkg/distro/bootc/partition.go
+++ b/pkg/distro/bootc/partition.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/osbuild/blueprint/pkg/blueprint"
 
+	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/disk/partition"
 	"github.com/osbuild/images/pkg/pathpolicy"
@@ -208,7 +209,7 @@ func checkMountpoints(filesystems []blueprint.FilesystemCustomization, policy *p
 //
 // Note that a custom "/usr" is not supported in image mode so splitting
 // rootfsMinSize between / and /usr is not a concern.
-func calcRequiredDirectorySizes(distCust *blueprint.DiskCustomization, rootfsMinSize uint64) (map[string]uint64, error) {
+func calcRequiredDirectorySizes(distCust *blueprint.DiskCustomization, rootfsMinSize uint64) (map[string]datasizes.Size, error) {
 	// XXX: this has *way* too much low-level knowledge about the
 	// inner workings of blueprint.DiskCustomizations plus when
 	// a new type it needs to get added here too, think about
@@ -231,8 +232,8 @@ func calcRequiredDirectorySizes(distCust *blueprint.DiskCustomization, rootfsMin
 		}
 	}
 	// ensure rootfsMinSize is respected
-	return map[string]uint64{
-		"/": max(rootfsMinSize, mounts["/"]),
+	return map[string]datasizes.Size{
+		"/": datasizes.Size(max(rootfsMinSize, mounts["/"])),
 	}, nil
 }
 

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -375,9 +375,9 @@ type ImageTypeYAML struct {
 
 	DefaultSize datasizes.Size `yaml:"default_size"`
 	// the image func name: disk,container,live-installer,...
-	Image                  string            `yaml:"image_func"`
-	Exports                []string          `yaml:"exports"`
-	RequiredPartitionSizes map[string]uint64 `yaml:"required_partition_sizes"`
+	Image                  string                    `yaml:"image_func"`
+	Exports                []string                  `yaml:"exports"`
+	RequiredPartitionSizes map[string]datasizes.Size `yaml:"required_partition_sizes"`
 
 	InternalPlatforms []platform.Data    `yaml:"platforms"`
 	PlatformsOverride *platformsOverride `yaml:"platforms_override"`

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -778,7 +778,7 @@ image_types:
 	assert.Equal(t, datasizes.Size(5*datasizes.GibiByte), imgType.DefaultSize)
 	assert.Equal(t, "disk", imgType.Image)
 	assert.Equal(t, []string{"qcow2"}, imgType.Exports)
-	assert.Equal(t, map[string]uint64{"/": 1_073_741_824}, imgType.RequiredPartitionSizes)
+	assert.Equal(t, map[string]datasizes.Size{"/": 1_073_741_824}, imgType.RequiredPartitionSizes)
 	assert.Equal(t, []platform.Data{
 		{
 			Arch:         arch.ARCH_PPC64LE,

--- a/pkg/osbuild/device_test.go
+++ b/pkg/osbuild/device_test.go
@@ -24,7 +24,7 @@ func TestGenDeviceCreationStages(t *testing.T) {
 
 	luks_lvm := testPartitionTables["luks+lvm"]
 
-	pt, err := disk.NewPartitionTable(&luks_lvm, []blueprint.FilesystemCustomization{}, 0, partition.AutoLVMPartitioningMode, arch.ARCH_AARCH64, make(map[string]uint64), "", rng)
+	pt, err := disk.NewPartitionTable(&luks_lvm, []blueprint.FilesystemCustomization{}, 0, partition.AutoLVMPartitioningMode, arch.ARCH_AARCH64, make(map[string]datasizes.Size), "", rng)
 	assert.NoError(err)
 
 	stages := GenDeviceCreationStages(pt, "image.raw")
@@ -87,7 +87,7 @@ func TestGenDeviceFinishStages(t *testing.T) {
 
 	luks_lvm := testPartitionTables["luks+lvm"]
 
-	pt, err := disk.NewPartitionTable(&luks_lvm, []blueprint.FilesystemCustomization{}, 0, partition.AutoLVMPartitioningMode, arch.ARCH_PPC64LE, make(map[string]uint64), "", rng)
+	pt, err := disk.NewPartitionTable(&luks_lvm, []blueprint.FilesystemCustomization{}, 0, partition.AutoLVMPartitioningMode, arch.ARCH_PPC64LE, make(map[string]datasizes.Size), "", rng)
 	assert.NoError(err)
 
 	stages := GenDeviceFinishStages(pt, "image.raw")
@@ -130,7 +130,7 @@ func TestGenDeviceFinishStagesOrderWithLVMClevisBind(t *testing.T) {
 
 	luks_lvm := testPartitionTables["luks+lvm+clevisBind"]
 
-	pt, err := disk.NewPartitionTable(&luks_lvm, []blueprint.FilesystemCustomization{}, 0, partition.AutoLVMPartitioningMode, arch.ARCH_S390X, make(map[string]uint64), "", rng)
+	pt, err := disk.NewPartitionTable(&luks_lvm, []blueprint.FilesystemCustomization{}, 0, partition.AutoLVMPartitioningMode, arch.ARCH_S390X, make(map[string]datasizes.Size), "", rng)
 	assert.NoError(err)
 
 	stages := GenDeviceFinishStages(pt, "image.raw")

--- a/pkg/osbuild/disk_test.go
+++ b/pkg/osbuild/disk_test.go
@@ -44,7 +44,7 @@ func TestGenImageKernelOptions(t *testing.T) {
 
 	luks_lvm := testPartitionTables["luks+lvm"]
 
-	pt, err := disk.NewPartitionTable(&luks_lvm, []blueprint.FilesystemCustomization{}, 0, partition.AutoLVMPartitioningMode, arch.ARCH_X86_64, make(map[string]uint64), "", rng)
+	pt, err := disk.NewPartitionTable(&luks_lvm, []blueprint.FilesystemCustomization{}, 0, partition.AutoLVMPartitioningMode, arch.ARCH_X86_64, make(map[string]datasizes.Size), "", rng)
 	assert.NoError(err)
 
 	uuids := collectUUIDs(pt)


### PR DESCRIPTION
[build on top of https://github.com/osbuild/images/pull/1929/commits]

This commit allows us to use nice strings in the
`required_partition_sizes` structs.

It might be a bit too much for the little gain but I'm opening it for feedback.