### PR TITLE
rhel10: add ism secret & top secret oscap profiles (HMS-9507)

### DIFF
--- a/data/distrodefs/distros.yaml
+++ b/data/distrodefs/distros.yaml
@@ -114,6 +114,8 @@ distros:
       - "xccdf_org.ssgproject.content_profile_e8"
       - "xccdf_org.ssgproject.content_profile_hipaa"
       - "xccdf_org.ssgproject.content_profile_ism_o"
+      - "xccdf_org.ssgproject.content_profile_ism_o_secret"
+      - "xccdf_org.ssgproject.content_profile_ism_o_top_secret"
       - "xccdf_org.ssgproject.content_profile_ospp"
       - "xccdf_org.ssgproject.content_profile_pci-dss"
       - "xccdf_org.ssgproject.content_profile_stig"


### PR DESCRIPTION
Add the ism_o_secret & ism_o_top_secret OpenSCAP profiles to the allow list for RHEL10 images.