### PR TITLE
distro: tweak distrodefs blueprint_{supported,required}_options

### DIFF
--- a/data/distrodefs/bootc-generic/imagetypes.yaml
+++ b/data/distrodefs/bootc-generic/imagetypes.yaml
@@ -116,7 +116,8 @@ image_types:
     partition_table: *default_bootc_partition_table
     image_config:
       kernel_options: *bootc_kernel_options
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "ami":
     <<: *raw_image_type
@@ -159,7 +160,8 @@ image_types:
     filename: "install.iso"
     boot_iso: true
     image_func: "bootc_iso"
-    supported_blueprint_options: *supported_options_iso
+    blueprint:
+      supported_options: *supported_options_iso
 
   # this image type is special (in many ways) and all is a bit ugly:
   # - we want to get rid of it (here for compat with bib)
@@ -173,7 +175,8 @@ image_types:
     filename: "install.iso"
     boot_iso: true
     image_func: "bootc_legacy_iso"
-    supported_blueprint_options: *supported_options_iso
+    blueprint:
+      supported_options: *supported_options_iso
 
   # XXX: ideally we would use name_aliases but the loader lib
   # does not not fully support this yet

--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -887,7 +887,8 @@ image_types:
         image_format: "vagrant_libvirt"
       - <<: *aarch64_platform
         image_format: "vagrant_libvirt"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "server-vagrant-virtualbox": &server_vagrant_virtualbox
     <<: *server_vagrant_libvirt
@@ -938,7 +939,8 @@ image_types:
         image_format: "qcow2"
       - <<: *s390x_zipl_platform
         image_format: "qcow2"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "server-ami":
     <<: *server_qcow2
@@ -1046,7 +1048,8 @@ image_types:
             - "zram-generator-defaults"
             - "grubby-deprecated"
             - "extlinux-bootloader"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "server-ova":
     <<: *server_vmdk
@@ -1206,7 +1209,8 @@ image_types:
               append:
                 include:
                   - "filesystem"
-    supported_blueprint_options: *supported_options_ostree_commit
+    blueprint:
+      supported_options: *supported_options_ostree_commit
 
   "iot-container":
     <<: *iot_commit
@@ -1299,7 +1303,8 @@ image_types:
           - ["/usr/lib/ostree-boot/efi/start_x.elf", "/boot/efi/"]
     partition_table:
       <<: *iot_base_partition_tables
-    supported_blueprint_options: *supported_options_ostree_disk
+    blueprint:
+      supported_options: *supported_options_ostree_disk
 
   "iot-qcow2":
     <<: *rpm_ostree_imgtype_common
@@ -1327,7 +1332,8 @@ image_types:
       - <<: *aarch64_platform
         image_format: "qcow2"
         qcow2_compat: "1.1"
-    supported_blueprint_options: *supported_options_ostree_disk
+    blueprint:
+      supported_options: *supported_options_ostree_disk
 
   "iot-bootable-container":
     <<: *rpm_ostree_imgtype_common
@@ -1474,7 +1480,8 @@ image_types:
                 exclude:
                   - "perl"
                   - "perl-interpreter"
-    supported_blueprint_options: *supported_options_ostree_commit
+    blueprint:
+      supported_options: *supported_options_ostree_commit
 
   "minimal-raw-xz": &minimal_raw_xz
     name_aliases: ["minimal-raw"]
@@ -1567,7 +1574,8 @@ image_types:
               append:
                 exclude:
                   - "firewalld"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "minimal-raw-zst":
     <<: *minimal_raw_xz
@@ -1614,15 +1622,16 @@ image_types:
           override:
             - *x86_64_installer_platform_compat
             - *aarch64_installer_platform
-    supported_blueprint_options:
-      - "distro"
-      - "customizations.installer"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.fips"
-      - "customizations.timezone"
-      - "customizations.locale"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "customizations.installer"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.fips"
+        - "customizations.timezone"
+        - "customizations.locale"
 
   "workstation-live-installer":
     name_aliases: ["live-installer"]
@@ -1691,9 +1700,10 @@ image_types:
           override:
             - *x86_64_installer_platform_compat
             - *aarch64_installer_platform
-    supported_blueprint_options:
-      - "distro"
-      - "customizations.installer"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "customizations.installer"
 
   "minimal-installer":
     name_aliases: ["image-installer", "fedora-image-installer"]
@@ -1744,32 +1754,33 @@ image_types:
         - *minimal_raw_pkgset
       installer:
         - *anaconda_pkgset
-    supported_blueprint_options:
-      - "distro"
-      - "packages"
-      - "modules"
-      - "groups"
-      - "enabled_modules"
-      - "containers"
-      - "minimal"
-      - "customizations.installer"
-      - "customizations.cacerts"
-      - "customizations.directories"
-      - "customizations.files"
-      - "customizations.firewall"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.fips"
-      - "customizations.timezone"
-      - "customizations.hostname"
-      - "customizations.kernel.name"
-      - "customizations.locale"
-      - "customizations.openscap"
-      - "customizations.repositories"
-      - "customizations.rpm"
-      - "customizations.services"
-      - "customizations.kernel.append"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "packages"
+        - "modules"
+        - "groups"
+        - "enabled_modules"
+        - "containers"
+        - "minimal"
+        - "customizations.installer"
+        - "customizations.cacerts"
+        - "customizations.directories"
+        - "customizations.files"
+        - "customizations.firewall"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.fips"
+        - "customizations.timezone"
+        - "customizations.hostname"
+        - "customizations.kernel.name"
+        - "customizations.locale"
+        - "customizations.openscap"
+        - "customizations.repositories"
+        - "customizations.rpm"
+        - "customizations.services"
+        - "customizations.kernel.append"
 
   container: &container
     filename: "container.tar"
@@ -1835,7 +1846,8 @@ image_types:
             - "trousers"
             - "whois-nls"
             - "xkeyboard-config"
-    supported_blueprint_options: *supported_options_container
+    blueprint:
+      supported_options: *supported_options_container
 
   wsl:
     # this is the eventual name, and `wsl` the alias but we've been
@@ -1924,7 +1936,8 @@ image_types:
             - "trousers"
             - "whois-nls"
             - "xkeyboard-config"
-    supported_blueprint_options: *supported_options_container
+    blueprint:
+      supported_options: *supported_options_container
 
   "iot-simplified-installer":
     <<: *rpm_ostree_imgtype_common
@@ -2045,18 +2058,19 @@ image_types:
             - "iwlwifi-mvm-firmware"
             - "realtek-firmware"
             - "uboot-images-armv8"
-    supported_blueprint_options:
-      - "distro"
-      - "customizations.installation_device"
-      - "customizations.fdo"
-      - "customizations.ignition"
-      - "customizations.kernel"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.fips"
-    required_blueprint_options:
-      - "customizations.installation_device"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "customizations.installation_device"
+        - "customizations.fdo"
+        - "customizations.ignition"
+        - "customizations.kernel"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.fips"
+      required_options:
+        - "customizations.installation_device"
 
   # Based on lorax runtime-install.tmpl
   "everything-network-installer":
@@ -2175,14 +2189,15 @@ image_types:
           override:
             - *x86_64_installer_platform_compat
             - *aarch64_installer_platform
-    supported_blueprint_options:
-      - "distro"
-      - "customizations.fips"
-      - "customizations.group"
-      - "customizations.installer"
-      - "customizations.kernel.append"
-      - "customizations.locale"
-      - "customizations.user"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "customizations.fips"
+        - "customizations.group"
+        - "customizations.installer"
+        - "customizations.kernel.append"
+        - "customizations.locale"
+        - "customizations.user"
 
   "pxe-tar-xz":
     filename: "pxe.tar.xz"
@@ -2202,7 +2217,8 @@ image_types:
     platforms:
       - *x86_64_bios_platform
       - *aarch64_platform
-    supported_blueprint_options: *supported_options_pxe
+    blueprint:
+      supported_options: *supported_options_pxe
 
   "bootc-rpm-installer":
     # Note that this image type is partial and only used by

--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -1020,7 +1020,8 @@ image_types:
                 include:
                   - "insights-client"
                   - "subscription-manager-cockpit"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "vagrant-libvirt": &vagrant_libvirt
     <<: *qcow2
@@ -1062,7 +1063,8 @@ image_types:
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "vagrant_virtualbox"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   oci:
     <<: *qcow2
@@ -1072,7 +1074,8 @@ image_types:
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "qcow2"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   vhd: &vhd
     <<: *qcow2
@@ -1121,7 +1124,8 @@ image_types:
     package_sets:
       os:
         - *azure_base_pkgset
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "azure": &azure
     <<: *vhd
@@ -1212,11 +1216,13 @@ image_types:
           # NB: we currently don't support /boot on LVM
           - *azure_rhui_part_boot
           - *azure_rhui_part_lvm
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "azure-rhui": &azure_rhui
     <<: *azure
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "azure-sap-rhui":
     <<: *azure_rhui
@@ -1230,7 +1236,8 @@ image_types:
         - *azure_base_pkgset
         - *sap_base_pkgset
         - *sap_extras_pkgset
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   azure-sapapps-rhui:
     <<: *azure_rhui
@@ -1243,7 +1250,8 @@ image_types:
       os:
         - *azure_base_pkgset
         - *sap_base_pkgset
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   tar:
     filename: "root.tar.xz"
@@ -1262,32 +1270,33 @@ image_types:
       - arch: "aarch64"
       - arch: "ppc64le"
       - arch: "s390x"
-    supported_blueprint_options:
-      # We've never tested many options or customizations with this image type
-      # and we also never restricted any, but it uses the OS pipeline, so it
-      # should support most standard/basic customizations
-      - "distro"
-      - "packages"
-      - "modules"
-      - "groups"
-      - "containers"
-      - "enabled_modules"
-      - "minimal"
-      - "customizations.cacerts"
-      - "customizations.directories"
-      - "customizations.dnf"
-      - "customizations.files"
-      - "customizations.firewall"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.hostname"
-      - "customizations.kernel.name"
-      - "customizations.locale"
-      - "customizations.repositories"
-      - "customizations.rpm"
-      - "customizations.services"
-      - "customizations.timezone"
+    blueprint:
+      supported_options:
+        # We've never tested many options or customizations with this image type
+        # and we also never restricted any, but it uses the OS pipeline, so it
+        # should support most standard/basic customizations
+        - "distro"
+        - "packages"
+        - "modules"
+        - "groups"
+        - "containers"
+        - "enabled_modules"
+        - "minimal"
+        - "customizations.cacerts"
+        - "customizations.directories"
+        - "customizations.dnf"
+        - "customizations.files"
+        - "customizations.firewall"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.hostname"
+        - "customizations.kernel.name"
+        - "customizations.locale"
+        - "customizations.repositories"
+        - "customizations.rpm"
+        - "customizations.services"
+        - "customizations.timezone"
 
   vmdk: &vmdk
     name_aliases: ["vshpere"]
@@ -1319,7 +1328,8 @@ image_types:
           exclude:
             - "dracut-config-rescue"
             - "rng-tools"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   ova:
     <<: *vmdk
@@ -1330,7 +1340,8 @@ image_types:
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "ova"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   ami: &ami
     name_aliases: ['aws']
@@ -1509,7 +1520,8 @@ image_types:
               append:
                 include:
                   - "insights-client"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   # RHEL internal-only x86_64 EC2 image type
   ec2: &ec2
@@ -1520,7 +1532,8 @@ image_types:
     exports: ["xz"]
     filename: "image.raw.xz"
     compression: "xz"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "ec2-ha":
     <<: *ec2
@@ -1536,7 +1549,8 @@ image_types:
             - "fence-agents-all"
             - "pacemaker"
             - "pcs"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "ec2-sap":
     <<: *ec2
@@ -1569,7 +1583,8 @@ image_types:
               # amiSapKernelOptions()
               - "processor.max_cstate=1"
               - "intel_idle.max_cstate=1"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   wsl:
     filename: "image.wsl"
@@ -1695,27 +1710,28 @@ image_types:
                   - "wsl-setup"
                   - "centos-logos"
                   - "centos-release"
-    supported_blueprint_options:
-      - "distro"
-      - "packages"
-      - "modules"
-      - "groups"
-      - "enabled_modules"
-      - "minimal"
-      - "containers"
-      - "customizations.dnf"
-      - "customizations.directories"
-      - "customizations.files"
-      - "customizations.firewall"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.hostname"
-      - "customizations.locale"
-      - "customizations.repositories"
-      - "customizations.services"
-      - "customizations.timezone"
-      - "customizations.rhsm"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "packages"
+        - "modules"
+        - "groups"
+        - "enabled_modules"
+        - "minimal"
+        - "containers"
+        - "customizations.dnf"
+        - "customizations.directories"
+        - "customizations.files"
+        - "customizations.firewall"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.hostname"
+        - "customizations.locale"
+        - "customizations.repositories"
+        - "customizations.services"
+        - "customizations.timezone"
+        - "customizations.rhsm"
 
   "image-installer":
     filename: "installer.iso"
@@ -1871,34 +1887,35 @@ image_types:
               append:
                 include:
                   - "dmidecode"
-    supported_blueprint_options:
-      - "distro"
-      - "packages"
-      - "modules"
-      - "groups"
-      - "enabled_modules"
-      - "containers"
-      - "minimal"
-      - "customizations.installer"
-      - "customizations.cacerts"
-      - "customizations.dnf"
-      - "customizations.directories"
-      - "customizations.files"
-      - "customizations.firewall"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.fips"
-      - "customizations.timezone"
-      - "customizations.hostname"
-      - "customizations.kernel.name"
-      - "customizations.locale"
-      - "customizations.openscap"
-      - "customizations.repositories"
-      - "customizations.rpm"
-      - "customizations.services"
-      - "customizations.rhsm"
-      - "customizations.kernel.append"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "packages"
+        - "modules"
+        - "groups"
+        - "enabled_modules"
+        - "containers"
+        - "minimal"
+        - "customizations.installer"
+        - "customizations.cacerts"
+        - "customizations.dnf"
+        - "customizations.directories"
+        - "customizations.files"
+        - "customizations.firewall"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.fips"
+        - "customizations.timezone"
+        - "customizations.hostname"
+        - "customizations.kernel.name"
+        - "customizations.locale"
+        - "customizations.openscap"
+        - "customizations.repositories"
+        - "customizations.rpm"
+        - "customizations.services"
+        - "customizations.rhsm"
+        - "customizations.kernel.append"
 
   gce:
     # this image type is set to `gcp` in image-builder-crc
@@ -2057,7 +2074,8 @@ image_types:
               append:
                 include:
                   - "insights-client"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "azure-cvm":
     <<: *vhd
@@ -2129,35 +2147,36 @@ image_types:
     package_sets:
       os:
         - *azure_base_pkgset
-    supported_blueprint_options:
-      # same as disk image types, but kernel customizations are not supported
-      - "distro"
-      - "packages"
-      - "modules"
-      - "groups"
-      - "enabled_modules"
-      - "containers"
-      - "minimal"
-      - "customizations.cacerts"
-      - "customizations.directories"
-      - "customizations.disk"
-      - "customizations.dnf"
-      - "customizations.files"
-      - "customizations.filesystem"
-      - "customizations.partitioning_mode"
-      - "customizations.fips"
-      - "customizations.firewall"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.hostname"
-      - "customizations.locale"
-      - "customizations.openscap"
-      - "customizations.repositories"
-      - "customizations.rpm"
-      - "customizations.services"
-      - "customizations.timezone"
-      - "customizations.rhsm"
+    blueprint:
+      supported_options:
+        # same as disk image types, but kernel customizations are not supported
+        - "distro"
+        - "packages"
+        - "modules"
+        - "groups"
+        - "enabled_modules"
+        - "containers"
+        - "minimal"
+        - "customizations.cacerts"
+        - "customizations.directories"
+        - "customizations.disk"
+        - "customizations.dnf"
+        - "customizations.files"
+        - "customizations.filesystem"
+        - "customizations.partitioning_mode"
+        - "customizations.fips"
+        - "customizations.firewall"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.hostname"
+        - "customizations.locale"
+        - "customizations.openscap"
+        - "customizations.repositories"
+        - "customizations.rpm"
+        - "customizations.services"
+        - "customizations.timezone"
+        - "customizations.rhsm"
 
   # Based on lorax runtime-install.tmpl
   "network-installer":
@@ -2269,10 +2288,11 @@ image_types:
             - "sg3_utils"
             - "perl-interpreter"
             - "restore"
-    supported_blueprint_options:
-      - "distro"
-      - "customizations.fips"
-      - "customizations.locale"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "customizations.fips"
+        - "customizations.locale"
 
   "pxe-tar-xz":
     filename: "pxe.tar.xz"
@@ -2292,7 +2312,8 @@ image_types:
     platforms:
       - *x86_64_bios_platform
       - *aarch64_platform
-    supported_blueprint_options: *supported_options_pxe
+    blueprint:
+      supported_options: *supported_options_pxe
 
   "bootc-rpm-installer":
     # Note that this image type is partial and only used by
@@ -2448,7 +2469,8 @@ image_types:
             - "publicsuffix-list-dafsa"
             - "rpm-plugin-audit"
             - "xkeyboard-config"
-    supported_blueprint_options: *supported_options_container
+    blueprint:
+      supported_options: *supported_options_container
 
   container-minimal:
     <<: *container

--- a/data/distrodefs/rhel-7/imagetypes.yaml
+++ b/data/distrodefs/rhel-7/imagetypes.yaml
@@ -215,30 +215,31 @@
           - "efibootmgr"
           - "grub2-efi-x64"
           - "shim-x64"
-  supported_blueprint_options: &supported_blueprint_options
-    - "distro"
-    - "packages"
-    - "modules"
-    - "groups"
-    - "minimal"
-    - "customizations.cacerts"
-    - "customizations.directories"
-    - "customizations.disk"
-    - "customizations.files"
-    - "customizations.filesystem"
-    - "customizations.partitioning_mode"
-    - "customizations.fips"
-    - "customizations.firewall"
-    - "customizations.user"
-    - "customizations.sshkey"
-    - "customizations.group"
-    - "customizations.hostname"
-    - "customizations.kernel"
-    - "customizations.locale"
-    - "customizations.repositories"
-    - "customizations.rpm"
-    - "customizations.services"
-    - "customizations.timezone"
+  blueprint:
+    supported_options: &supported_blueprint_options
+      - "distro"
+      - "packages"
+      - "modules"
+      - "groups"
+      - "minimal"
+      - "customizations.cacerts"
+      - "customizations.directories"
+      - "customizations.disk"
+      - "customizations.files"
+      - "customizations.filesystem"
+      - "customizations.partitioning_mode"
+      - "customizations.fips"
+      - "customizations.firewall"
+      - "customizations.user"
+      - "customizations.sshkey"
+      - "customizations.group"
+      - "customizations.hostname"
+      - "customizations.kernel"
+      - "customizations.locale"
+      - "customizations.repositories"
+      - "customizations.rpm"
+      - "customizations.services"
+      - "customizations.timezone"
 
 image_config:
   default:
@@ -413,7 +414,8 @@ image_types:
     package_sets:
       os:
         - *azure_rhui_common_pkgset
-    supported_blueprint_options: *supported_blueprint_options
+    blueprint:
+      supported_options: *supported_blueprint_options
 
   ec2:
     filename: "image.raw.xz"
@@ -567,7 +569,8 @@ image_types:
             # so we can't exclude it.
             # - "linux-firmware"
             - "firewalld"
-    supported_blueprint_options: *supported_blueprint_options
+    blueprint:
+      supported_options: *supported_blueprint_options
 
   qcow2:
     filename: "disk.qcow2"
@@ -656,4 +659,5 @@ image_types:
             - "libertas-usb8388-firmware"
           conditions:
             <<: *conditions_for_insights_client
-    supported_blueprint_options: *supported_blueprint_options
+    blueprint:
+      supported_options: *supported_blueprint_options

--- a/data/distrodefs/rhel-8/imagetypes.yaml
+++ b/data/distrodefs/rhel-8/imagetypes.yaml
@@ -1435,7 +1435,8 @@ image_types:
     partition_tables_override:
       <<: *ec2_partition_tables_override
     image_config: *ami_image_config
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   ec2: &ec2
     <<: *ami
@@ -1462,7 +1463,8 @@ image_types:
               append:
                 include:
                   - "redhat-cloud-client-configuration"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "ec2-ha":
     <<: *ec2
@@ -1491,7 +1493,8 @@ image_types:
             - "alsa-lib"
           conditions:
             <<: *conditions_rh_cloud_client
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "ec2-sap":
     <<: *ec2
@@ -1547,7 +1550,8 @@ image_types:
               append:
                 include:
                   - "rh-amazon-rhui-client-sap-bundle"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   qcow2: &qcow2
     name_aliases: ["guest-image"]
@@ -1597,7 +1601,8 @@ image_types:
     package_sets: &qcow2_pkgset
       os:
         - *qcow2_common_pkgset
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   vhd:
     name_aliases: ["azure"]
@@ -1758,7 +1763,8 @@ image_types:
             - "firewalld"
           exclude:
             - "alsa-lib"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "azure-rhui": &azure_rhui
     filename: "disk.vhd.xz"
@@ -1809,7 +1815,8 @@ image_types:
             - "alsa-lib"
     partition_table:
       <<: *azure_rhui_partition_tables
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "azure-sap-rhui":
     <<: *azure_rhui
@@ -1839,7 +1846,8 @@ image_types:
               append:
                 include:
                   - "rhui-azure-rhel8-sap-ha"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "azure-eap7-rhui":
     <<: *azure_rhui
@@ -1913,7 +1921,8 @@ image_types:
                   - "python3-html5lib"
     # the azure-eap7-rhui image type is internal only and generally is never
     # build with customizations, but let's treat it like a regular disk image
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "image-installer":
     filename: "installer.iso"
@@ -1955,34 +1964,35 @@ image_types:
         - *installer_pkgset
         - *anaconda_pkgset
         - *anaconda_boot_pkgset
-    supported_blueprint_options:
-      - "distro"
-      - "packages"
-      - "modules"
-      - "groups"
-      - "enabled_modules"
-      - "containers"
-      - "minimal"
-      - "customizations.installer"
-      - "customizations.cacerts"
-      - "customizations.dnf"
-      - "customizations.directories"
-      - "customizations.files"
-      - "customizations.firewall"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.fips"
-      - "customizations.timezone"
-      - "customizations.hostname"
-      - "customizations.kernel.name"
-      - "customizations.locale"
-      - "customizations.openscap"
-      - "customizations.repositories"
-      - "customizations.rpm"
-      - "customizations.services"
-      - "customizations.rhsm"
-      - "customizations.kernel.append"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "packages"
+        - "modules"
+        - "groups"
+        - "enabled_modules"
+        - "containers"
+        - "minimal"
+        - "customizations.installer"
+        - "customizations.cacerts"
+        - "customizations.dnf"
+        - "customizations.directories"
+        - "customizations.files"
+        - "customizations.firewall"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.fips"
+        - "customizations.timezone"
+        - "customizations.hostname"
+        - "customizations.kernel.name"
+        - "customizations.locale"
+        - "customizations.openscap"
+        - "customizations.repositories"
+        - "customizations.rpm"
+        - "customizations.services"
+        - "customizations.rhsm"
+        - "customizations.kernel.append"
 
   tar:
     filename: "root.tar.xz"
@@ -2001,33 +2011,34 @@ image_types:
             - "selinux-policy-targeted"
           exclude:
             - "rng-tools"
-    supported_blueprint_options:
-      # We've never tested many options or customizations with this image type
-      # and we also never restricted any, but it uses the OS pipeline, so it
-      # should support most standard/basic customizations
-      - "distro"
-      - "packages"
-      - "modules"
-      - "groups"
-      - "containers"
-      - "enabled_modules"
-      - "minimal"
-      - "customizations.dnf"
-      - "customizations.cacerts"
-      - "customizations.directories"
-      - "customizations.files"
-      - "customizations.firewall"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.hostname"
-      - "customizations.kernel.name"
-      - "customizations.locale"
-      - "customizations.repositories"
-      - "customizations.rpm"
-      - "customizations.services"
-      - "customizations.timezone"
-      - "customizations.rhsm"
+    blueprint:
+      supported_options:
+        # We've never tested many options or customizations with this image type
+        # and we also never restricted any, but it uses the OS pipeline, so it
+        # should support most standard/basic customizations
+        - "distro"
+        - "packages"
+        - "modules"
+        - "groups"
+        - "containers"
+        - "enabled_modules"
+        - "minimal"
+        - "customizations.dnf"
+        - "customizations.cacerts"
+        - "customizations.directories"
+        - "customizations.files"
+        - "customizations.firewall"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.hostname"
+        - "customizations.kernel.name"
+        - "customizations.locale"
+        - "customizations.repositories"
+        - "customizations.rpm"
+        - "customizations.services"
+        - "customizations.timezone"
+        - "customizations.rhsm"
 
   "edge-commit": &edge_commit
     name_aliases: ["rhel-edge-commit"]
@@ -2205,7 +2216,8 @@ image_types:
                   - "fdo-owner-cli"
                   - "greenboot-default-health-checks"
                   - "sos"
-    supported_blueprint_options: *supported_options_ostree_commit
+    blueprint:
+      supported_options: *supported_options_ostree_commit
 
   "edge-installer":
     name_aliases: ["rhel-edge-installer"]
@@ -2242,15 +2254,16 @@ image_types:
         - *installer_pkgset
         - *anaconda_pkgset
         - *anaconda_boot_pkgset
-    supported_blueprint_options:
-      - "distro"
-      - "customizations.installer"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.fips"
-      - "customizations.timezone"
-      - "customizations.locale"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "customizations.installer"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.fips"
+        - "customizations.timezone"
+        - "customizations.locale"
 
   # XXX: only available for rhel-8.6+, this is not possible to limit right now
   "edge-raw-image":
@@ -2283,7 +2296,8 @@ image_types:
     supported_partitioning_modes:
       - ""  # default partitioning mode is supported (in original go based code)
       - "raw"
-    supported_blueprint_options: *supported_options_ostree_disk
+    blueprint:
+      supported_options: *supported_options_ostree_disk
 
   "edge-simplified-installer":
     filename: "simplified-installer.iso"
@@ -2385,23 +2399,24 @@ image_types:
                 arch: "aarch64"
               append:
                 <<: *edge_commit_aarch64_pkgset
-    supported_blueprint_options:
-      - "distro"
-      - "customizations.installation_device"
-      - "customizations.filesystem"
-      - "customizations.disk"
-      - "customizations.fdo"
-      - "customizations.ignition"
-      - "customizations.kernel"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.fips"
-      - "customizations.files"
-      - "customizations.directories"
-      - "customizations.dnf"
-    required_blueprint_options:
-      - "customizations.installation_device"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "customizations.installation_device"
+        - "customizations.filesystem"
+        - "customizations.disk"
+        - "customizations.fdo"
+        - "customizations.ignition"
+        - "customizations.kernel"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.fips"
+        - "customizations.files"
+        - "customizations.directories"
+        - "customizations.dnf"
+      required_options:
+        - "customizations.installation_device"
 
   "edge-container":
     name_aliases: ["rhel-edge-container"]
@@ -2428,7 +2443,8 @@ image_types:
     package_sets:
       os:
         - *edge_commit_pkgset
-    supported_blueprint_options: *supported_options_ostree_commit
+    blueprint:
+      supported_options: *supported_options_ostree_commit
 
   vmdk: &vmdk
     name_aliases: ["vsphere"]
@@ -2461,7 +2477,8 @@ image_types:
           exclude:
             - "dracut-config-rescue"
             - "rng-tools"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   ova:
     <<: *vmdk
@@ -2472,7 +2489,8 @@ image_types:
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "ova"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   gce: &gce
     # this image type is set to `gcp` in image-builder-crc
@@ -2575,7 +2593,8 @@ image_types:
     package_sets:
       os:
         - *gce_common_pkgset
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "gce-rhui":
     <<: *gce
@@ -2602,7 +2621,8 @@ image_types:
         - *gce_common_pkgset
         - include:
             - "google-rhui-client-rhel8"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   oci:
     <<: *qcow2
@@ -2613,7 +2633,8 @@ image_types:
       - <<: *x86_64_bios_platform
         image_format: "qcow2"
         qcow2_compat: "0.10"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   openstack:
     <<: *qcow2
@@ -2645,7 +2666,8 @@ image_types:
           exclude:
             - "dracut-config-rescue"
             - "rng-tools"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   wsl:
     filename: "image.wsl"
@@ -2767,27 +2789,28 @@ image_types:
             - "unbound-libs"
             - "xkeyboard-config"
             - "xz"
-    supported_blueprint_options:
-      - "distro"
-      - "packages"
-      - "modules"
-      - "groups"
-      - "enabled_modules"
-      - "minimal"
-      - "containers"
-      - "customizations.dnf"
-      - "customizations.directories"
-      - "customizations.files"
-      - "customizations.firewall"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.hostname"
-      - "customizations.locale"
-      - "customizations.repositories"
-      - "customizations.services"
-      - "customizations.timezone"
-      - "customizations.rhsm"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "packages"
+        - "modules"
+        - "groups"
+        - "enabled_modules"
+        - "minimal"
+        - "containers"
+        - "customizations.dnf"
+        - "customizations.directories"
+        - "customizations.files"
+        - "customizations.firewall"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.hostname"
+        - "customizations.locale"
+        - "customizations.repositories"
+        - "customizations.services"
+        - "customizations.timezone"
+        - "customizations.rhsm"
 
   "minimal-raw":
     filename: "disk.raw.xz"
@@ -2832,7 +2855,8 @@ image_types:
             - "NetworkManager-wifi"
             - "iwl7260-firmware"
             - "iwl3160-firmware"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   # Based on lorax runtime-install.tmpl
   "network-installer":
@@ -2973,7 +2997,8 @@ image_types:
             - "hexedit"
             - "sg3_utils"
             - "perl-interpreter"
-    supported_blueprint_options:
-      - "distro"
-      - "customizations.fips"
-      - "customizations.locale"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "customizations.fips"
+        - "customizations.locale"

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -1544,7 +1544,8 @@ image_types:
                 include:
                   - "insights-client"
                   - "subscription-manager-cockpit"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "vagrant-libvirt": &vagrant_libvirt
     <<: *qcow2
@@ -1579,7 +1580,8 @@ image_types:
           mode: 440
           data: |
             vagrant ALL=(ALL) NOPASSWD: ALL
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "vagrant-virtualbox":
     <<: *vagrant_libvirt
@@ -1587,7 +1589,8 @@ image_types:
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "vagrant_virtualbox"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   oci:
     <<: *qcow2
@@ -1597,7 +1600,8 @@ image_types:
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "qcow2"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   vhd: &vhd
     <<: *qcow2
@@ -1650,7 +1654,8 @@ image_types:
     package_sets:
       os:
         - *azure_base_pkgset
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "azure": &azure
     <<: *vhd
@@ -1745,11 +1750,13 @@ image_types:
           # NB: we currently don't support /boot on LVM
           - *azure_rhui_part_boot
           - *azure_rhui_part_lvm
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "azure-rhui": &azure_rhui
     <<: *azure
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "azure-sap-rhui":
     <<: *azure_rhui
@@ -1763,7 +1770,8 @@ image_types:
         - *azure_base_pkgset
         - *sap_base_pkgset
         - *sap_extras_pkgset
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   azure-sapapps-rhui:
     <<: *azure_rhui
@@ -1776,7 +1784,8 @@ image_types:
       os:
         - *azure_base_pkgset
         - *sap_base_pkgset
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   tar:
     filename: "root.tar.xz"
@@ -1795,32 +1804,33 @@ image_types:
             - "selinux-policy-targeted"
           exclude:
             - "rng-tools"
-    supported_blueprint_options:
-      # We've never tested many options or customizations with this image type
-      # and we also never restricted any, but it uses the OS pipeline, so it
-      # should support most standard/basic customizations
-      - "distro"
-      - "packages"
-      - "modules"
-      - "groups"
-      - "containers"
-      - "enabled_modules"
-      - "minimal"
-      - "customizations.dnf"
-      - "customizations.cacerts"
-      - "customizations.directories"
-      - "customizations.files"
-      - "customizations.firewall"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.hostname"
-      - "customizations.kernel.name"
-      - "customizations.locale"
-      - "customizations.repositories"
-      - "customizations.rpm"
-      - "customizations.services"
-      - "customizations.timezone"
+    blueprint:
+      supported_options:
+        # We've never tested many options or customizations with this image type
+        # and we also never restricted any, but it uses the OS pipeline, so it
+        # should support most standard/basic customizations
+        - "distro"
+        - "packages"
+        - "modules"
+        - "groups"
+        - "containers"
+        - "enabled_modules"
+        - "minimal"
+        - "customizations.dnf"
+        - "customizations.cacerts"
+        - "customizations.directories"
+        - "customizations.files"
+        - "customizations.firewall"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.hostname"
+        - "customizations.kernel.name"
+        - "customizations.locale"
+        - "customizations.repositories"
+        - "customizations.rpm"
+        - "customizations.services"
+        - "customizations.timezone"
 
   vmdk: &vmdk
     name_aliases: ["vsphere"]
@@ -1852,7 +1862,8 @@ image_types:
           exclude:
             - "dracut-config-rescue"
             - "rng-tools"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   ova:
     <<: *vmdk
@@ -1863,7 +1874,8 @@ image_types:
     platforms:
       - <<: *x86_64_bios_platform
         image_format: "ova"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   ec2: &ec2
     filename: "image.raw.xz"
@@ -2009,7 +2021,8 @@ image_types:
         - *ec2_base_pkgset
         - exclude:
             - "alsa-lib"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   ami:
     <<: *ec2
@@ -2018,7 +2031,8 @@ image_types:
     filename: "image.raw"
     exports: ["image"]
     compression: ""
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "ec2-ha":
     <<: *ec2
@@ -2044,7 +2058,8 @@ image_types:
             - "pcs"
           exclude:
             - "alsa-lib"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "ec2-sap":
     <<: *ec2
@@ -2091,7 +2106,8 @@ image_types:
           exclude:
             # COMPOSER-1829
             - "firewalld"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   wsl: &wsl
     filename: "image.wsl"
@@ -2211,27 +2227,28 @@ image_types:
                   - "wsl-setup"
                   - "centos-logos"
                   - "centos-release"
-    supported_blueprint_options:
-      - "distro"
-      - "packages"
-      - "modules"
-      - "groups"
-      - "enabled_modules"
-      - "minimal"
-      - "containers"
-      - "customizations.dnf"
-      - "customizations.directories"
-      - "customizations.files"
-      - "customizations.firewall"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.hostname"
-      - "customizations.locale"
-      - "customizations.repositories"
-      - "customizations.services"
-      - "customizations.timezone"
-      - "customizations.rhsm"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "packages"
+        - "modules"
+        - "groups"
+        - "enabled_modules"
+        - "minimal"
+        - "containers"
+        - "customizations.dnf"
+        - "customizations.directories"
+        - "customizations.files"
+        - "customizations.firewall"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.hostname"
+        - "customizations.locale"
+        - "customizations.repositories"
+        - "customizations.services"
+        - "customizations.timezone"
+        - "customizations.rhsm"
 
 
   "image-installer":
@@ -2296,34 +2313,35 @@ image_types:
       installer:
         - *installer_pkgset
         - *anaconda_pkgset
-    supported_blueprint_options:
-      - "distro"
-      - "packages"
-      - "modules"
-      - "groups"
-      - "enabled_modules"
-      - "containers"
-      - "minimal"
-      - "customizations.dnf"
-      - "customizations.installer"
-      - "customizations.cacerts"
-      - "customizations.directories"
-      - "customizations.files"
-      - "customizations.firewall"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.fips"
-      - "customizations.timezone"
-      - "customizations.hostname"
-      - "customizations.kernel.name"
-      - "customizations.locale"
-      - "customizations.openscap"
-      - "customizations.repositories"
-      - "customizations.rpm"
-      - "customizations.services"
-      - "customizations.rhsm"
-      - "customizations.kernel.append"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "packages"
+        - "modules"
+        - "groups"
+        - "enabled_modules"
+        - "containers"
+        - "minimal"
+        - "customizations.dnf"
+        - "customizations.installer"
+        - "customizations.cacerts"
+        - "customizations.directories"
+        - "customizations.files"
+        - "customizations.firewall"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.fips"
+        - "customizations.timezone"
+        - "customizations.hostname"
+        - "customizations.kernel.name"
+        - "customizations.locale"
+        - "customizations.openscap"
+        - "customizations.repositories"
+        - "customizations.rpm"
+        - "customizations.services"
+        - "customizations.rhsm"
+        - "customizations.kernel.append"
 
   gce:
     # this image type is set to `gcp` in image-builder-crc
@@ -2481,7 +2499,8 @@ image_types:
             - "qemu-guest-agent"
           conditions:
             "insights clients on rhel": *conditions_pkgsets_insights_client_on_rhel
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "minimal-raw":
     filename: "disk.raw.xz"
@@ -2582,7 +2601,8 @@ image_types:
             - "NetworkManager-wifi"
             - "iwl7260-firmware"
             - "iwl3160-firmware"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   openstack:
     <<: *qcow2
@@ -2615,7 +2635,8 @@ image_types:
           exclude:
             - "dracut-config-rescue"
             - "rng-tools"
-    supported_blueprint_options: *supported_options_disk
+    blueprint:
+      supported_options: *supported_options_disk
 
   "edge-commit": &edge_commit
     name_aliases: ["rhel-edge-commit"]
@@ -2787,7 +2808,8 @@ image_types:
                 include:
                   # dnsmasq removed in 9.6+ but kept in older versions
                   - "dnsmasq"
-    supported_blueprint_options: *supported_options_ostree_commit
+    blueprint:
+      supported_options: *supported_options_ostree_commit
 
   "edge-container":
     name_aliases: ["rhel-edge-container"]
@@ -2808,7 +2830,8 @@ image_types:
             - *ostree_server_config_path
           exposed_ports:
             - *ostree_server_port
-    supported_blueprint_options: *supported_options_ostree_commit
+    blueprint:
+      supported_options: *supported_options_ostree_commit
 
   "edge-raw-image":
     name_aliases: ["rhel-edge-raw-image"]
@@ -2852,7 +2875,8 @@ image_types:
             ostree_conf_sysroot_readonly: false
             ignition_platform: ""
             kernel_options: ["modprobe.blacklist=vc4"]
-    supported_blueprint_options: *supported_options_ostree_disk
+    blueprint:
+      supported_options: *supported_options_ostree_disk
 
   # XXX: not a real pkgset but the "containerPkgsKey"
   "edge-container-pipeline-pkgset":
@@ -2889,15 +2913,16 @@ image_types:
       installer:
         - *installer_pkgset
         - *anaconda_pkgset
-    supported_blueprint_options:
-      - "distro"
-      - "customizations.installer"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.fips"
-      - "customizations.timezone"
-      - "customizations.locale"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "customizations.installer"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.fips"
+        - "customizations.timezone"
+        - "customizations.locale"
 
   "edge-simplified-installer":
     name_aliases: ["rhel-edge-simplified-installer"]
@@ -3005,23 +3030,24 @@ image_types:
                 arch: "aarch64"
               append:
                 <<: *edge_commit_aarch64_pkgset
-    supported_blueprint_options:
-      - "distro"
-      - "customizations.dnf"
-      - "customizations.installation_device"
-      - "customizations.filesystem"
-      - "customizations.disk"
-      - "customizations.fdo"
-      - "customizations.ignition"
-      - "customizations.kernel"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.fips"
-      - "customizations.files"
-      - "customizations.directories"
-    required_blueprint_options:
-      - "customizations.installation_device"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "customizations.dnf"
+        - "customizations.installation_device"
+        - "customizations.filesystem"
+        - "customizations.disk"
+        - "customizations.fdo"
+        - "customizations.ignition"
+        - "customizations.kernel"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.fips"
+        - "customizations.files"
+        - "customizations.directories"
+      required_options:
+        - "customizations.installation_device"
 
   "edge-ami": &edge_ami
     filename: "image.raw"
@@ -3076,7 +3102,8 @@ image_types:
               - "nvme_core.io_timeout=4294967295"
               # edge-ami
               - "modprobe.blacklist=vc4"
-    supported_blueprint_options: *supported_options_ostree_disk
+    blueprint:
+      supported_options: *supported_options_ostree_disk
 
   "edge-vsphere":
     <<: *edge_ami
@@ -3103,7 +3130,8 @@ image_types:
           shallow_merge:
             kernel_options:
               - "modprobe.blacklist=vc4"
-    supported_blueprint_options: *supported_options_ostree_disk
+    blueprint:
+      supported_options: *supported_options_ostree_disk
 
   "azure-cvm":
     <<: *vhd
@@ -3177,35 +3205,36 @@ image_types:
     package_sets:
       os:
         - *azure_base_pkgset
-    supported_blueprint_options:
-      # same as disk image types, but kernel customizations are not supported
-      - "distro"
-      - "packages"
-      - "modules"
-      - "groups"
-      - "enabled_modules"
-      - "containers"
-      - "minimal"
-      - "customizations.cacerts"
-      - "customizations.directories"
-      - "customizations.disk"
-      - "customizations.dnf"
-      - "customizations.files"
-      - "customizations.filesystem"
-      - "customizations.partitioning_mode"
-      - "customizations.fips"
-      - "customizations.firewall"
-      - "customizations.user"
-      - "customizations.sshkey"
-      - "customizations.group"
-      - "customizations.hostname"
-      - "customizations.locale"
-      - "customizations.openscap"
-      - "customizations.repositories"
-      - "customizations.rpm"
-      - "customizations.services"
-      - "customizations.timezone"
-      - "customizations.rhsm"
+    blueprint:
+      supported_options:
+        # same as disk image types, but kernel customizations are not supported
+        - "distro"
+        - "packages"
+        - "modules"
+        - "groups"
+        - "enabled_modules"
+        - "containers"
+        - "minimal"
+        - "customizations.cacerts"
+        - "customizations.directories"
+        - "customizations.disk"
+        - "customizations.dnf"
+        - "customizations.files"
+        - "customizations.filesystem"
+        - "customizations.partitioning_mode"
+        - "customizations.fips"
+        - "customizations.firewall"
+        - "customizations.user"
+        - "customizations.sshkey"
+        - "customizations.group"
+        - "customizations.hostname"
+        - "customizations.locale"
+        - "customizations.openscap"
+        - "customizations.repositories"
+        - "customizations.rpm"
+        - "customizations.services"
+        - "customizations.timezone"
+        - "customizations.rhsm"
 
   # Based on lorax runtime-install.tmpl
   "network-installer":
@@ -3355,10 +3384,11 @@ image_types:
             - "perl-interpreter"
             - "restore"
             - "spice-vdagent"
-    supported_blueprint_options:
-      - "distro"
-      - "customizations.fips"
-      - "customizations.locale"
+    blueprint:
+      supported_options:
+        - "distro"
+        - "customizations.fips"
+        - "customizations.locale"
 
   "pxe-tar-xz":
     filename: "pxe.tar.xz"
@@ -3378,7 +3408,8 @@ image_types:
     platforms:
       - *x86_64_bios_platform
       - *aarch64_platform
-    supported_blueprint_options: *supported_options_pxe
+    blueprint:
+      supported_options: *supported_options_pxe
 
   "bootc-rpm-installer":
     # Note that this image type is partial and only used by
@@ -3546,7 +3577,8 @@ image_types:
             - "publicsuffix-list-dafsa"
             - "rpm-plugin-audit"
             - "xkeyboard-config"
-    supported_blueprint_options: *supported_options_container
+    blueprint:
+      supported_options: *supported_options_container
 
   container-minimal:
     <<: *container

--- a/pkg/distro/bootc/bootc.go
+++ b/pkg/distro/bootc/bootc.go
@@ -303,7 +303,7 @@ func (t *BootcImageType) SupportedBlueprintOptions() []string {
 	// The blueprint contains a few fields that are essentially metadata and
 	// not configuration / customizations. These should always be implicitly
 	// supported by all image types.
-	return append(t.ImageTypeYAML.SupportedBlueprintOptions, "name", "version", "description")
+	return append(t.ImageTypeYAML.Blueprint.SupportedOptions, "name", "version", "description")
 }
 
 func (t *BootcImageType) RequiredBlueprintOptions() []string {

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -430,8 +430,10 @@ type ImageTypeYAML struct {
 
 	SupportedPartitioningModes []partition.PartitioningMode `yaml:"supported_partitioning_modes"`
 
-	SupportedBlueprintOptions []string `yaml:"supported_blueprint_options"`
-	RequiredBlueprintOptions  []string `yaml:"required_blueprint_options"`
+	Blueprint struct {
+		SupportedOptions []string `yaml:"supported_options"`
+		RequiredOptions  []string `yaml:"required_options"`
+	} `yaml:"blueprint"`
 
 	// name is set by the loader
 	name string

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -333,14 +333,14 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 }
 
 func (t *imageType) RequiredBlueprintOptions() []string {
-	return t.ImageTypeYAML.RequiredBlueprintOptions
+	return t.ImageTypeYAML.Blueprint.RequiredOptions
 }
 
 func (t *imageType) SupportedBlueprintOptions() []string {
 	// The blueprint contains a few fields that are essentially metadata and
 	// not configuration / customizations. These should always be implicitly
 	// supported by all image types.
-	return append(t.ImageTypeYAML.SupportedBlueprintOptions, "name", "version", "description")
+	return append(t.ImageTypeYAML.Blueprint.SupportedOptions, "name", "version", "description")
 }
 
 func bootstrapContainerFor(t *imageType) string {


### PR DESCRIPTION
This commit moves the `blueprint_{supported,required}_options` into a new nested structure:
```yaml
    blueprint:
      supported_options:
        - ...
      required_options:
        - ...
```
this was suggested for `image-builder describe-image` in: https://github.com/osbuild/image-builder-cli/pull/376#discussion_r2549045694 but we need to start here to keep things symetric.