### PR TITLE
test: set the correct tag for openstack runners

### DIFF
--- a/test/scripts/generate-build-config
+++ b/test/scripts/generate-build-config
@@ -17,6 +17,8 @@ build/{distro}/{arch}/{image_type}/{config_name}:
     - ./test/scripts/boot-image "{image_path}"
     - ./test/scripts/upload-results "{distro}" "{image_type}" "{config}"
   extends: .terraform
+  tags:
+    - {tag}
   variables:
     RUNNER: {runner}-{arch}
     INTERNAL_NETWORK: "{internal}"
@@ -64,9 +66,12 @@ def generate_configs(build_requests, pipeline_file):
         build_name = testlib.gen_build_name(distro, arch, image_type, config_name)
         image_path = f"./build/{build_name}"
 
+        runner = testlib.get_ci_runner_for(arch, image_type)
+        tag = testlib.get_tag_for(runner)
+
         config_path = os.path.join(testlib.CONFIGS_PATH, config_name+".json")
         pipeline_file.write(JOB_TEMPLATE.format(distro=distro, arch=arch, image_type=image_type,
-                                                runner=testlib.get_ci_runner_for(arch, image_type),
+                                                runner=runner, tag=tag,
                                                 config_name=config_name, config=config_path,
                                                 internal="true" if "rhel" in distro else "false",
                                                 image_path=image_path))

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -546,6 +546,13 @@ def skopeo_inspect_id(image_name: str, arch: str) -> str:
     # don't error out, just return an empty string and let the caller handle it
     return ""
 
+def get_tag_for(runner):
+    if runner.startswith("aws/"):
+        return "terraform"
+    if runner.startswith("rhos-01/"):
+        return "terraform/openstack"
+
+    raise ValueError(f"Unknown runner: {runner}")
 
 def get_ci_runner_for(arch, image_type):
     with open(SCHUTZFILE, encoding="utf-8") as schutzfile:


### PR DESCRIPTION
schutzbot uses tags for limiting the number of concurrent PRs on different platforms. This is needed because we have different quotas on AWS vs. OpenStack. See
https://github.com/osbuild/gitlab-ci-config/blob/main/config.toml.tpl

This commits tags the rhos01 runners with the proper terraform/openstack tag which should prevent hitting the openstack quota which is way lower than the aws one.