### PR TITLE
support bootc verb in bootc-installer

### DIFF
--- a/data/distrodefs/bootc-generic/imagetypes.yaml
+++ b/data/distrodefs/bootc-generic/imagetypes.yaml
@@ -163,6 +163,9 @@ image_types:
     filename: "installer.iso"
     boot_iso: true
     image_func: "bootc_legacy_iso"
+    # Uncomment the following lines to use the bootc verb instead of ostreecontainer
+    # installer_config:
+      # bootc_install_verb: bootc
 
   # XXX: ideally we would use name_aliases but the loader lib
   # does not not fully support this yet

--- a/pkg/distro/bootc/bootc.go
+++ b/pkg/distro/bootc/bootc.go
@@ -556,6 +556,11 @@ func (t *BootcImageType) manifestForISO(bp *blueprint.Blueprint, options distro.
 	// see https://github.com/osbuild/bootc-image-builder/issues/733
 	img.InstallerCustomizations.ISORootfsType = manifest.SquashfsRootfs
 
+	installerConfig := t.ImageTypeYAML.InstallerConfig(t.arch.distro.id, t.arch.Name())
+	if installerConfig != nil && installerConfig.BootcInstallVerb != nil {
+		img.BootcInstallVerb = *installerConfig.BootcInstallVerb
+	}
+
 	installRootfsType, err := disk.NewFSType(t.arch.distro.defaultFs)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/distro/installer_config.go
+++ b/pkg/distro/installer_config.go
@@ -32,6 +32,10 @@ type InstallerConfig struct {
 	LoraxTemplatePackage *string                           `yaml:"lorax_template_package"`
 	LoraxLogosPackage    *string                           `yaml:"lorax_logos_package"`
 	LoraxReleasePackage  *string                           `yaml:"lorax_release_package"`
+
+	// BootcInstallVerb controls which directive to use in kickstart files for bootc installer ISOs.
+	// Valid values are "ostreecontainer" (default) and "bootc"
+	BootcInstallVerb *string `yaml:"bootc_install_verb,omitempty"`
 }
 
 // InheritFrom inherits unset values from the provided parent configuration and

--- a/pkg/image/anaconda_container_installer.go
+++ b/pkg/image/anaconda_container_installer.go
@@ -46,6 +46,10 @@ type AnacondaContainerInstaller struct {
 	InitramfsPath string
 	// bootc installer cannot use /root as installer home
 	InstallerHome string
+
+	// BootcInstallVerb controls which directive to use in kickstart files.
+	// Valid values are "ostreecontainer" (default) and "bootc"
+	BootcInstallVerb string
 }
 
 func NewAnacondaContainerInstaller(platform platform.Platform, filename string, container container.SourceSpec, ref string) *AnacondaContainerInstaller {
@@ -131,6 +135,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifestFromContainer(m *manif
 	isoTreePipeline.PartitionTable = efiBootPartitionTable(rng)
 	isoTreePipeline.Release = img.InstallerCustomizations.Release
 	isoTreePipeline.Kickstart = img.Kickstart
+	isoTreePipeline.BootcInstallVerb = img.BootcInstallVerb
 
 	isoTreePipeline.RootfsCompression = img.RootfsCompression
 	isoTreePipeline.RootfsType = img.InstallerCustomizations.ISORootfsType

--- a/pkg/osbuild/kickstart_stage.go
+++ b/pkg/osbuild/kickstart_stage.go
@@ -22,6 +22,7 @@ type KickstartStageOptions struct {
 
 	OSTreeCommit    *OSTreeCommitOptions    `json:"ostree,omitempty"`
 	OSTreeContainer *OSTreeContainerOptions `json:"ostreecontainer,omitempty"`
+	Bootc           *BootcOptions           `json:"bootc,omitempty"`
 
 	LiveIMG *LiveIMGOptions `json:"liveimg,omitempty"`
 
@@ -65,6 +66,11 @@ type OSTreeContainerOptions struct {
 	Transport             string `json:"transport"`
 	Remote                string `json:"remote"`
 	SignatureVerification bool   `json:"signatureverification"`
+}
+
+type BootcOptions struct {
+	SourceImgRef string `json:"source-imgref"`
+	TargetImgRef string `json:"target-imgref,omitempty"`
 }
 
 type RebootOptions struct {
@@ -303,6 +309,31 @@ func NewKickstartStageOptionsWithOSTreeContainer(
 		}
 
 		options.OSTreeContainer = ostreeContainerOptions
+	}
+
+	return options, nil
+}
+
+func NewKickstartStageOptionsWithBootc(
+	path string,
+	userCustomizations []users.User,
+	groupCustomizations []users.Group,
+	sourceImgRef string,
+	targetImgRef string) (*KickstartStageOptions, error) {
+
+	options, err := NewKickstartStageOptions(path, userCustomizations, groupCustomizations)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if sourceImgRef != "" {
+		bootcOptions := &BootcOptions{
+			SourceImgRef: sourceImgRef,
+			TargetImgRef: targetImgRef,
+		}
+
+		options.Bootc = bootcOptions
 	}
 
 	return options, nil


### PR DESCRIPTION
Anaconda has recently got a new verb for bootc container images, this commit adds support for it for bootc-installer.

This is currently opt-in via yaml configs, we need to decide how to enable it automatically.

The code is testable with this `Containerfile`:

```dockerfile
FROM quay.io/fedora/fedora-bootc:rawhide
RUN dnf --setopt=tsflags=noscripts install -y dnf5-plugins  && dnf copr enable -y @rhinstaller/Anaconda
RUN dnf install -y \
     anaconda \
     anaconda-install-env-deps \
     anaconda-dracut \
     dracut-config-generic \
     dracut-network \
     net-tools \
     squashfs-tools \
     grub2-efi-x64-cdboot \
     python3-mako \
     lorax-templates-* \
     biosdevname \
     prefixdevname \
     && dnf clean all
# shim-x64 is marked installed but the files are not in the expected
# place for https://github.com/osbuild/osbuild/blob/v160/stages/org.osbuild.grub2.iso#L91, see
# workaround via reinstall, we could add a config to the grub2.iso
# stage to allow a different prefix that then would be used by
# anaconda.
# once https://github.com/osbuild/osbuild/pull/2202 is merged we
# can update images/ to set the correct efi_src_dir and this can
# be removed
RUN dnf reinstall -y shim-x64
RUN mkdir -p /boot/efi && cp -av /usr/lib/efi/{shim,grub2}/*/EFI /boot/efi/
# lorax wants to create a symlink in /mnt which points to /var/mnt
# on bootc but /var/mnt does not exist on some images.
#
# If https://gitlab.com/fedora/bootc/base-images/-/merge_requests/294
# gets merged this will be no longer needed
RUN mkdir /var/mnt
```

and this command:

```console
# podman build -t fedora-installer:44 .
# podman pull quay.io/centos-bootc/centos-bootc:stream10
# image-builder build --bootc-ref localhost/fedora-installer:44 --bootc-installer-payload-ref quay.io/centos-bootc/centos-bootc:stream10 bootc-installer --default-fstype ext4
```

Note that you have to have osbuild with https://github.com/osbuild/osbuild/pull/2242, marking as a draft until it gets merged.