### PR TITLE
[wip] distro,image: add support for unattended installs in network-installer

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -2275,6 +2275,7 @@ image_types:
             - *aarch64_installer_platform
     supported_blueprint_options:
       - "distro"
+      - "customizations.installer.unattended"
       - "customizations.fips"
       - "customizations.locale"
 

--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -2271,6 +2271,7 @@ image_types:
             - "restore"
     supported_blueprint_options:
       - "distro"
+      - "customizations.installer.unattended"
       - "customizations.fips"
       - "customizations.locale"
 

--- a/data/distrodefs/rhel-8/imagetypes.yaml
+++ b/data/distrodefs/rhel-8/imagetypes.yaml
@@ -2962,5 +2962,6 @@ image_types:
             - "perl-interpreter"
     supported_blueprint_options:
       - "distro"
+      - "customizations.installer.unattended"
       - "customizations.fips"
       - "customizations.locale"

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -3342,6 +3342,7 @@ image_types:
             - "spice-vdagent"
     supported_blueprint_options:
       - "distro"
+      - "customizations.installer.unattended"
       - "customizations.fips"
       - "customizations.locale"
 


### PR DESCRIPTION
This is generally useful but also required if we want to do an automatic network-installer test.