### PR TITLE
pkg/cloud/awscloud: allow specifying AWS credentials profile

### DIFF
--- a/pkg/cloud/awscloud/awscloud.go
+++ b/pkg/cloud/awscloud/awscloud.go
@@ -107,10 +107,11 @@ func NewFromFile(filename string, region string) (*AWS, error) {
 
 // Initialize a new AWS object from defaults.
 // Looks for env variables, shared credential file, and EC2 Instance Roles.
-func NewDefault(region string) (*AWS, error) {
+func NewDefault(region string, profile string) (*AWS, error) {
 	cfg, err := config.LoadDefaultConfig(
 		context.TODO(),
 		config.WithRegion(region),
+		config.WithSharedConfigProfile(profile),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/cloud/awscloud/export_test.go
+++ b/pkg/cloud/awscloud/export_test.go
@@ -24,7 +24,7 @@ func NewAWSForTest(ec2cli EC2Client, s3cli S3Client, upldr S3Uploader, sign S3Pr
 	}
 }
 
-func MockNewAwsClient(f func(string) (awsClient, error)) (restore func()) {
+func MockNewAwsClient(f func(string, string) (awsClient, error)) (restore func()) {
 	saved := newAwsClient
 	newAwsClient = f
 	return func() {

--- a/pkg/cloud/awscloud/uploader_test.go
+++ b/pkg/cloud/awscloud/uploader_test.go
@@ -82,7 +82,7 @@ func TestUploaderCheckHappy(t *testing.T) {
 		buckets:               []string{"bucket"},
 		checkBucketPermission: true,
 	}
-	restore := awscloud.MockNewAwsClient(func(string) (awscloud.AwsClient, error) {
+	restore := awscloud.MockNewAwsClient(func(string, string) (awscloud.AwsClient, error) {
 		return fa, nil
 	})
 	defer restore()
@@ -147,7 +147,7 @@ func TestUploaderUploadHappy(t *testing.T) {
 				registerImageId:    "image-id",
 				registerSnapshotId: "snapshot-id",
 			}
-			restore := awscloud.MockNewAwsClient(func(string) (awscloud.AwsClient, error) {
+			restore := awscloud.MockNewAwsClient(func(string, string) (awscloud.AwsClient, error) {
 				return fa, nil
 			})
 			defer restore()
@@ -183,7 +183,7 @@ func TestUploaderUploadButRegisterError(t *testing.T) {
 		},
 		registerErr: fmt.Errorf("fake-register-err"),
 	}
-	restore := awscloud.MockNewAwsClient(func(string) (awscloud.AwsClient, error) {
+	restore := awscloud.MockNewAwsClient(func(string, string) (awscloud.AwsClient, error) {
 		return fa, nil
 	})
 	defer restore()
@@ -214,7 +214,7 @@ func TestUploaderUploadButRegisterErrorAndDeleteError(t *testing.T) {
 		registerErr:     fmt.Errorf("fake-register-err"),
 		deleteObjectErr: fmt.Errorf("fake-delete-object-err"),
 	}
-	restore := awscloud.MockNewAwsClient(func(string) (awscloud.AwsClient, error) {
+	restore := awscloud.MockNewAwsClient(func(string, string) (awscloud.AwsClient, error) {
 		return fa, nil
 	})
 	defer restore()


### PR DESCRIPTION
The `$HOME/.aws/credentials` file looks like this

    [default]
    aws_access_key_id = secretString1
    aws_secret_access_key = secretString2

    [some-profile]
    aws_access_key_id = secretString3
    aws_secret_access_key = secretString4

This allows us to specify the non-default profile.