### PR TITLE
Add RHUI support for cloud instance authentication

### DIFF
--- a/pkg/depsolvednf/depsolvednf.go
+++ b/pkg/depsolvednf/depsolvednf.go
@@ -506,11 +506,13 @@ func validatePackageSetRepoChain(pkgSets []rpmmd.PackageSet) error {
 }
 
 // validateSubscriptionsForRepos checks that RHSM subscriptions are available
-// for any repositories that require them.
+// for any repositories that require them. Repositories with RHUI set to true
+// are skipped since they use cloud instance identity for authentication
+// instead of RHSM entitlement certificates.
 func validateSubscriptionsForRepos(pkgSets []rpmmd.PackageSet, haveSubscriptions bool, subsErr error) error {
 	for _, ps := range pkgSets {
 		for _, repo := range ps.Repositories {
-			if repo.RHSM && !haveSubscriptions {
+			if repo.RHSM && !repo.RHUI && !haveSubscriptions {
 				return fmt.Errorf("This system does not have any valid subscriptions. Subscribe it before specifying rhsm: true in sources (error details: %w)", subsErr)
 			}
 		}

--- a/pkg/osbuild/curl_source.go
+++ b/pkg/osbuild/curl_source.go
@@ -45,6 +45,10 @@ func NewCurlPackageItem(pkg rpmmd.Package) (CurlSourceItem, error) {
 		item.Secrets = &URLSecrets{
 			Name: "org.osbuild.rhsm",
 		}
+	case "org.osbuild.rhui":
+		item.Secrets = &URLSecrets{
+			Name: "org.osbuild.rhui",
+		}
 	case "org.osbuild.mtls":
 		item.Secrets = &URLSecrets{
 			Name: "org.osbuild.mtls",

--- a/pkg/rpmmd/repository.go
+++ b/pkg/rpmmd/repository.go
@@ -24,6 +24,7 @@ type repository struct {
 	CheckGPG       bool     `json:"check_gpg,omitempty"`
 	IgnoreSSL      bool     `json:"ignore_ssl,omitempty"`
 	RHSM           bool     `json:"rhsm,omitempty"`
+	RHUI           bool     `json:"rhui,omitempty"`
 	ModuleHotfixes *bool    `json:"module_hotfixes,omitempty"`
 	MetadataExpire string   `json:"metadata_expire,omitempty"`
 	ImageTypeTags  []string `json:"image_type_tags,omitempty"`
@@ -83,6 +84,7 @@ type RepoConfig struct {
 	MetadataExpire string   `json:"metadata_expire,omitempty"`
 	ModuleHotfixes *bool    `json:"module_hotfixes,omitempty"`
 	RHSM           bool     `json:"rhsm,omitempty"`
+	RHUI           bool     `json:"rhui,omitempty"`
 	Enabled        *bool    `json:"enabled,omitempty"`
 	ImageTypeTags  []string `json:"image_type_tags,omitempty"`
 	PackageSets    []string `json:"package_sets,omitempty"`
@@ -119,6 +121,7 @@ func (r *RepoConfig) Hash() string {
 		bpts(r.IgnoreSSL)+
 		r.MetadataExpire+
 		bts(r.RHSM)+
+		bts(r.RHUI)+
 		bpts(r.ModuleHotfixes)+
 		r.SSLCACert+
 		r.SSLClientKey+
@@ -164,6 +167,7 @@ func LoadRepositoriesFromReader(r io.Reader) (map[string][]RepoConfig, error) {
 				GPGKeys:        keys,
 				CheckGPG:       &repo.CheckGPG,
 				RHSM:           repo.RHSM,
+				RHUI:           repo.RHUI,
 				MetadataExpire: repo.MetadataExpire,
 				ModuleHotfixes: repo.ModuleHotfixes,
 				ImageTypeTags:  repo.ImageTypeTags,


### PR DESCRIPTION
## Summary

Adds RHUI (Red Hat Update Infrastructure) support so that cloud RHEL instances can build images using RHUI repos instead of requiring RHSM subscriptions.

All secrets discovery logic (SSL cert resolution, cloud identity headers) lives in the Python depsolve solver in osbuild/osbuild#2355 — this PR only adds the data model plumbing and request/response wiring needed for the Go side to pass `rhui: true` to the solver and consume its response. No depsolver secrets discovery logic is added here, per #2055.

Closes #2207
Related: osbuild/osbuild-composer#820 (original report), osbuild/osbuild#2355 (Python solver RHUI support), osbuild/osbuild-composer#5028

## Changes

### 1. `rpmmd,osbuild: add RHUI field and curl source support`
- Add `RHUI bool` field to `RepoConfig` and `repository` structs in `pkg/rpmmd/repository.go`
- Include `RHUI` in `RepoConfig.Hash()` so RHUI repos get distinct cache keys
- Wire `RHUI` through `LoadRepositoriesFromReader()`
- Add `case "org.osbuild.rhui"` to `NewCurlPackageItem()` in `pkg/osbuild/curl_source.go`

### 2. `depsolvednf: wire RHUI flag through solver request and response`
- Add `RHUI bool` to `v2Repository` and pass it through `reposFromRPMMD()` so the Python solver can discover RHUI SSL certs from host repo files
- Propagate `RHUI` from solver response repos via `toRPMMDRepoConfig()`
- Set `org.osbuild.rhui` secrets in `toRPMMDPackage()` based on the response repo's RHUI flag
- Update `validateSubscriptionsForRepos()` to skip RHUI repos (they use cloud instance identity, not RHSM entitlement certs)
- `applyRHSMSecrets()` is **unchanged** — it is still needed for the existing RHSM path since Go does not yet send `rhsm=true` to the solver (see TODO in `reposFromRPMMD`)

## How it works

1. osbuild-composer sets `RHUI: true` on repo configs for cloud RHEL repos
2. Go passes `rhui: true` in the depsolve request to `osbuild-depsolve-dnf`
3. The Python solver discovers SSL certs from `/etc/pki/rhui/` and cloud identity headers (AWS/GCP) — all in osbuild/osbuild#2355
4. The solver response returns `rhui: true` + `secrets: "org.osbuild.rhui"` on resolved repos
5. Go reads the response flags and sets `org.osbuild.rhui` on packages from those repos
6. The curl source uses `org.osbuild.rhui` secrets provider to download RPMs with cloud-specific auth

## Test plan

- [x] End-to-end on AWS EC2 RHEL 8.10 — full qcow2 compose with 469 RPMs from RHUI repos
- [x] Existing `TestApplyRHSMSecrets` tests pass (function unchanged from main)

## Stopgap

Until this is merged, users can use [osbuild-rhui-shim](https://github.com/brandonrc/osbuild-rhui-shim) as a workaround.