### PR TITLE
bootc: resolve much less for build containers

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -569,7 +569,7 @@ func main() {
 		var buildBootcRef string
 		if len(l) > 1 {
 			buildBootcRef = l[1]
-			buildBootcInfo, err := bootc.ResolveBootcInfo(buildBootcRef)
+			buildBootcInfo, err := bootc.ResolveBootcBuildInfo(buildBootcRef)
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
For the build container we don't need *any* information from inside the container at all. Just the information we have up front is enough.

Introduce a new resolve function for build containers specifically. Do this as a separate function because it feels nice to use this in the executables this way and it lives in the right place.

This resolves (haha) the following issue [1] after it lands in executables.

There's a larger story here that we probably shouldn't treat inspection errors as errors unless an image type *actually* needs the information.

[1]: https://github.com/osbuild/image-builder-cli/issues/464