### PR TITLE
check-host-config: print unit journal on timeout

### DIFF
--- a/cmd/check-host-config/main.go
+++ b/cmd/check-host-config/main.go
@@ -26,6 +26,10 @@ func waitForSystem(timeout time.Duration) error {
 		if errors.Is(err, ErrTimeout) {
 			if activatingUnits := listBadUnits(); len(activatingUnits) > 0 {
 				fmt.Fprintf(os.Stderr, "Units still activating: %s\n", strings.Join(activatingUnits, " "))
+				for _, unit := range activatingUnits {
+					fmt.Fprintf(os.Stderr, "Unit %s journal:\n", unit)
+					printUnitJournal(unit)
+				}
 			}
 		}
 		return err

--- a/cmd/check-host-config/wait.go
+++ b/cmd/check-host-config/wait.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -82,4 +83,9 @@ func listBadUnits() []string {
 	}
 
 	return units
+}
+
+func printUnitJournal(unit string) {
+	stdout, _, _, _ := check.Exec("journalctl", "-u", unit, "-o", "cat")
+	fmt.Fprintf(os.Stderr, "%s\n", stdout)
 }

--- a/cmd/check-host-config/wait_test.go
+++ b/cmd/check-host-config/wait_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"bytes"
+	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -8,6 +11,13 @@ import (
 	"github.com/osbuild/images/cmd/check-host-config/check"
 	"github.com/osbuild/images/internal/test"
 )
+
+func joinArgs(name string, arg ...string) string {
+	if len(arg) == 0 {
+		return name
+	}
+	return name + " " + strings.Join(arg, " ")
+}
 
 func TestRunningWait(t *testing.T) {
 	responses := make(chan []byte, 2)
@@ -82,5 +92,37 @@ bar.service loaded activating auto vendor preset: enabled
 				t.Errorf("expected %q, got %q", tt.expected, result)
 			}
 		})
+	}
+}
+
+func TestPrintUnitJournal(t *testing.T) {
+	const unit = "foo.service"
+	const journalOut = "line 1\nline 2\n"
+
+	test.MockGlobal(t, &check.Exec, func(name string, arg ...string) ([]byte, []byte, int, error) {
+		if joinArgs(name, arg...) != joinArgs("journalctl", "-u", unit, "-o", "cat") {
+			return nil, nil, 1, nil
+		}
+		return []byte(journalOut), nil, 0, nil
+	})
+
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+
+	printUnitJournal(unit)
+	w.Close()
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+	want := journalOut + "\n" // Fprintf uses "%s\n"
+	if got := buf.String(); got != want {
+		t.Errorf("expected %q, got %q", want, got)
 	}
 }


### PR DESCRIPTION
When the system is not running after the timeout, print the journal for the units that are still activating.