### PR TITLE
bootc: Select manifest based on YAML image_func

### DIFF
--- a/data/distrodefs/bootc-generic/imagetypes.yaml
+++ b/data/distrodefs/bootc-generic/imagetypes.yaml
@@ -149,6 +149,7 @@ image_types:
     exports: ["bootiso"]
     filename: "installer.iso"
     boot_iso: true
+    image_func: "bootc_iso"
 
   # this image type is special (in many ways) and all is a bit ugly:
   # - we want to get rid of it (here for compat with bib)
@@ -161,6 +162,7 @@ image_types:
     exports: ["bootiso"]
     filename: "installer.iso"
     boot_iso: true
+    image_func: "bootc_legacy_iso"
 
   # XXX: ideally we would use name_aliases but the loader lib
   # does not not fully support this yet

--- a/pkg/distro/bootc/bootc.go
+++ b/pkg/distro/bootc/bootc.go
@@ -356,14 +356,16 @@ func (t *BootcImageType) manifestWithoutValidation(bp *blueprint.Blueprint, opti
 	//nolint:gosec
 	rng := rand.New(rand.NewSource(seed))
 
-	switch {
-	// XXX: make this a yaml property
-	case slices.Contains([]string{"iso", "anaconda-iso"}, t.Name()):
+	switch t.Image {
+	case "bootc_legacy_iso":
 		return t.manifestForLegacyISO(bp, options, repos, rng)
-	case t.BootISO:
+	case "bootc_iso":
 		return t.manifestForISO(bp, options, repos, rng)
-	default:
+	case "bootc_disk":
 		return t.manifestForDisk(bp, options, repos, rng)
+	default:
+		err := fmt.Errorf("unknown image func: %v for %v", t.Image, t.Name())
+		panic(err)
 	}
 }
 


### PR DESCRIPTION
Instead of using the name use the image_func field like we do for non-bootc images.

Disk types were already setting "bootc_disk", just not using it. Add "bootc_iso" and "bootc_legacy_iso".