### PR TITLE
ci: resolve dubious ownership for git

### DIFF
--- a/.github/workflows/test-osbuild-composer-integration.yml
+++ b/.github/workflows/test-osbuild-composer-integration.yml
@@ -79,12 +79,14 @@ jobs:
           path: osbuild-composer
           repository: osbuild/osbuild-composer
           ref: main
+          set-safe-directory: true
 
       - name: Check out osbuild/images for the PR
         uses: actions/checkout@v6
         with:
           path: images
           ref: ${{ github.event.pull_request.head.sha }}
+          set-safe-directory: true
 
       - name: Mark the working directory as safe for git
         run: git config --global --add safe.directory "$(pwd)"
@@ -191,12 +193,14 @@ jobs:
           path: image-builder-cli
           repository: osbuild/image-builder-cli
           ref: main
+          set-safe-directory: true
 
       - name: Check out osbuild/images for the PR
         uses: actions/checkout@v6
         with:
           path: images
           ref: ${{ github.event.pull_request.head.sha }}
+          set-safe-directory: true
 
       - name: Mark the working directory as safe for git
         run: git config --global --add safe.directory "$(pwd)"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          set-safe-directory: true
 
       - name: Install python3
         # The Fedora 41 container doesn't have python3 installed by default
@@ -82,6 +83,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          set-safe-directory: true
 
       - name: Apt update
         run: sudo apt update
@@ -132,6 +134,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          set-safe-directory: true
 
       - name: Set up repository for pinned osbuild commit
         run: ./test/scripts/setup-osbuild-repo
@@ -166,6 +169,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          set-safe-directory: true
 
       - name: Apt update
         run: sudo apt update
@@ -198,6 +202,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          set-safe-directory: true
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38
         with:
@@ -225,6 +230,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          set-safe-directory: true
 
       - name: Testing imgtestlib and test scripts
         run: |
@@ -249,6 +255,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          set-safe-directory: true
 
       - name: Analysing the code with pylint
         run: |
@@ -264,6 +271,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          set-safe-directory: true
 
       - name: Install checkers
         run: |
@@ -312,6 +320,8 @@ jobs:
           ls /proc/sys/fs/binfmt_misc/
       - name: Check out code into the Go module directory
         uses: actions/checkout@v6
+        with:
+          set-safe-directory: true
       - name: Cross arch integration test
         run: |
           pip install .

--- a/.github/workflows/update-bootc-image-builder.yml
+++ b/.github/workflows/update-bootc-image-builder.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           path: images
           ref: main
+          set-safe-directory: true
 
       - name: Update Schutzfile
         working-directory: ./images

--- a/.github/workflows/update-osbuild.yml
+++ b/.github/workflows/update-osbuild.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           path: images
           ref: main
+          set-safe-directory: true
 
       - name: Update Schutzfile
         working-directory: ./images

--- a/.github/workflows/validate-checksums.yml
+++ b/.github/workflows/validate-checksums.yml
@@ -33,6 +33,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           # we need the history of the branch and main
           fetch-depth: 0
+          set-safe-directory: true
 
       - name: apt update
         run: sudo apt update


### PR DESCRIPTION
This patch addresses the recurring error obtaining `VCS status: exit status 128` seen during the build phase of our GitHub Actions.

```
error obtaining VCS status: exit status 128
Use -buildvcs=false to disable VCS stamping
```

This error is caused by a Git security update (CVE-2022-24765) that prevents Git commands from running in directories owned by a user different from the current one. In our CI/CD environment—especially when using containers—the workspace owner often differs from the build user, causing Go's VCS stamping to fail.

This is safe, because our CI environments are not shared.

---

For the record, `git build` in fact actually does work and produce binary (at least versions 1.20+) but it still returns 128 which our wrapper treats as error, correctly so. Therefore whole test fails.