### PR TITLE
bootloaders: Move the iso bootloader setup into its own struct

### DIFF
--- a/pkg/image/anaconda_installer_base.go
+++ b/pkg/image/anaconda_installer_base.go
@@ -18,59 +18,6 @@ type AnacondaInstallerBase struct {
 	InteractiveDefaultsKickstart *kickstart.Options
 }
 
-func (img *AnacondaInstallerBase) Bootloaders(buildPipeline manifest.Build, platform platform.Platform, kernelOpts []string) []manifest.ISOBootloader {
-	// Setup the bootloaders
-	bootloaders := make([]manifest.ISOBootloader, 0)
-
-	var addUEFIBootTree bool
-	switch img.ISOCustomizations.BootType {
-	case manifest.Grub2UEFIOnlyISOBoot:
-		addUEFIBootTree = true
-
-	case manifest.SyslinuxISOBoot:
-		syslinux := manifest.NewISOLinuxBootloader(buildPipeline, img.InstallerCustomizations.Product, img.InstallerCustomizations.OSVersion)
-		syslinux.Platform = platform
-		syslinux.KernelOpts = kernelOpts
-		bootloaders = append(bootloaders, syslinux)
-		addUEFIBootTree = true
-
-	case manifest.Grub2ISOBoot:
-		grub2 := manifest.NewGrub2X86Bootloader(buildPipeline, img.InstallerCustomizations.Product, img.InstallerCustomizations.OSVersion)
-		grub2.Platform = platform
-		grub2.ISOLabel = img.ISOCustomizations.Label
-		grub2.KernelOpts = kernelOpts
-		grub2.DefaultMenu = img.InstallerCustomizations.DefaultMenu
-		bootloaders = append(bootloaders, grub2)
-		addUEFIBootTree = true
-
-	case manifest.Grub2PPCISOBoot:
-		grub2ppc64 := manifest.NewGrub2PPC64Bootloader(buildPipeline, img.InstallerCustomizations.Product, img.InstallerCustomizations.OSVersion)
-		grub2ppc64.Platform = platform
-		grub2ppc64.ISOLabel = img.ISOCustomizations.Label
-		grub2ppc64.KernelOpts = kernelOpts
-		grub2ppc64.DefaultMenu = img.InstallerCustomizations.DefaultMenu
-		bootloaders = append(bootloaders, grub2ppc64)
-
-	case manifest.S390ISOBoot:
-		s390 := manifest.NewS390Bootloader(buildPipeline)
-		s390.Platform = platform
-		s390.KernelOpts = kernelOpts
-		bootloaders = append(bootloaders, s390)
-	}
-
-	if addUEFIBootTree {
-		// EFI bootloader adds a pipeline and adds stages
-		bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.InstallerCustomizations.Product, img.InstallerCustomizations.OSVersion)
-		bootTreePipeline.Platform = platform
-		bootTreePipeline.UEFIVendor = platform.GetUEFIVendor()
-		bootTreePipeline.ISOLabel = img.ISOCustomizations.Label
-		bootTreePipeline.DefaultMenu = img.InstallerCustomizations.DefaultMenu
-		bootTreePipeline.KernelOpts = kernelOpts
-		bootloaders = append(bootloaders, bootTreePipeline)
-	}
-	return bootloaders
-}
-
 func initIsoTreePipeline(isoTreePipeline *manifest.AnacondaInstallerISOTree, img *AnacondaInstallerBase, rng *rand.Rand) {
 	isoTreePipeline.PartitionTable = efiBootPartitionTable(rng)
 	isoTreePipeline.Release = img.InstallerCustomizations.Release
@@ -80,4 +27,12 @@ func initIsoTreePipeline(isoTreePipeline *manifest.AnacondaInstallerISOTree, img
 	isoTreePipeline.RootfsType = img.ISOCustomizations.RootfsType
 
 	isoTreePipeline.ISOBoot = img.ISOCustomizations.BootType
+}
+
+func (img *AnacondaInstallerBase) Bootloaders(buildPipeline manifest.Build, platform platform.Platform, kernelOpts []string) []manifest.ISOBootloader {
+	ibo := ISOBootloaders{
+		InstallerCustomizations: &img.InstallerCustomizations,
+		ISOCustomizations:       &img.ISOCustomizations,
+	}
+	return ibo.Bootloaders(buildPipeline, platform, kernelOpts)
 }

--- a/pkg/image/export_test.go
+++ b/pkg/image/export_test.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	AddBuildBootstrapPipelines = addBuildBootstrapPipelines
+	EFIBootPartitionTable      = efiBootPartitionTable
 )
 
 func MockManifestNewBuild(new func(m *manifest.Manifest, runner runner.Runner, repos []rpmmd.RepoConfig, opts *manifest.BuildOptions) manifest.Build) (restore func()) {

--- a/pkg/image/iso_bootloaders.go
+++ b/pkg/image/iso_bootloaders.go
@@ -1,0 +1,65 @@
+package image
+
+import (
+	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/platform"
+)
+
+// common struct that all anaconda installers share
+type ISOBootloaders struct {
+	InstallerCustomizations *manifest.InstallerCustomizations
+	ISOCustomizations       *manifest.ISOCustomizations
+}
+
+func (img *ISOBootloaders) Bootloaders(buildPipeline manifest.Build, platform platform.Platform, kernelOpts []string) []manifest.ISOBootloader {
+	// Setup the bootloaders
+	bootloaders := make([]manifest.ISOBootloader, 0)
+
+	var addUEFIBootTree bool
+	switch img.ISOCustomizations.BootType {
+	case manifest.Grub2UEFIOnlyISOBoot:
+		addUEFIBootTree = true
+
+	case manifest.SyslinuxISOBoot:
+		syslinux := manifest.NewISOLinuxBootloader(buildPipeline, img.InstallerCustomizations.Product, img.InstallerCustomizations.OSVersion)
+		syslinux.Platform = platform
+		syslinux.KernelOpts = kernelOpts
+		bootloaders = append(bootloaders, syslinux)
+		addUEFIBootTree = true
+
+	case manifest.Grub2ISOBoot:
+		grub2 := manifest.NewGrub2X86Bootloader(buildPipeline, img.InstallerCustomizations.Product, img.InstallerCustomizations.OSVersion)
+		grub2.Platform = platform
+		grub2.ISOLabel = img.ISOCustomizations.Label
+		grub2.KernelOpts = kernelOpts
+		grub2.DefaultMenu = img.InstallerCustomizations.DefaultMenu
+		bootloaders = append(bootloaders, grub2)
+		addUEFIBootTree = true
+
+	case manifest.Grub2PPCISOBoot:
+		grub2ppc64 := manifest.NewGrub2PPC64Bootloader(buildPipeline, img.InstallerCustomizations.Product, img.InstallerCustomizations.OSVersion)
+		grub2ppc64.Platform = platform
+		grub2ppc64.ISOLabel = img.ISOCustomizations.Label
+		grub2ppc64.KernelOpts = kernelOpts
+		grub2ppc64.DefaultMenu = img.InstallerCustomizations.DefaultMenu
+		bootloaders = append(bootloaders, grub2ppc64)
+
+	case manifest.S390ISOBoot:
+		s390 := manifest.NewS390Bootloader(buildPipeline)
+		s390.Platform = platform
+		s390.KernelOpts = kernelOpts
+		bootloaders = append(bootloaders, s390)
+	}
+
+	if addUEFIBootTree {
+		// EFI bootloader adds a pipeline and adds stages
+		bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.InstallerCustomizations.Product, img.InstallerCustomizations.OSVersion)
+		bootTreePipeline.Platform = platform
+		bootTreePipeline.UEFIVendor = platform.GetUEFIVendor()
+		bootTreePipeline.ISOLabel = img.ISOCustomizations.Label
+		bootTreePipeline.DefaultMenu = img.InstallerCustomizations.DefaultMenu
+		bootTreePipeline.KernelOpts = kernelOpts
+		bootloaders = append(bootloaders, bootTreePipeline)
+	}
+	return bootloaders
+}

--- a/pkg/image/iso_bootloaders_test.go
+++ b/pkg/image/iso_bootloaders_test.go
@@ -1,0 +1,129 @@
+package image_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/osbuild/images/pkg/customizations/fsnode"
+	"github.com/osbuild/images/pkg/image"
+	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/osbuild"
+	"github.com/osbuild/images/pkg/runner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBootType(t *testing.T) {
+	ibl := image.ISOBootloaders{
+		InstallerCustomizations: &manifest.InstallerCustomizations{Product: "Fedora", OSVersion: "44"},
+		ISOCustomizations:       &manifest.ISOCustomizations{Label: "Fedora-44-test"},
+	}
+
+	source := rand.NewSource(int64(0))
+	// math/rand is good enough in this case
+	/* #nosec G404 */
+	rng := rand.New(source)
+
+	runner := &runner.Fedora{Version: 44}
+	pt := image.EFIBootPartitionTable(rng)
+
+	type results struct {
+		stages []string
+		paths  []string
+	}
+
+	type testCase struct {
+		bootType manifest.ISOBootType
+		expected []results
+	}
+
+	// Check the stages and files for each bootloader type
+	tests := []testCase{
+		testCase{manifest.Grub2UEFIOnlyISOBoot, []results{{
+			stages: []string{
+				"org.osbuild.truncate",
+				"org.osbuild.mkfs.fat",
+				"org.osbuild.copy",
+				"org.osbuild.copy"},
+			paths: []string{}},
+		}},
+		testCase{manifest.SyslinuxISOBoot, []results{
+			{stages: []string{"org.osbuild.isolinux"}, paths: []string{}}, {
+				stages: []string{
+					"org.osbuild.truncate",
+					"org.osbuild.mkfs.fat",
+					"org.osbuild.copy",
+					"org.osbuild.copy"},
+				paths: []string{}},
+		}},
+		testCase{manifest.Grub2ISOBoot, []results{{
+			stages: []string{
+				"org.osbuild.grub2.iso.legacy",
+				"org.osbuild.grub2.inst"},
+			paths: []string{}}, {
+			stages: []string{
+				"org.osbuild.truncate",
+				"org.osbuild.mkfs.fat",
+				"org.osbuild.copy",
+				"org.osbuild.copy"},
+			paths: []string{}},
+		}},
+		testCase{manifest.Grub2PPCISOBoot, []results{{
+			stages: []string{
+				"org.osbuild.grub2.iso.legacy",
+				"org.osbuild.mkdir",
+				"org.osbuild.copy"},
+			paths: []string{"/ppc/bootinfo.txt"}},
+		}},
+		testCase{manifest.S390ISOBoot, []results{{
+			stages: []string{
+				"org.osbuild.copy",
+				"org.osbuild.copy",
+				"org.osbuild.copy",
+				"org.osbuild.copy",
+				"org.osbuild.copy",
+				"org.osbuild.createaddrsize",
+				"org.osbuild.mks390image"},
+			paths: []string{
+				"/images/redhat.exec",
+				"/images/generic.prm",
+				"/images/genericdvd.prm",
+				"/images/generic.ins",
+				"/images/cdboot.prm"}},
+		}},
+	}
+
+	for _, tc := range tests {
+		mf := manifest.New()
+		buildPipeline := image.AddBuildBootstrapPipelines(&mf, runner, nil, nil)
+		ibl.ISOCustomizations.BootType = tc.bootType
+		bootloaders := ibl.Bootloaders(buildPipeline, testPlatform, []string{})
+		require.Len(t, bootloaders, len(tc.expected))
+
+		for i := range tc.expected {
+			stages, files, err := bootloaders[i].GetISOBootStages("iso-bootloaders", pt)
+			require.NoError(t, err)
+			assert.Len(t, stages, len(tc.expected[i].stages), fmt.Sprintf("%v", stageNames(stages)))
+			assert.Equal(t, stageNames(stages), tc.expected[i].stages)
+			assert.Len(t, files, len(tc.expected[i].paths), fmt.Sprintf("%v", filePaths(files)))
+			assert.Equal(t, filePaths(files), tc.expected[i].paths)
+		}
+	}
+}
+
+func stageNames(stages []*osbuild.Stage) []string {
+	names := []string{}
+	for _, s := range stages {
+		names = append(names, s.Type)
+	}
+	return names
+}
+
+func filePaths(files []*fsnode.File) []string {
+	paths := []string{}
+	for _, f := range files {
+		paths = append(paths, f.Path())
+	}
+	return paths
+}


### PR DESCRIPTION
This will allow sharing this code between image types. It depends on the ISOCustomizations and InstallerCustomizations structs.

Includes tests for all the ISO boot types returned by Bootloaders.

Related: HMS-10627