### PR TITLE
osbuild/monitor: add error flag to status message

### DIFF
--- a/pkg/osbuild/monitor.go
+++ b/pkg/osbuild/monitor.go
@@ -9,6 +9,8 @@ import (
 	"math"
 	"strings"
 	"time"
+
+	"github.com/osbuild/images/pkg/olog"
 )
 
 // Status is a high level aggregation of the low-level osbuild monitor
@@ -41,6 +43,9 @@ type Status struct {
 
 	// Duration as measured by osbuild
 	Duration time.Duration
+
+	// Error is set to the last error message from the status message (or empty if no error)
+	Error string
 }
 
 // Progress provides progress information from an osbuild build.
@@ -183,6 +188,12 @@ func (sr *StatusScanner) Status() (*Status, error) {
 		sr.metadataMap[id] = status.Metadata
 	}
 
+	// log error if set via olog
+	if status.Error && status.Result.Output != "" {
+		olog.Printf("Error in stage %q in pipeline %q: %q, result output: %s", context.Pipeline.Stage.Name, pipelineName, status.Message, status.Result.Output)
+		st.Error = status.Result.Output
+	}
+
 	return st, nil
 }
 
@@ -273,6 +284,7 @@ type statusJSON struct {
 	Message   string  `json:"message"`
 	Timestamp float64 `json:"timestamp"`
 	Duration  float64 `json:"duration"`
+	Error     bool    `json:"error"`
 }
 
 // contextJSON is the context for which a status is given. Once a context

--- a/pkg/osbuild/monitor_test.go
+++ b/pkg/osbuild/monitor_test.go
@@ -210,6 +210,16 @@ func TestScannerEmpty(t *testing.T) {
 	}, st)
 }
 
+func TestScannerErrorFlag(t *testing.T) {
+	r := bytes.NewBufferString(`{"message": "stage failed", "context": {"origin": "org.osbuild", "id": "ctx1", "pipeline": {"name": "build", "id": "p1", "stage": {"name": "org.osbuild.rpm", "id": "s1"}}}, "progress": {"total": 1, "done": 1}, "result": {"id": "s1", "success": false, "output": "error output"}, "timestamp": 1731589338.0, "error": true}` + "\n")
+	scanner := osbuild.NewStatusScanner(r)
+	st, err := scanner.Status()
+	assert.NoError(t, err)
+	require.NotNil(t, st)
+	assert.Equal(t, "error output", st.Error, "Status.Error should be set to result output when error flag is set")
+	assert.Equal(t, "stage failed", strings.TrimSpace(st.Trace))
+}
+
 //go:embed testdata/monitor-validation.json
 var osbuildMonitorValidation []byte
 


### PR DESCRIPTION
This flag is set when the status message contains an error. It is used to log the error in the olog package.

---

Build on top of https://github.com/osbuild/osbuild/pull/2370 but this can be safely merged anytime - it will work with any osbuild version.

The log via the `olog` package turns out to be not that useful in the worker context, but the last error passed as string can be quite useful. In the RunOSBuild in worker, the full log JSON is downloaded in case of build failure and the `StatusScanner` can easily be used to find the last error which can be possibly logged into structured logger and (if configured) into GlitchTip as well.

```go
	if err := handleBuild(inputArchive, executorHost, logger, job); err != nil {
		log, logErr := fetchLog(executorHost)
		if logErr != nil {
			logrus.Errorf("something went wrong during the executor's build: %v, unable to fetch log: %v", err, logErr)
			return nil, fmt.Errorf("something went wrong during the executor's build: %w, unable to fetch log: %w", err, logErr)
		}
		logrus.Errorf("something went wrong handling the executor's build: %v\nosbuild log: %v", err, log)

		ss := osbuild.NewStatusScanner(strings.NewReader(log)) // HERE
		st, err := ss.Status()
		if err != nil {
			logrus.Warnf("Unable to parse osbuild log: %v", err)
		}
		if st != nil && st.Error != "" {
			// If GlitchTip is enabled, this can be passed into it
			logrus.Errorf("OSBuild error: %s", st.Error)
		}
		return nil, fmt.Errorf("osbuild failed: %s", log)
	}
```