### PR TITLE
readme: update link to image definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See also the [local developer documentation](./docs/developer) for useful inform
 #### YAML based image definitions
 
 More and more parts of the library are converted to use yaml to define core
-parts of an image. See this [example](./pkg/distro/packagesets/fedora/)
+parts of an image. See this [example](./data/distrodefs/)
 directory. For local development that just changes the YAML based
 definitions the library can be forced to use alternative yaml dirs.
 


### PR DESCRIPTION
I was trying to gain some knowledge, and it took me a while to find the file, since it was moved several times:
f16cc07210ae038c9a9a98ba7c91ab342b174183
be97c70693471ffb5784135f17cfaf72a67e06ee
e04d8a11367660e6d1aefa9410041a993205de10
6c13109bf893337b66fdcf8f7c1ffa2b54d273aa

But hopefully this is what the docs mean?