### PR TITLE
distro: Make isoCustomizations usable by bootcImageType

### DIFF
--- a/pkg/distro/generic/bootc_imagetype.go
+++ b/pkg/distro/generic/bootc_imagetype.go
@@ -130,6 +130,14 @@ func (t *bootcImageType) RequiredBlueprintOptions() []string {
 	return nil
 }
 
+func (t *bootcImageType) getDefaultISOConfig() (*distro.ISOConfig, error) {
+	if !t.ImageTypeYAML.BootISO {
+		return nil, fmt.Errorf("image type %q is not an ISO", t.Name())
+	}
+	d := t.Arch().Distro()
+	return t.ISOConfig(d.ID(), t.arch.arch.String()), nil
+}
+
 // keep in sync with "generic/imagetype.go:checkOptions()"
 func (t *bootcImageType) checkOptions(bp *blueprint.Blueprint) []string {
 	if bp == nil {

--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -557,7 +557,12 @@ func installerCustomizations(t *imageType, c *blueprint.Customizations, o distro
 	return isc, nil
 }
 
-func isoCustomizations(t *imageType, c *blueprint.Customizations) (manifest.ISOCustomizations, error) {
+type ISOImageType interface {
+	ISOLabel() (string, error)
+	getDefaultISOConfig() (*distro.ISOConfig, error)
+}
+
+func isoCustomizations(t ISOImageType, c *blueprint.Customizations) (manifest.ISOCustomizations, error) {
 	isoLabel, err := t.ISOLabel()
 	if err != nil {
 		return manifest.ISOCustomizations{}, err
@@ -601,6 +606,11 @@ func isoCustomizations(t *imageType, c *blueprint.Customizations) (manifest.ISOC
 			isc.ExcludePaths = excludePaths
 		}
 
+	}
+
+	// No blueprint customizations, just return the defaults from the YAML
+	if c == nil {
+		return isc, nil
 	}
 
 	isoCust, err := c.GetISO()


### PR DESCRIPTION
The function only depends on ISOLabel() and getDefaultISOConfig(). Make it take a new interface, ISOImageType, so that it can be shared between regular images and bootc images.

Related: HMS-10627