### PR TITLE
test: touch files in cache when downloading [HMS-9628]

### DIFF
--- a/test/scripts/dl-one-image-build-cache
+++ b/test/scripts/dl-one-image-build-cache
@@ -66,6 +66,7 @@ def main():
         sys.exit(1)
 
     print("✅ Successfully downloaded the image build cache")
+    testlib.touch_s3(distro, arch, manifest_id, osbuild_ref, runner_distro)
 
 
 if __name__ == "__main__":

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -651,14 +651,12 @@ def write_build_info(build_path: str, data: Dict):
         json.dump(data, info_fp, indent=2)
 
 
-def touch_s3(distro, arch, manifest_id):
+def touch_s3(distro, arch, manifest_id, osbuild_ref=None, runner_distro=None):
     """
     Update the timestamps of a path in S3 by adding a metadata field to each file recursively. This can be used to
     "freshen up" relevant files in the build cache so that images that are still current but haven't been updated in a
     while don't get garbage collected.
     """
-    runner_distro = get_host_distro()
-    osbuild_ref = get_osbuild_commit(runner_distro)
     s3url = gen_build_info_s3_dir_path(distro, arch, manifest_id, osbuild_ref, runner_distro)
     # the exact key and value don't matter, but let's add the current datetime to make it a bit more meaningful
     now = str(datetime.now())


### PR DESCRIPTION
dl-one-image-build-cache is used in osbuild's CI to download images for testing.  Keep the images in the cache fresh when they're used by osbuild.  This makes it less likely that an image will be garbage collected by the retention policy when osbuild's CI is still testing them.

Currently, images that osbuild wants to boot test might have already been cleaned up if the images ref in osbuild gets too old.  With this change, osbuild's CI will continuously keep the timestamps of the images it's testing updated.

We will still run into issues if osbuild's CI doesn't run for too long.