### PR TITLE
osbuild/osbuild-exec: extract building the osbuild cmd to helper

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -136,7 +136,11 @@ func run() error {
 	fmt.Printf("Building manifest: %s\n", manifestPath)
 
 	jobOutput := filepath.Join(outputDir, buildName)
-	_, err = osbuild.RunOSBuild(mf, osbuildStore, jobOutput, imgType.Exports(), checkpoints, nil, false, os.Stderr)
+	_, err = osbuild.RunOSBuild(mf, imgType.Exports(), checkpoints, os.Stderr, &osbuild.OSBuildOptions{
+		StoreDir:   osbuildStore,
+		OutputDir:  jobOutput,
+		JSONOutput: false,
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -57,7 +57,11 @@ func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos
 
 	store := path.Join(state_dir, "osbuild-store")
 
-	_, err = osbuild.RunOSBuild(bytes, store, "./", manifest.GetExports(), manifest.GetCheckpoints(), nil, false, os.Stdout)
+	_, err = osbuild.RunOSBuild(bytes, manifest.GetExports(), manifest.GetCheckpoints(), os.Stdout, &osbuild.OSBuildOptions{
+		StoreDir:   store,
+		OutputDir:  "./",
+		JSONOutput: false,
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not run osbuild: %s", err.Error())
 	}

--- a/pkg/osbuild/osbuild-exec_test.go
+++ b/pkg/osbuild/osbuild-exec_test.go
@@ -1,0 +1,93 @@
+package osbuild_test
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/datasizes"
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+func TestNewOSBuildCmdNilOptions(t *testing.T) {
+	mf := []byte(`{"real": "manifest"}`)
+	cmd := osbuild.NewOSBuildCmd(mf, nil, nil, nil)
+	assert.NotNil(t, cmd)
+
+	assert.Equal(
+		t,
+		[]string{
+			"osbuild",
+			"--store",
+			"",
+			"--output-directory",
+			"",
+			fmt.Sprintf("--cache-max-size=%d", int64(20*datasizes.GiB)),
+			"-",
+		},
+		cmd.Args,
+	)
+
+	stdin, err := io.ReadAll(cmd.Stdin)
+	assert.NoError(t, err)
+	assert.Equal(t, mf, stdin)
+}
+
+func TestNewOSBuildCmdFullOptions(t *testing.T) {
+	mf := []byte(`{"real": "manifest"}`)
+	cmd := osbuild.NewOSBuildCmd(
+		mf,
+		[]string{
+			"export-1",
+			"export-2",
+		},
+		[]string{
+			"checkpoint-1",
+			"checkpoint-2",
+		},
+		&osbuild.OSBuildOptions{
+			StoreDir:     "store",
+			OutputDir:    "output",
+			ExtraEnv:     []string{"EXTRA_ENV_1=1", "EXTRA_ENV_2=2"},
+			Monitor:      osbuild.MonitorLog,
+			MonitorFD:    10,
+			JSONOutput:   true,
+			CacheMaxSize: 10 * datasizes.GiB,
+		},
+	)
+	assert.NotNil(t, cmd)
+
+	assert.Equal(
+		t,
+		[]string{
+			"osbuild",
+			"--store",
+			"store",
+			"--output-directory",
+			"output",
+			fmt.Sprintf("--cache-max-size=%d", int64(10*datasizes.GiB)),
+			"-",
+			"--export",
+			"export-1",
+			"--export",
+			"export-2",
+			"--checkpoint",
+			"checkpoint-1",
+			"--checkpoint",
+			"checkpoint-2",
+			"--monitor=LogMonitor",
+			"--monitor-fd=10",
+			"--json",
+		},
+		cmd.Args,
+	)
+
+	assert.Contains(t, cmd.Env, "EXTRA_ENV_1=1")
+	assert.Contains(t, cmd.Env, "EXTRA_ENV_2=2")
+
+	stdin, err := io.ReadAll(cmd.Stdin)
+	assert.NoError(t, err)
+	assert.Equal(t, mf, stdin)
+}


### PR DESCRIPTION
`NewOSBuildCmd` takes inspiration from images[1], allowing consumers to manipulate the exec.Cmd as they see fit. This is useful for asynchronous invocations, `io.MultiWriter`s and use with `StatusScanner`s.

[1] https://github.com/osbuild/image-builder-cli/blob/e348fc2542c6f09e969b021de7ac20e96840895e/pkg/progress/command.go#L51-L69

---

TODO:
- [ ] add support for BuildLog option (io.Writer)? https://github.com/osbuild/image-builder-cli/blob/e348fc2542c6f09e969b021de7ac20e96840895e/pkg/progress/command.go#L126-L132
- [ ] add a version of RunOSBuild which returns a StatusScanner