### PR TITLE
deps: switch yaml libraries

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/gobwas/glob"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/blueprint/pkg/blueprint"
 	"github.com/osbuild/images/internal/buildconfig"

--- a/go.mod
+++ b/go.mod
@@ -40,13 +40,13 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/ubccr/kerby v0.0.0-20230802201021-412be7bfaee5
 	github.com/vmware/govmomi v0.52.0
+	go.yaml.in/yaml/v3 v3.0.3
 	golang.org/x/exp v0.0.0-20250103183323-7d7fa50e5329
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sys v0.35.0
 	golang.org/x/tools v0.36.0
 	google.golang.org/api v0.248.0
 	gopkg.in/ini.v1 v1.67.0
-	gopkg.in/yaml.v3 v3.0.1
 	libvirt.org/go/libvirt v1.11006.0
 )
 
@@ -200,5 +200,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250818200422-3122310a409c // indirect
 	google.golang.org/grpc v1.74.2 // indirect
 	google.golang.org/protobuf v1.36.7 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.5.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -501,6 +501,8 @@ go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeX
 go.opentelemetry.io/proto/otlp v1.3.1/go.mod h1:0X1WI4de4ZsLrrJNLAQbFeLCm3T7yBkR0XqQ7niQU+8=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
 go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
+go.yaml.in/yaml/v3 v3.0.3 h1:bXOww4E/J3f66rav3pX3m8w6jDE4knZjGOw8b5Y6iNE=
+go.yaml.in/yaml/v3 v3.0.3/go.mod h1:tBHosrYAkRZjRAOREWbDnBXUf08JOwYq++0QNwQiWzI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/images/internal/environment"
 	"github.com/osbuild/images/pkg/rpmmd"

--- a/pkg/arch/arch_test.go
+++ b/pkg/arch/arch_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/images/internal/common"
 )

--- a/pkg/bib/osinfo/osinfo.go
+++ b/pkg/bib/osinfo/osinfo.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/blueprint/pkg/blueprint"
 	"github.com/osbuild/images/pkg/bib/blueprintload"

--- a/pkg/customizations/fsnode/fsnode_test.go
+++ b/pkg/customizations/fsnode/fsnode_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/images/internal/common"
 )

--- a/pkg/datasizes/size_test.go
+++ b/pkg/datasizes/size_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/images/pkg/datasizes"
 )

--- a/pkg/disk/enums_test.go
+++ b/pkg/disk/enums_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/images/pkg/disk"
 )

--- a/pkg/disk/partition_table_yaml_test.go
+++ b/pkg/disk/partition_table_yaml_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -12,7 +12,7 @@ import (
 	"sort"
 	"text/template"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/images/data/distrodefs"
 	"github.com/osbuild/images/internal/common"

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"

--- a/pkg/manifest/anaconda_installer_iso_tree_test.go
+++ b/pkg/manifest/anaconda_installer_iso_tree_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"

--- a/pkg/osbuild/chrony_stage_test.go
+++ b/pkg/osbuild/chrony_stage_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/images/internal/common"
 )

--- a/pkg/osbuild/modprobe_stage_test.go
+++ b/pkg/osbuild/modprobe_stage_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestNewModprobeStage(t *testing.T) {

--- a/pkg/osbuild/sshd_config_stage_test.go
+++ b/pkg/osbuild/sshd_config_stage_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/images/internal/common"
 )

--- a/pkg/osbuild/udev_rules_stage_test.go
+++ b/pkg/osbuild/udev_rules_stage_test.go
@@ -3,7 +3,7 @@ package osbuild
 import (
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/images/pkg/platform"
 )

--- a/pkg/platform/yaml_test.go
+++ b/pkg/platform/yaml_test.go
@@ -3,7 +3,7 @@ package platform_test
 import (
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/stretchr/testify/assert"
 

--- a/pkg/runner/yaml_test.go
+++ b/pkg/runner/yaml_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/images/pkg/runner"
 )


### PR DESCRIPTION
During a recent chat it was brought up that `go.pkg.in/yaml.v3` is unmaintained. The YAML organization forked the unmaintained package and is now updating it. The `v3` we use here only receives security fixes while `v4` will eventually support new features and more of YAML.

Let's do the easy an uncontroversial swap first as this is a maintained drop-in replacement.

---

Note, this is *not* `goccy/go-yaml` which has additional features it is `yaml/go-yaml`.