### PR TITLE
network-installer: Do not set timezone or locale in Kickstart

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -2551,7 +2551,6 @@ image_types:
         - "customizations.group"
         - "customizations.installer"
         - "customizations.kernel.append"
-        - "customizations.locale"
         - "customizations.user"
 
   "server-network-installer":

--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -2460,7 +2460,6 @@ image_types:
       supported_options:
         - "distro"
         - "customizations.fips"
-        - "customizations.locale"
 
   "pxe-tar-xz":
     filename: "pxe.tar.xz"

--- a/data/distrodefs/rhel-8/imagetypes.yaml
+++ b/data/distrodefs/rhel-8/imagetypes.yaml
@@ -2981,4 +2981,3 @@ image_types:
       supported_options:
         - "distro"
         - "customizations.fips"
-        - "customizations.locale"

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -3572,7 +3572,6 @@ image_types:
       supported_options:
         - "distro"
         - "customizations.fips"
-        - "customizations.locale"
 
   "pxe-tar-xz":
     filename: "pxe.tar.xz"

--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -1308,40 +1308,22 @@ func networkInstallerImage(t *imageType,
 
 	var err error
 	img.Kickstart, err = kickstart.New(customizations)
-
 	if err != nil {
 		return nil, err
 	}
-
-	// So this is slightly funky. Normally we set these kickstart options based on the
-	// OSCustomizations. I've explicitly chosen not to do that because the values in
-	// OSCustomizations can come either from the image config *or* from the blueprint.
-	// Since OSCustomizations *always* contains values we cannot determine based on it
-	// if we want a kickstart or not.
-
-	// With the duplication below we only add a kickstart if the user actually provided
-	// values through the blueprint instead of always.
-	language, keyboard := customizations.GetPrimaryLocale()
-
-	if language != nil {
-		img.Language = *language
-		img.Kickstart.Language = language
-	}
-
-	if keyboard != nil {
-		img.Kickstart.Keyboard = keyboard
-	}
-
-	timezone, _ := customizations.GetTimezoneSettings()
-	if timezone != nil {
-		img.Kickstart.Timezone = timezone
-	}
+	// NOTE: The network installer only supports adding users and groups
 
 	// If we have an empty kickstart options we don't want to put it on
 	// the image at all as an empty kickstart will create an empty kickstart
 	// file. In the netinst case we want *no* kickstart file at all.
 	if img.Kickstart.IsZero() {
 		img.Kickstart = nil
+	}
+
+	language, _ := customizations.GetPrimaryLocale()
+
+	if language != nil {
+		img.Language = *language
 	}
 
 	img.ExtraBasePackages = packageSets[installerPkgsKey]


### PR DESCRIPTION
The network installer does not use these values to create a kickstart. The blueprint Locale is used for the locale of the booted iso, not the installed system. The timezone customization is not used at all. But setting these triggers creation of an empty osbuild.ks which causes Anaconda to crash.

Remove both of them, and remove locale from the list of supported blueprint options in the image definitions yaml.

Related: HMS-10469