### PR TITLE
pkg/rpmmd: remove tags from modularity structures

### DIFF
--- a/pkg/rpmmd/module.go
+++ b/pkg/rpmmd/module.go
@@ -1,23 +1,23 @@
 package rpmmd
 
 type ModuleSpec struct {
-	ModuleConfigFile ModuleConfigFile   `json:"module-file"`
-	FailsafeFile     ModuleFailsafeFile `json:"failsafe-file"`
+	ModuleConfigFile ModuleConfigFile
+	FailsafeFile     ModuleFailsafeFile
 }
 
 type ModuleConfigFile struct {
-	Path string           `json:"path"`
-	Data ModuleConfigData `json:"data"`
+	Path string
+	Data ModuleConfigData
 }
 
 type ModuleConfigData struct {
-	Name     string   `json:"name"`
-	Stream   string   `json:"stream"`
-	Profiles []string `json:"profiles"`
-	State    string   `json:"state"`
+	Name     string
+	Stream   string
+	Profiles []string
+	State    string
 }
 
 type ModuleFailsafeFile struct {
-	Path string `json:"path"`
-	Data string `json:"data"`
+	Path string
+	Data string
 }


### PR DESCRIPTION
The library data structures are not intended for direct JSON serialization by the library users. Each client should define their own DTO if they need to serialize any structure into or from JSON. Thus remove the tags to eliminate a false premise that serializing the struct directly is OK.