### PR TITLE
bootc: assert non-nil kernel info

### DIFF
--- a/pkg/distro/generic/bootc_imagetype.go
+++ b/pkg/distro/generic/bootc_imagetype.go
@@ -409,6 +409,12 @@ func (t *bootcImageType) manifestForISO(bp *blueprint.Blueprint, options distro.
 	img.InstallerCustomizations.LoraxTemplates = bootc.LoraxTemplates(sourceInfo.OSRelease)
 	img.InstallerCustomizations.LoraxTemplatePackage = bootc.LoraxTemplatePackage(sourceInfo.OSRelease)
 
+	// Potentially KernelInfo is nil when we couldn't read it from the container; handle that so
+	// we don't panic
+	if sourceInfo.KernelInfo == nil {
+		return nil, nil, fmt.Errorf("could not read kernel info from container")
+	}
+
 	// kernelVer is used by dracut
 	img.KernelVer = sourceInfo.KernelInfo.Version
 	img.KernelPath = fmt.Sprintf("lib/modules/%s/vmlinuz", sourceInfo.KernelInfo.Version)
@@ -465,6 +471,13 @@ func (t *bootcImageType) manifestForGenericISO(options distro.ImageOptions, rng 
 	}
 	img.RootfsCompression = "zstd"
 	img.RootfsType = manifest.SquashfsRootfs
+
+	// Potentially KernelInfo is nil when we couldn't read it from the container; handle that so
+	// we don't panic
+	if bd.sourceInfo.KernelInfo == nil {
+		return nil, nil, fmt.Errorf("could not read kernel info from container")
+	}
+
 	img.KernelPath = fmt.Sprintf("lib/modules/%s/vmlinuz", bd.sourceInfo.KernelInfo.Version)
 	img.InitramfsPath = fmt.Sprintf("lib/modules/%s/initramfs.img", bd.sourceInfo.KernelInfo.Version)
 	img.Product = bd.sourceInfo.OSRelease.Name
@@ -701,6 +714,12 @@ func (t *bootcImageType) manifestForPXETar(bp *blueprint.Blueprint, options dist
 	img.OSCustomizations.Directories, err = blueprint.DirectoryCustomizationsToFsNodeDirectories(dc)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// Potentially KernelInfo is nil when we couldn't read it from the container; handle that so
+	// we don't panic
+	if bd.sourceInfo.KernelInfo == nil {
+		return nil, nil, fmt.Errorf("could not read kernel info from container")
 	}
 
 	// Used when dracut rebuilds the initramfs in the bootc pipeline


### PR DESCRIPTION
We use the kernel information we read from the image for ISOs. Sometimes it is not available as we can't find the kernel in the container image.

If this happens we panicked on a `nil`, let's print a slightly more helpful error.

---

This 'resolves' https://github.com/osbuild/image-builder/issues/2424 in that the panic is no longer shown, but we still *require* `/usr/lib/modules/*/(vmlinuz|initramfs.img)` to exist as per: https://osbuild.org/docs/developer-guide/projects/image-builder/advanced/bootc/isos/#generic