### PR TITLE
container: guess at mime type

### DIFF
--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -497,7 +497,6 @@ func (cl *Client) resolveRawManifest(ctx context.Context, rm RawManifest, local 
 			return resolvedIds{}, nil, nil
 		}
 		imageID = m.ConfigInfo().Digest
-
 	default:
 		return resolvedIds{}, nil, fmt.Errorf("unsupported manifest format '%s'", rm.MimeType)
 	}
@@ -620,6 +619,12 @@ func parseMediaType(raw []byte) (string, error) {
 
 	if p.SchemaVersion != 2 {
 		return "", fmt.Errorf("unknown schema version: %d", p.SchemaVersion)
+	}
+
+	// we only guess when the field was omitted (it's optional), note that it
+	// might still be unknown after this guess but at least the odds are better
+	if p.MediaType == "" {
+		p.MediaType = manifest.GuessMIMEType(raw)
 	}
 
 	return p.MediaType, nil


### PR DESCRIPTION
When switching to the skopeo based resolver it was missed that the media type property is optional. If this is the case then the `containers/image` library guesses at the type since we don't always have access to the transfer information.

Let's call that function directly here; but only if it wasn't set initially.

When we drop `containers/image` dependencies entirely this function will need to be interned.

---

Resolves: https://github.com/osbuild/image-builder-cli/issues/527