### PR TITLE
distro: basic variable substitution (HMS-10479)

### DIFF
--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/osbuild/blueprint/pkg/blueprint"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/anaconda"
 	"github.com/osbuild/images/pkg/customizations/bootc"
@@ -536,7 +537,8 @@ func installerCustomizations(t *imageType, c *blueprint.Customizations, o distro
 				}
 
 				for _, reference := range bpFlatpak.References {
-					ref, err := flatpak.NewReferenceFromString(reference)
+					tpl := replaceBasicTemplate(reference, t.arch.arch)
+					ref, err := flatpak.NewReferenceFromString(tpl)
 					if err != nil {
 						return isc, err
 					}
@@ -1464,4 +1466,12 @@ func makeOSTreePayloadCommit(options *ostree.ImageOptions, defaultURL, defaultRe
 		Ref:  ref,
 		RHSM: rhsm,
 	}, nil
+}
+
+// replace basic variables that might come from blueprint(s), these are not intended to be
+// used elsewhere and are thus called only in specific places
+// concretely this is because we need to template the flatpak references coming from pungi
+// configs. they're currently only applied there; other places will need further discussion
+func replaceBasicTemplate(input string, architecture arch.Arch) string {
+	return strings.ReplaceAll(input, "$arch", architecture.String())
 }

--- a/pkg/distro/generic/images_test.go
+++ b/pkg/distro/generic/images_test.go
@@ -1,6 +1,7 @@
 package generic
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/osbuild/blueprint/pkg/blueprint"
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/defs"
 )
@@ -105,4 +107,30 @@ func TestInstallerCustomizationsOverridePreview(t *testing.T) {
 		assert.Equal(t, tc.expected, isc.Preview)
 	}
 
+}
+
+func TestReplaceBasictemplate(t *testing.T) {
+	for _, tc := range []struct {
+		input    string
+		arch     arch.Arch
+		expected string
+	}{
+		{
+			input:    "$arch",
+			arch:     arch.ARCH_X86_64,
+			expected: arch.ARCH_X86_64.String(),
+		},
+		{
+			input:    "foo/$arch/bar",
+			arch:     arch.ARCH_AARCH64,
+			expected: fmt.Sprintf("foo/%s/bar", arch.ARCH_AARCH64.String()),
+		},
+		{
+			input:    "foo",
+			arch:     arch.ARCH_AARCH64,
+			expected: "foo",
+		},
+	} {
+		assert.Equal(t, replaceBasicTemplate(tc.input, tc.arch), tc.expected)
+	}
 }


### PR DESCRIPTION
For Flatpak references defined in blueprints (specifically in `pungi`) the architecture should be templatable.

This implements a very narrow approach of only replacing `$arch` and *only* on Flatpak references coming from the customizations.

In the future we can have a discussion when there's no time pressure on if this should grow into basic substitution everywhere or if we should do this differently.

```toml
[[customizations.installer.payload.flatpaks.force]]                                                                                                                                                                                                                                                                                                                                                                                       
registry = { remote_name = "fedora", url = "oci+https://registry.fedoraproject.org" }                                                                                                                                                                                                                                                                                                                                                     
references = [                                                                                                                                                                                                                                                                                                                                                                                                                            
    "runtime/org.fedoraproject.KDE6Platform/$arch/f44"                                                                                                                                                                                                                                                                                                                                                                                    
]
```