### PR TITLE
ci: include flatpaks

### DIFF
--- a/test/scripts/generate-ostree-build-config
+++ b/test/scripts/generate-ostree-build-config
@@ -148,7 +148,8 @@ def gen_image_manifests(config_list, configs, distro, arch, outputdir):
             json.dump(config_list, config_list_file)
 
         err = testlib.gen_manifests(outputdir, config_list=config_list_path,
-                                    arches=[arch], distros=distros, commits=True, skip_no_config=True)
+                                    arches=[arch], distros=distros, commits=True,
+                                    flatpaks=True, skip_no_config=True)
 
     # print stderr in case there were errors or warnings about skipped configurations
     # but filter out the annoying ones

--- a/test/scripts/imgtestlib.py
+++ b/test/scripts/imgtestlib.py
@@ -246,7 +246,7 @@ def check_config_names():
 
 
 def gen_manifests(outputdir, config_list=None, distros=None, arches=None, images=None,
-                  commits=False, skip_no_config=False):
+                  commits=False, flatpaks=False, skip_no_config=False):
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     cmd = ["go", "run", "./cmd/gen-manifests",
            "--cache", os.path.join(TEST_CACHE_ROOT, "rpmmd"),
@@ -262,6 +262,8 @@ def gen_manifests(outputdir, config_list=None, distros=None, arches=None, images
         cmd.extend(["--types", ",".join(images)])
     if commits:
         cmd.append("--commits")
+    if flatpaks:
+        cmd.append("--flatpaks")
     if skip_no_config:
         cmd.append("--skip-noconfig")
     env = rng_seed_env()


### PR DESCRIPTION
Some image types in the ostree branch of things have flatpaks. Those should be resolved same as commits; if they're not their checksums do not match which in turn causes Kinoite and Silverblue installers to be continually rebuilt.