### PR TITLE
rhsm_facts: Add blueprint-id as optional fact (HMS-3881)

### DIFF
--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -828,6 +828,10 @@ func (p *OS) serialize() (osbuild.Pipeline, error) {
 			rhsmFacts.CompliancePolicyID = p.OSCustomizations.RHSMFacts.CompliancePolicyID.String()
 		}
 
+		if p.OSCustomizations.RHSMFacts.BlueprintID != uuid.Nil {
+			rhsmFacts.BlueprintID = p.OSCustomizations.RHSMFacts.BlueprintID.String()
+		}
+
 		pipeline.AddStage(osbuild.NewRHSMFactsStage(&osbuild.RHSMFactsStageOptions{
 			Facts: rhsmFacts,
 		}))

--- a/pkg/osbuild/rhsm_facts_stage.go
+++ b/pkg/osbuild/rhsm_facts_stage.go
@@ -8,6 +8,7 @@ type RHSMFacts struct {
 	ApiType            string `json:"image-builder.osbuild-composer.api-type"`
 	OpenSCAPProfileID  string `json:"image-builder.insights.compliance-profile-id,omitempty"`
 	CompliancePolicyID string `json:"image-builder.insights.compliance-policy-id,omitempty"`
+	BlueprintID        string `json:"image-builder.blueprint-id,omitempty"`
 }
 
 func (RHSMFactsStageOptions) isStageOptions() {}

--- a/pkg/osbuild/rhsm_facts_stage_test.go
+++ b/pkg/osbuild/rhsm_facts_stage_test.go
@@ -51,6 +51,15 @@ func TestRHSMFactsStageJson(t *testing.T) {
 			},
 			JsonString: fmt.Sprintf(`{"facts":{"image-builder.osbuild-composer.api-type":"%s","image-builder.insights.compliance-profile-id":"%s","image-builder.insights.compliance-policy-id":"%s"}}`, "test-api", "test-profile-id", "test-compliance-policy-id"),
 		},
+		{
+			Options: RHSMFactsStageOptions{
+				Facts: RHSMFacts{
+					ApiType:     "test-api",
+					BlueprintID: "123e4567-e89b-12d3-a456-426655440000",
+				},
+			},
+			JsonString: fmt.Sprintf(`{"facts":{"image-builder.osbuild-composer.api-type":"%s","image-builder.blueprint-id":"%s"}}`, "test-api", "123e4567-e89b-12d3-a456-426655440000"),
+		},
 	}
 	for _, test := range tests {
 		marshaledJson, err := json.Marshal(test.Options)

--- a/pkg/rhsm/facts/facts.go
+++ b/pkg/rhsm/facts/facts.go
@@ -35,4 +35,5 @@ type ImageOptions struct {
 	APIType            APIType
 	OpenSCAPProfileID  string
 	CompliancePolicyID uuid.UUID
+	BlueprintID        uuid.UUID
 }


### PR DESCRIPTION
This commit extends the existing RHSM facts stage to also allow for the blueprint id to be added to the fact. This change will enable us to bake the blueprint id into the image in the service and map running hosts to blueprints in Insights.

It also extends the existing test to cover the added fact.