### PR TITLE
test: add `--keep-booted` option to `boot-image`

### DIFF
--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -6,6 +6,7 @@ import os
 import pathlib
 import random
 import shutil
+import signal
 import string
 import subprocess
 import textwrap
@@ -190,7 +191,7 @@ def qemu_cmd_scp_and_run(vm, cmd, privkey_path):
     return vm.run(vmcmd, user="osbuild", keyfile=privkey_path)
 
 
-def boot_qemu(arch, image_path, config_file):
+def boot_qemu(arch, image_path, config_file, keep_booted=False):
     ensure_can_run_qemu_test(arch, image_path, config_file)
     cmd = [BASE_TEST_SCRIPT, config_file]
     with contextlib.ExitStack() as cm:
@@ -198,7 +199,17 @@ def boot_qemu(arch, image_path, config_file):
         (privkey_path, pubkey_path) = cm.enter_context(create_ssh_key())
         cloud_init_iso = cm.enter_context(make_cloud_init_iso(pubkey_path))
         with QEMU(uncompressed_image_path, arch=arch, cdrom=cloud_init_iso) as vm:
-            qemu_cmd_scp_and_run(vm, cmd, privkey_path)
+            try:
+                qemu_cmd_scp_and_run(vm, cmd, privkey_path)
+            finally:
+                if keep_booted:
+                    print("***********************************")
+                    print(f"keeping the image {image_path} booted as requested, press enter or ctrl-c to stop")
+                    print("to connect run:")
+                    print(
+                        f"ssh -i {privkey_path} -p {vm.ssh_port} -o UserKnownHostsFile=/dev/null "
+                        "-o StrictHostKeyChecking=no osbuild@localhost")
+                    signal.pause()
 
 
 def boot_qemu_iso_no_unattended_support(arch, installer_iso_path, config_file):
@@ -446,6 +457,9 @@ def main():
     desc = "Boot an image in the cloud environment it is built for and validate the configuration"
     parser = argparse.ArgumentParser(description=desc)
     parser.add_argument("image_search_path", type=str, help="path to search for image file")
+    parser.add_argument(
+        "--keep-booted", action="store_true",
+        help="keep the image booted (only qcow2 supported right now)")
 
     args = parser.parse_args()
     search_path = args.image_search_path
@@ -469,7 +483,7 @@ def main():
         # initial-setup and this blocks the boot.
         case "qcow2" | "generic-qcow2" | "cloud-qcow2":
             try:
-                boot_qemu(arch, image_path, build_config_path)
+                boot_qemu(arch, image_path, build_config_path, keep_booted=args.keep_booted)
             except CannotRunQemuTest as e:
                 print(f"WARNING: skipping {image_path}: {e.skip_reason}")
                 return

--- a/vmtest/vm.py
+++ b/vmtest/vm.py
@@ -122,6 +122,10 @@ class VM(abc.ABC):
         scp_cmd.append(f"{user}@{self._address}:{dst}")
         subprocess.check_call(scp_cmd)
 
+    @property
+    def ssh_port(self):
+        return self._ssh_port
+
     @abc.abstractmethod
     def running(self):
         """


### PR DESCRIPTION
[*if* this is getting merged I will do a small followup to add something to test/README.md]

Add a convenience way to keep the booted image around when using `test/scripts/boot-image`. When running:
```console
$ ./test/scripts/boot-image --keep-booted <path>
```
the image will stay around after the check script was run so that the image can be inspected. It also provides a convenient output how to login into the system:
```
$ ./test/scripts/boot-image --keep-booted ./build/centos_10-x86_64-qcow2-empty/
...
***********************************
keeping the image ./build/centos_10-x86_64-qcow2-empty/qcow2/disk.qcow2 booted as requested, press enter or ctrl-c to stop
to connect run:
ssh -i /tmp/tmpxbfzwzlo/testkey -p 50635 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no osbuild@localhost
```

Especially useful with https://github.com/osbuild/images/pull/2069 when building/booting tests images for other arches.

Note that currently only qcow2 is supported but if this is considered useful we can expand it to the other image types.

For some (like ISO image-installer) this is tricky as we cannot inject credentials via cloud-init. But that is a more general problem that we would ideally tackle at some point.