### PR TITLE
disk: partition table policies

### DIFF
--- a/pkg/disk/disk_test.go
+++ b/pkg/disk/disk_test.go
@@ -1081,3 +1081,40 @@ func TestCreatePartitionTableDefaultFs(t *testing.T) {
 	assert.Equal(t, "/var/stuff", mpt.Partitions[nParts-2].Payload.(*disk.Filesystem).Mountpoint)
 	assert.Equal(t, "ext4", mpt.Partitions[nParts-2].Payload.(*disk.Filesystem).Type)
 }
+
+func TestNewPartitionTablePolicyNoXBOOTLDR(t *testing.T) {
+	/* #nosec G404 */
+	rng := rand.New(rand.NewSource(13))
+	noBootPolicy := &disk.PartitionTablePolicy{EnsureXBOOTLDR: false}
+
+	t.Run("lvm-noboot-errors", func(t *testing.T) {
+		pt := testdisk.TestPartitionTables()["plain-noboot"]
+		pt.Policy = noBootPolicy
+		_, err := disk.NewPartitionTable(&pt, []blueprint.FilesystemCustomization{
+			{Mountpoint: "/home", MinSize: 1 * GiB},
+		}, 13*MiB, partition.AutoLVMPartitioningMode, arch.ARCH_X86_64, nil, "", rng)
+		assert.ErrorContains(t, err, "policy says to not create one")
+	})
+
+	t.Run("btrfs-noboot-succeeds", func(t *testing.T) {
+		pt := testdisk.TestPartitionTables()["plain-noboot"]
+		pt.Policy = noBootPolicy
+		mpt, err := disk.NewPartitionTable(&pt, []blueprint.FilesystemCustomization{
+			{Mountpoint: "/home", MinSize: 1 * GiB},
+		}, 13*MiB, partition.BtrfsPartitioningMode, arch.ARCH_X86_64, nil, "", rng)
+		require.NoError(t, err)
+		assert.Nil(t, disk.EntityPath(mpt, "/boot"), "no /boot should be created")
+		assert.NotNil(t, disk.EntityPath(mpt, "/"), "root should exist")
+	})
+
+	t.Run("lvm-with-boot-succeeds", func(t *testing.T) {
+		pt := testdisk.TestPartitionTables()["plain"]
+		pt.Policy = noBootPolicy
+		mpt, err := disk.NewPartitionTable(&pt, []blueprint.FilesystemCustomization{
+			{Mountpoint: "/home", MinSize: 1 * GiB},
+		}, 13*MiB, partition.AutoLVMPartitioningMode, arch.ARCH_X86_64, nil, "", rng)
+		require.NoError(t, err)
+		assert.NotNil(t, disk.EntityPath(mpt, "/boot"), "/boot should be preserved from base PT")
+		assert.NotNil(t, disk.EntityPath(mpt, "/"), "root should exist")
+	})
+}

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -32,6 +32,17 @@ type PartitionTable struct {
 	ExtraPadding uint64 `json:"extra_padding,omitempty" yaml:"extra_padding,omitempty"`
 	// Starting offset of the first partition in the table (in bytes)
 	StartOffset Offset `json:"start_offset,omitempty" yaml:"start_offset,omitempty"`
+
+	// Dictates if certain bits and bobs are required or not; uses the default
+	// policy if not set.
+	Policy *PartitionTablePolicy `json:"policy,omitempty" yaml:"policy,omitempty"`
+}
+
+type PartitionTablePolicy struct {
+	// Create an XBOOTLDR partition when the root filesystem is not generally
+	// readable by firmware (LVM, btrfs). When set to false an XBOOTLDR partition
+	// will not be created even for those filesystems.
+	EnsureXBOOTLDR bool `json:"ensure_xbootldr" yaml:"ensure_xbootldr"`
 }
 
 var _ = MountpointCreator(&PartitionTable{})
@@ -47,9 +58,19 @@ type Offset = datasizes.Size
 // specify one, but the image requires one to boot (/ is on btrfs, or an LV).
 const DefaultBootPartitionSize = 1 * datasizes.GiB
 
+// NewDefaultPartitionTablePolicy creates a default partition table policy.
+func NewDefaultPartitionTablePolicy() *PartitionTablePolicy {
+	return &PartitionTablePolicy{
+		EnsureXBOOTLDR: true,
+	}
+}
+
 // NewPartitionTable takes an existing base partition table and some parameters
 // and returns a new version of the base table modified to satisfy the
 // parameters.
+//
+// If the base partition table contains no policy then a default policy is used.
+// The policy on the partition table influences all the described behavior.
 //
 // Mountpoints: New filesystems and minimum partition sizes are defined in
 // mountpoints. By default, if new mountpoints are created, a partition table is
@@ -102,6 +123,11 @@ const DefaultBootPartitionSize = 1 * datasizes.GiB
 // Volume Group since they are trivial to grow on a live system.
 func NewPartitionTable(basePT *PartitionTable, mountpoints []blueprint.FilesystemCustomization, imageSize datasizes.Size, mode partition.PartitioningMode, architecture arch.Arch, requiredSizes map[string]datasizes.Size, defaultFs string, rng *rand.Rand) (*PartitionTable, error) {
 	newPT := basePT.Clone().(*PartitionTable)
+
+	// Default policy if no policy is present in the base partition table
+	if newPT.Policy == nil {
+		newPT.Policy = NewDefaultPartitionTablePolicy()
+	}
 
 	if basePT.features().LVM && (mode == partition.RawPartitioningMode || mode == partition.BtrfsPartitioningMode) {
 		return nil, fmt.Errorf("%s partitioning mode set for a base partition table with LVM, this is unsupported", mode)
@@ -196,6 +222,7 @@ func (pt *PartitionTable) Clone() Entity {
 		SectorSize:   pt.SectorSize,
 		ExtraPadding: pt.ExtraPadding,
 		StartOffset:  pt.StartOffset,
+		Policy:       pt.Policy,
 	}
 
 	for idx, partition := range pt.Partitions {
@@ -762,9 +789,16 @@ func (pt *PartitionTable) ensureLVM(defaultFS string) error {
 		panic("no root mountpoint for PartitionTable")
 	}
 
-	// we need a /boot partition to boot LVM, ensure one exists
+	// need a /boot partition to boot LVM, ensure one exists
 	bootPath := entityPath(pt, "/boot")
 	if bootPath == nil {
+		// for LVM we *always* need to create a /boot if none
+		// exists; if the policy explicitly tells us *not* to
+		// create one we error
+		if !pt.Policy.EnsureXBOOTLDR {
+			return fmt.Errorf("LVM partition table without /boot and policy says to not create one: manually create /boot")
+		}
+
 		_, err := pt.CreateMountpoint("/boot", defaultFS, DefaultBootPartitionSize)
 
 		if err != nil {
@@ -821,9 +855,9 @@ func (pt *PartitionTable) ensureBtrfs(defaultFS string, architecture arch.Arch) 
 		return fmt.Errorf("no root mountpoint for a partition table: %#v", pt)
 	}
 
-	// we need a /boot partition to boot btrfs, ensure one exists
+	// Depending on the policy we need a /boot partition to boot btrfs, ensure one exists
 	bootPath := entityPath(pt, "/boot")
-	if bootPath == nil {
+	if bootPath == nil && pt.Policy.EnsureXBOOTLDR {
 		_, err := pt.CreateMountpoint("/boot", defaultFS, DefaultBootPartitionSize)
 		if err != nil {
 			return fmt.Errorf("failed to create /boot partition when ensuring btrfs: %w", err)
@@ -1309,6 +1343,12 @@ func (options *CustomPartitionTableOptions) getfstype(fstype string) (string, er
 }
 
 func maybeAddBootPartition(pt *PartitionTable, disk *blueprint.DiskCustomization, defaultFSType FSType) error {
+	// We never add a boot partition when the policy doesn't require one to
+	// be created.
+	if !pt.Policy.EnsureXBOOTLDR {
+		return nil
+	}
+
 	// The boot type will be the default only if it's a supported filesystem
 	// type for /boot (ext4 or xfs). Otherwise, we default to xfs.
 	// FS_NONE also falls back to xfs.
@@ -1331,7 +1371,7 @@ func maybeAddBootPartition(pt *PartitionTable, disk *blueprint.DiskCustomization
 }
 
 // NewCustomPartitionTable creates a partition table based almost entirely on the disk customizations from a blueprint.
-func NewCustomPartitionTable(customizations *blueprint.DiskCustomization, options *CustomPartitionTableOptions, rng *rand.Rand) (*PartitionTable, error) {
+func NewCustomPartitionTable(customizations *blueprint.DiskCustomization, options *CustomPartitionTableOptions, policy *PartitionTablePolicy, rng *rand.Rand) (*PartitionTable, error) {
 	if options == nil {
 		options = &CustomPartitionTableOptions{}
 	}
@@ -1346,7 +1386,14 @@ func NewCustomPartitionTable(customizations *blueprint.DiskCustomization, option
 		return nil, fmt.Errorf("%s %w", errPrefix, err)
 	}
 
-	pt := &PartitionTable{}
+	// default policy when not passed
+	if policy == nil {
+		policy = NewDefaultPartitionTablePolicy()
+	}
+
+	pt := &PartitionTable{
+		Policy: policy,
+	}
 
 	switch customizations.Type {
 	case "dos":

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -1150,9 +1150,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Architecture:       arch.ARCH_AARCH64, // doesn't matter for dos
 			},
 			expected: &disk.PartitionTable{
-				Type: disk.PT_DOS,
-				Size: 201 * datasizes.MiB,
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type:   disk.PT_DOS,
+				Size:   201 * datasizes.MiB,
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start: 1 * datasizes.MiB,
@@ -1206,9 +1207,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Architecture:       arch.ARCH_X86_64,
 			},
 			expected: &disk.PartitionTable{
-				Type: disk.PT_DOS,
-				Size: 222 * datasizes.MiB,
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type:   disk.PT_DOS,
+				Size:   222 * datasizes.MiB,
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start:    1 * datasizes.MiB, // header
@@ -1290,9 +1292,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Architecture:       arch.ARCH_X86_64,
 			},
 			expected: &disk.PartitionTable{
-				Type: disk.PT_GPT,
-				Size: 223 * datasizes.MiB,
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type:   disk.PT_GPT,
+				Size:   223 * datasizes.MiB,
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start:    1 * datasizes.MiB, // header
@@ -1378,9 +1381,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Architecture:       arch.ARCH_AARCH64,
 			},
 			expected: &disk.PartitionTable{
-				Type: disk.PT_GPT,
-				Size: (1+200+20+5)*datasizes.MiB + datasizes.MiB,
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type:   disk.PT_GPT,
+				Size:   (1+200+20+5)*datasizes.MiB + datasizes.MiB,
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start: 1 * datasizes.MiB,
@@ -1467,9 +1471,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Architecture:       arch.ARCH_AARCH64,
 			},
 			expected: &disk.PartitionTable{
-				Type: disk.PT_GPT,
-				Size: 226*datasizes.MiB + datasizes.MiB, // last part + footer
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type:   disk.PT_GPT,
+				Size:   226*datasizes.MiB + datasizes.MiB, // last part + footer
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start: 1 * datasizes.MiB,
@@ -1553,9 +1558,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Architecture:       arch.ARCH_X86_64,
 			},
 			expected: &disk.PartitionTable{
-				Type: disk.PT_DOS,
-				Size: 22 * datasizes.MiB,
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type:   disk.PT_DOS,
+				Size:   22 * datasizes.MiB,
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start:    1 * datasizes.MiB, // header
@@ -1619,9 +1625,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Architecture:       arch.ARCH_X86_64,
 			},
 			expected: &disk.PartitionTable{
-				Type: disk.PT_DOS,
-				Size: 221 * datasizes.MiB,
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type:   disk.PT_DOS,
+				Size:   221 * datasizes.MiB,
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start: 1 * datasizes.MiB,
@@ -1699,6 +1706,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Size:        225*datasizes.MiB + 3*datasizes.GiB,
 				StartOffset: 3 * datasizes.MiB,
 				UUID:        "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy:      disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start:    4 * datasizes.MiB, // header + offset
@@ -1797,7 +1805,8 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Type: disk.PT_GPT,
 				Size: (20+12+1)*datasizes.MiB + 3*datasizes.GiB + datasizes.MiB, // start + size of last partition + footer
 
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start:    1 * datasizes.MiB,
@@ -1870,7 +1879,8 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Type: disk.PT_DOS,
 				Size: 4*datasizes.MiB + 3*datasizes.GiB + datasizes.MiB, // start + size of last partition + footer
 
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start:    1 * datasizes.MiB, // header
@@ -1922,7 +1932,8 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Type: disk.PT_GPT,
 				Size: (4+1)*datasizes.MiB + 3*datasizes.GiB + datasizes.MiB, // start + size of last partition + footer
 
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start:    1 * datasizes.MiB, // header
@@ -2006,9 +2017,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Architecture:  arch.ARCH_X86_64,
 			},
 			expected: &disk.PartitionTable{
-				Type: disk.PT_DOS,
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-				Size: 1226*datasizes.MiB + 200*datasizes.MiB, // start + size of last partition (VG)
+				Type:   disk.PT_DOS,
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Size:   1226*datasizes.MiB + 200*datasizes.MiB, // start + size of last partition (VG)
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start:    1 * datasizes.MiB, // header
@@ -2160,9 +2172,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Architecture:  arch.ARCH_X86_64,
 			},
 			expected: &disk.PartitionTable{
-				Type: disk.PT_GPT, // default when unspecified
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-				Size: 1226*datasizes.MiB + 200*datasizes.MiB + datasizes.MiB, // start + size of last partition (VG) + footer
+				Type:   disk.PT_GPT, // default when unspecified
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Size:   1226*datasizes.MiB + 200*datasizes.MiB + datasizes.MiB, // start + size of last partition (VG) + footer
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start:    1 * datasizes.MiB, // header
@@ -2307,9 +2320,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Architecture:     arch.ARCH_X86_64,
 			},
 			expected: &disk.PartitionTable{
-				Type: disk.PT_GPT, // default when unspecified
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-				Size: 1330*datasizes.MiB + 16*datasizes.MiB + 3*datasizes.GiB + datasizes.MiB, // start + size of last partition (VG) + footer
+				Type:   disk.PT_GPT, // default when unspecified
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Size:   1330*datasizes.MiB + 16*datasizes.MiB + 3*datasizes.GiB + datasizes.MiB, // start + size of last partition (VG) + footer
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start:    1 * datasizes.MiB, // header
@@ -2444,9 +2458,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Architecture:       arch.ARCH_X86_64,
 			},
 			expected: &disk.PartitionTable{
-				Type: disk.PT_DOS,
-				Size: 1226*datasizes.MiB + 230*datasizes.MiB, // start + size of last partition + footer
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type:   disk.PT_DOS,
+				Size:   1226*datasizes.MiB + 230*datasizes.MiB, // start + size of last partition + footer
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start:    1 * datasizes.MiB, // header
@@ -2552,9 +2567,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Architecture:       arch.ARCH_X86_64,
 			},
 			expected: &disk.PartitionTable{
-				Type: disk.PT_GPT,
-				Size: 1346*datasizes.MiB + 230*datasizes.MiB + datasizes.MiB, // start + size of last partition + footer
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type:   disk.PT_GPT,
+				Size:   1346*datasizes.MiB + 230*datasizes.MiB + datasizes.MiB, // start + size of last partition + footer
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start:    1 * datasizes.MiB, // header
@@ -2670,9 +2686,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Architecture:       arch.ARCH_X86_64,
 			},
 			expected: &disk.PartitionTable{
-				Type: disk.PT_GPT,
-				Size: 322*datasizes.MiB + 230*datasizes.MiB + datasizes.MiB, // start + size of last partition + footer
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type:   disk.PT_GPT,
+				Size:   322*datasizes.MiB + 230*datasizes.MiB + datasizes.MiB, // start + size of last partition + footer
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start:    1 * datasizes.MiB, // header
@@ -2750,9 +2767,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 			},
 			options: nil,
 			expected: &disk.PartitionTable{
-				Type: disk.PT_GPT,
-				Size: 1026 * datasizes.MiB,
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type:   disk.PT_GPT,
+				Size:   1026 * datasizes.MiB,
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start:    1 * datasizes.MiB,
@@ -2839,9 +2857,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Architecture:       arch.ARCH_X86_64,
 			},
 			expected: &disk.PartitionTable{
-				Type: disk.PT_GPT,
-				Size: (1 + 200 + 64 + 64 + 1 + 1) * datasizes.MiB,
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type:   disk.PT_GPT,
+				Size:   (1 + 200 + 64 + 64 + 1 + 1) * datasizes.MiB,
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					// ESP created by BOOT_UEFI option
 					{
@@ -2921,9 +2940,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Architecture:       arch.ARCH_X86_64,
 			},
 			expected: &disk.PartitionTable{
-				Type: disk.PT_GPT,
-				Size: (1 + 500 + 1) * datasizes.MiB,
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type:   disk.PT_GPT,
+				Size:   (1 + 500 + 1) * datasizes.MiB,
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start: 1 * datasizes.MiB,
@@ -2977,9 +2997,10 @@ func TestNewCustomPartitionTable(t *testing.T) {
 				Architecture:       arch.ARCH_X86_64,
 			},
 			expected: &disk.PartitionTable{
-				Type: disk.PT_DOS,
-				Size: (500 + 1) * datasizes.MiB,
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type:   disk.PT_DOS,
+				Size:   (500 + 1) * datasizes.MiB,
+				UUID:   "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Policy: disk.NewDefaultPartitionTablePolicy(),
 				Partitions: []disk.Partition{
 					{
 						Start: 1 * datasizes.MiB,
@@ -3023,7 +3044,7 @@ func TestNewCustomPartitionTable(t *testing.T) {
 			// order will affect results
 			/* #nosec G404 */
 			rnd := rand.New(rand.NewSource(0))
-			pt, err := disk.NewCustomPartitionTable(tc.customizations, tc.options, rnd)
+			pt, err := disk.NewCustomPartitionTable(tc.customizations, tc.options, nil, rnd)
 
 			assert.NoError(err)
 			assert.Equal(tc.expected, pt)
@@ -3098,7 +3119,7 @@ func TestNewCustomPartitionTableSectorSize(t *testing.T) {
 			assert := assert.New(t)
 			/* #nosec G404 */
 			rnd := rand.New(rand.NewSource(0))
-			pt, err := disk.NewCustomPartitionTable(tc.customizations, options, rnd)
+			pt, err := disk.NewCustomPartitionTable(tc.customizations, options, nil, rnd)
 
 			assert.NoError(err)
 			assert.Equal(tc.expectedSize, pt.SectorSize, "SectorSize should match the customization")
@@ -3339,7 +3360,7 @@ func TestNewCustomPartitionTableErrors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			_, err := disk.NewCustomPartitionTable(tc.customizations, tc.options, rnd)
+			_, err := disk.NewCustomPartitionTable(tc.customizations, tc.options, nil, rnd)
 			assert.EqualError(err, tc.errmsg)
 		})
 	}
@@ -3419,4 +3440,80 @@ func TestUnmarshalSizeUnitStringPartitionTable(t *testing.T) {
 			assert.Equal(t, datasizes.Size(tc.expected), pt.Size)
 		})
 	}
+}
+
+func TestNewCustomPartitionTablePolicyNoXBOOTLDR(t *testing.T) {
+	noBootPolicy := &disk.PartitionTablePolicy{EnsureXBOOTLDR: false}
+	/* #nosec G404 */
+	rnd := rand.New(rand.NewSource(0))
+
+	t.Run("lvm-gpt-no-boot", func(t *testing.T) {
+		customizations := &blueprint.DiskCustomization{
+			Partitions: []blueprint.PartitionCustomization{
+				{
+					Type:    "lvm",
+					MinSize: 100 * datasizes.MiB,
+					VGCustomization: blueprint.VGCustomization{
+						Name: "testvg",
+						LogicalVolumes: []blueprint.LVCustomization{
+							{
+								Name:    "rootlv",
+								MinSize: 50 * datasizes.MiB,
+								FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+									Mountpoint: "/",
+									Label:      "root",
+									FSType:     "xfs",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		options := &disk.CustomPartitionTableOptions{
+			DefaultFSType:      disk.FS_EXT4,
+			BootMode:           platform.BOOT_HYBRID,
+			PartitionTableType: disk.PT_GPT,
+			Architecture:       arch.ARCH_X86_64,
+		}
+
+		pt, err := disk.NewCustomPartitionTable(customizations, options, noBootPolicy, rnd)
+		require.NoError(t, err)
+
+		assert.Nil(t, disk.EntityPath(pt, "/boot"), "no /boot should be created with EnsureXBOOTLDR=false")
+		assert.NotNil(t, disk.EntityPath(pt, "/"), "root should exist")
+		assert.Equal(t, noBootPolicy, pt.Policy)
+	})
+
+	t.Run("btrfs-gpt-no-boot", func(t *testing.T) {
+		customizations := &blueprint.DiskCustomization{
+			Partitions: []blueprint.PartitionCustomization{
+				{
+					Type:    "btrfs",
+					MinSize: 230 * datasizes.MiB,
+					BtrfsVolumeCustomization: blueprint.BtrfsVolumeCustomization{
+						Subvolumes: []blueprint.BtrfsSubvolumeCustomization{
+							{
+								Name:       "subvol/root",
+								Mountpoint: "/",
+							},
+						},
+					},
+				},
+			},
+		}
+		options := &disk.CustomPartitionTableOptions{
+			DefaultFSType:      disk.FS_EXT4,
+			BootMode:           platform.BOOT_HYBRID,
+			PartitionTableType: disk.PT_GPT,
+			Architecture:       arch.ARCH_X86_64,
+		}
+
+		pt, err := disk.NewCustomPartitionTable(customizations, options, noBootPolicy, rnd)
+		require.NoError(t, err)
+
+		assert.Nil(t, disk.EntityPath(pt, "/boot"), "no /boot should be created with EnsureXBOOTLDR=false")
+		assert.NotNil(t, disk.EntityPath(pt, "/"), "root should exist")
+		assert.Equal(t, noBootPolicy, pt.Policy)
+	})
 }

--- a/pkg/distro/generic/bootc_imagetype.go
+++ b/pkg/distro/generic/bootc_imagetype.go
@@ -848,7 +848,7 @@ func (t *bootcImageType) genPartitionTableDiskCust(basept *disk.PartitionTable, 
 		RequiredMinSizes: requiredMinSizes,
 		Architecture:     t.arch.arch,
 	}
-	return disk.NewCustomPartitionTable(diskCust, partOptions, rng)
+	return disk.NewCustomPartitionTable(diskCust, partOptions, nil, rng)
 }
 
 func (t *bootcImageType) genPartitionTableFsCust(basept *disk.PartitionTable, fsCust []blueprint.FilesystemCustomization, rootfsMinSize uint64, rng *rand.Rand) (*disk.PartitionTable, error) {

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -197,7 +197,7 @@ func (t *imageType) getPartitionTable(customizations *blueprint.Customizations, 
 			RequiredMinSizes:   t.ImageTypeYAML.RequiredPartitionSizes,
 			Architecture:       t.platform.GetArch(),
 		}
-		return disk.NewCustomPartitionTable(partitioning, partOptions, rng)
+		return disk.NewCustomPartitionTable(partitioning, partOptions, nil, rng)
 	}
 
 	mountpoints := customizations.GetFilesystems()


### PR DESCRIPTION
Introduces the concept of partition table policies. The policy, much like the options, defines rules on how partition tables should be created.

It lives separately from the options because it can be used both for filesystem customizations and disk customizations. It's also meant to be configurable from image definitions, including those potentially stored inside a container (in `disk.yaml`).

Initially we add a boolean to be able to disable the creation of the /boot mountpoint (generally XBOOTLDR). This is a necessary bit for the conversion of sealed bootable containers. Creating a non-VFAT /boot there leads to broken boot (as systemd auto-mounting verifies that /boot is FAT nowadays?) and in general /boot isn't wanted on these.

This carries over to package mode where it's very possible we want to create images that do *not* introduce a `/boot` by default as everything would be stored in the ESP for some cases.

---

Note that since we currently do define a `/boot` in our default partition tables for bootc image types you can only test the behavior with an embedded `disk.yaml` that omits `/boot` (or temporarily adjust the definitions) until those files are included in the upstream containers.

---

I'm a bit torn about the options vs policy split here; it kinda fits, but it also kinda feels like this /should/ live in options instead though options and policies are different and sourced from different places. The main argument for me is that image types (through their base partition table) know the bootloader(s) involved and what is necessary to boot.

I'm *also* unsure about the abstraction level of this. It makes sense to make these tunables really low level; it *also* makes sense to have a higher level "Unified" or whatever. I've opted for the lower level here because a unified kernel doesn't imply there to never be an XBOOTLDR.

In fact we might want to expand the policy in a follow-up to have a tunable to actively *disallow* adding XBOOTLDR that is non-VFAT in diskcust or fscust. Adding one makes systemd's auto mounting break if it's of the wrong filesystem type. Again something only the image type knows.

---

Related: https://github.com/osbuild/image-builder/issues/2427