### PR TITLE
ci: use f43 for cross-arch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -302,7 +302,7 @@ jobs:
       GOPROXY: "https://proxy.golang.org|direct"
       GOFLAGS: "-buildvcs=false"
     container:
-      image: registry.fedoraproject.org/fedora:latest
+      image: registry.fedoraproject.org/fedora:43
       options: "--privileged"
     steps:
       - name: Check out code into the Go module directory


### PR DESCRIPTION
Until we have f44 RPMs for osbuild in our CI lets pin the cross-arch test to an f43 container so it isn't constantly red.