### PR TITLE
many: copy ErofsOptions in manifest

### DIFF
--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -492,7 +492,7 @@ func isoCustomizations(t *imageType, c *blueprint.Customizations) (manifest.ISOC
 		}
 
 		if erofsOptions := isoConfig.ErofsOptions; erofsOptions != nil {
-			isc.ErofsOptions = erofsOptions
+			isc.ErofsOptions = *erofsOptions
 		}
 	}
 

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -293,16 +293,15 @@ func (p *AnacondaInstallerISOTree) NewSquashfsStage() (*osbuild.Stage, error) {
 // NewErofsStage returns an osbuild stage configured to build
 // the erofs root filesystem for the ISO.
 func (p *AnacondaInstallerISOTree) NewErofsStage() (*osbuild.Stage, error) {
-	var erofsOptions *osbuild.ErofsStageOptions
 	if p.anacondaPipeline == nil {
 		return nil, fmt.Errorf("Anaconda pipeline not set for %s pipeline", p.name)
 	}
 
-	if p.RootfsType != ErofsRootfs || p.anacondaPipeline.ISOCustomizations.ErofsOptions == nil {
-		return nil, fmt.Errorf("Rootfs not set to Erofs or options set to nil for %s pipeline, can not create erofs stage", p.name)
+	if p.RootfsType != ErofsRootfs {
+		return nil, fmt.Errorf("Rootfs not set to Erofs for %s pipeline, can not create erofs stage", p.name)
 	}
 
-	erofsOptions = p.anacondaPipeline.ISOCustomizations.ErofsOptions
+	erofsOptions := p.anacondaPipeline.ISOCustomizations.ErofsOptions
 
 	switch p.anacondaPipeline.Type {
 	case AnacondaInstallerTypePayload, AnacondaInstallerTypeNetinst:

--- a/pkg/manifest/anaconda_installer_iso_tree_test.go
+++ b/pkg/manifest/anaconda_installer_iso_tree_test.go
@@ -110,7 +110,7 @@ func newTestAnacondaISOTreeErofs() *manifest.AnacondaInstallerISOTree {
 			Preview:   preview,
 		},
 		manifest.ISOCustomizations{
-			ErofsOptions: &osbuild.ErofsStageOptions{},
+			ErofsOptions: osbuild.ErofsStageOptions{},
 		},
 	)
 	rootfsImagePipeline := manifest.NewISORootfsImg(build, anacondaPipeline)

--- a/pkg/manifest/iso.go
+++ b/pkg/manifest/iso.go
@@ -19,7 +19,7 @@ type ISOCustomizations struct {
 	Application string
 
 	RootfsType   ISORootfsType
-	ErofsOptions *osbuild.ErofsStageOptions
+	ErofsOptions osbuild.ErofsStageOptions
 	BootType     ISOBootType
 }
 

--- a/pkg/manifest/iso_tree.go
+++ b/pkg/manifest/iso_tree.go
@@ -93,7 +93,7 @@ func (p *ISOTree) NewErofsStage() (*osbuild.Stage, error) {
 		return nil, fmt.Errorf("Rootfs not set to Erofs or options set to nil for %s pipeline, can not create erofs stage", p.name)
 	}
 
-	erofsOptions := p.ErofsOptions
+	erofsOptions := *p.ErofsOptions
 	erofsOptions.Filename = "LiveOS/squashfs.img"
 
 	// Clean up the root filesystem's /boot to save space

--- a/pkg/manifest/pxetree.go
+++ b/pkg/manifest/pxetree.go
@@ -94,7 +94,7 @@ func (p *PXETree) serialize() (osbuild.Pipeline, error) {
 		// TODO this is shared with the ISO, should it be?
 		// Clean up the root filesystem's /boot to save space
 		erofsOptions.ExcludePaths = installerBootExcludePaths
-		pipeline.AddStage(osbuild.NewErofsStage(&erofsOptions, p.osPipeline.Name()))
+		pipeline.AddStage(osbuild.NewErofsStage(erofsOptions, p.osPipeline.Name()))
 	} else {
 		var squashfsOptions osbuild.SquashfsStageOptions
 

--- a/pkg/osbuild/erofs_stage.go
+++ b/pkg/osbuild/erofs_stage.go
@@ -17,10 +17,11 @@ type ErofsStageOptions struct {
 
 func (ErofsStageOptions) isStageOptions() {}
 
-func NewErofsStage(options *ErofsStageOptions, inputPipeline string) *Stage {
+func NewErofsStage(options ErofsStageOptions, inputPipeline string) *Stage {
+	opts := options
 	return &Stage{
 		Type:    "org.osbuild.erofs",
-		Options: options,
+		Options: &opts,
 		Inputs:  NewPipelineTreeInputs("tree", inputPipeline),
 	}
 }

--- a/pkg/osbuild/erofs_stage_test.go
+++ b/pkg/osbuild/erofs_stage_test.go
@@ -28,7 +28,7 @@ func TestErofStageJsonMinimal(t *testing.T) {
         }
 }`
 
-	opts := &osbuild.ErofsStageOptions{
+	opts := osbuild.ErofsStageOptions{
 		Filename: "foo.ero",
 	}
 	stage := osbuild.NewErofsStage(opts, "input-pipeline")
@@ -70,7 +70,7 @@ func TestErofStageJsonFull(t *testing.T) {
         }
 }`
 
-	opts := &osbuild.ErofsStageOptions{
+	opts := osbuild.ErofsStageOptions{
 		Filename: "foo.ero",
 		Source:   "mount://-/",
 		ExcludePaths: []string{


### PR DESCRIPTION
The Go race detector identified a data race occurring when `serialize` is called. Now, we do not use `t.Parallel()` (I think) but we run tests with `go test -race` and it fails. This patch resolves the issue by converting **ErofsOptions** into a value type, allowing it to be copied safely. Additionally, the argument in **NewErofsStage** has been updated to a value type for consistency.

---

While our codebase frequently uses pointers to leverage the omitempty tag in the standard encoding/json library, we should avoid pointers in non-JSON types unless strictly necessary.

Benefits of using value types here:

* Thread Safety: Eliminates shared state risks during concurrent operations.
* Performance: Go is highly optimized for copying small structs; value types can be more efficient than pointer indirection and reduce GC pressure.
* Simplicity: Removes the need for nil-checks and dereferencing.

Go 1.25/26 experimental JSON v2 introduces the omitzero flag, which will eventually allow us to omit empty structs without needing pointers. Until that is standard, moving toward value types for internal logic is the preferred approach for safety.

Fixes: https://issues.redhat.com/browse/HMS-10222

Edit: Reworded the description a bit.