### PR TITLE
boot: estimate container size for OCI archives

### DIFF
--- a/pkg/distro/bootc/util.go
+++ b/pkg/distro/bootc/util.go
@@ -2,17 +2,76 @@ package bootc
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 )
 
+// podmanInspectFunc is a function type for executing podman image inspect commands.
+// This allows the function to be mocked in tests.
+type podmanInspectFunc func(name string, args ...string) ([]byte, error)
+
+// defaultPodmanInspect is the default implementation that executes podman commands.
+var defaultPodmanInspect podmanInspectFunc = func(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// podmanInspect is the function used to execute podman commands. It can be overridden in tests.
+var podmanInspect = defaultPodmanInspect
+
+// statFunc is a function type for getting file info.
+// This allows the function to be mocked in tests.
+type statFunc func(name string) (os.FileInfo, error)
+
+// defaultStat is the default implementation that uses os.Stat.
+var defaultStat statFunc = os.Stat
+
+// fileStat is the function used to get file info. It can be overridden in tests.
+var fileStat = defaultStat
+
+// isOCIArchive checks if the container reference is an OCI archive and extracts the file path.
+// It handles the following formats:
+//   - oci-archive:/path/to/file.tar
+//   - oci-archive:///path/to/file.tar
+//
+// Returns ok=true if the reference is an OCI archive along with the file path.
+// Returns ok=false if the reference is not an OCI archive, with an empty path.
+func isOCIArchive(ref string) (ok bool, path string) {
+	if path, hadPrefix := strings.CutPrefix(ref, "oci-archive:"); hadPrefix {
+		// Handle oci-archive:// prefix (three slashes)
+		path = strings.TrimPrefix(path, "//")
+		// If it's a relative path without ./ prefix, add it
+		if !strings.HasPrefix(path, "/") && !strings.HasPrefix(path, "./") {
+			path = "./" + path
+		}
+		return true, path
+	}
+	// Not an OCI archive
+	return false, ""
+}
+
 // getContainerSize returns the size of an already pulled container image in bytes
 func getContainerSize(imgref string) (uint64, error) {
-	output, err := exec.Command("podman", "image", "inspect", imgref, "--format", "{{.Size}}").Output()
+	// Podman inspect does not work for OCI archives, let's do estimation instead
+	if ok, path := isOCIArchive(imgref); ok {
+		// Get file size directly for OCI archive
+		fileInfo, err := fileStat(path)
+		if err != nil {
+			return 0, fmt.Errorf("failed to stat OCI archive: %w", err)
+		}
+
+		// Typical compression ratio for OCI archives is 2x
+		// #nosec G115
+		return uint64(fileInfo.Size()) * 2, nil
+	}
+
+	// For regular images, use podman to inspect
+	output, err := podmanInspect("podman", "image", "inspect", imgref, "--format", "{{.Size}}")
 	if err != nil {
 		return 0, fmt.Errorf("failed inspect image: %w, output\n%s", err, output)
 	}
+
 	size, err := strconv.ParseUint(strings.TrimSpace(string(output)), 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("cannot parse image size: %w", err)

--- a/pkg/distro/bootc/util_test.go
+++ b/pkg/distro/bootc/util_test.go
@@ -1,0 +1,203 @@
+package bootc
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsOCIArchive(t *testing.T) {
+	testCases := []struct {
+		name         string
+		ref          string
+		expected     bool
+		expectedPath string
+	}{
+		{
+			name:         "oci-archive with single slash",
+			ref:          "oci-archive:/path/to/file.tar",
+			expected:     true,
+			expectedPath: "/path/to/file.tar",
+		},
+		{
+			name:         "oci-archive with triple slash",
+			ref:          "oci-archive:///path/to/file.tar",
+			expected:     true,
+			expectedPath: "/path/to/file.tar",
+		},
+		{
+			name:         "oci-archive with relative path",
+			ref:          "oci-archive:./file.tar",
+			expected:     true,
+			expectedPath: "./file.tar",
+		},
+		{
+			name:         "oci-archive with relative path without prefix",
+			ref:          "oci-archive:file.tar",
+			expected:     true,
+			expectedPath: "./file.tar",
+		},
+		{
+			name:         "regular container image",
+			ref:          "quay.io/example/image:latest",
+			expected:     false,
+			expectedPath: "",
+		},
+		{
+			name:         "docker image reference",
+			ref:          "docker://quay.io/example/image:latest",
+			expected:     false,
+			expectedPath: "",
+		},
+		{
+			name:         "plain file path without prefix",
+			ref:          "/path/to/file.tar",
+			expected:     false,
+			expectedPath: "",
+		},
+		{
+			name:         "relative file path without prefix",
+			ref:          "./file.tar",
+			expected:     false,
+			expectedPath: "",
+		},
+		{
+			name:         "empty string",
+			ref:          "",
+			expected:     false,
+			expectedPath: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, path := isOCIArchive(tc.ref)
+			assert.Equal(t, tc.expected, ok, "Expected ok=%v, got ok=%v", tc.expected, ok)
+			assert.Equal(t, tc.expectedPath, path, "Expected path=%q, got path=%q", tc.expectedPath, path)
+		})
+	}
+}
+
+func TestGetContainerSize(t *testing.T) {
+	// Save original functions to restore after tests
+	originalPodmanInspect := podmanInspect
+	originalFileStat := fileStat
+	defer func() {
+		podmanInspect = originalPodmanInspect
+		fileStat = originalFileStat
+	}()
+
+	t.Run("OCI archive success", func(t *testing.T) {
+		// Mock fileStat to return a file with known size
+		fileStat = func(name string) (os.FileInfo, error) {
+			return mockFileInfo{size: 1000}, nil
+		}
+
+		size, err := getContainerSize("oci-archive:/path/to/file.tar")
+		assert.NoError(t, err)
+		// Should return 2x the file size (compression ratio)
+		assert.Equal(t, uint64(2000), size)
+	})
+
+	t.Run("OCI archive with triple slash", func(t *testing.T) {
+		fileStat = func(name string) (os.FileInfo, error) {
+			return mockFileInfo{size: 500}, nil
+		}
+
+		size, err := getContainerSize("oci-archive:///path/to/file.tar")
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(1000), size)
+	})
+
+	t.Run("OCI archive stat error", func(t *testing.T) {
+		fileStat = func(name string) (os.FileInfo, error) {
+			return nil, errors.New("file not found")
+		}
+
+		size, err := getContainerSize("oci-archive:/path/to/file.tar")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to stat OCI archive")
+		assert.Equal(t, uint64(0), size)
+	})
+
+	t.Run("OCI archive relative path", func(t *testing.T) {
+		fileStat = func(name string) (os.FileInfo, error) {
+			assert.Equal(t, "./file.tar", name)
+			return mockFileInfo{size: 750}, nil
+		}
+
+		size, err := getContainerSize("oci-archive:file.tar")
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(1500), size)
+	})
+
+	t.Run("regular container image success", func(t *testing.T) {
+		// Mock podmanInspect to return a valid size
+		podmanInspect = func(name string, args ...string) ([]byte, error) {
+			assert.Equal(t, "podman", name)
+			return []byte("1073741824\n"), nil // 1GB
+		}
+
+		size, err := getContainerSize("quay.io/example/image:latest")
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(1073741824), size)
+	})
+
+	t.Run("regular container image with whitespace", func(t *testing.T) {
+		podmanInspect = func(name string, args ...string) ([]byte, error) {
+			return []byte("  2048  \n"), nil
+		}
+
+		size, err := getContainerSize("quay.io/example/image:latest")
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(2048), size)
+	})
+
+	t.Run("regular container image inspect error", func(t *testing.T) {
+		podmanInspect = func(name string, args ...string) ([]byte, error) {
+			return []byte("error output"), errors.New("podman command failed")
+		}
+
+		size, err := getContainerSize("quay.io/example/image:latest")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed inspect image")
+		assert.Equal(t, uint64(0), size)
+	})
+
+	t.Run("regular container image parse error", func(t *testing.T) {
+		podmanInspect = func(name string, args ...string) ([]byte, error) {
+			return []byte("not a number"), nil
+		}
+
+		size, err := getContainerSize("quay.io/example/image:latest")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot parse image size")
+		assert.Equal(t, uint64(0), size)
+	})
+
+	t.Run("regular container image empty output", func(t *testing.T) {
+		podmanInspect = func(name string, args ...string) ([]byte, error) {
+			return []byte(""), nil
+		}
+
+		size, err := getContainerSize("quay.io/example/image:latest")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot parse image size")
+		assert.Equal(t, uint64(0), size)
+	})
+}
+
+// mockFileInfo is a mock implementation of os.FileInfo for testing
+type mockFileInfo struct {
+	size int64
+}
+
+func (m mockFileInfo) Name() string       { return "mock" }
+func (m mockFileInfo) Size() int64        { return m.size }
+func (m mockFileInfo) Mode() os.FileMode  { return 0 }
+func (m mockFileInfo) ModTime() time.Time { return time.Time{} }
+func (m mockFileInfo) IsDir() bool        { return false }
+func (m mockFileInfo) Sys() interface{}   { return nil }


### PR DESCRIPTION
Podman inspect does not work for OCI archives, let's do estimation instead by assuming a typical compression ratio of 2x.

---

I know this is a bit crazy, but currently I cannot build bootable container images from OCI archives and I would love to. I want to confirm this works since osbuild itself support that. If that is confirmed, then it makes bootc support in composer much easier as we only need to transfer one (or two or three) OCI files from worker to the executor and put them into osbuild cache/store.

Since I am assuming the "suggested" image size is only a "guess", I am proposing to do times two. I checked the size of CentOS10 Stream and the compression ratio is 45% (1.4 GiB vs 800 MiB). User should be able to override if needed.

For the record, the detected size is also multiplied with an extra 2 so in total the disk size for CentOS 10 Stream bootable container will be 800 MiB * 2 * 2 = 3.2 GiB (with 1.4 of installed data) which sounds quite sane.

The problem this patch should solve:

```
lzap@dev:~$ ibcli manifest qcow2 --bootc-ref=oci-archive:/var/tmp/centos-bootc-stream10.tar:stream10
WARNING: bootc support is experimental
error: cannot get container size: failed inspect image: exit status 125, output
```

The root cause is that podman does not support inspecting OCI archives:

```
lzap@dev:~$ podman image inspect quay.io/centos-bootc/centos-bootc:stream10 --format '{{ .Size }}'
1539497738

lzap@dev:~$ podman image inspect oci-archive:/var/tmp/centos-bootc-stream10.tar:stream10
Error: unsupported transport "oci-archive" for looking up local images
```

Edit: Rebased (added a unit test)