### PR TITLE
osbuild/monitor: increase status scanner buffer size to 16MiB

### DIFF
--- a/pkg/osbuild/monitor.go
+++ b/pkg/osbuild/monitor.go
@@ -72,10 +72,10 @@ func NewStatusScanner(r io.Reader) *StatusScanner {
 	scanner := bufio.NewScanner(r)
 	// osbuild can currently generate very long messages, the default
 	// 64kb is too small for e.g. the dracut stage (see also
-	// https://github.com/osbuild/osbuild/issues/1976). Increase for
-	// but to unblock us.
-	buf := make([]byte, 0, 512_000)
-	scanner.Buffer(buf, 512_000)
+	// https://github.com/osbuild/osbuild/issues/1976) and the rpm stage.
+	// Increase for but to unblock us.
+	buf := make([]byte, 0, 1024_000*16)
+	scanner.Buffer(buf, 1024_000*16)
 	return &StatusScanner{
 		scanner:         scanner,
 		contextMap:      make(map[string]*contextJSON),


### PR DESCRIPTION
The size of the status message from the org.osbuild.rpm stage in the os pipeline depends on how many packages a user has requested on top of the base set. As a result, the monitor will always be breakable, but let's increase the buffer size substantially to make it very unlikely that users will hit this.

Especially with the addition of metadata [1], the status entry size grew substantially for rpm stages. The rpm stage has an entry in the metadata for each package that was installed (in addition to a very large output message).

[1]: osbuild/osbuild#2215