### PR TITLE
test: drop distro,arch,image-type args from boot-image

### DIFF
--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -229,21 +229,18 @@ def boot_wsl(distro, arch, image_path, config):
 def main():
     desc = "Boot an image in the cloud environment it is built for and validate the configuration"
     parser = argparse.ArgumentParser(description=desc)
-    parser.add_argument("distro", type=str, default=None, help="distro for the image to boot test")
-    parser.add_argument("arch", type=str, default=None, help="architecture of the image to boot test")
-    parser.add_argument("image_type", type=str, default=None, help="type of the image to boot test")
     parser.add_argument("image_search_path", type=str, help="path to search for image file")
 
     args = parser.parse_args()
-    distro = args.distro
-    arch = args.arch
-    image_type = args.image_type
     search_path = args.image_search_path
 
     image_path = testlib.find_image_file(search_path)
     build_info = testlib.read_build_info(search_path)
     build_config_name = build_info["config"]
     build_config_path = f"test/configs/{build_config_name}.json"
+    distro = build_info["distro"]
+    arch = build_info["arch"]
+    image_type = build_info["image-type"]
 
     print(f"Testing image at {image_path}")
     bib_image_id = ""

--- a/test/scripts/generate-build-config
+++ b/test/scripts/generate-build-config
@@ -14,7 +14,7 @@ build/{distro}/{arch}/{image_type}/{config_name}:
     - sudo ./test/scripts/setup-osbuild-repo
     - sudo ./test/scripts/install-dependencies
     - ./test/scripts/build-image "{distro}" "{image_type}" "{config}"
-    - ./test/scripts/boot-image "{distro}" "{arch}" "{image_type}" "{image_path}"
+    - ./test/scripts/boot-image "{image_path}"
     - ./test/scripts/upload-results "{distro}" "{image_type}" "{config}"
   extends: .terraform
   variables:

--- a/test/scripts/generate-ostree-build-config
+++ b/test/scripts/generate-ostree-build-config
@@ -16,7 +16,7 @@ build/{distro}/{arch}/{image_type}/{config_name}:
     - {dl_container}
     - {start_container}
     - ./test/scripts/build-image "{distro}" "{image_type}" "{config}"
-    - ./test/scripts/boot-image "{distro}" "{arch}" "{image_type}" "{image_path}"
+    - ./test/scripts/boot-image "{image_path}"
     - ./test/scripts/upload-results "{distro}" "{image_type}" "{config}"
   extends: .terraform
   variables:


### PR DESCRIPTION
Passing the `image_path` to the boot-image script is enough, all the other data is already encoded in the `build.info` file that is part of the `image_path`. This makes running this manually now that we have qemu based testing much nicer.