### PR TITLE
distro: direct access to mount configuration

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -1946,7 +1946,7 @@ image_types:
       grub2_config:
         timeout: 5
       install_weak_deps: false
-      mount_units: true
+      mount_configuration: "units"
       machine_id_uninitialized: false
       enabled_services:
         - "NetworkManager.service"
@@ -1960,7 +1960,7 @@ image_types:
             version_less_than: "43"
           shallow_merge:
             install_weak_deps: true
-            mount_units: false
+            mount_configuration: "fstab"
             enabled_services:
               - "NetworkManager.service"
               - "initial-setup.service"

--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -353,8 +353,8 @@ func osCustomizations(t *imageType, osPackageSet rpmmd.PackageSet, options distr
 		osc.MachineIdUninitialized = *imageConfig.MachineIdUninitialized
 	}
 
-	if imageConfig.MountUnits != nil && *imageConfig.MountUnits {
-		osc.MountConfiguration = osbuild.MOUNT_CONFIGURATION_UNITS
+	if imageConfig.MountConfiguration != nil {
+		osc.MountConfiguration = *imageConfig.MountConfiguration
 	}
 
 	osc.VersionlockPackages = imageConfig.VersionlockPackages

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -18,6 +18,7 @@ import (
 	"github.com/osbuild/images/pkg/experimentalflags"
 	"github.com/osbuild/images/pkg/image"
 	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -288,7 +289,7 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 		if t.ImageConfigYAML.ImageConfig != nil {
 			t.ImageConfigYAML.ImageConfig = &distro.ImageConfig{}
 		}
-		t.ImageConfigYAML.ImageConfig.MountUnits = common.ToPtr(true)
+		t.ImageConfigYAML.ImageConfig.MountConfiguration = common.ToPtr(osbuild.MOUNT_CONFIGURATION_UNITS)
 	}
 
 	containerSources := make([]container.SourceSpec, len(bp.Containers))

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -139,9 +139,10 @@ type ImageConfig struct {
 	// to be triggered in systemd
 	MachineIdUninitialized *bool `yaml:"machine_id_uninitialized,omitempty"`
 
-	// MountUnits creates systemd .mount units to describe the filesystem
-	// instead of writing to /etc/fstab
-	MountUnits *bool `yaml:"mount_units,omitempty"`
+	// MountConfiguration determines the mounting system used by the image. For
+	// example systemd .mount units to describe the filesystem instead of writing
+	// to /etc/fstab or none
+	MountConfiguration *osbuild.MountConfiguration `yaml:"mount_configuration,omitempty"`
 
 	// Indicates if rhc should be set to permissive when creating the registration script
 	PermissiveRHC *bool `yaml:"permissive_rhc,omitempty"`


### PR DESCRIPTION
Instead of having a single boolean for enabling systemd mount unit generation let's expose the entire `osbuild.MountConfiguration` enum instead.

This allows users to directly control if they want `none`, e.g. no mount units, no fstab, full automatic detection by
`systemd-gpt-auto-generator`.

---

Note that this was already possible on the `disk.yaml` format that we use to read partition tables out of containers.

---

No manifests change; after this there will be a follow-up to also allow users picking if `mount.usr` should be set to `dissect`; instead of filling in its UUID, etc. @alexlarsson for this follow-up would you be interested to have that in `disk.yaml` as well? I know @jbtrystram probably is as we've discussed this previously.