### PR TITLE
arch: add ARCH_ARM

### DIFF
--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -12,6 +12,7 @@ type Arch uint64
 
 const ( // architecture enum
 	ARCH_UNSET Arch = iota
+	ARCH_ARM
 	ARCH_AARCH64
 	ARCH_PPC64LE
 	ARCH_S390X
@@ -23,6 +24,8 @@ func (a Arch) String() string {
 	switch a {
 	case ARCH_UNSET:
 		return "unset"
+	case ARCH_ARM:
+		return "arm"
 	case ARCH_AARCH64:
 		return "aarch64"
 	case ARCH_PPC64LE:
@@ -55,6 +58,8 @@ func FromString(a string) (Arch, error) {
 	switch a {
 	case "amd64", "x86_64":
 		return ARCH_X86_64, nil
+	case "arm", "armv7":
+		return ARCH_ARM, nil
 	case "arm64", "aarch64":
 		return ARCH_AARCH64, nil
 	case "s390x":
@@ -76,6 +81,10 @@ func Current() Arch {
 
 func IsX86_64() bool {
 	return Current() == ARCH_X86_64
+}
+
+func IsArm() bool {
+	return Current() == ARCH_ARM
 }
 
 func IsAarch64() bool {

--- a/pkg/arch/arch_test.go
+++ b/pkg/arch/arch_test.go
@@ -17,6 +17,14 @@ func TestCurrentArchAMD64(t *testing.T) {
 	assert.True(t, IsX86_64())
 }
 
+func TestCurrentArchARM(t *testing.T) {
+	origRuntimeGOARCH := runtimeGOARCH
+	defer func() { runtimeGOARCH = origRuntimeGOARCH }()
+	runtimeGOARCH = "arm"
+	assert.Equal(t, "arm", Current().String())
+	assert.True(t, IsArm())
+}
+
 func TestCurrentArchARM64(t *testing.T) {
 	origRuntimeGOARCH := runtimeGOARCH
 	defer func() { runtimeGOARCH = origRuntimeGOARCH }()
@@ -62,6 +70,8 @@ func TestFromStringUnsupported(t *testing.T) {
 }
 
 func TestFromString(t *testing.T) {
+	assert.Equal(t, ARCH_ARM, common.Must(FromString("arm")))
+	assert.Equal(t, ARCH_ARM, common.Must(FromString("armv7")))
 	assert.Equal(t, ARCH_AARCH64, common.Must(FromString("arm64")))
 	assert.Equal(t, ARCH_AARCH64, common.Must(FromString("aarch64")))
 	assert.Equal(t, ARCH_X86_64, common.Must(FromString("amd64")))
@@ -76,6 +86,7 @@ func TestUnmarshal(t *testing.T) {
 		inp      string
 		expected Arch
 	}{
+		{"arch: arm", ARCH_ARM},
 		{"arch: arm64", ARCH_AARCH64},
 		{"arch: amd64", ARCH_X86_64},
 		{"arch: s390x", ARCH_S390X},


### PR DESCRIPTION
This is first attempt to add the legacy `arm` i.e. `armv7` support. I'm not sure what else might be missing or requires adaption. Let's discuss it here.