### PR TITLE
bootc: directly embed OSCustomizations

### DIFF
--- a/pkg/image/bootc_disk.go
+++ b/pkg/image/bootc_disk.go
@@ -107,13 +107,7 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 		rawImage.SourcePipeline = customSourcePipeline
 	}
 	rawImage.PartitionTable = img.PartitionTable
-	rawImage.Users = img.OSCustomizations.Users
-	rawImage.Groups = img.OSCustomizations.Groups
-	rawImage.Files = img.OSCustomizations.Files
-	rawImage.Directories = img.OSCustomizations.Directories
-	rawImage.KernelOptionsAppend = img.OSCustomizations.KernelOptionsAppend
-	rawImage.SELinux = img.OSCustomizations.SELinux
-	rawImage.MountConfiguration = img.OSCustomizations.MountConfiguration
+	rawImage.OSCustomizations = img.OSCustomizations
 
 	// In BIB, we export multiple images from the same pipeline so we use the
 	// filename as the basename for each export and set the extensions based on

--- a/pkg/image/bootc_pxetar.go
+++ b/pkg/image/bootc_pxetar.go
@@ -108,13 +108,7 @@ func (img *BootcPXEImage) InstantiateManifestFromContainers(m *manifest.Manifest
 		rawImage.SourcePipeline = customSourcePipeline
 	}
 	rawImage.PartitionTable = img.PartitionTable
-	rawImage.Users = img.OSCustomizations.Users
-	rawImage.Groups = img.OSCustomizations.Groups
-	rawImage.Files = img.OSCustomizations.Files
-	rawImage.Directories = img.OSCustomizations.Directories
-	rawImage.KernelOptionsAppend = img.OSCustomizations.KernelOptionsAppend
-	rawImage.SELinux = img.OSCustomizations.SELinux
-	rawImage.MountConfiguration = img.OSCustomizations.MountConfiguration
+	rawImage.OSCustomizations = img.OSCustomizations
 	rawImage.KernelVersion = img.KernelVersion
 
 	// Setup root filesystem so that dmsquash-live will boot it

--- a/pkg/manifest/bootc_pxetree.go
+++ b/pkg/manifest/bootc_pxetree.go
@@ -173,7 +173,7 @@ func (p *BootcPXETree) makeGrubConfig() ([]*osbuild.Stage, error) {
 		return nil, err
 	}
 
-	template := strings.ReplaceAll(string(grubTemplate), "@CMDLINE@", strings.Join(p.bootcPipeline.KernelOptionsAppend, " "))
+	template := strings.ReplaceAll(string(grubTemplate), "@CMDLINE@", strings.Join(p.bootcPipeline.OSCustomizations.KernelOptionsAppend, " "))
 	f, err := fsnode.NewFile("/grub.cfg", nil, nil, nil, []byte(template))
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Instead of duplicating a bunch of options we already have let's follow the idiom we do for other pipeline generators and put the customizations directly into the relevant struct.

---

Am I missing something here?

cc @jbtrystram (since we spoke about this on Matrix and you might be working on things related to this).