### PR TITLE
boot-image: bump iso boot timeout from 4 to 7 minutes

### DIFF
--- a/test/scripts/boot-image
+++ b/test/scripts/boot-image
@@ -22,7 +22,7 @@ from vmtest.vm import QEMU
 
 BASE_TEST_EXEC = "check-host-config-" # + arch
 WSL_TEST_SCRIPT = "test/scripts/wsl-entrypoint.bat"
-ISO_BOOT_TIMEOUT = 240
+ISO_BOOT_TIMEOUT = 420
 
 
 def get_aws_config():


### PR DESCRIPTION
It is still not enough for our CICD pipeline.

---

Followup of https://github.com/osbuild/images/pull/2224

Fedora 45 and RHEL 9.7 both did not pass (x86_64):

https://gitlab.com/redhat/services/products/image-builder/ci/images/-/jobs/13238896346
https://gitlab.com/redhat/services/products/image-builder/ci/images/-/jobs/13238886383

They were both in the middle of the boot process so they passed the md5implant thing but there was simply not enough time.