### PR TITLE
boot-image: Extend the ISO boot timeout to 240s

### DIFF
--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -22,6 +22,7 @@ from vmtest.vm import QEMU
 
 BASE_TEST_EXEC = "check-host-config-" # + arch
 WSL_TEST_SCRIPT = "test/scripts/wsl-entrypoint.bat"
+ISO_BOOT_TIMEOUT = 240
 
 
 def get_aws_config():
@@ -300,7 +301,7 @@ def _boot_qemu_iso(arch, installer_iso_path, config_file, privkey_path):
         # boot from installer to install to test disk, anaconda will
         # reboot automatically for the unattended-iso config.
         with QEMU(test_disk_path, cdrom=installer_iso_path) as vm:
-            vm.start(wait_event="qmp:RESET", snapshot=False, use_ovmf=True)
+            vm.start(wait_event="qmp:RESET", snapshot=False, use_ovmf=True, timeout_sec=ISO_BOOT_TIMEOUT)
             vm.force_stop()
         # now boot test disk and wait for ssh to come up as a minimal boot test
         with QEMU(test_disk_path, arch=arch) as vm:


### PR DESCRIPTION
Currently the minimal iso being tested has a default timeout of 60s before it even starts booting, and then it runs the isomd5check which adds even more time.

Ideally we would be booting immediately and skipping the iso check (see #2223)