### PR TITLE
bootc: actually use `BootMode`

### DIFF
--- a/pkg/distro/bootc/partition.go
+++ b/pkg/distro/bootc/partition.go
@@ -11,7 +11,6 @@ import (
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/disk/partition"
 	"github.com/osbuild/images/pkg/pathpolicy"
-	"github.com/osbuild/images/pkg/platform"
 )
 
 const (
@@ -148,7 +147,7 @@ func (t *BootcImageType) genPartitionTableDiskCust(basept *disk.PartitionTable, 
 	partOptions := &disk.CustomPartitionTableOptions{
 		PartitionTableType: basept.Type,
 		// XXX: not setting/defaults will fail to boot with btrfs/lvm
-		BootMode:         platform.BOOT_HYBRID,
+		BootMode:         t.BootMode(),
 		DefaultFSType:    defaultFSType,
 		RequiredMinSizes: requiredMinSizes,
 		Architecture:     t.arch.arch,


### PR DESCRIPTION
In a previous PR [1] I made the `BootMode` for bootc-images architecture dependent.

Sadly the method I updated there doesn't *actually* get used hence this second commit and PR to also use the method.

[1]: https://github.com/osbuild/images/pull/1927

---

Found in #1923.