### PR TITLE
distro: extend interface with getting image types (HMS-9642)

### DIFF
--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -183,3 +183,22 @@ func SeedFrom(p *int64) int64 {
 	}
 	return *p
 }
+
+// Helper: Returns all image types supported by the given distro for the specified architecture.
+func GetImageTypes(d Distro, archName string) ([]ImageType, error) {
+	arch, err := d.GetArch(archName)
+	if err != nil {
+		return nil, err
+	}
+
+	imageTypeNames := arch.ListImageTypes()
+	imageTypes := make([]ImageType, len(imageTypeNames))
+	for i, imageTypeName := range imageTypeNames {
+		imageType, err := arch.GetImageType(imageTypeName)
+		if err != nil {
+			return nil, err
+		}
+		imageTypes[i] = imageType
+	}
+	return imageTypes, nil
+}

--- a/pkg/distro/distro_test.go
+++ b/pkg/distro/distro_test.go
@@ -717,3 +717,38 @@ func TestOSTreeOptionsErrorForNonOSTreeImgTypes(t *testing.T) {
 		}
 	}
 }
+
+func TestGetImageTypes(t *testing.T) {
+	assert := assert.New(t)
+	distroFactory := distrofactory.NewDefault()
+	assert.NotNil(distroFactory)
+
+	distros := listTestedDistros(t)
+	assert.NotEmpty(distros)
+
+	for _, distroName := range distros {
+		d := distroFactory.GetDistro(distroName)
+		assert.NotNil(d)
+
+		arches := d.ListArches()
+		assert.NotEmpty(arches)
+
+		for _, archName := range arches {
+			imageTypes, err := distro.GetImageTypes(d, archName)
+			assert.Nil(err)
+			assert.NotEmpty(imageTypes)
+
+			arch, err := d.GetArch(archName)
+			assert.Nil(err)
+
+			expectedNames := arch.ListImageTypes()
+			assert.Len(imageTypes, len(expectedNames))
+
+			for i, imageType := range imageTypes {
+				assert.Equal(expectedNames[i], imageType.Name())
+				assert.Equal(arch, imageType.Arch())
+			}
+
+		}
+	}
+}


### PR DESCRIPTION
This is a draft proposal of how we can make accessing image types more straightforward. The usage could be following:
```
architectures := distro.ListArches()
for _, architecture := range architectures {
  imageTypes, err := distro.GetImageTypes(architecture)
  if err != nil {
	  return err
  }
  for _, imageType := range imageTypes {
	  fmt.Printf("Parent Arch: %v, Image Type: %v, Supported Blueprint Options: %v\n", imageType.Arch().Name(), imageType.Name(), imageType.SupportedBlueprintOptions())
  }
}
```