### PR TITLE
gen-manifests: respect SIGINT/SIGTERM

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -6,16 +6,19 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime/debug"
 	"slices"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gobwas/glob"
@@ -222,7 +225,7 @@ func loadImgConfig(configPath string, opts *buildconfig.Options) *BuildConfigs {
 	return cm
 }
 
-type manifestJob func(chan string) error
+type manifestJob func(context.Context, chan string) error
 
 func makeManifestJob(
 	bc *buildconfig.BuildConfig,
@@ -296,7 +299,7 @@ func makeManifestJob(
 		allRepos = append(allRepos, bc.CustomRepos...)
 	}
 
-	job := func(msgq chan string) (err error) {
+	job := func(ctx context.Context, msgq chan string) (err error) {
 		defer func() {
 			msg := fmt.Sprintf("Finished job %s", filename)
 			if err != nil {
@@ -312,6 +315,9 @@ func makeManifestJob(
 				})
 			}
 		}()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		msgq <- fmt.Sprintf("Starting job %s", filename)
 
 		manifest, _, err := imgType.Manifest(&bp, options, allRepos, &seedArg)
@@ -323,7 +329,7 @@ func makeManifestJob(
 		var depsolvedSets map[string]depsolvednf.DepsolveResult
 		if content["packages"] {
 			solver := depsolvednf.NewSolver(distribution.ModulePlatformID(), distribution.Releasever(), archName, distribution.Name(), cacheDir)
-			depsolvedSets, err = solver.DepsolveAll(common.Must(manifest.GetPackageSetChains()))
+			depsolvedSets, err = solver.DepsolveAll(ctx, common.Must(manifest.GetPackageSetChains()))
 			if err != nil {
 				err = fmt.Errorf("[%s] depsolve failed: %s", filename, err.Error())
 				return
@@ -433,6 +439,9 @@ func u(s string) string {
 }
 
 func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	// common args
 	var outputDir, cacheRoot, configPath, configMapPath string
 	var nWorkers int
@@ -516,6 +525,9 @@ func main() {
 		fmt.Fprintf(os.Stderr, "WARNING: invalid distro names: [%s]\n", strings.Join(invalidDistros, ","))
 	}
 	for _, distroName := range distros {
+		if err := ctx.Err(); err != nil {
+			break
+		}
 		distribution := distroFac.GetDistro(distroName)
 		if distribution == nil {
 			fmt.Fprintf(os.Stderr, "WARNING: invalid distro name %q\n", distroName)
@@ -584,6 +596,9 @@ func main() {
 	}
 
 	for _, bootcRefTuple := range bootcRefs {
+		if err := ctx.Err(); err != nil {
+			break
+		}
 		l := strings.SplitN(bootcRefTuple, "#", 2)
 		bootcRef := l[0]
 
@@ -677,6 +692,9 @@ func main() {
 			panic(err)
 		}
 		for _, fakeBootcCnt := range fakeContainers.Containers {
+			if err := ctx.Err(); err != nil {
+				break
+			}
 			fakeBootcInfo := &bootc.Info{
 				Imgref:        fakeBootcCnt.ImageRef,
 				OSInfo:        &fakeBootcCnt.Info,
@@ -743,7 +761,7 @@ func main() {
 	fmt.Fprintf(os.Stderr, "Collected %d jobs\n", nJobs)
 
 	// nolint:gosec
-	wq := newWorkerQueue(uint32(nWorkers), uint32(nJobs))
+	wq := newWorkerQueue(ctx, uint32(nWorkers), uint32(nJobs))
 	wq.start()
 	fmt.Fprintf(os.Stderr, "Initialised %d workers\n", nWorkers)
 	fmt.Fprintf(os.Stderr, "Submitting %d jobs... ", nJobs)
@@ -753,6 +771,10 @@ func main() {
 	fmt.Fprintln(os.Stderr, "done")
 	errs := wq.wait()
 	exit := 0
+	if ctx.Err() != nil {
+		fmt.Fprintln(os.Stderr, "Interrupted")
+		exit = 130
+	}
 	if nErrs := len(errs); nErrs > 0 {
 		fmt.Fprintf(os.Stderr, "Encountered %d errors:\n", nErrs)
 		var err1 *panicError
@@ -766,7 +788,9 @@ func main() {
 		if err1 != nil {
 			fmt.Fprintf(os.Stderr, "\nStack trace of the first error:\n%s\n", err1.stack)
 		}
-		exit = 1
+		if exit == 0 {
+			exit = 1
+		}
 	}
 	fmt.Fprintf(os.Stderr, "RPM metadata cache kept in %s\n", cacheRoot)
 	os.Exit(exit)

--- a/cmd/gen-manifests/workerqueue.go
+++ b/cmd/gen-manifests/workerqueue.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -8,6 +9,8 @@ import (
 )
 
 type workerQueue struct {
+	ctx context.Context
+
 	// manifest job channel
 	jobQueue chan manifestJob
 
@@ -35,10 +38,13 @@ type workerQueue struct {
 
 	// wait group for internal routines (printer and error collector)
 	utilWG sync.WaitGroup
+
+	stopOnce sync.Once
 }
 
-func newWorkerQueue(nworkers uint32, njobs uint32) *workerQueue {
+func newWorkerQueue(ctx context.Context, nworkers uint32, njobs uint32) *workerQueue {
 	wq := workerQueue{
+		ctx:           ctx,
 		jobQueue:      make(chan manifestJob, njobs),
 		msgQueue:      make(chan string, nworkers),
 		errQueue:      make(chan error, nworkers),
@@ -59,10 +65,17 @@ func (wq *workerQueue) start() {
 	}
 }
 
+// shutdown stops accepting new jobs. Workers exit once in-flight jobs finish or
+// the context is cancelled.
+func (wq *workerQueue) shutdown() {
+	wq.stopOnce.Do(func() {
+		close(wq.jobQueue)
+	})
+}
+
 // close all queues and wait for waitgroups
 func (wq *workerQueue) wait() []error {
-	// close job channel and wait for workers to finish
-	close(wq.jobQueue)
+	wq.shutdown()
 	wq.workerWG.Wait()
 
 	// close message channels and wait for them to finish their work so we don't miss any messages or errors
@@ -78,10 +91,21 @@ func (wq *workerQueue) startWorker(idx uint32) {
 		atomic.AddInt32(&(wq.activeWorkers), 1)
 		defer atomic.AddInt32(&(wq.activeWorkers), -1)
 		defer wq.workerWG.Done()
-		for job := range wq.jobQueue {
-			err := job(wq.msgQueue)
-			if err != nil {
-				wq.errQueue <- err
+		for {
+			select {
+			case <-wq.ctx.Done():
+				return
+			case job, ok := <-wq.jobQueue:
+				if !ok {
+					return
+				}
+				if wq.ctx.Err() != nil {
+					return
+				}
+				err := job(wq.ctx, wq.msgQueue)
+				if err != nil {
+					wq.errQueue <- err
+				}
 			}
 		}
 	}()
@@ -113,5 +137,9 @@ func (wq *workerQueue) startErrorCollector() {
 }
 
 func (wq *workerQueue) submitJob(j manifestJob) {
-	wq.jobQueue <- j
+	select {
+	case <-wq.ctx.Done():
+		return
+	case wq.jobQueue <- j:
+	}
 }

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -38,7 +39,7 @@ func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos
 
 	depsolvedSets := make(map[string]depsolvednf.DepsolveResult)
 	for name, chain := range common.Must(manifest.GetPackageSetChains()) {
-		res, err := solver.Depsolve(chain, sbom.StandardTypeNone)
+		res, err := solver.Depsolve(context.Background(), chain, sbom.StandardTypeNone)
 		if err != nil {
 			panic(fmt.Sprintf("failed to depsolve for pipeline %s: %s\n", name, err.Error()))
 		}

--- a/pkg/bootc/solver_test.go
+++ b/pkg/bootc/solver_test.go
@@ -1,6 +1,7 @@
 package bootc_test
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -62,7 +63,7 @@ func TestDepsolveDNFWorks(t *testing.T) {
 	require.NoError(t, err)
 	solver, err := cnt.NewContainerSolver(cacheRoot, arch.Current(), sourceInfo)
 	require.NoError(t, err)
-	res, err := solver.Depsolve([]rpmmd.PackageSet{
+	res, err := solver.Depsolve(context.Background(), []rpmmd.PackageSet{
 		{
 			Include: []string{"coreutils"},
 		},
@@ -141,7 +142,7 @@ func TestDepsolveDNFWorkWithSubscribedContent(t *testing.T) {
 	solver, err := cnt.NewContainerSolver(cacheRoot, arch.ARCH_X86_64, sourceInfo)
 	require.NoError(t, err)
 
-	res, err := solver.Depsolve([]rpmmd.PackageSet{
+	res, err := solver.Depsolve(context.Background(), []rpmmd.PackageSet{
 		{
 			Include: []string{"coreutils"},
 		},

--- a/pkg/depsolvednf/depsolvednf.go
+++ b/pkg/depsolvednf/depsolvednf.go
@@ -16,6 +16,7 @@ package depsolvednf
 import (
 	"bytes"
 	"cmp"
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -273,7 +274,10 @@ func (s *Solver) SetSBOMType(sbomType sbom.StandardType) {
 // their associated repositories.  Each package set is depsolved as a separate
 // transactions in a chain.  It returns a list of all packages (with solved
 // dependencies) that will be installed into the system.
-func (s *Solver) Depsolve(pkgSets []rpmmd.PackageSet, sbomType sbom.StandardType) (*DepsolveResult, error) {
+func (s *Solver) Depsolve(ctx context.Context, pkgSets []rpmmd.PackageSet, sbomType sbom.StandardType) (*DepsolveResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if err := validatePackageSetRepoChain(pkgSets); err != nil {
 		return nil, err
 	}
@@ -296,7 +300,7 @@ func (s *Solver) Depsolve(pkgSets []rpmmd.PackageSet, sbomType sbom.StandardType
 	s.cache.locker.RLock()
 	defer s.cache.locker.RUnlock()
 
-	output, err := run(s.depsolveDNFCmd, reqData, s.Stderr)
+	output, err := run(ctx, s.depsolveDNFCmd, reqData, s.Stderr)
 	if err != nil {
 		return nil, parseError(output, allRepos, err)
 	}
@@ -338,10 +342,13 @@ func (s *Solver) Depsolve(pkgSets []rpmmd.PackageSet, sbomType sbom.StandardType
 
 // DepsolveAll calls [Solver.Depsolve] with each package set slice in the map and
 // returns a map of results with the corresponding keys as the input argument.
-func (s *Solver) DepsolveAll(pkgSetsMap map[string][]rpmmd.PackageSet) (map[string]DepsolveResult, error) {
+func (s *Solver) DepsolveAll(ctx context.Context, pkgSetsMap map[string][]rpmmd.PackageSet) (map[string]DepsolveResult, error) {
 	results := make(map[string]DepsolveResult, len(pkgSetsMap))
 	for name, pkgSet := range pkgSetsMap {
-		res, err := s.Depsolve(pkgSet, s.sbomType)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		res, err := s.Depsolve(ctx, pkgSet, s.sbomType)
 		if err != nil {
 			return nil, fmt.Errorf("error depsolving package sets for %q: %w", name, err)
 		}
@@ -369,7 +376,7 @@ func (s *Solver) FetchMetadata(repos []rpmmd.RepoConfig) (rpmmd.PackageList, err
 		return pkgs, nil
 	}
 
-	rawRes, err := run(s.depsolveDNFCmd, reqData, s.Stderr)
+	rawRes, err := run(context.Background(), s.depsolveDNFCmd, reqData, s.Stderr)
 	if err != nil {
 		return nil, parseError(rawRes, repos, err)
 	}
@@ -417,7 +424,7 @@ func (s *Solver) SearchMetadata(repos []rpmmd.RepoConfig, packages []string) (rp
 		return pkgs, nil
 	}
 
-	rawRes, err := run(s.depsolveDNFCmd, reqData, s.Stderr)
+	rawRes, err := run(context.Background(), s.depsolveDNFCmd, reqData, s.Stderr)
 	if err != nil {
 		return nil, parseError(rawRes, repos, err)
 	}
@@ -596,7 +603,7 @@ func parseError(data []byte, repos []rpmmd.RepoConfig, cmdError error) Error {
 	return e
 }
 
-func run(dnfJsonCmd []string, reqData []byte, stderr io.Writer) ([]byte, error) {
+func run(ctx context.Context, dnfJsonCmd []string, reqData []byte, stderr io.Writer) ([]byte, error) {
 	if len(dnfJsonCmd) == 0 {
 		dnfJsonCmd = []string{findDepsolveDnf()}
 	}
@@ -608,7 +615,7 @@ func run(dnfJsonCmd []string, reqData []byte, stderr io.Writer) ([]byte, error) 
 	if len(dnfJsonCmd) > 1 {
 		args = dnfJsonCmd[1:]
 	}
-	cmd := exec.Command(ex, args...)
+	cmd := exec.CommandContext(ctx, ex, args...)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, fmt.Errorf("creating stdin pipe for %s failed: %w", ex, err)
@@ -635,8 +642,11 @@ func run(dnfJsonCmd []string, reqData []byte, stderr io.Writer) ([]byte, error) 
 
 	err = cmd.Wait()
 	output := stdout.Bytes()
-	if err != nil {
-		return output, fmt.Errorf("running the depsolver failed: %w", err)
+	if ctx.Err() != nil {
+		return output, ctx.Err()
+	}
+	if runError, ok := err.(*exec.ExitError); ok && runError.ExitCode() != 0 {
+		return output, fmt.Errorf("depsolve failed with exit code %d", runError.ExitCode())
 	}
 	return output, nil
 }

--- a/pkg/depsolvednf/depsolvednf_test.go
+++ b/pkg/depsolvednf/depsolvednf_test.go
@@ -2,6 +2,7 @@ package depsolvednf
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -238,7 +239,7 @@ func TestSolverDepsolve(t *testing.T) {
 
 					solver := newTestSolver(t)
 					solver.SetRootDir(tc.rootDir)
-					actualResult, err := solver.Depsolve(pkgsets, tc.sbomType)
+					actualResult, err := solver.Depsolve(context.Background(), pkgsets, tc.sbomType)
 					if tc.err {
 						assert.Error(err)
 						assert.Contains(err.Error(), tc.expMsg)
@@ -441,7 +442,7 @@ func TestSolverDepsolveAll(t *testing.T) {
 
 					solver := NewSolver("platform:el9", "9", "x86_64", "rhel9.0", tmpdir)
 					solver.SetSBOMType(tc.sbomType)
-					res, err := solver.DepsolveAll(tc.packageSets)
+					res, err := solver.DepsolveAll(context.Background(), tc.packageSets)
 					if len(tc.expErrs) != 0 {
 						assert.Error(err)
 						for _, expErr := range tc.expErrs {
@@ -975,7 +976,7 @@ func TestErrorRepoInfo(t *testing.T) {
 			solver := NewSolver("platform:f38", "38", "x86_64", "fedora-38", "/tmp/cache")
 			for idx, tc := range testCases {
 				t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
-					_, err := solver.Depsolve([]rpmmd.PackageSet{
+					_, err := solver.Depsolve(context.Background(), []rpmmd.PackageSet{
 						{
 							Include:      []string{"osbuild"},
 							Exclude:      nil,
@@ -1043,7 +1044,7 @@ exit 1
 
 			solver := NewSolver("platform:f38", "38", "x86_64", "fedora-38", t.TempDir())
 			solver.depsolveDNFCmd = []string{fakeSolverPath}
-			res, err := solver.Depsolve(nil, sbom.StandardTypeNone)
+			res, err := solver.Depsolve(context.Background(), nil, sbom.StandardTypeNone)
 
 			assert.EqualError(t, err, `DNF error occurred: InternalError: osbuild-depsolve-dnf output was empty: running the depsolver failed: exit status 1`)
 			assert.Nil(t, res)
@@ -1071,7 +1072,7 @@ echo '{"solver": "zypper"}'
 			solver := NewSolver("platform:f38", "38", "x86_64", "fedora-38", "/tmp/cache")
 			solver.Stderr = &capturedStderr
 			solver.depsolveDNFCmd = []string{fakeSolverPath}
-			res, err := solver.Depsolve(nil, sbom.StandardTypeNone)
+			res, err := solver.Depsolve(context.Background(), nil, sbom.StandardTypeNone)
 			assert.NoError(t, err)
 			assert.NotNil(t, res)
 			assert.Equal(t, "output-on-stderr\n", capturedStderr.String())
@@ -1118,7 +1119,7 @@ func TestDepsolverSubscriptionsError(t *testing.T) {
 				},
 			}
 			solver.SetRootDir(rootDir)
-			_, err := solver.Depsolve(pkgsets, 0)
+			_, err := solver.Depsolve(context.Background(), pkgsets, 0)
 			assert.EqualError(t, err, "This system does not have any valid subscriptions. Subscribe it before specifying rhsm: true in sources (error details: no matching key and certificate pair)")
 		})
 	}

--- a/pkg/manifestgen/manifestgen.go
+++ b/pkg/manifestgen/manifestgen.go
@@ -2,6 +2,7 @@ package manifestgen
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -348,7 +349,7 @@ func DefaultDepsolve(solver *depsolvednf.Solver, cacheDir string, depsolveWarnin
 	// type. Once we have more types than Spdx of course
 	// we need to add a option to select the type.
 	solver.SetSBOMType(sbom.StandardTypeSpdx)
-	return solver.DepsolveAll(packageSets)
+	return solver.DepsolveAll(context.Background(), packageSets)
 }
 
 type (


### PR DESCRIPTION
It was not possible to interrupt the generation of manifests by sending
SIGINT/SIGTERM.

---

Plus a little change in the YAML loader.