### PR TITLE
various: fix `make gh-action-test` and update README

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -9,9 +9,7 @@ WORKDIR /setup
 COPY ./test/scripts ./test/scripts/
 COPY Schutzfile .
 RUN ./test/scripts/setup-osbuild-repo
-
-# NOTE: keep in sync with README.md#Contributing
-RUN dnf -y install krb5-devel go gpgme-devel osbuild-depsolve-dnf btrfs-progs-devel device-mapper-devel
+RUN ./test/scripts/install-dependencies
 
 COPY go.mod go.sum .
 RUN go mod download

--- a/README.md
+++ b/README.md
@@ -48,12 +48,20 @@ required.
 
 #### Build requirements
 
-The build-requirements of the Go library for Fedora and rpm-based distributions are:
+The build-requirements of the Go library for Fedora and rpm-based
+distributions can be installed with:
+
+```console
+sudo ./test/scripts/install-dependencies
+```
+
+(see also [`Containerfile`](Containerfile) )
+
+The minimal dependencies are:
 
 - `go`
 - `gpgme-devel`
-
-(see also [`Containerfile`](Containerfile) )
+- `libvirt-devel`
 
 Other dependencies only needed in some cases are:
 


### PR DESCRIPTION
We have the new `./test/scripts/install-dependencies` helper that centralizes the installation of the build dependencies. So use it in the Containerfile and update the README to point to it.