### PR TITLE
Remove unused anchors from imagetypes

### DIFF
--- a/data/distrodefs/bootc-generic/imagetypes.yaml
+++ b/data/distrodefs/bootc-generic/imagetypes.yaml
@@ -33,7 +33,7 @@
       x86_64:
         type: "gpt"
         partitions:
-          - &default_partition_table_part_bios
+          -
             size: "1 MiB"
             bootable: true
             type: *bios_boot_partition_guid
@@ -60,11 +60,11 @@
             size: "2 GiB"
             type: *filesystem_data_guid
             payload_type: "filesystem"
-            payload: &default_partition_table_part_root_payload
+            payload:
               label: "root"
               mountpoint: "/"
               fstab_options: "ro"
-      aarch64: &default_partition_table_aarch64
+      aarch64:
         type: "gpt"
         partitions:
           - *default_partition_table_part_efi

--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -155,7 +155,7 @@
           - "s390utils-base"
 
   default_installer_config: &default_installer_config
-    enabled_anaconda_modules: &install_config_enabled_anaconda_modules
+    enabled_anaconda_modules:
       - "org.fedoraproject.Anaconda.Modules.Network"
       - "org.fedoraproject.Anaconda.Modules.Payloads"
       - "org.fedoraproject.Anaconda.Modules.Runtime"
@@ -432,7 +432,7 @@
               fstab_options: "defaults"
               fstab_freq: 0
               fstab_passno: 0
-      aarch64: &default_partition_table_aarch64
+      aarch64:
         type: "gpt"
         partitions:
           - *default_partition_table_part_efi
@@ -980,8 +980,7 @@ image_types:
       <<: *default_partition_tables
     package_sets:
       os:
-        - &qcow2_pkgset
-          include:
+        - include:
             - "@core"
             - "chrony"
             - "cloud-init"
@@ -1728,7 +1727,7 @@ image_types:
           when:
             distro_name: "rocky"
           shallow_merge:
-            wsl: &wsl_distribution_config_rocky
+            wsl:
               <<: *wsl_config
               distribution_config:
                 <<: *wsl_distribution_config

--- a/data/distrodefs/rhel-7/imagetypes.yaml
+++ b/data/distrodefs/rhel-7/imagetypes.yaml
@@ -62,7 +62,7 @@
             size: "1 MiB"
             bootable: true
             type: *bios_boot_partition_guid
-          - &default_partition_table_part_efi
+          -
             size: "200 MiB"
             type: *efi_system_partition_guid
             payload_type: "filesystem"
@@ -73,7 +73,7 @@
               fstab_options: "defaults,uid=0,gid=0,umask=077,shortname=winnt"
               fstab_freq: 0
               fstab_passno: 2
-          - &default_partition_table_part_boot
+          -
             size: "500 MiB"
             type: *filesystem_data_guid
             payload_type: "filesystem"
@@ -84,7 +84,7 @@
               fstab_options: "defaults"
               fstab_freq: 0
               fstab_passno: 0
-          - &default_partition_table_part_root
+          -
             size: "2 GiB"
             type: *filesystem_data_guid
             payload_type: "filesystem"
@@ -113,7 +113,7 @@
         type: "gpt"
         size: "64 GiB"
         partitions:
-          - &azure_rhui_part_boot_efi
+          -
             size: 524_288_000   # 500 * datasizes.MebiByte
             type: *efi_system_partition_guid
             payload_type: "filesystem"
@@ -123,7 +123,7 @@
               fstab_options: "defaults,uid=0,gid=0,umask=077,shortname=winnt"
               fstab_freq: 0
               fstab_passno: 2
-          - &azure_rhui_part_boot
+          -
             size: "500 MiB"
             type: *filesystem_data_guid
             payload_type: "filesystem"
@@ -136,7 +136,7 @@
           - size: "2 MiB"
             bootable: true
             type: *bios_boot_partition_guid
-          - &azure_rhui_part_lvm
+          -
             type: *lvm_partition_guid
             payload_type: "lvm"
             payload:

--- a/data/distrodefs/rhel-8/imagetypes.yaml
+++ b/data/distrodefs/rhel-8/imagetypes.yaml
@@ -217,7 +217,7 @@
       "x86_64 specific dracut conf":
         when:
           arch: "x86_64"
-        shallow_merge: &ami_image_config_cond_x86_64
+        shallow_merge:
           dracut_conf:
             - *sgdisk_dracut_conf
             - filename: "ec2.conf"
@@ -927,7 +927,7 @@
           - "s390utils-base"
 
   default_installer_config: &default_installer_config
-    enabled_anaconda_modules: &install_config_enabled_anaconda_modules
+    enabled_anaconda_modules:
       - "org.fedoraproject.Anaconda.Modules.Network"
       - "org.fedoraproject.Anaconda.Modules.Payloads"
       - "org.fedoraproject.Anaconda.Modules.Storage"
@@ -1011,7 +1011,7 @@
           - *default_partition_table_part_bios
           - *default_partition_table_part_efi
           - *default_partition_table_part_root
-      aarch64: &default_partition_table_aarch64
+      aarch64:
         uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
         type: "gpt"
         partitions:
@@ -1089,7 +1089,7 @@
                 fstab_options: "defaults"
                 fstab_freq: 0
                 fstab_passno: 0
-      aarch64: &edge_base_partition_table_aarch64
+      aarch64:
         uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
         type: "gpt"
         partitions:
@@ -1602,7 +1602,7 @@ image_types:
                     enabled: false
     partition_table:
       <<: *default_partition_tables
-    package_sets: &qcow2_pkgset
+    package_sets:
       os:
         - *qcow2_common_pkgset
     blueprint:
@@ -1762,7 +1762,7 @@ image_types:
     package_sets:
       os:
         - *azure_common_pkgset
-        - &azure_pkgset
+        -
           include:
             - "firewalld"
           exclude:
@@ -2041,7 +2041,7 @@ image_types:
         - "customizations.timezone"
         - "customizations.rhsm"
 
-  "edge-commit": &edge_commit
+  "edge-commit":
     name_aliases: ["rhel-edge-commit"]
     filename: "commit.tar"
     mime_type: "application/x-tar"
@@ -2169,7 +2169,7 @@ image_types:
             - "xz"
           exclude:
             - "rng-tools"
-          conditions: &conditions_pkgsets_edge_commit
+          conditions:
             "x86_64 specific packages for edge-commit":
               when:
                 arch: "x86_64"
@@ -2464,7 +2464,7 @@ image_types:
         - "net.ifnames=0"
     partition_table:
       <<: *default_partition_tables
-    package_sets: &vmdk_pkgsets
+    package_sets:
       os:
         - include:
             - "@core"

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -770,19 +770,19 @@
           - *default_partition_table_part_efi
           - *default_partition_table_part_boot
           - *default_partition_table_part_root
-      ppc64le: &default_partition_table_ppc64le
+      ppc64le:
         uuid: "0x14fc63d2"
         type: "dos"
         partitions:
           - *default_partition_table_part_bios_ppc64le
           - *default_partition_table_part_boot_ppc64le
           - *default_partition_table_part_root_ppc64le
-      s390x: &default_partition_table_s390x
+      s390x:
         uuid: "0x14fc63d2"
         type: "dos"
         partitions:
           - *default_partition_table_part_boot_ppc64le
-          - &default_partition_table_part_root_s390x
+          -
             <<: *default_partition_table_part_root_ppc64le
             bootable: true
 
@@ -862,7 +862,7 @@
                       fstab_options: "defaults"
                       fstab_freq: 0
                       fstab_passno: 0
-      aarch64: &edge_base_partition_table_aarch64
+      aarch64:
         uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
         type: "gpt"
         partitions:
@@ -1183,7 +1183,7 @@
                     V: "1"
 
   default_installer_config: &default_installer_config
-    enabled_anaconda_modules: &install_config_enabled_anaconda_modules
+    enabled_anaconda_modules:
       - "org.fedoraproject.Anaconda.Modules.Network"
       - "org.fedoraproject.Anaconda.Modules.Payloads"
       - "org.fedoraproject.Anaconda.Modules.Runtime"
@@ -1410,7 +1410,7 @@ image_types:
             - "tuned"
           exclude:
             - "dracut-config-rescue"
-          conditions: &conditions_subscription_manager_cockpit
+          conditions:
             "add subscription-manager-cockpit on rhel":
               when:
                 distro_name: "rhel"
@@ -1518,7 +1518,7 @@ image_types:
             - "plymouth"
             - "rng-tools"
             - "udisks2"
-          conditions: &conditions_pkgsets_insigths_pkgs
+          conditions:
             "add insights pkgs on rhel":
               when:
                 distro_name: "rhel"
@@ -1645,8 +1645,8 @@ image_types:
     exports: ["xz"]
     compression: "xz"
     filename: "disk.vhd.xz"
-    partition_table: &partition_table_azure_internal
-      x86_64: &azure_rhui_partition_table_x86_64
+    partition_table:
+      x86_64:
         uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
         type: "gpt"
         size: "64 GiB"
@@ -1672,7 +1672,7 @@ image_types:
               fstab_options: "defaults"
               fstab_freq: 0
               fstab_passno: 0
-          - &azure_rhui_part_bios
+          -
             size: "2 MiB"
             bootable: true
             type: *bios_boot_partition_guid
@@ -1723,7 +1723,7 @@ image_types:
                     label: "var"
                     mountpoint: "/var"
                     fstab_options: "defaults"
-      aarch64: &azure_rhui_partition_table_aarch64
+      aarch64:
         uuid: "D209C89E-EA5E-4FBD-B161-B461CCE297E0"
         type: "gpt"
         size: "64 GiB"
@@ -2186,7 +2186,7 @@ image_types:
         - "customizations.rhsm"
 
 
-  wsl: &wsl
+  wsl:
     filename: "image.wsl"
     mime_type: "application/x-tar"
     image_func: "tar"
@@ -2214,7 +2214,7 @@ image_types:
           when:
             distro_name: "almalinux"
           shallow_merge:
-            wsl: &wsl_distribution_config_almalinux
+            wsl:
               <<: *wsl_config
               distribution_config:
                 <<: *wsl_distribution_config
@@ -2225,7 +2225,7 @@ image_types:
           when:
             distro_name: "rocky"
           shallow_merge:
-            wsl: &wsl_distribution_config_rocky
+            wsl:
               <<: *wsl_config
               distribution_config:
                 <<: *wsl_distribution_config
@@ -2796,7 +2796,7 @@ image_types:
             bootupd_gen_metadata: false
     package_sets:
       os:
-        - &edge_commit_pkgset
+        -
           include:
             - "redhat-release"
             - "glibc"
@@ -2875,7 +2875,7 @@ image_types:
             - "sos"
           exclude:
             - "rng-tools"
-          conditions: &conditions_pkgsets_edge_commit
+          conditions:
             "greenboot in 9.8 and c9s requires bootupd":
               # we don't want bootupd in edge commits, but greenboot requires
               # it in 9.8 and c9s, so we can only exclude it for older versions
@@ -2981,7 +2981,7 @@ image_types:
         keymap: "us"
       locale: "C.UTF-8"
       lock_root_user: true
-      kernel_options: &kernel_options_raw_image
+      kernel_options:
         - "modprobe.blacklist=vc4"
         - "rw"
         - "coreos.no_persist_ip"


### PR DESCRIPTION
Following two commits remove unused blocks of yaml anchors, as well as just named blocks that are inside another used anchor, just to make it less confusing.
But I believe we can drop 3a3042eb7d594abe4237ddb50e23dd6fef9a2170, someone might find those anchors useful, for example for naming those blocks.