### PR TITLE
osbuild: switch from a bufio.Scanner to a bufio.Reader

### DIFF
--- a/pkg/osbuild/monitor.go
+++ b/pkg/osbuild/monitor.go
@@ -69,15 +69,13 @@ type Progress struct {
 // NewStatusScanner returns a StatusScanner that can parse osbuild
 // jsonseq monitor status messages
 func NewStatusScanner(r io.Reader) *StatusScanner {
-	scanner := bufio.NewScanner(r)
-	// osbuild can currently generate very long messages, the default
-	// 64kb is too small for e.g. the dracut stage (see also
-	// https://github.com/osbuild/osbuild/issues/1976) and the rpm stage.
-	// Increase for but to unblock us.
-	buf := make([]byte, 0, 1024_000*16)
-	scanner.Buffer(buf, 1024_000*16)
+	// Note that we use a Reader instead of a Scanner because
+	// the Scanner has a fixed buffer and osbuild can produce
+	// very long log messages, see e.g. PR#1977. The Reader
+	// does not have this limit (but is less convenient to use).
+	reader := bufio.NewReader(r)
 	return &StatusScanner{
-		scanner:         scanner,
+		reader:          reader,
 		contextMap:      make(map[string]*contextJSON),
 		stageContextMap: make(map[string]*stageContextJSON),
 		resultMap:       make(map[string]*resultJSON),
@@ -87,7 +85,9 @@ func NewStatusScanner(r io.Reader) *StatusScanner {
 
 // StatusScanner scan scan the osbuild jsonseq monitor output
 type StatusScanner struct {
-	scanner         *bufio.Scanner
+	reader      *bufio.Reader
+	currentLine []byte
+
 	contextMap      map[string]*contextJSON
 	stageContextMap map[string]*stageContextJSON
 	resultMap       map[string]*resultJSON
@@ -97,16 +97,24 @@ type StatusScanner struct {
 // Status returns a single status struct from the scanner or nil
 // if the end of the status reporting is reached.
 func (sr *StatusScanner) Status() (*Status, error) {
-	if !sr.scanner.Scan() {
-		return nil, sr.scanner.Err()
-	}
-
 	var status statusJSON
-	line := sr.scanner.Bytes()
+	line, err := sr.reader.ReadBytes('\n')
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	// handle the case where we have a (final) line without a \n, here we
+	// get a EOF but still have line content to process before we can exit
+	// Note that we have not seen this in practise, its for compat with the
+	// previous bufio.Scanner implementation that had this behavior.
+	if err == io.EOF && len(line) == 0 {
+		return nil, nil
+	}
 	line = bytes.Trim(line, "\x1e")
 	if err := json.Unmarshal(line, &status); err != nil {
 		return nil, fmt.Errorf("cannot scan line %q: %w", line, err)
 	}
+	sr.currentLine = line
+
 	// keep track of the context
 	id := status.Context.ID
 	context := sr.contextMap[id]
@@ -181,9 +189,7 @@ func (sr *StatusScanner) Status() (*Status, error) {
 func (sr *StatusScanner) Result() (*Result, error) {
 	// attempt to capture validation errors first
 	var valRes Result
-	line := sr.scanner.Bytes()
-	line = bytes.Trim(line, "\x1e")
-	if err := json.Unmarshal(line, &valRes); err == nil {
+	if err := json.Unmarshal(sr.currentLine, &valRes); err == nil {
 		if valRes.Type == "https://osbuild.org/validation-error" {
 			return &valRes, nil
 		}

--- a/pkg/osbuild/monitor_test.go
+++ b/pkg/osbuild/monitor_test.go
@@ -124,7 +124,7 @@ func TestScannerSmoke(t *testing.T) {
 func TestScannerVeryLongLines(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	fmt.Fprint(buf, `{"message": "`)
-	fmt.Fprint(buf, strings.Repeat("1", 128_000))
+	fmt.Fprint(buf, strings.Repeat("1", 16*1024*1024))
 	fmt.Fprint(buf, `"}`)
 
 	r := bytes.NewBufferString(buf.String())
@@ -132,7 +132,7 @@ func TestScannerVeryLongLines(t *testing.T) {
 	st, err := scanner.Status()
 	assert.NoError(t, err)
 	require.NotNil(t, st)
-	assert.Equal(t, 128_000, len(st.Trace))
+	assert.Equal(t, 16*1024*1024, len(st.Trace))
 }
 
 //go:embed testdata/monitor-duration.seq.json


### PR DESCRIPTION
It seems we hit more and more issues with the choice of using a bufio.Scanner. Switching to a bufio.Reader is slightly less convenient but it has no arbitrary limit, so maybe its worth the extra code. This commit switches from Scanner->Reader.

C.f. https://github.com/osbuild/images/pull/1977