### PR TITLE
experimental: drop `no-fstab`

### DIFF
--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -9,16 +9,13 @@ import (
 	"text/template"
 
 	"github.com/osbuild/blueprint/pkg/blueprint"
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/defs"
-	"github.com/osbuild/images/pkg/experimentalflags"
 	"github.com/osbuild/images/pkg/image"
 	"github.com/osbuild/images/pkg/manifest"
-	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -284,13 +281,6 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 	}
 	installFromRepos := blueprint.RepoCustomizationsInstallFromOnly(customRepos)
 	payloadRepos = append(payloadRepos, installFromRepos...)
-
-	if experimentalflags.Bool("no-fstab") {
-		if t.ImageConfigYAML.ImageConfig != nil {
-			t.ImageConfigYAML.ImageConfig = &distro.ImageConfig{}
-		}
-		t.ImageConfigYAML.ImageConfig.MountConfiguration = common.ToPtr(osbuild.MOUNT_CONFIGURATION_UNITS)
-	}
 
 	containerSources := make([]container.SourceSpec, len(bp.Containers))
 	for idx, cont := range bp.Containers {


### PR DESCRIPTION
When mount units were introduced we added an experimental option to generate any image type without an fstab file. With this recent PR [1] it is now possible to set this value directly in the definitions instead.

We can drop the experimental option.

[1] https://github.com/osbuild/images/pull/2218