### PR TITLE
bootc: default kernel arguments for bootc types

### DIFF
--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -162,6 +162,14 @@ type ImageType interface {
 
 type BootcImageOptions struct {
 	InstallerPayloadRef string `json:"installer_payload_ref,omitempty"`
+
+	// We introduce default kernel arguments in bootc generic image types which
+	// can clash with certain user use cases. Normally we only allow appending
+	// to the default kernel arguments through blueprints. This option allows turning
+	// off the default arguments; leaving them up to the user (in the container).
+	// This is introduced as an option here as it's likely that in the future we want
+	// to entirely stop adding default kernel arguments to bootc images.
+	OmitDefaultKernelArgs bool `json:"omit_default_kernel_args,omitempty"`
 }
 
 // The ImageOptions specify options for a specific image build

--- a/pkg/distro/generic/bootc_imagetype.go
+++ b/pkg/distro/generic/bootc_imagetype.go
@@ -221,6 +221,12 @@ func (t *bootcImageType) manifestForDisk(bp *blueprint.Blueprint, options distro
 	if imageConfig != nil {
 		img.OSCustomizations.KernelOptionsAppend = imageConfig.KernelOptions
 	}
+
+	// when we omit default kernel options reset them to be empty
+	if options.Bootc != nil && options.Bootc.OmitDefaultKernelArgs {
+		img.OSCustomizations.KernelOptionsAppend = []string{}
+	}
+
 	if kopts := customizations.GetKernel(); kopts != nil && kopts.Append != "" {
 		img.OSCustomizations.KernelOptionsAppend = append(img.OSCustomizations.KernelOptionsAppend, kopts.Append)
 	}


### PR DESCRIPTION
The default kernel arguments we have defined, while helpful, get in the way of use cases such as [1].
    
Since this is a breaking change (people might rely on these arguments being present) we can't remove them entirely in one go.
    
Let's introduce an `ImageOptions` toggle to turn off the default kernel arguments. This allows us to implement a command-line toggle for this behaviour to `(bootc-)image-builder`.
    
I've opted for an `ImageOption` here because I believe that in the future we will no longer ship any default kernel arguments for bootc image types; instead having users define them [2].
    
Having the argument allows us to emit a warning in `(bootc-)image-builder` that the behavior will change in the future and to opt in to the new behavior the user can pass the toggle.
    
This fits better than a blueprint option as those try to keep backwards compatibility much stricter.
    
[1]: https://github.com/osbuild/bootc-image-builder/issues/824
[2]: https://docs.fedoraproject.org/en-US/bootc/kernel-args/