### PR TITLE
depsolver: catch all errors from the child process

### DIFF
--- a/pkg/depsolvednf/depsolvednf.go
+++ b/pkg/depsolvednf/depsolvednf.go
@@ -635,8 +635,8 @@ func run(dnfJsonCmd []string, reqData []byte, stderr io.Writer) ([]byte, error) 
 
 	err = cmd.Wait()
 	output := stdout.Bytes()
-	if runError, ok := err.(*exec.ExitError); ok && runError.ExitCode() != 0 {
-		return output, fmt.Errorf("depsolve failed with exit code %d", runError.ExitCode())
+	if err != nil {
+		return output, fmt.Errorf("running the depsolver failed: %w", err)
 	}
 	return output, nil
 }

--- a/pkg/depsolvednf/depsolvednf_test.go
+++ b/pkg/depsolvednf/depsolvednf_test.go
@@ -1045,7 +1045,7 @@ exit 1
 			solver.depsolveDNFCmd = []string{fakeSolverPath}
 			res, err := solver.Depsolve(nil, sbom.StandardTypeNone)
 
-			assert.EqualError(t, err, `DNF error occurred: InternalError: osbuild-depsolve-dnf output was empty: depsolve failed with exit code 1`)
+			assert.EqualError(t, err, `DNF error occurred: InternalError: osbuild-depsolve-dnf output was empty: running the depsolver failed: exit status 1`)
 			assert.Nil(t, res)
 		})
 	}


### PR DESCRIPTION
exec.ExitError.ExitCode() gets weird if the process didn't exit normally. It actually returns -1 if the process' wstatus (see man 2 wait) is not WIFEXITED. Thus, if the process gets killed (which can happen quite easily since our depsolver is memory-hungry), we get a completely bogus error message - "depsolve failed with exit code -1". Exit code of -1 is impossible on Linux.

I could have fixed it by dropping the ExitCode condition but why stopping at that? It's actually not guaranteed that exec.Cmd.Wait() returns exec.ExitError! Thus, let's simplify the condition even further and just check for ANY errors. This makes our codebase more robust by not ignorning random errors.