### PR TITLE
vmtest: Set the default start timeout to 1800s

### DIFF
--- a/test/scripts/vmtest/vm.py
+++ b/test/scripts/vmtest/vm.py
@@ -255,7 +255,7 @@ class QEMU(VM):
         return qemu_cmdline
 
     # XXX: move args to init() so that __enter__ can use them?
-    def start(self, wait_event="ssh", snapshot=True, use_ovmf=False, timeout_sec=120):
+    def start(self, wait_event="ssh", snapshot=True, use_ovmf=False, timeout_sec=1800):
         if self.running():
             return
         self._ssh_port = get_free_port()


### PR DESCRIPTION
This code is imported from unknown places, some setting the timeout and others not setting it. This has resulted in playing whack-a-mole with the timeout override so let's set it long and if a user wants a shorter timeout they can override it.