### PR TITLE
experimental: use yamlplus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,9 +38,10 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7
 	github.com/stretchr/testify v1.11.1
+	github.com/supakeen/yamlplus v1.1.0
 	github.com/ubccr/kerby v0.0.0-20230802201021-412be7bfaee5
 	github.com/vmware/govmomi v0.52.0
-	go.yaml.in/yaml/v3 v3.0.3
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/exp v0.0.0-20250103183323-7d7fa50e5329
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/sys v0.39.0

--- a/go.sum
+++ b/go.sum
@@ -450,6 +450,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/supakeen/yamlplus v1.1.0 h1:UD0XVXoQ4qYT7aJv1DIKEx1siFe4SWOHx5P2OvBkirw=
+github.com/supakeen/yamlplus v1.1.0/go.mod h1:NJsFWyxKs90654Jy5E25tY5gCCJ0kcHyWbdNaJndGU0=
 github.com/sylabs/sif/v2 v2.21.1 h1:GZ0b5//AFAqJEChd8wHV/uSKx/l1iuGYwjR8nx+4wPI=
 github.com/sylabs/sif/v2 v2.21.1/go.mod h1:YoqEGQnb5x/ItV653bawXHZJOXQaEWpGwHsSD3YePJI=
 github.com/tchap/go-patricia/v2 v2.3.3 h1:xfNEsODumaEcCcY3gI0hYPZ/PcpVv5ju6RMAhgwZDDc=
@@ -501,8 +503,8 @@ go.opentelemetry.io/proto/otlp v1.7.1 h1:gTOMpGDb0WTBOP8JaO72iL3auEZhVmAQg4ipjOV
 go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzKhACevjI+ZnE=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
 go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
-go.yaml.in/yaml/v3 v3.0.3 h1:bXOww4E/J3f66rav3pX3m8w6jDE4knZjGOw8b5Y6iNE=
-go.yaml.in/yaml/v3 v3.0.3/go.mod h1:tBHosrYAkRZjRAOREWbDnBXUf08JOwYq++0QNwQiWzI=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -29,6 +29,8 @@ import (
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/runner"
+
+	"github.com/supakeen/yamlplus"
 )
 
 var (
@@ -271,7 +273,15 @@ func LoadDistroWithoutImageTypes(nameVer string) (*DistroYAML, error) {
 }
 
 func (d *DistroYAML) LoadImageTypes() error {
-	configs, err := loadImageTypeConfigs(d)
+	var configs []imageTypesYAML
+	var err error
+
+	if yamlplus := experimentalflags.Bool("yamlplus"); yamlplus {
+		configs, err = loadImageTypeConfigsPlus(d)
+	} else {
+		configs, err = loadImageTypeConfigs(d)
+	}
+
 	if err != nil {
 		return err
 	}
@@ -301,7 +311,50 @@ func loadImageTypeConfigs(d *DistroYAML) ([]imageTypesYAML, error) {
 		}
 
 		var toplevel imageTypesYAML
+
 		decoder := yaml.NewDecoder(reader)
+		decoder.KnownFields(true)
+		decodeErr := decoder.Decode(&toplevel)
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+
+		configs = append(configs, toplevel)
+	}
+
+	return configs, nil
+}
+
+func loadImageTypeConfigsPlus(d *DistroYAML) ([]imageTypesYAML, error) {
+	files, err := fs.Glob(dataFS(), filepath.Join(d.DefsPath, "[^_]*.yaml"))
+	if err != nil {
+		return nil, err
+	}
+
+	commonPath := filepath.Join(d.DefsPath, "_common.yaml")
+	commonContent, _ := fs.ReadFile(dataFS(), commonPath)
+
+	configs := make([]imageTypesYAML, 0, len(files))
+	for _, fileName := range files {
+		f, err := dataFS().Open(fileName)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+
+		var reader io.Reader = f
+		if len(commonContent) > 0 {
+			reader = io.MultiReader(bytes.NewReader(commonContent), f)
+		}
+
+		loader := yamlplus.NewLoader(dataFS())
+		if err = loader.RegisterRecursively("."); err != nil {
+			return nil, err
+		}
+
+		var toplevel imageTypesYAML
+
+		decoder := loader.NewDecoder(reader)
 		decoder.KnownFields(true)
 		decodeErr := decoder.Decode(&toplevel)
 		if decodeErr != nil {


### PR DESCRIPTION
Controversial to submit upstream, but I thought I'd give it a try since it's fully gated behind an experimental flag. I've duplicated the entire `loadImageTypeConfigs`-function so it's clear that there's no touching of the normal path.

---

This is a bit far out but over the past few weeks I've written a small YAML library that handles `!xref` tags in YAML. This commit enables the use of that library conditionally on an experimental boolean.

The following command would allow combining this additional behavior which will not be enabled by default.

`IMAGE_BUILDER_EXPERIMENTAL="yamlplus,yamldir=..." image-builder ...`

I'd like to use this *without* forking `images` and `image-builder` in my little remix to get a feel for how this works and how nice of an organization I can whip up for definitions.

If we decide to go down this path, and that's a big if, the `yamlplus` package will likely be interned into the `images` library and dropped from my personal GitHub.

---


Repository: https://github.com/supakeen/yamlplus
Documentation: https://pkg.go.dev/github.com/supakeen/yamlplus@v1.1.0