### PR TITLE
bootc: Fix selinux labeling when using separate build container

### DIFF
--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -41,9 +41,9 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 	runner runner.Runner,
 	rng *rand.Rand) error {
 
-	policy := img.OSCustomizations.SELinux
+	buildPolicy := img.OSCustomizations.SELinux
 	if img.OSCustomizations.BuildSELinux != "" {
-		policy = img.OSCustomizations.BuildSELinux
+		buildPolicy = img.OSCustomizations.BuildSELinux
 	}
 
 	var copyFilesFrom map[string][]string
@@ -79,7 +79,7 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 			&manifest.BuildOptions{
 				PipelineName:       pipelineName,
 				ContainerBuildable: true,
-				SELinuxPolicy:      policy,
+				SELinuxPolicy:      img.OSCustomizations.SELinux,
 				EnsureDirs:         ensureDirs,
 			})
 		targetBuildPipeline.Checkpoint()
@@ -91,7 +91,7 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 	buildPipeline := manifest.NewBuildFromContainer(m, runner, buildContainers,
 		&manifest.BuildOptions{
 			ContainerBuildable: true,
-			SELinuxPolicy:      policy,
+			SELinuxPolicy:      buildPolicy,
 			CopyFilesFrom:      copyFilesFrom,
 			EnsureDirs:         ensureDirs,
 		})


### PR DESCRIPTION
When the build container and the target container are using different selinux policies we need to label them as such. The build container needs to be labeled with img.OSCustomizations.BuildSELinux, and the "target" container should be labeled with the same policy as the source target.

Currently we're using the build policy for both, and in the case where the source container doesn't include that policy it fails.  For example, if the build container is using the targeted policy, but the bootc source image only has the automotive policy, then the relabeling in the target pipeline atm fails with "targeted policy not found".