### PR TITLE
manifest: add repository content labels to first-boot service

### DIFF
--- a/pkg/customizations/subscription/subscription.go
+++ b/pkg/customizations/subscription/subscription.go
@@ -9,16 +9,17 @@ import (
 // ServerUrl denotes the host to register the system with
 // BaseUrl specifies the repository URL for DNF
 type ImageOptions struct {
-	Organization  string `json:"organization"`
-	ActivationKey string `json:"activation_key"`
-	ServerUrl     string `json:"server_url"`
-	BaseUrl       string `json:"base_url"`
-	Insights      bool   `json:"insights"`
-	Rhc           bool   `json:"rhc"`
-	Proxy         string `json:"proxy"`
-	TemplateName  string `json:"template_name"`
-	TemplateUUID  string `json:"template_uuid"`
-	PatchURL      string `json:"patch_url"`
+	Organization  string   `json:"organization"`
+	ActivationKey string   `json:"activation_key"`
+	ServerUrl     string   `json:"server_url"`
+	BaseUrl       string   `json:"base_url"`
+	Insights      bool     `json:"insights"`
+	Rhc           bool     `json:"rhc"`
+	Proxy         string   `json:"proxy"`
+	TemplateName  string   `json:"template_name"`
+	TemplateUUID  string   `json:"template_uuid"`
+	PatchURL      string   `json:"patch_url"`
+	ContentSets   []string `json:"content_sets"` // List of repo IDs to enable using subscription-manager on first boot
 }
 
 type RHSMStatus string

--- a/pkg/manifest/subscription.go
+++ b/pkg/manifest/subscription.go
@@ -188,6 +188,14 @@ func subscriptionService(
 			}
 		}
 	}
+	// Enable content sets if specified
+	if len(subscriptionOptions.ContentSets) > 0 {
+		contentSetsCmd := "/usr/sbin/subscription-manager repos"
+		for _, contentSet := range subscriptionOptions.ContentSets {
+			contentSetsCmd += fmt.Sprintf(" --enable=%s", shutil.Quote(contentSet))
+		}
+		commands = append(commands, contentSetsCmd)
+	}
 
 	commands = append(commands, fmt.Sprintf("/usr/bin/rm %s", shutil.Quote(subkeyFilepath)))
 


### PR DESCRIPTION
Adds repository content labels to the first-boot service to support enabling specific layered RH repositories.

Jira: [HMS-8855](https://issues.redhat.com/browse/HMS-8855)