### PR TITLE
cloud/azure: update gallery image version source

### DIFF
--- a/pkg/cloud/azure/gallery.go
+++ b/pkg/cloud/azure/gallery.go
@@ -167,8 +167,10 @@ func (ac Client) createGalleryImageVersion(ctx context.Context, resourceGroup, l
 				},
 			},
 			StorageProfile: &armcompute.GalleryImageVersionStorageProfile{
-				Source: &armcompute.GalleryArtifactVersionFullSource{
-					ID: &uri,
+				OSDiskImage: &armcompute.GalleryOSDiskImage{
+					Source: &armcompute.GalleryDiskImageSource{
+						URI: &uri,
+					},
 				},
 			},
 		},

--- a/pkg/cloud/azure/gallery_test.go
+++ b/pkg/cloud/azure/gallery_test.go
@@ -94,8 +94,10 @@ func TestRegisterGalleryImage(t *testing.T) {
 				},
 			},
 			StorageProfile: &armcompute.GalleryImageVersionStorageProfile{
-				Source: &armcompute.GalleryArtifactVersionFullSource{
-					ID: common.ToPtr("/subscriptions/test-subscription/resourceGroups/rg/providers/Microsoft.Compute/images/img-name-mimg"),
+				OSDiskImage: &armcompute.GalleryOSDiskImage{
+					Source: &armcompute.GalleryDiskImageSource{
+						URI: common.ToPtr("/subscriptions/test-subscription/resourceGroups/rg/providers/Microsoft.Compute/images/img-name-mimg"),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
The old source will be deprecated, an `OSDiskImage` now has to be given.

---

This might not be necessary, as the azure notice said to replace the `storageProfile.Source.id` with '’storageProfile.osDiskImage.source.storageAccountId', but we don't specify account IDs when pointing to a blob just the URI. Let's see if CI breaks first, and if so, this might help.