### PR TITLE
pkg/bootc/resolver: handle missing 'bootc container inspect'

### DIFF
--- a/pkg/bootc/resolver.go
+++ b/pkg/bootc/resolver.go
@@ -353,6 +353,11 @@ func (c *Container) UnifiedKernel() (bool, error) {
 	/* #nosec G204 */
 	output, err := exec.Command("podman", args...).Output()
 	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 2 {
+			// NOTE: the 'bootc container inspect' was added in version 1.12.0, which was not in RHEL-10.1.
+			// Treat exit value '2' as a non-error, since it means the command is not available and return false.
+			return false, nil
+		}
 		return false, fmt.Errorf("failed to run bootc container inspect: %w, output:\n%s", err, output)
 	}
 

--- a/pkg/bootc/resolver_test.go
+++ b/pkg/bootc/resolver_test.go
@@ -225,22 +225,39 @@ echo '%s'
 }
 
 func TestUnifiedKernelHappy(t *testing.T) {
-	for _, tc := range []struct {
-		In  string
-		Out bool
-	}{
-		{`{"kernel": {"unified": true}}`, true},
-		{`{"kernel": {"unified": false}}`, false},
-		{`{"kernel": {}}`, false},
-		{`{}`, false},
-	} {
-		makeFakePodman(t, fmt.Sprintf(`#!/bin/sh
-echo '%s'
-`, tc.In))
-		cnt := bootc.Container{}
-		unified, err := cnt.UnifiedKernel()
-		assert.NoError(t, err)
-		assert.Equal(t, tc.Out, unified)
+	type testCase struct {
+		Name     string
+		In       string
+		ExitCode int
+		Out      bool
+		ErrMsg   string
+	}
+
+	testCases := []testCase{
+		{Name: "unified", In: `{"kernel": {"unified": true}}`, ExitCode: 0, Out: true, ErrMsg: ""},
+		{Name: "not unified", In: `{"kernel": {"unified": false}}`, ExitCode: 0, Out: false, ErrMsg: ""},
+		{Name: "empty", In: `{"kernel": {}}`, ExitCode: 0, Out: false, ErrMsg: ""},
+		{Name: "empty", In: `{}`, ExitCode: 0, Out: false, ErrMsg: ""},
+		{Name: "unknown command", In: "", ExitCode: 2, Out: false, ErrMsg: ""},
+		{Name: "error", In: "", ExitCode: 1, Out: false, ErrMsg: "failed to run bootc container inspect"},
+		{Name: "error", In: "", ExitCode: 127, Out: false, ErrMsg: "failed to run bootc container inspect"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			makeFakePodman(t, fmt.Sprintf(`#!/bin/sh
+				echo '%s'
+				exit %d
+				`, tc.In, tc.ExitCode))
+			cnt := bootc.Container{}
+			unified, err := cnt.UnifiedKernel()
+			if tc.ErrMsg != "" {
+				assert.ErrorContains(t, err, tc.ErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.Out, unified)
+		})
 	}
 }
 


### PR DESCRIPTION
The 'bootc container inspect' subcommand was added in bootc 1.12.0, which is not available in RHEL-10.1. When the command is unavailable, bootc exits with code 2. Treat this as a non-error and return false for the unified kernel check instead of failing.

Also refactor the UnifiedKernel test to use subtests and cover the new exit code handling paths.