### PR TITLE
bib: ban logrus from the project

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/oracle/oci-go-sdk/v54 v54.0.0
 	github.com/osbuild/blueprint v1.23.0
-	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7
 	github.com/stretchr/testify v1.11.1
@@ -166,6 +165,7 @@ require (
 	github.com/sigstore/fulcio v1.6.6 // indirect
 	github.com/sigstore/protobuf-specs v0.4.1 // indirect
 	github.com/sigstore/sigstore v1.9.5 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smallstep/pkcs7 v0.1.1 // indirect
 	github.com/sony/gobreaker v0.4.2-0.20210216022020-dd874f9dd33b // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect

--- a/pkg/bib/blueprintload/config.go
+++ b/pkg/bib/blueprintload/config.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
-	"github.com/sirupsen/logrus"
 
 	"github.com/osbuild/blueprint/pkg/blueprint"
+	"github.com/osbuild/images/pkg/olog"
 )
 
 // legacyBuildConfig is the json based configuration that was used in
@@ -35,7 +35,7 @@ func decodeJsonBuildConfig(r io.Reader, what string) (*blueprint.Blueprint, erro
 	var legacyBC legacyBuildConfig
 	if err := json.Unmarshal(content, &legacyBC); err == nil {
 		if legacyBC.Blueprint != nil {
-			logrus.Warningf("Using legacy config")
+			olog.Println("Using legacy config")
 			content = *legacyBC.Blueprint
 		}
 	}

--- a/pkg/bib/osinfo/osinfo.go
+++ b/pkg/bib/osinfo/osinfo.go
@@ -9,13 +9,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/blueprint/pkg/blueprint"
 	"github.com/osbuild/images/pkg/bib/blueprintload"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/olog"
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
@@ -257,7 +257,7 @@ func Load(root string) (*Info, error) {
 
 	vendor, err := uefiVendor(root)
 	if err != nil {
-		logrus.Debugf("cannot read UEFI vendor: %v, setting it to none", err)
+		olog.Printf("cannot read UEFI vendor: %v, setting it to none", err)
 	}
 
 	customization, err := readImageCustomization(root)
@@ -300,12 +300,12 @@ func Load(root string) (*Info, error) {
 
 	kernelInfo, err := readKernelInfo(root)
 	if err != nil {
-		logrus.Debugf("cannot read kernel info: %v", err)
+		olog.Printf("cannot read kernel info: %v", err)
 	}
 
 	selinuxPolicy, err := readSelinuxPolicy(root)
 	if err != nil {
-		logrus.Debugf("cannot read selinux policy: %v, setting it to none", err)
+		olog.Printf("cannot read selinux policy: %v, setting it to none", err)
 	}
 
 	var idLike []string

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -15,6 +15,12 @@ $GO_BINARY download
 # Ensure that go.mod and go.sum are up to date.
 $GO_BINARY mod tidy
 
+# Check banned packages
+if grep "github.com/(go-yaml/yaml|sirupsen/logrus)" go.mod | grep -v "// indirect" | grep -q .; then
+	echo "error: banned direct dependency found" >&2
+	exit 1
+fi
+
 # Ensure the code is formatted correctly.
 $GO_BINARY fmt ./...
 


### PR DESCRIPTION
Images library must not depend on any logging library, there is a global olog package that provides a simple wrapper around the standard log package if anything needs to be printed. Output is discarded by default but visible in image-builder-cli verbose mode.

On top of that, we are moving away from logrus to log/slog standard library package.