### PR TITLE
reporegistry: check for error before repo count

### DIFF
--- a/pkg/reporegistry/repository.go
+++ b/pkg/reporegistry/repository.go
@@ -1,6 +1,7 @@
 package reporegistry
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -22,10 +23,13 @@ func LoadAllRepositories(confPaths []string, confFSes []fs.FS) (rpmmd.DistrosRep
 	mergedFSes = append(mergedFSes, confFSes...)
 
 	distrosRepoConfigs, err := loadAllRepositoriesFromFS(mergedFSes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load repositories: %w", err)
+	}
 	if len(distrosRepoConfigs) == 0 {
 		return nil, &NoReposLoadedError{confPaths, confFSes}
 	}
-	return distrosRepoConfigs, err
+	return distrosRepoConfigs, nil
 }
 
 func loadAllRepositoriesFromFS(confPaths []fs.FS) (rpmmd.DistrosRepoConfigs, error) {


### PR DESCRIPTION
When an error occurs in loadAllRepositoriesFromFS(), the number of returned repositories is always 0.  In LoadAllRepositories(), we check for the number of loaded repos to return an error when no repositories are loaded.  This means that when an error occurs while loading a repository configuration, that error never bubbles up to the caller of LoadAllRepositories().  Instead, it will always return NoReposLoadedError, which makes troubleshooting very confusing.

Check for errors before verifying that the number of returned repos is non-zero and return the underlying error if there is one.