### PR TITLE
[RFC] data: introduce `data/distrodefs/shared/shared.yaml`

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -4,3 +4,7 @@ extends: default
 rules:
   line-length:
     max: 300
+  anchors:
+    forbid-undeclared-aliases: false
+  document-start:
+    present: false

--- a/data/distrodefs/distros.yaml
+++ b/data/distrodefs/distros.yaml
@@ -1,4 +1,3 @@
----
 distros:
   - &fedora_rawhide
     name: fedora-44

--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -1,4 +1,3 @@
----
 .common:
   cloud_base_pkgset: &cloud_base_pkgset
     include:
@@ -484,22 +483,6 @@
       locale: "C.UTF-8"
       ostree_conf_sysroot_readonly: true
       lock_root_user: true
-
-  disk_sizes:
-    default_required_partition_sizes: &default_required_dir_sizes
-      "/": "1 GiB"
-      "/usr": "2 GiB"
-
-  partitioning:
-    ids:
-      - &prep_partition_dosid "41"
-      - &filesystem_linux_dosid "83"
-      - &fat16_bdosid "06"
-    guids:
-      - &bios_boot_partition_guid "21686148-6449-6E6F-744E-656564454649"
-      - &efi_system_partition_guid "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
-      - &filesystem_data_guid "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
-      - &xboot_ldr_partition_guid "BC13C2FF-59E6-4262-A352-B275FD6F7172"
 
     # the invidual partitions for easier composibility
     partitions:

--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -1,4 +1,3 @@
----
 .common:
   distro_build_pkgset: &distro_build_pkgset
     include:
@@ -29,11 +28,6 @@
           include:
             - "grub2-ppc64le"
             - "grub2-ppc64le-modules"
-
-  disk_sizes:
-    default_required_partition_sizes: &default_required_dir_sizes
-      "/": "1 GiB"
-      "/usr": "2 GiB"
 
   platforms:
     x86_64_uefi_platform: &x86_64_uefi_platform
@@ -388,18 +382,6 @@
             - "shim-aa64"
 
   partitioning:
-    ids:
-      - &prep_partition_dosid "41"
-      - &filesystem_linux_dosid "83"
-      - &fat16_bdosid "06"
-    guids:
-      - &bios_boot_partition_guid "21686148-6449-6E6F-744E-656564454649"
-      - &efi_system_partition_guid "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
-      - &filesystem_data_guid "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
-      - &xboot_ldr_partition_guid "BC13C2FF-59E6-4262-A352-B275FD6F7172"
-      - &lvm_partition_guid "E6D6D379-F507-44C2-A23C-238F2A3DF928"
-      - &root_partition_x86_64_guid "4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709"
-
     default_partition_tables: &default_partition_tables
       x86_64:
         type: "gpt"

--- a/data/distrodefs/rhel-7/imagetypes.yaml
+++ b/data/distrodefs/rhel-7/imagetypes.yaml
@@ -1,4 +1,3 @@
----
 .common:
   azure_rhui_common_pkgset: &azure_rhui_common_pkgset
     include:
@@ -47,17 +46,6 @@
             - "insights-client"
 
   partitioning:
-    ids:
-      - &prep_partition_dosid "41"
-      - &filesystem_linux_dosid "83"
-      - &fat16_bdosid "06"
-    guids:
-      - &bios_boot_partition_guid "21686148-6449-6E6F-744E-656564454649"
-      - &efi_system_partition_guid "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
-      - &filesystem_data_guid "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
-      - &xboot_ldr_partition_guid "BC13C2FF-59E6-4262-A352-B275FD6F7172"
-      - &lvm_partition_guid "E6D6D379-F507-44C2-A23C-238F2A3DF928"
-
     default_partition_tables: &default_partition_tables
       x86_64:
         uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
@@ -188,11 +176,6 @@
                     label: "var"
                     mountpoint: "/var"
                     fstab_options: "defaults"
-
-  disk_sizes:
-    default_required_partition_sizes: &default_required_dir_sizes
-      "/": "1 GiB"
-      "/usr": "2 GiB"
 
   platforms:
     x86_64_bios_platform: &x86_64_bios_platform

--- a/data/distrodefs/rhel-8/imagetypes.yaml
+++ b/data/distrodefs/rhel-8/imagetypes.yaml
@@ -1,4 +1,3 @@
----
 .common:
   ec2_common_pkgset: &ec2_common_pkgset
     include:
@@ -765,11 +764,6 @@
             - "insights-client"
             - "subscription-manager-cockpit"
 
-  disk_sizes:
-    default_required_partition_sizes: &default_required_dir_sizes
-      "/": "1 GiB"
-      "/usr": "2 GiB"
-
   platforms:
     x86_64_uefi_platform: &x86_64_uefi_platform
       arch: "x86_64"
@@ -950,17 +944,6 @@
           iso_boot_type: "syslinux"
 
   partitioning:
-    ids:
-      - &prep_partition_dosid "41"
-      - &filesystem_linux_dosid "83"
-      - &fat16_bdosid "06"
-    guids:
-      - &bios_boot_partition_guid "21686148-6449-6E6F-744E-656564454649"
-      - &efi_system_partition_guid "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
-      - &filesystem_data_guid "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
-      - &xboot_ldr_partition_guid "BC13C2FF-59E6-4262-A352-B275FD6F7172"
-      - &lvm_partition_guid "E6D6D379-F507-44C2-A23C-238F2A3DF928"
-
     partitions:
       - &default_partition_table_part_bios
         size: "1 MiB"

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -1,4 +1,3 @@
----
 .common:
   distro_build_pkgset: &distro_build_pkgset
     include:
@@ -29,11 +28,6 @@
           include:
             - "grub2-ppc64le"
             - "grub2-ppc64le-modules"
-
-  disk_sizes:
-    default_required_partition_sizes: &default_required_dir_sizes
-      "/": "1 GiB"
-      "/usr": "2 GiB"
 
   platforms:
     x86_64_uefi_platform: &x86_64_uefi_platform
@@ -724,18 +718,6 @@
             - "dmidecode"
 
   partitioning:
-    ids:
-      - &prep_partition_dosid "41"
-      - &filesystem_linux_dosid "83"
-      - &fat16_bdosid "06"
-    guids:
-      - &bios_boot_partition_guid "21686148-6449-6E6F-744E-656564454649"
-      - &efi_system_partition_guid "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
-      - &filesystem_data_guid "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
-      - &xboot_ldr_partition_guid "BC13C2FF-59E6-4262-A352-B275FD6F7172"
-      - &lvm_partition_guid "E6D6D379-F507-44C2-A23C-238F2A3DF928"
-      - &root_partition_x86_64_guid "4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709"
-
     partitions:
       - &default_partition_table_part_bios
         size: "1 MiB"

--- a/data/distrodefs/shared/shared.yaml
+++ b/data/distrodefs/shared/shared.yaml
@@ -1,0 +1,18 @@
+.shared:
+  disk_sizes:
+    default_required_partition_sizes: &default_required_dir_sizes
+      "/": "1 GiB"
+      "/usr": "2 GiB"
+
+  partitioning:
+    ids:
+      - &prep_partition_dosid "41"
+      - &filesystem_linux_dosid "83"
+      - &fat16_bdosid "06"
+    guids:
+      - &bios_boot_partition_guid "21686148-6449-6E6F-744E-656564454649"
+      - &efi_system_partition_guid "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+      - &filesystem_data_guid "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
+      - &xboot_ldr_partition_guid "BC13C2FF-59E6-4262-A352-B275FD6F7172"
+      - &lvm_partition_guid "E6D6D379-F507-44C2-A23C-238F2A3DF928"
+      - &root_partition_x86_64_guid "4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709"


### PR DESCRIPTION
[draft as I want to get feedback if this is desired first and if its worth it, it only de-duplicates the absolute minimum right now but there might be not that much more actually. If we consider it not worth it this can be closed, it was mostly a quick brainstorm/experiment]

This commit adds a new `data/distrodefs/shared/shared.yaml` that can be used to share yaml anchors between the various distros.

We have not that much duplicated data but some is the same so de-duplicating it seems nice. The downside is that without the move to `goccy/go-yaml` we need to add hackish code to make it work [1].

[1] See https://github.com/osbuild/images/compare/main...mvo5:images:go-yaml-go for the current showstoppers for this move.