### PR TITLE
depsolvednf: Check for empty depsolve executable string

### DIFF
--- a/pkg/depsolvednf/depsolvednf.go
+++ b/pkg/depsolvednf/depsolvednf.go
@@ -919,7 +919,7 @@ func run(dnfJsonCmd []string, req *Request, stderr io.Writer) ([]byte, error) {
 	if len(dnfJsonCmd) == 0 {
 		dnfJsonCmd = []string{findDepsolveDnf()}
 	}
-	if len(dnfJsonCmd) == 0 {
+	if len(dnfJsonCmd) == 0 || len(dnfJsonCmd[0]) == 0 {
 		return nil, fmt.Errorf("osbuild-depsolve-dnf command undefined")
 	}
 	ex := dnfJsonCmd[0]


### PR DESCRIPTION
Improve the error message when no osbuild-depsolve-dnf is installed. Without this check the error looks like:

error: error depsolving: running osbuild-depsolve-dnf failed:
starting  failed: exec: no command

Which is a bit unclear. With this extra check the error looks like:

error: error depsolving: running osbuild-depsolve-dnf failed:
osbuild-depsolve-dnf command undefined