### PR TITLE
vmtest: recognize `.raw`

### DIFF
--- a/vmtest/vm.py
+++ b/vmtest/vm.py
@@ -222,7 +222,7 @@ class QEMU(VM):
 
         if self._img.suffix == ".qcow2":
             img_format = "qcow2"
-        elif self._img.suffix == ".img":
+        elif self._img.suffix in (".img", ".raw"):
             img_format = "raw"
         else:
             raise ValueError(f"Unsupported image extension: {self._img}. Must be .qcow2 or .img")


### PR DESCRIPTION
`vmtest` is being used in multiple places including `bootc-image-builder`. Tests are failing there because they do not recognize the `.raw` extension:

```
 test/test_build_disk.py:563: in assert_disk_image_boots
    test_vm.run("true", user=image_type.username, ***
```

```
ValueError: Unsupported image extension: /mnt/var/tmp/bib-tests/shared0/5d75e63f69b88795/image/disk.raw. Must be .qcow2 or .img
```

Allow `.raw` as well as `.img` to be raw.