### PR TITLE
deps: update to Go 1.24

### DIFF
--- a/.github/workflows/gitlab-helper.yml
+++ b/.github/workflows/gitlab-helper.yml
@@ -22,10 +22,10 @@ jobs:
       GOPROXY: "https://proxy.golang.org|direct"
     steps:
 
-      - name: Set up Go 1.23
+      - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.24.12"
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,10 +73,10 @@ jobs:
       GOPROXY: "https://proxy.golang.org|direct"
 
     steps:
-      - name: Set up Go 1.23
+      - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.24.12"
         id: go
 
       - name: Check out code into the Go module directory
@@ -159,10 +159,10 @@ jobs:
       # (go.opencensus.io/trace)
       GOPROXY: "https://proxy.golang.org|direct"
     steps:
-      - name: Set up Go 1.23
+      - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.24.12"
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/validate-checksums.yml
+++ b/.github/workflows/validate-checksums.yml
@@ -21,10 +21,10 @@ jobs:
       DEBIAN_FRONTEND: "noninteractive"
 
     steps:
-      - name: Set up Go 1.23
+      - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.24.12"
         id: go
 
       - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/images
 
-go 1.23.9
+go 1.24.12
 
 require (
 	cloud.google.com/go/compute v1.45.0

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -4,7 +4,7 @@ set -eux
 
 # Go version must be consistent with image-builder which uses UBI
 # container that is typically few months behind
-GO_VERSION=1.23.9
+GO_VERSION=1.24.12
 GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
 
 # this is the official way to get a different version of golang


### PR DESCRIPTION
Update the Go version to the latest available version on GitHub Actions.

---

That is 1.24.12 (although latest is 1.24.13 at the moment). Previously, Go version was vaguely specified in GHA (1.23) but this caused the installed Go to redownload itself, I think it is better if we specify the exact version via GHA YAML.

And gobump will pick it from here.