### PR TITLE
test/scripts: upload image and manifest first then info.json

### DIFF
--- a/test/scripts/upload-results
+++ b/test/scripts/upload-results
@@ -40,7 +40,14 @@ def main():
 
     s3url = testlib.gen_build_info_s3_dir_path(distro, arch, manifest_id)
 
-    print(f"⬆️ Uploading {build_dir} to {s3url}")
+    # It can happen that the upload fails before finishing. This can cause problems with inconsistent cache state if,
+    # for example, the info.json file is uploaded but the manifest or image is not. Since the info.json is the important
+    # file for identifying if a build was successful, let's upload everything else first, without info.json, and then
+    # upload the info.json separately as a final step.
+    print(f"⬆️ Uploading {build_dir} to {s3url} (without info)")
+    testlib.runcmd_nc(["aws", "s3", "cp", "--no-progress", "--acl=private", "--recursive", "--exclude=info.json",
+                       build_dir+"/", s3url])
+    print(f"⬆️ Uploading info.json to {s3url}")
     testlib.runcmd_nc(["aws", "s3", "cp", "--no-progress", "--acl=private", "--recursive", build_dir+"/", s3url])
     print("✅ DONE!!")
 


### PR DESCRIPTION
It can happen that the upload fails before finishing [1].  This can cause problems with inconsistent cache state if, for example, the info.json file is uploaded but the manifest or image is not [2].  Since the info.json is the important file for identifying if a build was successful, let's upload everything else first, without info.json, and then upload the info.json separately as a final step.

[1] https://gitlab.com/redhat/services/products/image-builder/ci/images/-/jobs/12876636293
[2] https://gitlab.com/redhat/services/products/image-builder/ci/osbuild/-/jobs/13017643200