### PR TITLE
distro: fix bootc default filesystem handling when missing

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/osbuild/images/pkg/depsolvednf"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/bootc"
+	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/distrofactory"
 	"github.com/osbuild/images/pkg/experimentalflags"
 	"github.com/osbuild/images/pkg/manifest"
@@ -534,19 +535,19 @@ func main() {
 			buildBootcRef = l[1]
 		}
 
-		distribution, err := bootc.NewBootcDistro(bootcRef)
+		distribution, err := bootc.NewBootcDistro(bootcRef, nil)
+		if err != nil && errors.Is(err, defs.ErrNoDefaultFs) {
+			// XXX: consider making this configurable but for now
+			// we just need diffable manifests
+			distribution, err = bootc.NewBootcDistro(bootcRef, &bootc.DistroOptions{
+				DefaultFs: "ext4",
+			})
+		}
 		if err != nil {
 			panic(err)
 		}
 		if buildBootcRef != "" {
 			if err := distribution.SetBuildContainer(buildBootcRef); err != nil {
-				panic(err)
-			}
-		}
-		// XXX: consider making this configurable but for now
-		// we just need diffable manifests
-		if distribution.DefaultFs() == "" {
-			if err := distribution.SetDefaultFs("ext4"); err != nil {
 				panic(err)
 			}
 		}

--- a/pkg/distro/bootc/export_test.go
+++ b/pkg/distro/bootc/export_test.go
@@ -19,13 +19,17 @@ var (
 )
 
 func NewTestBootcDistro() *BootcDistro {
+	return NewTestBootcDistroWithDefaultFs("xfs")
+}
+
+func NewTestBootcDistroWithDefaultFs(defaultFs string) *BootcDistro {
 	info := &osinfo.Info{
 		OSRelease: osinfo.OSRelease{
 			ID:        "bootc-test",
 			VersionID: "1",
 		},
 	}
-	return common.Must(newBootcDistroAfterIntrospect("x86_64", info, "quay.io/example/example:ref", "xfs", 0))
+	return common.Must(newBootcDistroAfterIntrospect("x86_64", info, "quay.io/example/example:ref", defaultFs, 0))
 }
 
 func NewTestBootcImageType() *BootcImageType {

--- a/pkg/distro/bootc/image_test.go
+++ b/pkg/distro/bootc/image_test.go
@@ -348,9 +348,10 @@ func TestGenPartitionTableSetsRootfsForAllFilesystemsXFS(t *testing.T) {
 func TestGenPartitionTableSetsRootfsForAllFilesystemsBtrfs(t *testing.T) {
 	rng := createRand()
 
-	imgType := bootc.NewTestBootcImageType()
-	err := imgType.Arch().Distro().(*bootc.BootcDistro).SetDefaultFs("btrfs")
+	d := bootc.NewTestBootcDistroWithDefaultFs("btrfs")
+	it, err := common.Must(d.GetArch("x86_64")).GetImageType("qcow2")
 	assert.NoError(t, err)
+	imgType := it.(*bootc.BootcImageType)
 	cus := &blueprint.Customizations{}
 	rootfsMinSize := uint64(0)
 	pt, err := imgType.GenPartitionTable(cus, rootfsMinSize, rng)
@@ -359,9 +360,9 @@ func TestGenPartitionTableSetsRootfsForAllFilesystemsBtrfs(t *testing.T) {
 	mnt, _ := findMountableSizeableFor(pt, "/")
 	assert.Equal(t, "btrfs", mnt.GetFSType())
 
-	// btrfs has a default (xfs) /boot
+	// btrfs has a default (ext4) /boot
 	mnt, _ = findMountableSizeableFor(pt, "/boot")
-	assert.Equal(t, "xfs", mnt.GetFSType())
+	assert.Equal(t, "ext4", mnt.GetFSType())
 
 	// ESP is always vfat
 	mnt, _ = findMountableSizeableFor(pt, "/boot/efi")

--- a/pkg/distro/bootc/integration_test.go
+++ b/pkg/distro/bootc/integration_test.go
@@ -66,7 +66,7 @@ func TestBuildContainerHandling(t *testing.T) {
 
 	for _, withBuildContainer := range []bool{true, false} {
 		t.Run(fmt.Sprintf("build-cnt:%v", withBuildContainer), func(t *testing.T) {
-			distri, err := bootc.NewBootcDistro(imgTag)
+			distri, err := bootc.NewBootcDistro(imgTag, nil)
 			require.NoError(t, err)
 			if withBuildContainer {
 				err = distri.SetBuildContainer(buildImgTag)
@@ -129,7 +129,7 @@ partition_table:
 
 	for _, withBuildContainer := range []bool{true, false} {
 		t.Run(fmt.Sprintf("build-cnt:%v", withBuildContainer), func(t *testing.T) {
-			distri, err := bootc.NewBootcDistro(imgTag)
+			distri, err := bootc.NewBootcDistro(imgTag, nil)
 			require.NoError(t, err)
 			if withBuildContainer {
 				err = distri.SetBuildContainer(buildImgTag)

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -438,7 +438,7 @@ image_types:
 	restore := defs.MockDataFS(baseDir)
 	defer restore()
 	_, err := defs.NewDistroYAML("test-distro-1")
-	assert.EqualError(t, err, `mount "/" requires a default filesystem for the distribution but none set`)
+	assert.EqualError(t, err, `no default fs set: mount "/" requires a filesystem but none set`)
 }
 
 var fakeImageTypesYaml = `

--- a/pkg/osbuild/mkfs_stage.go
+++ b/pkg/osbuild/mkfs_stage.go
@@ -72,7 +72,7 @@ func GenFsStages(pt *disk.PartitionTable, filename string, soucePipeline string)
 
 				stages = append(stages, NewMkfsExt4Stage(options, stageDevices))
 			default:
-				panic(fmt.Sprintf("unknown fs type: %s", e.GetFSType()))
+				panic(fmt.Sprintf("unknown fs type: %s for %s", e.GetFSType(), e.GetMountpoint()))
 			}
 
 			if mkfsOptions.Geometry != nil {

--- a/pkg/osbuild/mkfs_stages_test.go
+++ b/pkg/osbuild/mkfs_stages_test.go
@@ -515,13 +515,14 @@ func TestGenFsStagesUnhappy(t *testing.T) {
 		Partitions: []disk.Partition{
 			{
 				Payload: &disk.Filesystem{
-					Type: "ext2",
+					Type:       "ext2",
+					Mountpoint: "/",
 				},
 			},
 		},
 	}
 
-	assert.PanicsWithValue(t, "unknown fs type: ext2", func() {
+	assert.PanicsWithValue(t, "unknown fs type: ext2 for /", func() {
 		GenFsStages(pt, "file.img", "build")
 	})
 }


### PR DESCRIPTION
[this will unblock https://github.com/osbuild/image-builder-cli/pull/324]

We need a way to
a) set the bootc default filesystem
b) detect when its unset and provide a clear error

This commit fixes both issue, we had a way to setup the default filesystem but that is now applied too late because we now share the partition table loading with the generic image types which have no concept of an empty default. So this moves the default-fs setting into the `bootc.NewBootcDistro()` as a new `DistroOptions` struct.

It also adds a proper error type for when no default-fs is set, this way ibcli can detect this and pick a default on its own (this is what Achilleas suggested in [0]).

There is also a bugfix in setupDefaultFS() so that we do not switch to "btrfs" on the /boot partition. This is the wrong layer to know about /boot and details like this, we will need a followup that moves this into disk instead.

[0] https://github.com/osbuild/image-builder-cli/pull/324#issuecomment-3455685910