### PR TITLE
stage/grub2: allow VFAT for boot fs

### DIFF
--- a/pkg/osbuild/grub2_stage.go
+++ b/pkg/osbuild/grub2_stage.go
@@ -18,7 +18,7 @@ import (
 type GRUB2StageOptions struct {
 	CompatVersion      int          `json:"compat_version,omitempty"`
 	RootFilesystemUUID uuid.UUID    `json:"root_fs_uuid"`
-	BootFilesystemUUID *uuid.UUID   `json:"boot_fs_uuid,omitempty"`
+	BootFilesystemUUID *string      `json:"boot_fs_uuid,omitempty"`
 	KernelOptions      string       `json:"kernel_opts,omitempty"`
 	Legacy             string       `json:"legacy,omitempty"`
 	UEFI               *GRUB2UEFI   `json:"uefi,omitempty"`
@@ -94,7 +94,12 @@ func NewGrub2StageOptions(pt *disk.PartitionTable,
 	}
 
 	if bootFs := pt.FindMountableOnPlain("/boot"); bootFs != nil {
-		bootFsUUID := uuid.MustParse(bootFs.GetFSSpec().UUID)
+		bootFsUUID := bootFs.GetFSSpec().UUID
+		// validate the UUID but only when it's not vfat since vfat doesn't use actual
+		// UUIDs
+		if bootFs.GetFSType() != "vfat" {
+			bootFsUUID = uuid.MustParse(bootFsUUID).String()
+		}
 		stageOptions.BootFilesystemUUID = &bootFsUUID
 	}
 

--- a/pkg/osbuild/grub2_stage_test.go
+++ b/pkg/osbuild/grub2_stage_test.go
@@ -4,6 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/disk"
 )
 
 func TestNewGRUB2Stage(t *testing.T) {
@@ -13,4 +17,101 @@ func TestNewGRUB2Stage(t *testing.T) {
 	}
 	actualStage := NewGRUB2Stage(&GRUB2StageOptions{})
 	assert.Equal(t, expectedStage, actualStage)
+}
+
+func makePartitionTable(rootUUID string, boot *disk.Filesystem) *disk.PartitionTable {
+	partitions := []disk.Partition{
+		{
+			Type: disk.FilesystemDataGUID,
+			UUID: disk.RootPartitionUUID,
+			Payload: &disk.Filesystem{
+				Type:       "xfs",
+				UUID:       rootUUID,
+				Mountpoint: "/",
+			},
+		},
+	}
+
+	if boot != nil {
+		partitions = append(partitions, disk.Partition{
+			Type:    disk.FilesystemDataGUID,
+			Payload: boot,
+		})
+	}
+
+	return &disk.PartitionTable{
+		Type:       disk.PT_GPT,
+		Partitions: partitions,
+	}
+}
+
+func TestNewGrub2StageOptions(t *testing.T) {
+	rootUUID := "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+
+	t.Run("ext4 boot partition", func(t *testing.T) {
+		bootUUID := "dbd21911-1c4e-4107-8a9f-14fe6e751358"
+		pt := makePartitionTable(rootUUID, &disk.Filesystem{
+			Type:       "ext4",
+			UUID:       bootUUID,
+			Mountpoint: "/boot",
+		})
+
+		opts := NewGrub2StageOptions(pt, "root=/dev/sda2", "5.14.0", true, "", "fedora", true)
+
+		require.NotNil(t, opts.BootFilesystemUUID)
+		assert.Equal(t, bootUUID, *opts.BootFilesystemUUID)
+	})
+
+	t.Run("vfat boot partition", func(t *testing.T) {
+		vfatSerial := "7B77-95E7"
+		pt := makePartitionTable(rootUUID, &disk.Filesystem{
+			Type:       "vfat",
+			UUID:       vfatSerial,
+			Mountpoint: "/boot",
+		})
+
+		opts := NewGrub2StageOptions(pt, "root=/dev/sda2", "5.14.0", true, "", "fedora", true)
+
+		require.NotNil(t, opts.BootFilesystemUUID)
+		assert.Equal(t, vfatSerial, *opts.BootFilesystemUUID)
+	})
+
+	t.Run("no boot partition", func(t *testing.T) {
+		pt := makePartitionTable(rootUUID, nil)
+
+		opts := NewGrub2StageOptions(pt, "root=/dev/sda2", "5.14.0", true, "", "fedora", true)
+
+		assert.Nil(t, opts.BootFilesystemUUID)
+	})
+
+	t.Run("ext4 boot with invalid UUID panics", func(t *testing.T) {
+		pt := makePartitionTable(rootUUID, &disk.Filesystem{
+			Type:       "ext4",
+			UUID:       "not-a-uuid",
+			Mountpoint: "/boot",
+		})
+
+		assert.Panics(t, func() {
+			NewGrub2StageOptions(pt, "root=/dev/sda2", "5.14.0", true, "", "fedora", true)
+		})
+	})
+
+	t.Run("common fields are set correctly", func(t *testing.T) {
+		pt := makePartitionTable(rootUUID, nil)
+
+		opts := NewGrub2StageOptions(pt, "console=ttyS0", "5.14.0", true, "i386-pc", "fedora", true)
+
+		assert.Equal(t, 2, opts.CompatVersion)
+		assert.Equal(t, rootUUID, opts.RootFilesystemUUID.String())
+		assert.Equal(t, "console=ttyS0", opts.KernelOptions)
+		assert.Equal(t, "i386-pc", opts.Legacy)
+		assert.Equal(t, common.ToPtr(false), opts.WriteCmdLine)
+		assert.Equal(t, "ffffffffffffffffffffffffffffffff-5.14.0", opts.SavedEntry)
+		require.NotNil(t, opts.Config)
+		assert.Equal(t, "saved", opts.Config.Default)
+		require.NotNil(t, opts.UEFI)
+		assert.Equal(t, "fedora", opts.UEFI.Vendor)
+		assert.True(t, opts.UEFI.Install)
+		assert.True(t, opts.UEFI.Unified)
+	})
 }


### PR DESCRIPTION
The grub2 stage implementation here panicked on non-UUID values for the boot filesystem. When `/boot` is VFAT the UUID won't be an actual UUID.

In `osbuild` we already accept both values. Let's allow both values here as well but still validate the UUID as we did before when it's *not* VFAT.

Note that according to the bootloader specification [1] /boot 'SHOULD' be VFAT.

Also note that this only helps with XBOOTLDR being VFAT. We probably need to adjust the code more in the future when we mount the ESP to /boot. Probably by expanding it to check if it's the ESP in which case we *don't* inject the boot fs uuid at all?