### PR TITLE
manifestgen: add missing options documentation

### DIFF
--- a/pkg/manifestgen/manifestgen.go
+++ b/pkg/manifestgen/manifestgen.go
@@ -39,8 +39,13 @@ var (
 // Options contains the optional settings for the manifest generation.
 // For unset values defaults will be used.
 type Options struct {
+	// Cachedir specified the rpmmd cache directory (rpm metadata)
+	// If unset a default based on the xdgCacheHome is used
+	// (e.g. /root/.cache/osbuild-store)
 	Cachedir string
 
+	// RpmDownloader allows to switch between the librepo and
+	// libcurl download backends.
 	RpmDownloader osbuild.RpmDownloader
 
 	// SBOMWriter will be called for each generated SBOM the

--- a/pkg/osbuild/source.go
+++ b/pkg/osbuild/source.go
@@ -13,12 +13,13 @@ import (
 )
 
 // RpmDownloader specifies what backend to use for rpm downloads
-// Note that the librepo backend requires a newer osbuild.
+// Note that the librepo backend requires osbuild v138 from
+// 2025-01-15.
 type RpmDownloader uint64
 
 const (
-	RpmDownloaderCurl    = iota
-	RpmDownloaderLibrepo = iota
+	RpmDownloaderCurl = iota
+	RpmDownloaderLibrepo
 )
 
 // SourceInputs contains the inputs to generate osbuild.Sources


### PR DESCRIPTION
Quick drive-by to add missing docstrings and update requirements for using librepo.