### PR TITLE
Use the correct libvirt pool instead of hardcoded default

### DIFF
--- a/pkg/cloud/libvirt/libvirt.go
+++ b/pkg/cloud/libvirt/libvirt.go
@@ -41,7 +41,7 @@ func (lu *libvirtUploader) UploadAndRegister(r io.Reader, uploadSize uint64, sta
 	}
 	defer conn.Close()
 
-	pool, err := conn.LookupStoragePoolByName("default")
+	pool, err := conn.LookupStoragePoolByName(lu.pool)
 	if err != nil {
 		return fmt.Errorf("Failed to find storage pool: %w", err)
 	}


### PR DESCRIPTION
We always used the "default"

    $ image-builder upload -to libvirt --libvirt-pool images ...
    ...
    error: Failed to find storage pool: virError(Code=49, Domain=18, Message='Storage pool not found: no storage pool with matching name 'default'')