### PR TITLE
distro,manifest: have a single `LoraxTemplates` type

### DIFF
--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -391,13 +391,7 @@ func installerCustomizations(t *imageType, c *blueprint.Customizations) (manifes
 			isc.ISOBoot = *isoboot
 		}
 
-		for _, tmpl := range installerConfig.LoraxTemplates {
-			isc.LoraxTemplates = append(isc.LoraxTemplates, manifest.InstallerLoraxTemplate{
-				Path:        tmpl.Path,
-				AfterDracut: tmpl.AfterDracut,
-			})
-		}
-
+		isc.LoraxTemplates = installerConfig.LoraxTemplates
 		if pkg := installerConfig.LoraxTemplatePackage; pkg != nil {
 			isc.LoraxTemplatePackage = *pkg
 		}

--- a/pkg/distro/installer_config.go
+++ b/pkg/distro/installer_config.go
@@ -28,15 +28,10 @@ type InstallerConfig struct {
 	ISOBootType *manifest.ISOBootType `yaml:"iso_boot_type,omitempty"`
 
 	// Lorax template settings for org.osbuild.lorax stage
-	LoraxTemplates       []InstallerLoraxTemplate `yaml:"lorax_templates,omitempty"`
-	LoraxTemplatePackage *string                  `yaml:"lorax_template_package"`
-	LoraxLogosPackage    *string                  `yaml:"lorax_logos_package"`
-	LoraxReleasePackage  *string                  `yaml:"lorax_release_package"`
-}
-
-type InstallerLoraxTemplate struct {
-	Path        string `yaml:"path"`
-	AfterDracut bool   `yaml:"after_dracut,omitempty"`
+	LoraxTemplates       []manifest.InstallerLoraxTemplate `yaml:"lorax_templates,omitempty"`
+	LoraxTemplatePackage *string                           `yaml:"lorax_template_package"`
+	LoraxLogosPackage    *string                           `yaml:"lorax_logos_package"`
+	LoraxReleasePackage  *string                           `yaml:"lorax_release_package"`
 }
 
 // InheritFrom inherits unset values from the provided parent configuration and

--- a/pkg/manifest/installer.go
+++ b/pkg/manifest/installer.go
@@ -36,6 +36,7 @@ type InstallerCustomizations struct {
 }
 
 type InstallerLoraxTemplate struct {
-	Path        string
-	AfterDracut bool // Should this template be executed after dracut? Defaults to not.
+	Path string `yaml:"path"`
+	// Should this template be executed after dracut? Defaults to not.
+	AfterDracut bool `yaml:"after_dracut,omitempty"`
 }


### PR DESCRIPTION
[maybe this was discussed already and I missed it but when working on https://github.com/osbuild/bootc-image-builder/pull/1066 I ran into this and it seems a target for simpliciation]

We had two identical copies of the LoraxTemplates type, one in distro and one in manifest. This makes working with this type harder as they cannot be assigned and there is also the risk of drift. Given that they are identical lets just merge them.

(c.f. https://github.com/osbuild/images/pull/1949)