### PR TITLE
GHA: bump used golangci-lint version to 2.8 (HMS-10069)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.3
+          version: v2.8
           args: --verbose --timeout 5m0s
 
   shellcheck:


### PR DESCRIPTION
Let's use the used golangci-lint, because the version that we've been running is from mid July 2025.

/jira-epic HMS-10034

JIRA: [HMS-10069](https://issues.redhat.com/browse/HMS-10069)