### PR TITLE
imgtestlib: Make NullBuild more descriptive

### DIFF
--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -68,7 +68,7 @@ BASE_CONFIG = """
 NULL_CONFIG = """
 NullBuild:
   stage: test
-  script: "true"
+  script: echo "No manifest changes detected. Skipping build."
   tags:
     - "shell"
 """


### PR DESCRIPTION
The NullBuild task doesn't actually tell you why it was generated, the logging of that is elsewhere. This changes it to actually tell you why there is no build.