### PR TITLE
fedora: document root kickstart

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -1556,8 +1556,11 @@ image_types:
         bootloader: "grub2"
       - *riscv64_uefi_platform
     image_config:
-      # NOTE: temporary workaround for a bug in initial-setup that
-      # requires a kickstart file in the root directory.
+      # NOTE: initial-setup doesn't allow a system to be reconfigured
+      # NOTE: if certain files are already configured (locale, users,
+      # NOTE: that sort of stuff). With this kickstart we enable reconfig
+      # NOTE: of those values since we have already written them in the
+      # NOTE: disk image but they might not be what the user wants.
       files:
         - path: "/root/anaconda-ks.cfg"
           user: "root"


### PR DESCRIPTION
Document the root kickstart reasoning a bit better than what was written there before since I have forgotten why we do this twice now. See [1] and [2] for (some) details.

[1]: https://github.com/osbuild/images/pull/137
[2]: https://pykickstart.readthedocs.io/en/latest/kickstart-docs.html#firstboot