### PR TITLE
sfdisk: check for extended partitions with MBR

### DIFF
--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -93,6 +93,9 @@ const (
 	// Partition type ID for PRep on dos
 	PRepPartitionDOSID = "41"
 
+	// Partition type ID for extended partition on dos
+	ExtendedPartitionDOSID = "0f"
+
 	// static UUIDs for partitions and filesystems
 	// NOTE(akoutsou): These are unnecessary and have stuck around since the
 	// beginning where (I believe) the goal was to have predictable,

--- a/pkg/osbuild/sfdisk_stage.go
+++ b/pkg/osbuild/sfdisk_stage.go
@@ -47,6 +47,15 @@ type SfdiskPartition struct {
 
 func (o SfdiskStageOptions) validate() error {
 	if o.Label == disk.PT_DOS.String() && len(o.Partitions) > 4 {
+		// DOS partition tables only support more than 4 partitions if one of the first
+		// 4 (primary) slots is an extended partition. Since the JSON format doesn't
+		// explicitly distinguish between primary and logical partitions, we simply
+		// verify that an extended partition exists within these primary slots.
+		for i := range 4 {
+			if o.Partitions[i].Type == disk.ExtendedPartitionDOSID {
+				return nil
+			}
+		}
 		return fmt.Errorf("sfdisk stage creation failed: \"dos\" partition table only supports up to 4 partitions: got %d", len(o.Partitions))
 	}
 	return nil


### PR DESCRIPTION
When validating a `dos` partition (MBR) with more than 4 partitions, check also if there is an extended partition type (0f) before actually failing.