### PR TITLE
distrodefs: add new (hidden) bootc-rpm-installer imgtype

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -2297,3 +2297,123 @@ image_types:
       - *x86_64_bios_platform
       - *aarch64_platform
     supported_blueprint_options: *supported_options_pxe
+
+  "bootc-rpm-installer":
+    # Note that this image type is partial and only used by
+    # bootc-image-builder not by the "images" library directly. We
+    # still keep the config here so that there is a single place for
+    # all imagetype configs.
+    installer_config: *default_installer_config
+    package_sets:
+      installer:
+        - include:
+            - aajohan-comfortaa-fonts
+            - abattis-cantarell-fonts
+            - alsa-firmware
+            - alsa-tools-firmware
+            - anaconda
+            - anaconda-dracut
+            - anaconda-install-img-deps
+            - anaconda-widgets
+            - atheros-firmware
+            - audit
+            - bind-utils
+            - bitmap-fangsongti-fonts
+            - brcmfmac-firmware
+            - bzip2
+            - cryptsetup
+            - curl
+            - dbus-x11
+            - dejavu-sans-fonts
+            - dejavu-sans-mono-fonts
+            - device-mapper-persistent-data
+            - dmidecode
+            - dnf
+            - dracut-config-generic
+            - dracut-network
+            - efibootmgr
+            - ethtool
+            - fcoe-utils
+            - ftp
+            - gdb-gdbserver
+            - gdisk
+            - glibc-all-langpacks
+            - gnome-kiosk
+            - google-noto-sans-cjk-ttc-fonts
+            - grub2-tools
+            - grub2-tools-extra
+            - grub2-tools-minimal
+            - grubby
+            - gsettings-desktop-schemas
+            - hdparm
+            - hexedit
+            - hostname
+            - initscripts
+            - ipmitool
+            - iwlwifi-dvm-firmware
+            - iwlwifi-mvm-firmware
+            - jomolhari-fonts
+            - kbd
+            - kbd-misc
+            - kdump-anaconda-addon
+            - kernel
+            - khmeros-base-fonts
+            - less
+            - libblockdev-lvm-dbus
+            - libibverbs
+            - libreport-plugin-bugzilla
+            - libreport-plugin-reportuploader
+            - librsvg2
+            - linux-firmware
+            - lldpad
+            - lsof
+            - madan-fonts
+            - mt-st
+            - mtr
+            - net-tools
+            - nfs-utils
+            - nm-connection-editor
+            - nmap-ncat
+            - nss-tools
+            - openssh-clients
+            - openssh-server
+            - ostree
+            - pciutils
+            - perl-interpreter
+            - pigz
+            - plymouth
+            - prefixdevname
+            - python3-pyatspi
+            - rdma-core
+            - realtek-firmware
+            - rit-meera-new-fonts
+            - rng-tools
+            - rpcbind
+            - rpm-ostree
+            - rsync
+            - rsyslog
+            - selinux-policy-targeted
+            - sg3_utils
+            - sil-abyssinica-fonts
+            - sil-padauk-fonts
+            - smartmontools
+            - spice-vdagent
+            - strace
+            - systemd
+            - tar
+            - tigervnc-server-minimal
+            - tigervnc-server-module
+            - udisks2
+            - udisks2-iscsi
+            - usbutils
+            - vim-minimal
+            - volume_key
+            - wget
+            - xfsdump
+            - xfsprogs
+            - xorg-x11-drivers
+            - xorg-x11-fonts-misc
+            - xorg-x11-server-Xorg
+            - xorg-x11-xauth
+            - xrdb
+            - xz

--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -2272,3 +2272,104 @@ image_types:
       - *x86_64_bios_platform
       - *aarch64_platform
     supported_blueprint_options: *supported_options_pxe
+
+  "bootc-rpm-installer":
+    # Note that this image type is partial and only used by
+    # bootc-image-builder not by the "images" library directly. We
+    # still keep the config here so that there is a single place for
+    # all imagetype configs.
+    installer_config: *default_installer_config
+    package_sets:
+      installer:
+        - include:
+            - "@hardware-support"
+            - alsa-firmware
+            - alsa-tools-firmware
+            - anaconda
+            - anaconda-dracut
+            - anaconda-install-img-deps
+            - anaconda-widgets
+            - audit
+            - bind-utils
+            - bzip2
+            - cryptsetup
+            - curl
+            - dbus-x11
+            - dejavu-sans-fonts
+            - dejavu-sans-mono-fonts
+            - device-mapper-persistent-data
+            - dmidecode
+            - dnf
+            - dracut-config-generic
+            - dracut-network
+            - efibootmgr
+            - ethtool
+            - fcoe-utils
+            - ftp
+            - gdb-gdbserver
+            - glibc-all-langpacks
+            - gnome-kiosk
+            - google-noto-sans-cjk-ttc-fonts
+            - grub2-tools
+            - grub2-tools-extra
+            - grub2-tools-minimal
+            - grubby
+            - gsettings-desktop-schemas
+            - hdparm
+            - hexedit
+            - hostname
+            - initscripts
+            - ipmitool
+            - jomolhari-fonts
+            - kbd
+            - kbd-misc
+            - kdump-anaconda-addon
+            - kernel
+            - less
+            - libblockdev-lvm-dbus
+            - libibverbs
+            - librsvg2
+            - linux-firmware
+            - lldpad
+            - lsof
+            - madan-fonts
+            - mt-st
+            - mtr
+            - net-tools
+            - nfs-utils
+            - nm-connection-editor
+            - nmap-ncat
+            - nss-tools
+            - openssh-clients
+            - openssh-server
+            - ostree
+            - pciutils
+            - perl-interpreter
+            - pigz
+            - plymouth
+            - prefixdevname
+            - python3-pyatspi
+            - rdma-core
+            - rng-tools
+            - rpcbind
+            - rpm-ostree
+            - rsync
+            - rsyslog
+            - selinux-policy-targeted
+            - sg3_utils
+            - sil-padauk-fonts
+            - smartmontools
+            - spice-vdagent
+            - strace
+            - systemd
+            - tar
+            - udisks2
+            - udisks2-iscsi
+            - usbutils
+            - vim-minimal
+            - volume_key
+            - wget
+            - xfsdump
+            - xfsprogs
+            - xrdb
+            - xz

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -3343,3 +3343,119 @@ image_types:
       - *x86_64_bios_platform
       - *aarch64_platform
     supported_blueprint_options: *supported_options_pxe
+
+  "bootc-rpm-installer":
+    # Note that this image type is partial and only used by
+    # bootc-image-builder not by the "images" library directly. We
+    # still keep the config here so that there is a single place for
+    # all imagetype configs.
+    installer_config: *default_installer_config
+    package_sets:
+      installer:
+        - include:
+            # This is the same set as the Fedora one, but without packages not available in CentOS/RHEL:
+            # atheros-firmware, brcmfmac-firmware, iwlwifi-dvm-firmware, iwlwifi-mvm-firmware, realtek-firmware, rit-meera-new-fonts
+            - aajohan-comfortaa-fonts
+            - abattis-cantarell-fonts
+            - alsa-firmware
+            - alsa-tools-firmware
+            - anaconda
+            - anaconda-dracut
+            - anaconda-install-env-deps
+            - anaconda-widgets
+            - audit
+            - bind-utils
+            - bitmap-fangsongti-fonts
+            - bzip2
+            - cryptsetup
+            - curl
+            - dbus-x11
+            - dejavu-sans-fonts
+            - dejavu-sans-mono-fonts
+            - device-mapper-persistent-data
+            - dmidecode
+            - dnf
+            - dracut-config-generic
+            - dracut-network
+            - efibootmgr
+            - ethtool
+            - fcoe-utils
+            - ftp
+            - gdb-gdbserver
+            - gdisk
+            - glibc-all-langpacks
+            - gnome-kiosk
+            - google-noto-sans-cjk-ttc-fonts
+            - grub2-tools
+            - grub2-tools-extra
+            - grub2-tools-minimal
+            - grubby
+            - gsettings-desktop-schemas
+            - hdparm
+            - hexedit
+            - hostname
+            - initscripts
+            - ipmitool
+            - jomolhari-fonts
+            - kbd
+            - kbd-misc
+            - kdump-anaconda-addon
+            - kernel
+            - khmeros-base-fonts
+            - less
+            - libblockdev-lvm-dbus
+            - libibverbs
+            - libreport-plugin-bugzilla
+            - libreport-plugin-reportuploader
+            - librsvg2
+            - linux-firmware
+            - lldpad
+            - lsof
+            - madan-fonts
+            - mt-st
+            - mtr
+            - net-tools
+            - nfs-utils
+            - nm-connection-editor
+            - nmap-ncat
+            - nss-tools
+            - openssh-clients
+            - openssh-server
+            - ostree
+            - pciutils
+            - perl-interpreter
+            - pigz
+            - plymouth
+            - prefixdevname
+            - python3-pyatspi
+            - rdma-core
+            - rng-tools
+            - rpcbind
+            - rpm-ostree
+            - rsync
+            - rsyslog
+            - selinux-policy-targeted
+            - sg3_utils
+            - sil-abyssinica-fonts
+            - sil-padauk-fonts
+            - smartmontools
+            - spice-vdagent
+            - strace
+            - systemd
+            - tar
+            - tigervnc-server-minimal
+            - tigervnc-server-module
+            - udisks2
+            - udisks2-iscsi
+            - usbutils
+            - vim-minimal
+            - volume_key
+            - wget
+            - xfsdump
+            - xfsprogs
+            - xorg-x11-drivers
+            - xorg-x11-fonts-misc
+            - xorg-x11-server-Xorg
+            - xorg-x11-xauth
+            - xrdb
+            - xz


### PR DESCRIPTION
This commits adds a new `bootc-rpm-installer` image type that contains only the rpm packages lists and installer config for now so that bootc-image-builder can use the images library to get what rpm package it needs to install to build a bootable ISO.

The advantage is that we can retire the code in bib that the YAML loading for the pacakge lists and that we have one central location when we need to update image definitions. The other advantage is that all the syntax for conditions on the exact version works.

Note that this image type is not visible by default because the loader will skip image types that have no filename set.

This is used by https://github.com/osbuild/bootc-image-builder/pull/1066