### PR TITLE
depsolvednf: improve error reporting

### DIFF
--- a/pkg/depsolvednf/depsolvednf.go
+++ b/pkg/depsolvednf/depsolvednf.go
@@ -300,7 +300,7 @@ func (s *Solver) Depsolve(pkgSets []rpmmd.PackageSet, sbomType sbom.StandardType
 
 	output, err := run(s.depsolveDNFCmd, reqData, s.Stderr)
 	if err != nil {
-		return nil, parseError(output, allRepos)
+		return nil, parseError(output, allRepos, err)
 	}
 
 	// touch repos to now
@@ -377,7 +377,7 @@ func (s *Solver) FetchMetadata(repos []rpmmd.RepoConfig) (rpmmd.PackageList, err
 
 	rawRes, err := run(s.depsolveDNFCmd, reqData, s.Stderr)
 	if err != nil {
-		return nil, parseError(rawRes, repos)
+		return nil, parseError(rawRes, repos, err)
 	}
 
 	// touch repos to now
@@ -425,7 +425,7 @@ func (s *Solver) SearchMetadata(repos []rpmmd.RepoConfig, packages []string) (rp
 
 	rawRes, err := run(s.depsolveDNFCmd, reqData, s.Stderr)
 	if err != nil {
-		return nil, parseError(rawRes, repos)
+		return nil, parseError(rawRes, repos, err)
 	}
 
 	// touch repos to now
@@ -544,21 +544,31 @@ func optionalMetadataForDistro(modulePlatformID string) []string {
 type Error struct {
 	Kind   string `json:"kind"`
 	Reason string `json:"reason"`
+	Err    error  `json:"-"`
 }
 
 func (err Error) Error() string {
-	return fmt.Sprintf("DNF error occurred: %s: %s", err.Kind, err.Reason)
+	if err.Err != nil {
+		return fmt.Sprintf("DNF error occurred: %s: %s: %s", err.Kind, err.Reason, err.Err)
+	} else {
+		return fmt.Sprintf("DNF error occurred: %s: %s", err.Kind, err.Reason)
+	}
+}
+
+func (err Error) Unwrap() error {
+	return err.Err
 }
 
 // parseError parses the response from osbuild-depsolve-dnf into the Error type and appends
 // the name and URL of a repository to all detected repository IDs in the
 // message.
-func parseError(data []byte, repos []rpmmd.RepoConfig) Error {
+func parseError(data []byte, repos []rpmmd.RepoConfig, cmdError error) Error {
 	var e Error
 	if len(data) == 0 {
 		return Error{
 			Kind:   "InternalError",
 			Reason: "osbuild-depsolve-dnf output was empty",
+			Err:    cmdError,
 		}
 	}
 
@@ -567,6 +577,7 @@ func parseError(data []byte, repos []rpmmd.RepoConfig) Error {
 		return Error{
 			Kind:   "InternalError",
 			Reason: fmt.Sprintf("Failed to unmarshal osbuild-depsolve-dnf error output %q: %s", string(data), err.Error()),
+			Err:    cmdError,
 		}
 	}
 

--- a/pkg/depsolvednf/depsolvednf_test.go
+++ b/pkg/depsolvednf/depsolvednf_test.go
@@ -1089,7 +1089,7 @@ exit 1
 			solver.depsolveDNFCmd = []string{fakeSolverPath}
 			res, err := solver.Depsolve(nil, sbom.StandardTypeNone)
 
-			assert.EqualError(t, err, `DNF error occurred: InternalError: osbuild-depsolve-dnf output was empty`)
+			assert.EqualError(t, err, `DNF error occurred: InternalError: osbuild-depsolve-dnf output was empty: depsolve failed with exit code 1`)
 			assert.Nil(t, res)
 		})
 	}


### PR DESCRIPTION
depsolvednf: improve error handling

Includes the OS error when calling the osbuild-depsolve-dnf command.

---

Without this, I thought that the command was executed but returned nothing...