### PR TITLE
pkg/manifest: use slices.Concat for repo slice merges

### DIFF
--- a/pkg/manifest/anaconda_installer.go
+++ b/pkg/manifest/anaconda_installer.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
@@ -231,7 +232,7 @@ func (p *AnacondaInstaller) getPackageSetChain(Distro) ([]rpmmd.PackageSet, erro
 		{
 			Include:         append(packages, p.ExtraPackages...),
 			Exclude:         p.ExcludePackages,
-			Repositories:    append(p.depsolveRepos, p.ExtraRepos...),
+			Repositories:    slices.Concat(p.depsolveRepos, p.ExtraRepos),
 			InstallWeakDeps: p.InstallerCustomizations.InstallWeakDeps,
 		},
 	}, nil

--- a/pkg/manifest/commit_server_tree.go
+++ b/pkg/manifest/commit_server_tree.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/customizations/ostreeserver"
@@ -67,7 +68,7 @@ func (p *OSTreeCommitServer) getPackageSetChain(Distro) ([]rpmmd.PackageSet, err
 	return []rpmmd.PackageSet{
 		{
 			Include:         append(packages, p.ExtraPackages...),
-			Repositories:    append(p.depsolveRepos, p.ExtraRepos...),
+			Repositories:    slices.Concat(p.depsolveRepos, p.ExtraRepos),
 			InstallWeakDeps: true,
 		},
 	}, nil

--- a/pkg/manifest/coreos_installer.go
+++ b/pkg/manifest/coreos_installer.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/customizations/fdo"
@@ -144,7 +145,7 @@ func (p *CoreOSInstaller) getPackageSetChain(Distro) ([]rpmmd.PackageSet, error)
 		{
 			Include:         append(packages, p.ExtraPackages...),
 			Exclude:         p.ExcludePackages,
-			Repositories:    append(p.depsolveRepos, p.ExtraRepos...),
+			Repositories:    slices.Concat(p.depsolveRepos, p.ExtraRepos),
 			InstallWeakDeps: true,
 		},
 	}, nil

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -329,7 +330,7 @@ func (p *OS) getPackageSetChain(Distro) ([]rpmmd.PackageSet, error) {
 		customizationPackages = append(customizationPackages, "dnf", "python3-dnf-plugin-versionlock")
 	}
 
-	osRepos := append(p.depsolveRepos, p.OSCustomizations.ExtraBaseRepos...)
+	osRepos := slices.Concat(p.depsolveRepos, p.OSCustomizations.ExtraBaseRepos)
 
 	// merge all package lists for the pipeline
 	baseOSPackages := make([]string, 0)
@@ -364,7 +365,7 @@ func (p *OS) getPackageSetChain(Distro) ([]rpmmd.PackageSet, error) {
 	if len(bpPackages) > 0 {
 		ps := rpmmd.PackageSet{
 			Include:      bpPackages,
-			Repositories: append(osRepos, p.OSCustomizations.PayloadRepos...),
+			Repositories: slices.Concat(osRepos, p.OSCustomizations.PayloadRepos),
 			// Although 'false' is the default value, set it explicitly to make
 			// it visible that we are not adding weak dependencies.
 			InstallWeakDeps: false,


### PR DESCRIPTION
Replace append() with slices.Concat() when merging depsolveRepos and extra repos to avoid backing array mutation.

Fixes: #2149