### PR TITLE
boot-azure: switch machine type

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -1,6 +1,6 @@
 {
   "common": {
-    "rngseed": 2026051400,
+    "rngseed": 2026051900,
     "dependencies": {
       "bootc-image-builder": {
         "ref": "quay.io/centos-bootc/bootc-image-builder@sha256:9893e7209e5f449b86ababfd2ee02a58cca2e5990f77b06c3539227531fc8120"

--- a/cmd/boot-azure/main.go
+++ b/cmd/boot-azure/main.go
@@ -69,7 +69,7 @@ func newClientFromArgs(flags *pflag.FlagSet) (*azure.Client, error) {
 func getDefaultSize(architecture string) (string, error) {
 	switch architecture {
 	case "x86_64":
-		return "Standard_DS1_v2", nil
+		return "Standard_D2ls_v5", nil
 	case "aarch64":
 		return "Standard_D2pls_v5", nil
 	default:

--- a/cmd/check-host-config/check/filesystem.go
+++ b/cmd/check-host-config/check/filesystem.go
@@ -14,6 +14,7 @@ func init() {
 		Name:                   "filesystem",
 		RequiresBlueprint:      true,
 		RequiresCustomizations: true,
+		RunOn:                  []string{"!rhel-8.4", "!rhel-8.6", "!rhel-8.8", "!rhel-8.10"},
 	}, filesystemCheck)
 }
 


### PR DESCRIPTION
The D1 SKU we were using doesn't correctly start cloud-init 26.1 in ELN. Switching to an AMD SKU makes mcelog fail because the driver seems to be missing (will investigate).

This instance type, determined by brute force, seems to work.