### PR TITLE
osbuild: tweak how we can mock osbuild slightly

### DIFF
--- a/pkg/osbuild/export_test.go
+++ b/pkg/osbuild/export_test.go
@@ -3,3 +3,11 @@ package osbuild
 type (
 	StatusJSON = statusJSON
 )
+
+func MockOsbuildCmd(s string) (restore func()) {
+	saved := osbuildCmd
+	osbuildCmd = s
+	return func() {
+		osbuildCmd = saved
+	}
+}

--- a/pkg/osbuild/osbuild-exec.go
+++ b/pkg/osbuild/osbuild-exec.go
@@ -24,7 +24,7 @@ const (
 	MonitorLog     = "LogMonitor"
 )
 
-var OSBuildCmd = "osbuild"
+var osbuildCmd = "osbuild"
 
 type OSBuildOptions struct {
 	StoreDir  string
@@ -49,7 +49,7 @@ func NewOSBuildCmd(manifest []byte, exports, checkpoints []string, optsPtr *OSBu
 
 	// nolint: gosec
 	cmd := exec.Command(
-		OSBuildCmd,
+		osbuildCmd,
 		"--store", opts.StoreDir,
 		"--output-directory", opts.OutputDir,
 		fmt.Sprintf("--cache-max-size=%v", cacheMaxSize),
@@ -156,7 +156,7 @@ func CheckMinimumOSBuildVersion() error {
 // OSBuildVersion returns the version of osbuild.
 func OSBuildVersion() (string, error) {
 	var stdoutBuffer bytes.Buffer
-	cmd := exec.Command(OSBuildCmd, "--version")
+	cmd := exec.Command(osbuildCmd, "--version")
 	cmd.Stdout = &stdoutBuffer
 
 	err := cmd.Run()
@@ -173,7 +173,7 @@ func OSBuildVersion() (string, error) {
 
 // OSBuildInspect converts a manifest to an inspected manifest.
 func OSBuildInspect(manifest []byte) ([]byte, error) {
-	cmd := exec.Command(OSBuildCmd, "--inspect")
+	cmd := exec.Command(osbuildCmd, "--inspect")
 	cmd.Stdin = bytes.NewBuffer(manifest)
 
 	out, err := cmd.Output()

--- a/pkg/osbuild/osbuild-exec_test.go
+++ b/pkg/osbuild/osbuild-exec_test.go
@@ -13,14 +13,6 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
-func mockOsbuildCmd(s string) (restore func()) {
-	saved := osbuild.OSBuildCmd
-	osbuild.OSBuildCmd = s
-	return func() {
-		osbuild.OSBuildCmd = saved
-	}
-}
-
 func makeFakeOsbuild(t *testing.T, content string) string {
 	p := filepath.Join(t.TempDir(), "fake-osbuild")
 	err := os.WriteFile(p, []byte("#!/bin/sh\n"+content), 0755)
@@ -117,7 +109,7 @@ else
     echo '{"success": true}'
 fi
 `)
-	restore := mockOsbuildCmd(fakeOsbuildBinary)
+	restore := osbuild.MockOsbuildCmd(fakeOsbuildBinary)
 	defer restore()
 
 	opts := &osbuild.OSBuildOptions{


### PR DESCRIPTION
Tiny commit to tweak the way we allow to change the osbuild binary to run. This is a followup for PR#1965. The main motivation is to unexport `osbuild.OSBuildCmd` as it is global state and potentially racy, i.e. two threads doing:
```go
osbuild.OSBuildCmd = "foo"
osbuild.RunOSBuild()
```
and
```go
osbuild.OSBuildCmd = "bar"
osbuild.RunOSBuild()
```
would potentially race.

I know the risk is small (because this is mean only for testing and tests are run in sequence in the same pkg by default) but if it is ever used outside of tests it can becomes a source of subtle and hard to spot bugs.

The use-case to tweak osbuild.OSBuildCmd to test osbuild.RunOSBuild() from the outside one can just modify PATH to point to a different osbuild binary (we do something similar in e.g. ibcli, i.e. just modifying PATH).