### PR TITLE
pyproject: add empty py-modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,4 @@ dependencies = [
 
 [tool.setuptools]
 packages = []
+py-modules = []


### PR DESCRIPTION
We need the pyproject.toml so that we can pull in
the vmtest dependencies. However this brings its own issues as pip/setuptools are usually used for real python packages not to bring in dependencies and this commit (hopefully) fixes one more fallout from that.

There is a strange error from pip in [0]:
```
Run pip install .
WARNING: The directory '/github/home/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
Processing /__w/images/images
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [14 lines of output]
      error: Multiple top-level packages discovered in a flat-layout: ['cmd', 'pkg', 'data', 'internal', 'schutzbot'].

      To avoid accidental inclusion of unwanted files or directories,
      setuptools will not proceed with this build.

      If you are trying to create a single distribution with multiple packages
      on purpose, you should not rely on automatic discovery.
      Instead, consider the following options:

      1. set up custom discovery (`find` directive with `include` or `exclude`)
      2. use a `src-layout`
      3. explicitly set `py_modules` or `packages` with a list of names

      To find more information, look for "package discovery" on setuptools docs.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
Error: Process completed with exit code 1.
```

I cannot reproduce this locally but I suspect we need to make setuptools exclude more. So this commits also adds an explicit empty `py-modules = []`.

[0] https://github.com/osbuild/images/actions/runs/19296480600/job/55179612760?pr=2008