### PR TITLE
chore: add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Collapse by default on GitHub
+test/data/manifest-checksums/** linguist-generated
+
+go.sum linguist-generated


### PR DESCRIPTION
This file [allows to hide generated files](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) from GitHub diffs (but still being able to display them explicitly if needed).

For a screenshot of how this looks like go here: https://github.com/osbuild/image-builder-crc/pull/1783