### PR TITLE
check-host-config: invert condition

### DIFF
--- a/test/scripts/check-host-config.sh
+++ b/test/scripts/check-host-config.sh
@@ -341,7 +341,7 @@ if (( $# > 0 )); then
 
     config="$1"
 
-    if [[ -e "${config}" ]]; then
+    if [[ ! -e "${config}" ]]; then
         echo "Error: config file does not exist"
         exit 1
     fi


### PR DESCRIPTION
Currently we're testing if the config file exists and if it doesn't we exit unsuccesfully. However, the condition checks if the file exists and if it *does* exits.

Invert the logic to check if the file does *not* exist.