### PR TITLE
manifest/subscription: support scheme specifier for subscription proxy url

### DIFF
--- a/pkg/manifest/subscription.go
+++ b/pkg/manifest/subscription.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -132,10 +133,14 @@ func subscriptionService(
 		commands = append(commands, fmt.Sprintf("/usr/sbin/subscription-manager config --server.hostname %s", shutil.Quote(subscriptionOptions.ServerUrl)))
 	}
 	if subscriptionOptions.Proxy != "" {
-		proxy := strings.Split(subscriptionOptions.Proxy, ":")
-		commands = append(commands, fmt.Sprintf("/usr/sbin/subscription-manager config --server.proxy_hostname %s", shutil.Quote(proxy[0])))
-		if len(proxy) == 2 {
-			commands = append(commands, fmt.Sprintf("/usr/sbin/subscription-manager config --server.proxy_port %s", shutil.Quote(proxy[1])))
+		scheme, hostname, port, err := parseProxyUrl(subscriptionOptions.Proxy)
+		if err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("invalid proxy url: %v", err)
+		}
+		commands = append(commands, fmt.Sprintf("/usr/sbin/subscription-manager config --server.proxy_scheme %s", shutil.Quote(scheme)))
+		commands = append(commands, fmt.Sprintf("/usr/sbin/subscription-manager config --server.proxy_hostname %s", shutil.Quote(hostname)))
+		if port != "" {
+			commands = append(commands, fmt.Sprintf("/usr/sbin/subscription-manager config --server.proxy_port %s", shutil.Quote(port)))
 		}
 	}
 
@@ -268,6 +273,20 @@ ExecStartPre=
 [Install]
 WantedBy=multi-user.target
 `
+}
+
+// Parses a proxy url in formats  host:port * scheme://host:port
+// Defaults to http if scheme is not specified
+// Port may be blank
+func parseProxyUrl(proxyUrl string) (scheme, hostname, port string, err error) {
+	if !strings.Contains(proxyUrl, "://") {
+		proxyUrl = fmt.Sprintf("http://%s", proxyUrl)
+	}
+	proxyUri, err := url.Parse(proxyUrl)
+	if err != nil {
+		return scheme, hostname, port, fmt.Errorf("invalid proxy URI: %s", proxyUrl)
+	}
+	return proxyUri.Scheme, proxyUri.Hostname(), proxyUri.Port(), nil
 }
 
 func getCurlToAssociateSystem(subscriptionOptions subscription.ImageOptions) string {

--- a/pkg/manifest/subscription_test.go
+++ b/pkg/manifest/subscription_test.go
@@ -137,7 +137,7 @@ func TestSubscriptionService(t *testing.T) {
 				Insights:      true,
 				Rhc:           false,
 				TemplateUUID:  "template-uuid",
-				Proxy:         "proxy-url",
+				Proxy:         "https://proxy-url",
 				PatchURL:      "https://cert.console.redhat.com/api/patch/v3/",
 			},
 			srvcOpts: nil,
@@ -160,10 +160,11 @@ func TestSubscriptionService(t *testing.T) {
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
 								"/usr/sbin/subscription-manager config --server.hostname 'theserverurl-wi'",
+								"/usr/sbin/subscription-manager config --server.proxy_scheme 'https'",
 								"/usr/sbin/subscription-manager config --server.proxy_hostname 'proxy-url'",
 								`/usr/sbin/subscription-manager register --org="${ORG_ID}" --activationkey="${ACTIVATION_KEY}" --baseurl 'thebaseurl-wi'`,
 								"/usr/bin/insights-client --register", // added when insights is enabled
-								"curl -v --retry 5 --cert /etc/pki/consumer/cert.pem --key /etc/pki/consumer/key.pem -X PATCH 'https://cert.console.redhat.com/api/patch/v3/templates/template-uuid/subscribed-systems' --proxy 'proxy-url'",
+								"curl -v --retry 5 --cert /etc/pki/consumer/cert.pem --key /etc/pki/consumer/key.pem -X PATCH 'https://cert.console.redhat.com/api/patch/v3/templates/template-uuid/subscribed-systems' --proxy 'https://proxy-url'",
 								"/usr/sbin/subscription-manager refresh",
 								"/usr/bin/rm '" + subkeyFilepath + "'",
 							},
@@ -387,7 +388,7 @@ func TestSubscriptionService(t *testing.T) {
 				Rhc:           true,
 				TemplateName:  "template-name",
 				TemplateUUID:  "template-uuid",
-				Proxy:         "proxy-url",
+				Proxy:         "proxy-url:8080",
 				PatchURL:      "https://cert.console.redhat.com/api/patch/v3/",
 			},
 			srvcOpts: &subscriptionServiceOptions{
@@ -412,10 +413,12 @@ func TestSubscriptionService(t *testing.T) {
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
 								"/usr/sbin/subscription-manager config --server.hostname 'theserverurl-wir'",
+								"/usr/sbin/subscription-manager config --server.proxy_scheme 'http'",
 								"/usr/sbin/subscription-manager config --server.proxy_hostname 'proxy-url'",
+								"/usr/sbin/subscription-manager config --server.proxy_port '8080'",
 								`/usr/bin/rhc connect --organization="${ORG_ID}" --activation-key="${ACTIVATION_KEY}"`,
 								"/usr/sbin/semanage permissive --add rhcd_t", // added when rhc is enabled
-								"curl -v --retry 5 --cert /etc/pki/consumer/cert.pem --key /etc/pki/consumer/key.pem -X PATCH 'https://cert.console.redhat.com/api/patch/v3/templates/template-uuid/subscribed-systems' --proxy 'proxy-url'",
+								"curl -v --retry 5 --cert /etc/pki/consumer/cert.pem --key /etc/pki/consumer/key.pem -X PATCH 'https://cert.console.redhat.com/api/patch/v3/templates/template-uuid/subscribed-systems' --proxy 'proxy-url:8080'",
 								"/usr/sbin/subscription-manager refresh",
 								"/usr/bin/rm '" + subkeyFilepath + "'",
 							},
@@ -597,7 +600,7 @@ func TestSubscriptionService(t *testing.T) {
 				BaseUrl:       "thebaseurl-pp",
 				Insights:      false,
 				Rhc:           false,
-				Proxy:         "proxy-url:8080",
+				Proxy:         "http://proxy-url:8080",
 			},
 			srvcOpts: nil,
 			expectedStage: &osbuild.Stage{
@@ -619,6 +622,7 @@ func TestSubscriptionService(t *testing.T) {
 							Type: osbuild.OneshotServiceType,
 							ExecStart: []string{
 								"/usr/sbin/subscription-manager config --server.hostname 'theserverurl-pp'",
+								"/usr/sbin/subscription-manager config --server.proxy_scheme 'http'",
 								"/usr/sbin/subscription-manager config --server.proxy_hostname 'proxy-url'",
 								"/usr/sbin/subscription-manager config --server.proxy_port '8080'",
 								"/usr/sbin/subscription-manager register --org=\"${ORG_ID}\" --activationkey=\"${ACTIVATION_KEY}\" --baseurl 'thebaseurl-pp'",


### PR DESCRIPTION
and properly set it in subscription-manager (Fixing HMS-9612)

Currently in insights, we are using a full url (http://proxy-host:8080), but here we expect just a hostname and port (proxy-host:8080).  This results in things not being set properly in sub-man.  This fixes this by fully parsing the URL.  Note that this will not support just the proxy-host:8080 format, as it seems go doesn't have a great way to parse both easily (without doing some ugly   string.contains("://")