### PR TITLE
pkg: add rpmlist writer for koji format

### DIFF
--- a/pkg/manifestgen/manifestgen.go
+++ b/pkg/manifestgen/manifestgen.go
@@ -22,6 +22,7 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/reporegistry"
+	"github.com/osbuild/images/pkg/rpmlist"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/sbom"
 )
@@ -82,6 +83,8 @@ type Options struct {
 	// Use the a bootstrap container to buildroot (useful for e.g.
 	// cross-arch or cross-distro builds)
 	UseBootstrapContainer bool
+
+	RPMListWriter RPMListWriterFunc
 }
 
 // Generator can generate an osbuild manifest from a given repository
@@ -105,6 +108,7 @@ type Generator struct {
 	overrideRepos []rpmmd.RepoConfig
 
 	useBootstrapContainer bool
+	rpmlistWriter         RPMListWriterFunc
 }
 
 // New will create a new manifest generator
@@ -126,6 +130,7 @@ func New(reporegistry *reporegistry.RepoRegistry, opts *Options) (*Generator, er
 		customSeed:             opts.CustomSeed,
 		overrideRepos:          opts.OverrideRepos,
 		useBootstrapContainer:  opts.UseBootstrapContainer,
+		rpmlistWriter:          opts.RPMListWriter,
 	}
 	if mg.depsolve == nil {
 		mg.depsolve = DefaultDepsolve
@@ -245,7 +250,8 @@ func (mg *Generator) Generate(bp *blueprint.Blueprint, imgType distro.ImageType,
 		return nil, err
 	}
 
-	if mg.sbomWriter != nil {
+	if mg.sbomWriter != nil || mg.rpmlistWriter != nil {
+		uniquePackages := make(map[string]rpmmd.Package)
 		// XXX: this is very similar to
 		// osbuild-composer:jobimpl-osbuild.go, see if code
 		// can be shared
@@ -259,20 +265,56 @@ func (mg *Generator) Generate(bp *blueprint.Blueprint, imgType distro.ImageType,
 			}
 			// XXX: sync with image-builder-cli:build.go name generation - can we have a shared helper?
 			imageName := fmt.Sprintf("%s-%s-%s", dist.Name(), imgType.Name(), a.Name())
-			sbomDocOutputFilename := fmt.Sprintf("%s.%s-%s.%s", imageName, pipelinePurpose, plName, defaultSBOMExt)
-
-			var buf bytes.Buffer
-			enc := json.NewEncoder(&buf)
-			if err := enc.Encode(depsolvedPipeline.SBOM.Document); err != nil {
-				return nil, err
+			if mg.sbomWriter != nil {
+				sbomDocOutputFilename := fmt.Sprintf("%s.%s-%s.%s", imageName, pipelinePurpose, plName, defaultSBOMExt)
+				var buf bytes.Buffer
+				enc := json.NewEncoder(&buf)
+				if err := enc.Encode(depsolvedPipeline.SBOM.Document); err != nil {
+					return nil, err
+				}
+				if err := mg.sbomWriter(sbomDocOutputFilename, &buf, depsolvedPipeline.SBOM.DocType); err != nil {
+					return nil, err
+				}
 			}
-			if err := mg.sbomWriter(sbomDocOutputFilename, &buf, depsolvedPipeline.SBOM.DocType); err != nil {
+
+			if mg.rpmlistWriter != nil && pipelinePurpose == "image" {
+				addUniquePackagesFromPipeline(uniquePackages, depsolvedPipeline)
+			}
+		}
+
+		if mg.rpmlistWriter != nil {
+			if err := writeRPMList(mg.rpmlistWriter, uniquePackages); err != nil {
 				return nil, err
 			}
 		}
 	}
 
 	return mf, nil
+}
+
+func addUniquePackagesFromPipeline(unique map[string]rpmmd.Package, pipeline depsolvednf.DepsolveResult) {
+	for _, pkg := range pipeline.Transactions.AllPackages() {
+		var key string
+		key = pkg.Checksum.Value
+		if pkg.Checksum.Value == "" {
+			key = fmt.Sprintf("%s-%s-%s.%s", pkg.Name, pkg.Version, pkg.Release, pkg.Arch)
+		}
+		if _, exists := unique[key]; !exists {
+			unique[key] = pkg
+		}
+	}
+}
+
+func writeRPMList(writer RPMListWriterFunc, unique map[string]rpmmd.Package) error {
+	var packages rpmmd.PackageList
+	for _, pkg := range unique {
+		packages = append(packages, pkg)
+	}
+	rpmListJSON, err := rpmlist.EncodePackages(packages)
+	if err != nil {
+		return err
+	}
+	return writer("rpmlist.json", rpmListJSON)
 }
 
 func xdgCacheHome() (string, error) {
@@ -319,4 +361,6 @@ type (
 	FlatpakResolverFunc func(flatpakSources map[string][]flatpak.SourceSpec) (map[string][]flatpak.Spec, error)
 
 	SBOMWriterFunc func(filename string, content io.Reader, docType sbom.StandardType) error
+
+	RPMListWriterFunc func(filename string, content io.Reader) error
 )

--- a/pkg/manifestgen/manifestgen_test.go
+++ b/pkg/manifestgen/manifestgen_test.go
@@ -3,6 +3,7 @@ package manifestgen_test
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"io"
 	"regexp"
@@ -265,6 +266,43 @@ func TestManifestGeneratorDepsolveWithSbomWriter(t *testing.T) {
 		"centos-9-qcow2-x86_64.image-os.spdx.json":        `{"sbom-for":"os"}`,
 	}
 	assert.Equal(t, expected, generatedSboms)
+}
+
+func TestManifestGeneratorWithRPMListWriter(t *testing.T) {
+	repos, err := testrepos.New()
+	assert.NoError(t, err)
+	fac := distrofactory.NewDefault()
+
+	filter, err := imagefilter.New(fac, repos)
+	assert.NoError(t, err)
+	res, err := filter.Filter("distro:centos-9", "type:qcow2", "arch:x86_64")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(res))
+
+	generated := map[string]string{}
+	opts := &manifestgen.Options{
+		Depsolve:          fakeDepsolve,
+		CommitResolver:    panicCommitResolver,
+		ContainerResolver: panicContainerResolver,
+		RPMListWriter: func(filename string, content io.Reader) error {
+			b, err := io.ReadAll(content)
+			assert.NoError(t, err)
+			generated[filename] = strings.TrimSpace(string(b))
+			return nil
+		},
+	}
+	mg, err := manifestgen.New(repos, opts)
+	assert.NoError(t, err)
+	assert.NotNil(t, mg)
+	var bp blueprint.Blueprint
+	_, err = mg.Generate(&bp, res[0].ImgType, nil)
+	require.NoError(t, err)
+
+	assert.Contains(t, generated, "rpmlist.json")
+	require.Len(t, generated, 1)
+	var rows []json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(generated["rpmlist.json"]), &rows))
+	assert.NotEmpty(t, rows)
 }
 
 func TestManifestGeneratorSeed(t *testing.T) {

--- a/pkg/rpmlist/rpmlist.go
+++ b/pkg/rpmlist/rpmlist.go
@@ -1,0 +1,61 @@
+package rpmlist
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/osbuild/images/pkg/rpmmd"
+)
+
+// rpmlist item entry expected by koji
+type kojiRpmListEntry struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	Release     string `json:"release"`
+	Epoch       uint   `json:"epoch"`
+	Arch        string `json:"arch"`
+	BuildTime   int64  `json:"buildtime"`
+	Size        uint64 `json:"size"`
+	PayloadHash string `json:"payloadhash,omitempty"`
+}
+
+func PackageToKojiRpmListEntry(p rpmmd.Package) kojiRpmListEntry {
+	hash := p.Checksum.Value
+	if hash == "" {
+		hash = p.HeaderChecksum.Value
+	}
+	buildTime := int64(0)
+	if !p.BuildTime.IsZero() {
+		buildTime = p.BuildTime.Unix()
+	}
+	return kojiRpmListEntry{
+		Name:        p.Name,
+		Version:     p.Version,
+		Release:     p.Release,
+		Epoch:       p.Epoch,
+		Arch:        p.Arch,
+		BuildTime:   buildTime,
+		PayloadHash: hash,
+		Size:        p.DownloadSize,
+	}
+}
+
+// EncodePackages returns JSON in a format that Koji expects for the given package list
+// it expects a list of dictionaries, e.g. https://riscv-koji.fedoraproject.org/koji/taskinfo?taskID=136875
+// https://github.com/koji-project/koji/blob/67cc2cdbac97d3af96ac2b2a4a34b5fe84a3435e/plugins/builder/kiwi.py#L263
+func EncodePackages(packages rpmmd.PackageList) (*bytes.Buffer, error) {
+	var buf bytes.Buffer
+	if len(packages) == 0 {
+		buf.Write([]byte("[]\n"))
+		return &buf, nil
+	}
+	out := make([]kojiRpmListEntry, 0, len(packages))
+	for _, p := range packages {
+		out = append(out, PackageToKojiRpmListEntry(p))
+	}
+	enc := json.NewEncoder(&buf)
+	if err := enc.Encode(out); err != nil {
+		return nil, err
+	}
+	return &buf, nil
+}

--- a/pkg/rpmlist/rpmlist_test.go
+++ b/pkg/rpmlist/rpmlist_test.go
@@ -1,0 +1,88 @@
+package rpmlist
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/osbuild/images/pkg/rpmmd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodePackages(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		b, err := EncodePackages(nil)
+		require.NoError(t, err)
+		assert.JSONEq(t, "[]", b.String())
+	})
+
+	t.Run("one package", func(t *testing.T) {
+		pkgs := rpmmd.PackageList{
+			{
+				Name: "bash", Version: "5.2", Release: "1.fc43", Epoch: 0, Arch: "x86_64",
+				DownloadSize:   12345,
+				BuildTime:      time.Unix(1700000000, 0).UTC(),
+				Checksum:       rpmmd.Checksum{Type: "sha256", Value: "a250e0b22938f0630f64b0b534141ba0"},
+				HeaderChecksum: rpmmd.Checksum{Type: "sha256", Value: "478549d2e9fde87833938316d695a36d"},
+			},
+		}
+		b, err := EncodePackages(pkgs)
+		require.NoError(t, err)
+
+		var decoded []kojiRpmListEntry
+		require.NoError(t, json.Unmarshal(b.Bytes(), &decoded))
+		require.Len(t, decoded, 1)
+		assert.Equal(t, "bash", decoded[0].Name)
+		assert.Equal(t, "5.2", decoded[0].Version)
+		assert.Equal(t, "1.fc43", decoded[0].Release)
+		assert.Equal(t, uint(0), decoded[0].Epoch)
+		assert.Equal(t, "x86_64", decoded[0].Arch)
+		assert.Equal(t, int64(1700000000), decoded[0].BuildTime)
+		assert.Equal(t, uint64(12345), decoded[0].Size)
+		assert.Equal(t, "a250e0b22938f0630f64b0b534141ba0", decoded[0].PayloadHash)
+	})
+
+	t.Run("nonzero epoch", func(t *testing.T) {
+		pkgs := rpmmd.PackageList{
+			{Name: "dnf5", Version: "1.12", Release: "1.fc43", Epoch: 1, Arch: "riscv64"},
+		}
+		b, err := EncodePackages(pkgs)
+		require.NoError(t, err)
+		var decoded []kojiRpmListEntry
+		require.NoError(t, json.Unmarshal(b.Bytes(), &decoded))
+		require.Len(t, decoded, 1)
+		require.NotNil(t, decoded[0].Epoch)
+		assert.Equal(t, uint(1), decoded[0].Epoch)
+	})
+
+	t.Run("more packages", func(t *testing.T) {
+		pkgs := rpmmd.PackageList{
+			{
+				Name: "bash", Version: "5.2", Release: "1.fc43", Epoch: 0, Arch: "x86_64",
+				DownloadSize:   12345,
+				BuildTime:      time.Unix(1700000000, 0).UTC(),
+				Checksum:       rpmmd.Checksum{Type: "sha256", Value: "a250e0b22938f0630f64b0b534141ba0"},
+				HeaderChecksum: rpmmd.Checksum{Type: "sha256", Value: "478549d2e9fde87833938316d695a36d"},
+			},
+			{Name: "dnf5", Version: "1.12", Release: "1.fc43", Epoch: 1, Arch: "riscv64"},
+		}
+		b, err := EncodePackages(pkgs)
+		require.NoError(t, err)
+
+		var decoded []kojiRpmListEntry
+		require.NoError(t, json.Unmarshal(b.Bytes(), &decoded))
+		require.Len(t, decoded, 2)
+		assert.Equal(t, "bash", decoded[0].Name)
+		assert.Equal(t, "5.2", decoded[0].Version)
+		assert.Equal(t, "1.fc43", decoded[0].Release)
+		assert.Equal(t, uint(0), decoded[0].Epoch)
+		assert.Equal(t, "x86_64", decoded[0].Arch)
+		assert.Equal(t, int64(1700000000), decoded[0].BuildTime)
+		assert.Equal(t, uint64(12345), decoded[0].Size)
+		assert.Equal(t, "a250e0b22938f0630f64b0b534141ba0", decoded[0].PayloadHash)
+		require.NotNil(t, decoded[1].Epoch)
+		assert.Equal(t, uint(1), decoded[1].Epoch)
+	})
+
+}


### PR DESCRIPTION
There are still tests missing, and I want to think if we can unify this somehow with the sbom writer and reuse some lines.

Adds parsing of packages in order to provide koji rpm list in the format it expects. this works similarly to how the sbom json file is created.