### PR TITLE
test: use `--no-pager` when running `Checking system status`

### DIFF
--- a/test/scripts/check-host-config.sh
+++ b/test/scripts/check-host-config.sh
@@ -292,12 +292,12 @@ if ! running_wait; then
     echo "❌ Listing units"
     # system is not fully operational
     # (try to) list units so we can troubleshoot any failures
-    systemctl list-units
+    systemctl --no-pager list-units
 
     echo "❌ Status for all failed units"
     # the default 10 lines might be a bit too short for troubleshooting some
     # units, 100 should be more than enough
-    systemctl status --failed --full --lines=100
+    systemctl --no-pager status --failed --full --lines=100
 
     # exit with failure; we don't care about the exact exit code from the
     # failed condition


### PR DESCRIPTION
We had a hang in the new qemu based unattended-installer image tests. The hang was [0]:
```
echo '❌ Listing units'
❌ Listing units
+ systemctl list-units
  UNIT                                                                         >
  proc-sys-fs-binfmt_misc.automount                                            >
  sys-devices-pci0000:00-0000:00:01.1-ata1-host0-target0:0:0-0:0:0:0-block-sda->
  sys-devices-pci0000:00-0000:00:01.1-ata1-host0-target0:0:0-0:0:0:0-block-sda->
  sys-devices-pci0000:00-0000:00:01.1-ata1-host0-target0:0:0-0:0:0:0-block-sda->
  sys-devices-pci0000:00-0000:00:01.1-ata1-host0-target0:0:0-0:0:0:0-block-sda->
  sys-devices-pci0000:00-0000:00:01.1-ata1-host0-target0:0:0-0:0:0:0-block-sda.>
  sys-devices-pci0000:00-0000:00:01.1-ata2-host1-target1:0:0-1:0:0:0-block-sr0.>
  sys-devices-pci0000:00-0000:00:03.0-net-ens3.device                          >
  sys-devices-platform-serial8250-serial8250:0-serial8250:0.1-tty-ttyS1.device >
  sys-devices-platform-serial8250-serial8250:0-serial8250:0.2-tty-ttyS2.device >
  sys-devices-platform-serial8250-serial8250:0-serial8250:0.3-tty-ttyS3.device >
  sys-devices-pnp0-00:04-00:04:0-00:04:0.0-tty-ttyS0.device                    >
  sys-devices-virtual-misc-rfkill.device                                       >
  sys-module-configfs.device                                                   >
  sys-module-fuse.device                                                       >
  sys-subsystem-net-devices-ens3.device                                        >
  -.mount                                                                      >
  boot-efi.mount                                                               >
  boot.mount                                                                   >
  dev-hugepages.mount                                                          >
  dev-mqueue.mount                                                             >
  run-user-1000.mount                                                          >
```
and it turns out that it happend because systemctl was run via ssh and because of the associated pty assumed it should use a pager.

So as an easy fix we run just add --no-pager when running systemctl.

[0] https://gitlab.com/redhat/services/products/image-builder/ci/images/-/jobs/12098997345