### PR TITLE
distrodefs: drop `use_syslinux` as it has no effect

### DIFF
--- a/data/distrodefs/rhel-8/imagetypes.yaml
+++ b/data/distrodefs/rhel-8/imagetypes.yaml
@@ -1927,8 +1927,6 @@ image_types:
     mime_type: "application/x-iso9660-image"
     bootable: true
     boot_iso: true
-    # XXX: merge with boot_iso above
-    use_syslinux: true
     # NOTE: RHEL 8 only supports the older Anaconda configs
     use_legacy_anaconda_config: true
     image_func: "image_installer"
@@ -2221,8 +2219,6 @@ image_types:
     mime_type: "application/x-iso9660-image"
     rpm_ostree: true
     boot_iso: true
-    # XXX: merge with boot_iso above
-    use_syslinux: true
     # NOTE: RHEL 8 only supports the older Anaconda configs
     use_legacy_anaconda_config: true
     image_func: "iot_installer"
@@ -2301,8 +2297,6 @@ image_types:
     rpm_ostree: true
     bootable: true
     boot_iso: true
-    # XXX: merge with boot_iso above
-    use_syslinux: true
     # NOTE: RHEL 8 only supports the older Anaconda configs
     use_legacy_anaconda_config: true
     default_size: "10 GiB"

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -2252,8 +2252,6 @@ image_types:
     mime_type: "application/x-iso9660-image"
     bootable: true
     boot_iso: true
-    # XXX: merge with boot_iso above
-    use_syslinux: true
     image_func: "image_installer"
     # We don't know the variant of the OS pipeline being installed
     iso_label: "Unknown"
@@ -2886,8 +2884,6 @@ image_types:
     mime_type: "application/x-iso9660-image"
     rpm_ostree: true
     boot_iso: true
-    # XXX: merge with boot_iso above
-    use_syslinux: true
     image_func: "iot_installer"
     iso_label: "edge"
     variant: "edge"
@@ -2926,8 +2922,6 @@ image_types:
     rpm_ostree: true
     bootable: true
     boot_iso: true
-    # XXX: merge with boot_iso above
-    use_syslinux: true
     # NOTE: RHEL 8 only supports the older Anaconda configs
     use_legacy_anaconda_config: true
     default_size: "10 GiB"

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -392,9 +392,7 @@ type ImageTypeYAML struct {
 	Environment environment.EnvironmentConf `yaml:"environment"`
 	Bootable    bool                        `yaml:"bootable"`
 
-	BootISO bool `yaml:"boot_iso"`
-	// XXX merge with BootISO above, controls if grub2 or syslinux are used for ISO boots
-	UseSyslinux             bool `yaml:"use_syslinux"`
+	BootISO                 bool `yaml:"boot_iso"`
 	UseLegacyAnacondaConfig bool `yaml:"use_legacy_anaconda_config"`
 
 	ISOLabel string `yaml:"iso_label"`


### PR DESCRIPTION
This commit drops the `use_syslinux:` YAML key as it is not actually used and has no effect at the image manifest.

The `use_syslinux` was actually covered by https://github.com/osbuild/images/pull/1669 already so this yaml key is superfluous and confusing.

Thanks to Simon for asking about it that lead to this investigation.