### PR TITLE
manifest/subscription: fix selinux systemd race condition (HMS-10142)

### DIFF
--- a/pkg/manifest/subscription.go
+++ b/pkg/manifest/subscription.go
@@ -214,7 +214,12 @@ func subscriptionService(
 				Description:         "First-boot service for registering with Red Hat subscription manager and/or insights",
 				ConditionPathExists: []string{subkeyFilepath},
 				Wants:               []string{"network-online.target"},
-				After:               []string{"network-online.target"},
+				After: []string{
+					// The selinux-autorelabel reboot was killing rhc mid-execution,
+					// causing partial rhsm registration without insights enrollment.
+					"selinux-autorelabel.service",
+					"network-online.target",
+				},
 			},
 			Service: &osbuild.ServiceSection{
 				Type:            osbuild.OneshotServiceType,

--- a/pkg/manifest/subscription_test.go
+++ b/pkg/manifest/subscription_test.go
@@ -31,7 +31,7 @@ func TestSubscriptionService(t *testing.T) {
 	unitType := osbuild.SystemUnitType
 	serviceDescription := "First-boot service for registering with Red Hat subscription manager and/or insights"
 	serviceWants := []string{"network-online.target"}
-	serviceAfter := serviceWants
+	serviceAfter := []string{"selinux-autorelabel.service", "network-online.target"}
 	serviceWantedBy := []string{"default.target"}
 
 	testCases := map[string]testCase{


### PR DESCRIPTION
On first boot, selinux-autorelabel.service and osbuild-subscription-register.service
run concurrently. The SELinux relabel triggers a system reboot upon completion,
which interrupts osbuild-subscription-register while rhc is mid-execution.

This results in:
  - partial registration (subscribed to rhsm but not registered with insights)
  - service failure on second boot ("system already connected" exit code 64)

Adding After=selinux-autorelabel.service ensures the subscription service only
runs after the relabel-triggered reboot, allowing it to complete successfully.

JIRA: [HMS-10142](https://issues.redhat.com/browse/HMS-10142)