### PR TITLE
generic: rename `iot_` -> `ostree_`

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -1196,7 +1196,7 @@
     filename: "installer.iso"
     mime_type: "application/x-iso9660-image"
     boot_iso: true
-    image_func: "iot_installer"
+    image_func: "ostree_installer"
     ostree: *ostree_atomic
     exports: ["bootiso"]
     required_partition_sizes: *default_required_dir_sizes
@@ -1240,7 +1240,7 @@
     mime_type: "application/x-qemu-disk"
     default_size: "10 GiB"
     bootable: true
-    image_func: "iot"
+    image_func: "ostree_disk"
     ostree: *ostree_atomic
     exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
@@ -1504,7 +1504,7 @@ image_types:
     name_aliases: ["fedora-iot-commit"]
     filename: "commit.tar"
     mime_type: "application/x-tar"
-    image_func: "iot_commit"
+    image_func: "ostree_commit"
     exports: ["commit-archive"]
     required_partition_sizes: *default_required_dir_sizes
     ostree:
@@ -1652,7 +1652,7 @@ image_types:
     name_aliases: ["fedora-iot-container"]
     filename: "container.tar"
     mime_type: "application/x-tar"
-    image_func: "iot_container"
+    image_func: "ostree_container"
     exports: ["container"]
     required_partition_sizes: *default_required_dir_sizes
     ostree:
@@ -1681,7 +1681,7 @@ image_types:
     mime_type: "application/xz"
     default_size: "6 GiB"
     bootable: true
-    image_func: "iot"
+    image_func: "ostree_disk"
     ostree: *ostree_iot
     exports: ["xz"]
     # Passing an empty map into the required partition sizes disables the
@@ -1740,7 +1740,7 @@ image_types:
     mime_type: "application/x-qemu-disk"
     default_size: "10 GiB"
     bootable: true
-    image_func: "iot"
+    image_func: "ostree_disk"
     ostree: *ostree_iot
     exports: ["qcow2"]
     required_partition_sizes: *default_required_dir_sizes
@@ -2023,7 +2023,7 @@ image_types:
     filename: "installer.iso"
     mime_type: "application/x-iso9660-image"
     boot_iso: true
-    image_func: "iot_installer"
+    image_func: "ostree_installer"
     iso_label: "IoT"
     variant: "IoT"
     ostree: *ostree_iot
@@ -2378,7 +2378,7 @@ image_types:
     bootable: true
     boot_iso: true
     default_size: "10 GiB"
-    image_func: "iot_simplified_installer"
+    image_func: "ostree_simplified_installer"
     iso_label: "IoT"
     variant: "IoT"
     ostree:

--- a/data/distrodefs/rhel-8/imagetypes.yaml
+++ b/data/distrodefs/rhel-8/imagetypes.yaml
@@ -2046,7 +2046,7 @@ image_types:
     filename: "commit.tar"
     mime_type: "application/x-tar"
     rpm_ostree: true
-    image_func: "iot_commit"
+    image_func: "ostree_commit"
     exports: ["commit-archive"]
     platforms:
       - *x86_64_bios_platform
@@ -2230,7 +2230,7 @@ image_types:
     boot_iso: true
     # NOTE: RHEL 8 only supports the older Anaconda configs
     use_legacy_anaconda_config: true
-    image_func: "iot_installer"
+    image_func: "ostree_installer"
     iso_label: "edge"
     variant: "edge"
     ostree:
@@ -2277,7 +2277,7 @@ image_types:
     default_size: "10 GiB"
     rpm_ostree: true
     bootable: true
-    image_func: "iot"
+    image_func: "ostree_disk"
     ostree: *ostree_edge
     use_ostree_remotes: true
     exports: ["xz"]
@@ -2309,7 +2309,7 @@ image_types:
     # NOTE: RHEL 8 only supports the older Anaconda configs
     use_legacy_anaconda_config: true
     default_size: "10 GiB"
-    image_func: "iot_simplified_installer"
+    image_func: "ostree_simplified_installer"
     iso_label: "edge"
     variant: "edge"
     ostree: *ostree_edge
@@ -2421,7 +2421,7 @@ image_types:
     filename: "container.tar"
     mime_type: "application/x-tar"
     rpm_ostree: true
-    image_func: "iot_container"
+    image_func: "ostree_container"
     exports: ["container"]
     required_partition_sizes: *default_required_dir_sizes
     platforms:

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -2748,7 +2748,7 @@ image_types:
     filename: "commit.tar"
     mime_type: "application/x-tar"
     rpm_ostree: true
-    image_func: "iot_commit"
+    image_func: "ostree_commit"
     exports: ["commit-archive"]
     platforms:
       - *x86_64_bios_platform
@@ -2939,7 +2939,7 @@ image_types:
     filename: "container.tar"
     mime_type: "application/x-tar"
     rpm_ostree: true
-    image_func: "iot_container"
+    image_func: "ostree_container"
     exports: ["container"]
     <<: *edge_commit
     image_config:
@@ -2965,7 +2965,7 @@ image_types:
     default_size: "10 GiB"
     rpm_ostree: true
     bootable: true
-    image_func: "iot"
+    image_func: "ostree_disk"
     ostree: *ostree_edge
     use_ostree_remotes: true
     platforms:
@@ -3012,7 +3012,7 @@ image_types:
     mime_type: "application/x-iso9660-image"
     rpm_ostree: true
     boot_iso: true
-    image_func: "iot_installer"
+    image_func: "ostree_installer"
     iso_label: "edge"
     variant: "edge"
     ostree:
@@ -3055,7 +3055,7 @@ image_types:
     # NOTE: RHEL 8 only supports the older Anaconda configs
     use_legacy_anaconda_config: true
     default_size: "10 GiB"
-    image_func: "iot_simplified_installer"
+    image_func: "ostree_simplified_installer"
     iso_label: "edge"
     variant: "edge"
     ostree: *ostree_edge
@@ -3174,7 +3174,7 @@ image_types:
     exports: ["image"]
     rpm_ostree: true
     bootable: true
-    image_func: "iot"
+    image_func: "ostree_disk"
     ostree: *ostree_edge
     use_ostree_remotes: true
     platforms:

--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -856,7 +856,7 @@ func imageInstallerImage(t *imageType,
 	return img, nil
 }
 
-func iotCommitImage(t *imageType,
+func ostreeCommitImage(t *imageType,
 	bp *blueprint.Blueprint,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
@@ -937,7 +937,7 @@ func bootableContainerImage(t *imageType,
 	return img, nil
 }
 
-func iotContainerImage(t *imageType,
+func ostreeContainerImage(t *imageType,
 	bp *blueprint.Blueprint,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
@@ -977,7 +977,7 @@ func iotContainerImage(t *imageType,
 	return img, nil
 }
 
-func iotInstallerImage(t *imageType,
+func ostreeInstallerImage(t *imageType,
 	bp *blueprint.Blueprint,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
@@ -1078,7 +1078,7 @@ func iotInstallerImage(t *imageType,
 	return img, nil
 }
 
-func iotImage(t *imageType,
+func ostreeDiskImage(t *imageType,
 	bp *blueprint.Blueprint,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
@@ -1126,7 +1126,7 @@ func iotImage(t *imageType,
 	return img, nil
 }
 
-func iotSimplifiedInstallerImage(t *imageType,
+func ostreeSimplifiedInstallerImage(t *imageType,
 	bp *blueprint.Blueprint,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -56,16 +56,16 @@ func newImageTypeFrom(d *distribution, ar *architecture, imgYAML defs.ImageTypeY
 		it.image = liveInstallerImage
 	case "bootable_container":
 		it.image = bootableContainerImage
-	case "iot":
-		it.image = iotImage
-	case "iot_commit":
-		it.image = iotCommitImage
-	case "iot_container":
-		it.image = iotContainerImage
-	case "iot_installer":
-		it.image = iotInstallerImage
-	case "iot_simplified_installer":
-		it.image = iotSimplifiedInstallerImage
+	case "ostree_disk":
+		it.image = ostreeDiskImage
+	case "ostree_commit":
+		it.image = ostreeCommitImage
+	case "ostree_container":
+		it.image = ostreeContainerImage
+	case "ostree_installer":
+		it.image = ostreeInstallerImage
+	case "ostree_simplified_installer":
+		it.image = ostreeSimplifiedInstallerImage
 	case "tar":
 		it.image = tarImage
 	case "network-installer":


### PR DESCRIPTION
Since we now have multiple ostree-based image types let's rename some of the generic image funcs to be prefixed with `ostree` instead of `iot`.