### PR TITLE
pkg/manifest: remove `--server` option from rhc connect (HMS-9809)

### DIFF
--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -78,7 +78,8 @@ func TestSubscriptionManagerCommands(t *testing.T) {
 	pipeline, err := os.Serialize()
 	assert.NoError(t, err)
 	CheckSystemdStageOptions(t, pipeline.Stages, []string{
-		`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --serverurl 'subscription.rhsm.redhat.com' --baseurl 'http://cdn.redhat.com/'`,
+		"/usr/sbin/subscription-manager config --server.hostname 'subscription.rhsm.redhat.com'",
+		`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --baseurl 'http://cdn.redhat.com/'`,
 	})
 }
 
@@ -94,7 +95,8 @@ func TestSubscriptionManagerInsightsCommands(t *testing.T) {
 	pipeline, err := os.Serialize()
 	assert.NoError(t, err)
 	CheckSystemdStageOptions(t, pipeline.Stages, []string{
-		`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --serverurl 'subscription.rhsm.redhat.com' --baseurl 'http://cdn.redhat.com/'`,
+		"/usr/sbin/subscription-manager config --server.hostname 'subscription.rhsm.redhat.com'",
+		`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --baseurl 'http://cdn.redhat.com/'`,
 		"/usr/bin/insights-client --register",
 	})
 }

--- a/pkg/manifest/subscription.go
+++ b/pkg/manifest/subscription.go
@@ -128,19 +128,18 @@ func subscriptionService(
 	}
 
 	var commands []string
+	if subscriptionOptions.ServerUrl != "" {
+		commands = append(commands, fmt.Sprintf("/usr/sbin/subscription-manager config --server.hostname %s", shutil.Quote(subscriptionOptions.ServerUrl)))
+	}
+	if subscriptionOptions.Proxy != "" {
+		proxy := strings.Split(subscriptionOptions.Proxy, ":")
+		commands = append(commands, fmt.Sprintf("/usr/sbin/subscription-manager config --server.proxy_hostname %s", shutil.Quote(proxy[0])))
+		if len(proxy) == 2 {
+			commands = append(commands, fmt.Sprintf("/usr/sbin/subscription-manager config --server.proxy_port %s", shutil.Quote(proxy[1])))
+		}
+	}
+
 	if subscriptionOptions.Rhc {
-		if subscriptionOptions.ServerUrl != "" {
-			commands = append(commands, fmt.Sprintf("/usr/sbin/subscription-manager config --server.hostname %s", shutil.Quote(subscriptionOptions.ServerUrl)))
-
-		}
-		if subscriptionOptions.Proxy != "" {
-			proxy := strings.Split(subscriptionOptions.Proxy, ":")
-			commands = append(commands, fmt.Sprintf("/usr/sbin/subscription-manager config --server.proxy_hostname %s", shutil.Quote(proxy[0])))
-			if len(proxy) == 2 {
-				commands = append(commands, fmt.Sprintf("/usr/sbin/subscription-manager config --server.proxy_port %d", shutil.Quote(proxy[1])))
-			}
-		}
-
 		var curlToAssociateSystem string
 		// Use rhc for registration instead of subscription manager
 		rhcConnect := `/usr/bin/rhc connect --organization="${ORG_ID}" --activation-key="${ACTIVATION_KEY}"`
@@ -168,13 +167,6 @@ func subscriptionService(
 			files = append(files, icFile)
 		}
 	} else {
-		if subscriptionOptions.Proxy != "" {
-			proxy := strings.Split(subscriptionOptions.Proxy, ":")
-			commands = append(commands, fmt.Sprintf("/usr/sbin/subscription-manager config --server.proxy_hostname %s", shutil.Quote(proxy[0])))
-			if len(proxy) == 2 {
-				commands = append(commands, fmt.Sprintf("/usr/sbin/subscription-manager config --server.proxy_port %d", shutil.Quote(proxy[1])))
-			}
-		}
 		commands = append(commands, fmt.Sprintf(`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --baseurl %s`, shutil.Quote(subscriptionOptions.BaseUrl)))
 
 		// Insights is optional when using subscription-manager

--- a/pkg/manifest/subscription_test.go
+++ b/pkg/manifest/subscription_test.go
@@ -63,7 +63,8 @@ func TestSubscriptionService(t *testing.T) {
 						Service: &osbuild.ServiceSection{
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
-								`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --serverurl 'theserverurl' --baseurl 'thebaseurl'`,
+								"/usr/sbin/subscription-manager config --server.hostname 'theserverurl'",
+								`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --baseurl 'thebaseurl'`,
 								"/usr/bin/rm '" + subkeyFilepath + "'",
 							},
 							EnvironmentFile: []string{
@@ -108,7 +109,8 @@ func TestSubscriptionService(t *testing.T) {
 						Service: &osbuild.ServiceSection{
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
-								`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --serverurl 'theserverurl-wi' --baseurl 'thebaseurl-wi'`,
+								"/usr/sbin/subscription-manager config --server.hostname 'theserverurl-wi'",
+								`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --baseurl 'thebaseurl-wi'`,
 								"/usr/bin/insights-client --register", // added when insights is enabled
 								"/usr/bin/rm '" + subkeyFilepath + "'",
 							},
@@ -157,7 +159,9 @@ func TestSubscriptionService(t *testing.T) {
 						Service: &osbuild.ServiceSection{
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
-								`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --serverurl 'theserverurl-wi' --baseurl 'thebaseurl-wi'`,
+								"/usr/sbin/subscription-manager config --server.hostname 'theserverurl-wi'",
+								"/usr/sbin/subscription-manager config --server.proxy_hostname 'proxy-url'",
+								`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --baseurl 'thebaseurl-wi'`,
 								"/usr/bin/insights-client --register", // added when insights is enabled
 								"curl -v --retry 5 --cert /etc/pki/consumer/cert.pem --key /etc/pki/consumer/key.pem -X PATCH 'https://cert.console.redhat.com/api/patch/v3/templates/template-uuid/subscribed-systems' --proxy 'proxy-url'",
 								"/usr/sbin/subscription-manager refresh",
@@ -408,6 +412,7 @@ func TestSubscriptionService(t *testing.T) {
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
 								"/usr/sbin/subscription-manager config --server.hostname 'theserverurl-wir'",
+								"/usr/sbin/subscription-manager config --server.proxy_hostname 'proxy-url'",
 								`/usr/bin/rhc connect --organization="${ORG_ID}" --activation-key="${ACTIVATION_KEY}"`,
 								"/usr/sbin/semanage permissive --add rhcd_t", // added when rhc is enabled
 								"curl -v --retry 5 --cert /etc/pki/consumer/cert.pem --key /etc/pki/consumer/key.pem -X PATCH 'https://cert.console.redhat.com/api/patch/v3/templates/template-uuid/subscribed-systems' --proxy 'proxy-url'",
@@ -458,7 +463,8 @@ func TestSubscriptionService(t *testing.T) {
 						Service: &osbuild.ServiceSection{
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
-								`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --serverurl 'theserverurl-iob' --baseurl 'thebaseurl-iob'`,
+								"/usr/sbin/subscription-manager config --server.hostname 'theserverurl-iob'",
+								`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --baseurl 'thebaseurl-iob'`,
 								"/usr/bin/insights-client --register", // added when insights is enabled
 								"/usr/bin/rm '" + subkeyFilepath + "'",
 							},
@@ -510,7 +516,8 @@ func TestSubscriptionService(t *testing.T) {
 						Service: &osbuild.ServiceSection{
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
-								`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --serverurl 'theserverurl-etc' --baseurl 'thebaseurl-etc'`,
+								"/usr/sbin/subscription-manager config --server.hostname 'theserverurl-etc'",
+								`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --baseurl 'thebaseurl-etc'`,
 								"/usr/bin/rm '" + subkeyFilepath + "'",
 							},
 							EnvironmentFile: []string{
@@ -560,7 +567,8 @@ func TestSubscriptionService(t *testing.T) {
 						Service: &osbuild.ServiceSection{
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
-								`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --serverurl 'theserverurl-iob-etc' --baseurl 'thebaseurl-iob-etc'`,
+								"/usr/sbin/subscription-manager config --server.hostname 'theserverurl-iob-etc'",
+								`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --baseurl 'thebaseurl-iob-etc'`,
 								"/usr/bin/insights-client --register", // added when insights is enabled
 								"/usr/bin/rm '" + subkeyFilepath + "'",
 							},


### PR DESCRIPTION
The `rhc` command has a non-zero exit code for undefined flags. The `--server` flag was removed from the `rhc` cli causing the command to fail, resulting in the image not being auto-registered.

This changed with: https://github.com/RedHatInsights/rhc/pull/230