### PR TITLE
Enable BSI OpenSCAP profile for RHEL 10.2 (HMS-9407)

### DIFF
--- a/data/distrodefs/rhel.yaml
+++ b/data/distrodefs/rhel.yaml
@@ -50,6 +50,7 @@ distros:
       - "xccdf_org.ssgproject.content_profile_anssi_bp28_high"
       - "xccdf_org.ssgproject.content_profile_anssi_bp28_intermediary"
       - "xccdf_org.ssgproject.content_profile_anssi_bp28_minimal"
+      - "xccdf_org.ssgproject.content_profile_bsi"
       - "xccdf_org.ssgproject.content_profile_cis"
       - "xccdf_org.ssgproject.content_profile_cis_server_l1"
       - "xccdf_org.ssgproject.content_profile_cis_workstation_l1"

--- a/pkg/customizations/oscap/oscap.go
+++ b/pkg/customizations/oscap/oscap.go
@@ -19,6 +19,7 @@ const (
 	AnssiBp28High         Profile = "xccdf_org.ssgproject.content_profile_anssi_bp28_high"
 	AnssiBp28Intermediary Profile = "xccdf_org.ssgproject.content_profile_anssi_bp28_intermediary"
 	AnssiBp28Minimal      Profile = "xccdf_org.ssgproject.content_profile_anssi_bp28_minimal"
+	BSI                   Profile = "xccdf_org.ssgproject.content_profile_bsi"
 	CcnAdvanced           Profile = "xccdf_org.ssgproject.content_profile_ccn_advanced"
 	CcnBasic              Profile = "xccdf_org.ssgproject.content_profile_ccn_basic"
 	CcnIntermediate       Profile = "xccdf_org.ssgproject.content_profile_ccn_intermediate"


### PR DESCRIPTION
## Summary
Add support for the BSI (German Federal Office for Information Security) OpenSCAP profile on RHEL 10.2 by registering it in the distro definitions and oscap mapping.

## Changes
- Add `bsi` profile to the supported OpenSCAP profiles list for RHEL 10.2 in `data/distrodefs/rhel.yaml`
- Register RHEL 10 BSI profile mapping in `pkg/customizations/oscap/oscap.go`