### PR TITLE
fedora/minimal: riscv comps groups

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -1614,9 +1614,12 @@ image_types:
             "riscv64 specific pkgs for minimal-raw-xz":
               when:
                 arch: "riscv64"
+                version_less_than: "42"
               append:
                 include:
-                  # missing from @core in riscv64
+                  # missing from @core in riscv64 but only
+                  # in Fedora 41, they've been subsequently
+                  # added in 42 and up
                   - "dnf5"
                   - "policycoreutils"
                   - "selinux-policy-targeted"


### PR DESCRIPTION
When the initial RISC-V enablement was done several packages were missing from the comps groups for the RISC-V repositories. These packages have subsequently been added to Fedora 42 and up [1].

Change the condition to apply both so we can drop it once Fedora 41 goes end of life.

[1]: http://fedora.riscv.rocks:3000/davidlt/fedora-comps/src/branch/main-riscv64-v2