### PR TITLE
distro/generic: propagate kernel options to kickstart for installers

### DIFF
--- a/cmd/check-host-config/check/kernel.go
+++ b/cmd/check-host-config/check/kernel.go
@@ -41,7 +41,7 @@ func kernelCheck(meta *Metadata, config *buildconfig.BuildConfig) error {
 		}
 
 		if !strings.Contains(string(cmdline), expected.Append) {
-			return Warning("kernel options append does not match:", expected.Append)
+			return Fail("kernel options append does not match:", expected.Append)
 		}
 	}
 

--- a/cmd/check-host-config/check/kernel_test.go
+++ b/cmd/check-host-config/check/kernel_test.go
@@ -22,7 +22,6 @@ func TestKernelCheck(t *testing.T) {
 		wantError     bool
 		wantSkip      bool
 		wantFail      bool
-		wantWarn      bool
 	}{
 		{
 			name:      "skip when kernel is nil",
@@ -70,7 +69,7 @@ func TestKernelCheck(t *testing.T) {
 			},
 			readFileData: []byte("BOOT_IMAGE=/vmlinuz-6.1.0 root=UUID=1234-5678 ro quiet"),
 			wantError:    true,
-			wantWarn:     true,
+			wantFail:     true,
 		},
 		{
 			name: "pass with matching kernel-debug name",
@@ -124,9 +123,6 @@ func TestKernelCheck(t *testing.T) {
 				}
 				if tt.wantFail {
 					assert.True(t, check.IsFail(err))
-				}
-				if tt.wantWarn {
-					assert.True(t, check.IsWarning(err))
 				}
 			} else {
 				require.NoError(t, err)

--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -729,6 +729,11 @@ func imageInstallerImage(t *imageType,
 	img.Kickstart.Keyboard = img.OSCustomizations.Keyboard
 	img.Kickstart.Timezone = &img.OSCustomizations.Timezone
 
+	// Set kernel options for the installed system's bootloader
+	if kopts := customizations.GetKernel(); kopts != nil && kopts.Append != "" {
+		img.Kickstart.KernelOptionsAppend = append(img.Kickstart.KernelOptionsAppend, kopts.Append)
+	}
+
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
 
 	img.InstallerCustomizations, err = installerCustomizations(t, bp.Customizations, options)
@@ -901,6 +906,11 @@ func iotInstallerImage(t *imageType,
 	// ignore ntp servers - we don't currently support setting these in the
 	// kickstart though kickstart does support setting them
 	img.Kickstart.Timezone, _ = customizations.GetTimezoneSettings()
+
+	// Set kernel options for the installed system's bootloader
+	if kopts := customizations.GetKernel(); kopts != nil && kopts.Append != "" {
+		img.Kickstart.KernelOptionsAppend = append(img.Kickstart.KernelOptionsAppend, kopts.Append)
+	}
 
 	img.InstallerCustomizations, err = installerCustomizations(t, bp.Customizations, options)
 	if err != nil {
@@ -1084,6 +1094,11 @@ func networkInstallerImage(t *imageType,
 	timezone, _ := customizations.GetTimezoneSettings()
 	if timezone != nil {
 		img.Kickstart.Timezone = timezone
+	}
+
+	// Set kernel options for the installed system's bootloader
+	if kopts := customizations.GetKernel(); kopts != nil && kopts.Append != "" {
+		img.Kickstart.KernelOptionsAppend = append(img.Kickstart.KernelOptionsAppend, kopts.Append)
 	}
 
 	// If we have an empty kickstart options we don't want to put it on

--- a/pkg/distro/generic/images_test.go
+++ b/pkg/distro/generic/images_test.go
@@ -1,6 +1,7 @@
 package generic
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,9 @@ import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/defs"
+	"github.com/osbuild/images/pkg/image"
+	"github.com/osbuild/images/pkg/ostree"
+	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 func isoTestImageType() *imageType {
@@ -103,5 +107,85 @@ func TestInstallerCustomizationsOverridePreview(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, tc.expected, isc.Preview)
 	}
+}
 
+// TestKickstartKernelOptionsAppend tests that the kernel.append blueprint
+// customization is properly propagated to the kickstart configuration for the
+// installed system's bootloader in all installer image types.
+func TestKickstartKernelOptionsAppend(t *testing.T) {
+	// math/rand is good enough for testing
+	/* #nosec G404 */
+	rng := rand.New(rand.NewSource(0))
+
+	kernelAppend := "debug console=ttyS0"
+
+	bp := &blueprint.Blueprint{
+		Customizations: &blueprint.Customizations{
+			Kernel: &blueprint.KernelCustomization{
+				Append: kernelAppend,
+			},
+		},
+	}
+
+	packageSets := map[string]rpmmd.PackageSet{
+		osPkgsKey:        {},
+		installerPkgsKey: {},
+	}
+
+	testCases := []struct {
+		name     string
+		imageFn  imageFunc
+		isOSTree bool
+	}{
+		{
+			name:    "imageInstallerImage",
+			imageFn: imageInstallerImage,
+		},
+		{
+			name:     "iotInstallerImage",
+			imageFn:  iotInstallerImage,
+			isOSTree: true,
+		},
+		{
+			name:    "networkInstallerImage",
+			imageFn: networkInstallerImage,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			it := isoTestImageType()
+			io := distro.ImageOptions{}
+			if tc.isOSTree {
+				it.ImageTypeYAML.OSTree.Name = "fedora"
+				it.ImageTypeYAML.OSTree.RemoteName = "fedora"
+				io.OSTree = &ostree.ImageOptions{
+					ImageRef: "test/ref",
+					URL:      "http://example.com/repo",
+				}
+			}
+
+			img, err := tc.imageFn(it, bp, io, packageSets, nil, nil, rng)
+			require.NoError(t, err)
+
+			// All installer image types embed AnacondaInstallerBase which has Kickstart
+			var kickstartOpts []string
+			switch v := img.(type) {
+			case *image.AnacondaTarInstaller:
+				require.NotNil(t, v.Kickstart)
+				kickstartOpts = v.Kickstart.KernelOptionsAppend
+			case *image.AnacondaOSTreeInstaller:
+				require.NotNil(t, v.Kickstart)
+				kickstartOpts = v.Kickstart.KernelOptionsAppend
+			case *image.AnacondaNetInstaller:
+				require.NotNil(t, v.Kickstart)
+				kickstartOpts = v.Kickstart.KernelOptionsAppend
+			default:
+				t.Fatalf("unexpected image type: %T", img)
+			}
+
+			assert.Contains(t, kickstartOpts, kernelAppend,
+				"Kickstart.KernelOptionsAppend should contain the kernel.append from blueprint")
+		})
+	}
 }


### PR DESCRIPTION
The blueprint's customizations.kernel.append setting should configure kernel options for the installed system's bootloader, not just the installer ISO's boot menu. This was working for bootc installers but was missing from the generic distro's installer image functions.

Without this fix, users setting kernel.append in their blueprint would only see the options applied to the installer's boot menu, but after installation the system's bootloader would not have these options configured.

Add the missing KernelOptionsAppend propagation to the kickstart configuration in imageInstallerImage (minimal-installer),
iotInstallerImage (edge-installer), and networkInstallerImage (boot-iso) functions.