### PR TITLE
bib: fix incorrect dnf detection

### DIFF
--- a/pkg/bib/container/solver.go
+++ b/pkg/bib/container/solver.go
@@ -35,7 +35,7 @@ func forceSymlink(symlinkPath, target string) error {
 // option).
 func (c *Container) InitDNF() error {
 	/* #nosec G204 */
-	if err := exec.Command("podman", "exec", c.id, "dnf", "--version").Run(); err != nil {
+	if err := exec.Command("podman", "exec", c.id, "sh", "-c", `command -v dnf`).Run(); err != nil {
 		return ErrNoDnf
 	}
 


### PR DESCRIPTION
The existing code was checking if dnf could be run with --version to detect if dnf is installed at all. That is wrong, dnf can fail when it is just run with --version, e.g.:
```
Failed to open log file: /var/log/hawkey.log
4.14.0
```
But errors like this should be surfaced to the user (which the next call to dnf will do). So instead of running dnf just run:
```
sh -c "command -v dnf"
```
to check if its available. This will fix the test failures in https://github.com/osbuild/image-builder-cli/pull/374

Note that the detection is covered by an existing test so no new test needs adding.