### PR TITLE
[RFC] osbuild: introduce PathChanger interface and use it

### DIFF
--- a/pkg/osbuild/chmod_stage.go
+++ b/pkg/osbuild/chmod_stage.go
@@ -11,10 +11,20 @@ type ChmodStagePathOptions struct {
 
 func (ChmodStageOptions) isStageOptions() {}
 
+var _ = PathChanger(ChmodStageOptions{})
+
 // NewChmodStage creates a new org.osbuild.chmod stage
 func NewChmodStage(options *ChmodStageOptions) *Stage {
 	return &Stage{
 		Type:    "org.osbuild.chmod",
 		Options: options,
 	}
+}
+
+func (c ChmodStageOptions) PathsChanged() []string {
+	var paths []string
+	for path := range c.Items {
+		paths = append(paths, path)
+	}
+	return paths
 }

--- a/pkg/osbuild/chown_stage.go
+++ b/pkg/osbuild/chown_stage.go
@@ -16,6 +16,16 @@ type ChownStageOptions struct {
 
 func (ChownStageOptions) isStageOptions() {}
 
+var _ = PathChanger(ChownStageOptions{})
+
+func (c ChownStageOptions) PathsChanged() []string {
+	var paths []string
+	for path := range c.Items {
+		paths = append(paths, path)
+	}
+	return paths
+}
+
 func (o *ChownStageOptions) validate() error {
 	for path, options := range o.Items {
 		invalidPathRegex := regexp.MustCompile(invalidPathRegex)

--- a/pkg/osbuild/copy_stage.go
+++ b/pkg/osbuild/copy_stage.go
@@ -2,6 +2,7 @@ package osbuild
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/osbuild/images/pkg/disk"
 )
@@ -23,6 +24,18 @@ type CopyStagePath struct {
 }
 
 func (CopyStageOptions) isStageOptions() {}
+
+var _ = PathChanger(CopyStageOptions{})
+
+func (c CopyStageOptions) PathsChanged() []string {
+	var paths []string
+	for _, p := range c.Paths {
+		if strings.HasPrefix(p.To, "tree://") {
+			paths = append(paths, p.To[len("tree://"):])
+		}
+	}
+	return paths
+}
 
 func NewCopyStage(options *CopyStageOptions, inputs Inputs, devices map[string]Device, mounts []Mount) *Stage {
 	return &Stage{

--- a/pkg/osbuild/fstab_stage.go
+++ b/pkg/osbuild/fstab_stage.go
@@ -20,6 +20,12 @@ type FSTabStageOptions struct {
 
 func (FSTabStageOptions) isStageOptions() {}
 
+var _ = PathChanger(FSTabStageOptions{})
+
+func (f FSTabStageOptions) PathsChanged() []string {
+	return []string{"/etc/fstab"}
+}
+
 type OSTreeFstab struct {
 	Deployment OSTreeDeployment `json:"deployment"`
 }

--- a/pkg/osbuild/groups_stage.go
+++ b/pkg/osbuild/groups_stage.go
@@ -10,6 +10,15 @@ type GroupsStageOptions struct {
 
 func (GroupsStageOptions) isStageOptions() {}
 
+var _ = PathChanger(GroupsStageOptions{})
+
+func (g GroupsStageOptions) PathsChanged() []string {
+	// this is very precise but because we don't own the groupadd code if it
+	// would start writing some extra/aux files (in a few years) we would
+	// not catch it so maybe just return /etc here?
+	return []string{"/etc/group", "/etc/gshadow", "/etc/group-", "/etc/gshadow-"}
+}
+
 type GroupsStageOptionsGroup struct {
 	GID *int `json:"gid,omitempty"`
 }

--- a/pkg/osbuild/mkdir_stage.go
+++ b/pkg/osbuild/mkdir_stage.go
@@ -16,6 +16,16 @@ type MkdirStagePath struct {
 
 func (MkdirStageOptions) isStageOptions() {}
 
+var _ = PathChanger(MkdirStageOptions{})
+
+func (m MkdirStageOptions) PathsChanged() []string {
+	var paths []string
+	for _, path := range m.Paths {
+		paths = append(paths, path.Path)
+	}
+	return paths
+}
+
 // NewMkdirStage creates a new org.osbuild.mkdir stage to create FS directories
 func NewMkdirStage(options *MkdirStageOptions) *Stage {
 	return &Stage{

--- a/pkg/osbuild/stage.go
+++ b/pkg/osbuild/stage.go
@@ -28,3 +28,7 @@ func (s *Stage) MountOSTree(osName, ref string, serial int) {
 	ostreeMount := NewOSTreeDeploymentMount(name, osName, ref, serial)
 	s.Mounts = append(s.Mounts, *ostreeMount)
 }
+
+type PathChanger interface {
+	PathsChanged() []string
+}

--- a/pkg/osbuild/systemd_stage.go
+++ b/pkg/osbuild/systemd_stage.go
@@ -1,5 +1,9 @@
 package osbuild
 
+import (
+	"reflect"
+)
+
 type SystemdStageOptions struct {
 	EnabledServices  []string `json:"enabled_services,omitempty"`
 	DisabledServices []string `json:"disabled_services,omitempty"`
@@ -8,6 +12,17 @@ type SystemdStageOptions struct {
 }
 
 func (SystemdStageOptions) isStageOptions() {}
+
+var _ = PathChanger(SystemdStageOptions{})
+
+func (s SystemdStageOptions) PathsChanged() []string {
+	if reflect.ValueOf(s).IsZero() {
+		return nil
+	}
+	// we don't know what exactly systemctl will do so give a coarse view here
+	// (which is okay)
+	return []string{"/etc"}
+}
 
 func NewSystemdStage(options *SystemdStageOptions) *Stage {
 	return &Stage{

--- a/pkg/osbuild/systemd_stage_test.go
+++ b/pkg/osbuild/systemd_stage_test.go
@@ -13,4 +13,10 @@ func TestNewSystemdStage(t *testing.T) {
 	}
 	actualStage := NewSystemdStage(&SystemdStageOptions{})
 	assert.Equal(t, expectedStage, actualStage)
+	assert.Len(t, actualStage.Options.(PathChanger).PathsChanged(), 0)
+}
+
+func TestNewSystemdStageFilesChanged(t *testing.T) {
+	st := NewSystemdStage(&SystemdStageOptions{EnabledServices: []string{"foo"}})
+	assert.Equal(t, []string{"/etc"}, st.Options.(PathChanger).PathsChanged())
 }

--- a/pkg/osbuild/systemd_unit_create_stage.go
+++ b/pkg/osbuild/systemd_unit_create_stage.go
@@ -114,6 +114,13 @@ type SystemdUnitCreateStageOptions struct {
 
 func (SystemdUnitCreateStageOptions) isStageOptions() {}
 
+var _ = PathChanger(SystemdUnitCreateStageOptions{})
+
+func (s SystemdUnitCreateStageOptions) PathsChanged() []string {
+	// XXX: be more precise, I think we can
+	return []string{"/etc"}
+}
+
 func (o *SystemdUnitCreateStageOptions) validateService() error {
 	if o.Config.Service == nil {
 		return fmt.Errorf("systemd service unit %q requires a Service section", o.Filename)

--- a/pkg/osbuild/users_stage.go
+++ b/pkg/osbuild/users_stage.go
@@ -12,6 +12,22 @@ type UsersStageOptions struct {
 
 func (UsersStageOptions) isStageOptions() {}
 
+var _ = PathChanger(UsersStageOptions{})
+
+func (g UsersStageOptions) PathsChanged() []string {
+	// this is very precise but because we don't own the groupadd code if it
+	// would start writing some extra/aux files (in a few years) we would
+	// not catch it so maybe just return /etc here?
+	return []string{
+		"/etc/passwd", "/etc/shadow",
+		"/etc/passwd-", "/etc/shadow-",
+		"/etc/group", "/etc/gshadow",
+		"/etc/group-", "/etc/gshadow-",
+		"/etc/subuid", "/etc/subuid-",
+		"/etc/subgid", "/etc/subgid-",
+	}
+}
+
 type UsersStageOptionsUser struct {
 	UID                *int     `json:"uid,omitempty"`
 	GID                *int     `json:"gid,omitempty"`


### PR DESCRIPTION
[this is a version of the relabel bootc work that is fine grained, there is a simpler version in ihttps://github.com/osbuild/images/pull/2053  that I like (a lot!) based on the idea by Alex outlined in **https://github.com/osbuild/images/pull/2037#issuecomment-3575925113** - ie. simplify this to just /var, /etc if any postStages are found - but if we want the finer grained one I I would prefer if the detailed knowledge what changed is part of the stage itself instead of something that the manifest package investigates]

It is useful for the higher layers to know what files are
touched by a specific stage. This is used in e.g. the
bootc disk where we want to target the relabeling.

So this commit introduce a new `PathChanger` interface
that can be implemented by the relevant stages and is
then used in RawBootcImage to relabel only the specific
paths that the stages touch.

Build on top of the excellent work by Alex in PR#2037.

