### PR TITLE
test: add script for creating multi-arch container manifest

### DIFF
--- a/test/scripts/mk-container-manifest-list.sh
+++ b/test/scripts/mk-container-manifest-list.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/bash
+#
+# Create four containers (one for each architecture) with a simple README file
+# for testing resolving multi-arch manifest lists.
+#
+# Original source: https://github.com/osbuild/osbuild/commit/532a4c1166fd8297606933c8c209bd5eef7695c2
+
+set -eu
+
+arches=(
+    amd64
+    arm64
+    s390x
+    ppc64le
+)
+
+container_ids=()
+
+for arch in "${arches[@]}"; do
+    echo ":: Building ${arch} container"
+    container_name=$(buildah from --arch="${arch}" scratch)
+    buildah config --created-by "osbuild.org" "${container_name}"
+    readmedir=$(mktemp -d)
+    pushd "${readmedir}"
+
+    cat > "README.${arch}.md" << EOF
+# Test container
+
+Test container for preserving manifest list digest.
+Architecture: ${arch}
+EOF
+buildah copy "${container_name}" "README.${arch}.md"
+popd
+
+    rm -r "${readmedir}"
+    id=$(buildah commit --format=docker --rm "${container_name}")
+    container_ids+=("${id}")
+done
+
+echo ":: Creating manifest"
+name="registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+buildah manifest create "${name}" "${container_ids[@]}"
+
+echo "Push to registry with:"
+echo "podman manifest push ${name}"

--- a/test/scripts/test_imgtestlib.py
+++ b/test/scripts/test_imgtestlib.py
@@ -7,7 +7,7 @@ import pytest
 
 import imgtestlib as testlib
 
-TEST_ARCHES = ["amd64", "arm64"]
+TEST_ARCHES = ["amd64", "arm64", "ppc64le", "s390x"]
 
 
 def can_sudo_nopw() -> bool:
@@ -208,20 +208,24 @@ def test_gen_build_info_s3_dir_path(kwargs, expected):
 
 test_container = "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
 
-manifest_list_digest = "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+manifest_list_digest = "sha256:11b8172c893595bfcdea054e15457deb54f208afdaf16a602d05fad8e1f6adc1"
 
 # manifest IDs for
 #  registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:latest
 manifest_ids = {
-    "amd64": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
-    "arm64": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+    "amd64": "sha256:78bd1e02fb7b18fbcec064ec10eba0dabfbe94ab6c4513f4edf9e8c8e13396a5",
+    "arm64": "sha256:33d37d6b9a9ce7935494d053a0777ec7f764a75ad623a6f1e5285eb5ab785b6b",
+    "ppc64le": "sha256:8583990f74a6909c4267ba4e75a2e16c52c41c2a23bf237e12d980846c41efc3",
+    "s390x": "sha256:e34cb0973da8876807f945d9c0869c419b364cbcc5a1c069366cf370c429dbda",
 }
 
 # image IDs for
 #  registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:latest
 image_ids = {
-    "amd64": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
-    "arm64": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+    "amd64": "sha256:d0f28374e1a9b1ae28d543cadd0916b8ee4f8619a834900a964961a188bc16c4",
+    "arm64": "sha256:d012c8612b9c700f7651aca3f6b0853077ea97c306b97fd614c846929cc28ac4",
+    "ppc64le": "sha256:55da7d7b0a5a4585d40f4fe1922c6d42d99868d9f05aca6c879b7a9ea26693bc",
+    "s390x": "sha256:5bf4c5066f83f30a20b934cee2b6e84e4eb8c44362409776fe7376289ae52acd",
 }
 
 


### PR DESCRIPTION
The original version of this script was in a commit message in osbuild when we first created the multi-arch manifest for testing.  It's now expanded to create containers for all 4 architectures.  It also differentiates the contents a little bit between architectures.

The script has already been used to create the containers and they have been pushed to the gitlab registry.

Updated imgtestlib unit tests to match new digests and IDs.