### PR TITLE
manifest: relabel /etc and /var after bootc install

### DIFF
--- a/pkg/manifest/raw_bootc.go
+++ b/pkg/manifest/raw_bootc.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"slices"
-	"strings"
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/artifact"
@@ -133,62 +131,6 @@ func buildHomedirPaths(users []users.User) []osbuild.MkdirStagePath {
 	}
 }
 
-func findChangedFilesInStage(stage *osbuild.Stage) ([]string, error) {
-	paths := []string{}
-
-	switch stage.Type {
-	case "org.osbuild.systemd", "org.osbuild.systemd.unit.create", "org.osbuild.fstab", "org.osbuild.groups", "org.osbuild.users":
-		paths = append(paths, "/etc")
-	case "org.osbuild.mkdir":
-		if options, ok := stage.Options.(*osbuild.MkdirStageOptions); ok {
-			for _, path := range options.Paths {
-				paths = append(paths, path.Path)
-			}
-		}
-	case "org.osbuild.copy":
-		if options, ok := stage.Options.(*osbuild.CopyStageOptions); ok {
-			for _, p := range options.Paths {
-				if strings.HasPrefix(p.To, "tree://") {
-					paths = append(paths, p.To[len("tree://"):])
-				}
-			}
-		}
-	case "org.osbuild.chmod":
-		if options, ok := stage.Options.(*osbuild.ChmodStageOptions); ok {
-			for path := range options.Items {
-				paths = append(paths, path)
-			}
-		}
-	case "org.osbuild.chown":
-		if options, ok := stage.Options.(*osbuild.ChownStageOptions); ok {
-			for path := range options.Items {
-				paths = append(paths, path)
-			}
-		}
-	default:
-		return nil, fmt.Errorf("findChangedFilesInStage(): unhandled stage type %s", stage.Type)
-	}
-
-	return paths, nil
-}
-
-func findChangedFilesInStages(stages []*osbuild.Stage) ([]string, error) {
-	changes := []string{}
-	for _, stage := range stages {
-		stageChanges, err := findChangedFilesInStage(stage)
-		if err != nil {
-			return nil, err
-		}
-		for _, change := range stageChanges {
-			if !slices.Contains(changes, change) {
-				changes = append(changes, change)
-			}
-		}
-
-	}
-	return changes, nil
-}
-
 func (p *RawBootcImage) serialize() (osbuild.Pipeline, error) {
 	pipeline, err := p.Base.serialize()
 	if err != nil {
@@ -304,20 +246,18 @@ func (p *RawBootcImage) serialize() (osbuild.Pipeline, error) {
 	// In case we created any files in the deploy directory we need to relabel
 	// then per the selinux policy
 	if p.SELinux != "" {
-		changedFiles, err := findChangedFilesInStages(postStages)
-		if err != nil {
-			return osbuild.Pipeline{}, err
-		}
-		for _, changedFile := range changedFiles {
-			opts := &osbuild.SELinuxStageOptions{
-				Target:       "tree://" + changedFile,
-				FileContexts: fmt.Sprintf("etc/selinux/%s/contexts/files/file_contexts", p.SELinux),
-				ExcludePaths: []string{"/sysroot"},
+		if len(postStages) > 0 {
+			for _, changedFile := range []string{"/etc", "/var"} {
+				opts := &osbuild.SELinuxStageOptions{
+					Target:       "tree://" + changedFile,
+					FileContexts: fmt.Sprintf("etc/selinux/%s/contexts/files/file_contexts", p.SELinux),
+					ExcludePaths: []string{"/sysroot"},
+				}
+				selinuxStage := osbuild.NewSELinuxStage(opts)
+				selinuxStage.Mounts = mounts
+				selinuxStage.Devices = devices
+				pipeline.AddStage(selinuxStage)
 			}
-			selinuxStage := osbuild.NewSELinuxStage(opts)
-			selinuxStage.Mounts = mounts
-			selinuxStage.Devices = devices
-			pipeline.AddStage(selinuxStage)
 		}
 	}
 


### PR DESCRIPTION
[edit: alternative to #2042, we could pick this or the other (or keep things as they are if that is preferred)]

In the RawBootcImage struct, ff we add stages after `bootc install to-filesystem` we need to relabel the changed files.

Initially we did this in a very coarse matter, i.e. just relabeld the entire filesystem. This can lead to bugs like issue#1161 so Alex fixed this by adding fine grained relabeling in PR#2037.

However now the "manifest" packages has to deal with many details of the "osbuild" package which ideally we would like to keep hidden. So this commit changes the approach again to be less fine grained and just relabels "/etc/" and "/var" if we add any stages after "boot install to-filesystem". This should be sufficient as we know its a bootc system so the only mutable content is in /etc and /var and we have files/dir policies that prevent modifications outside for blueprint content.

This is a (much) simpler alterantive to PR#2042 which also address this area but keeps the fine grained control of the original work.