### PR TITLE
loader: allow custom path

### DIFF
--- a/pkg/distro/defs/export_test.go
+++ b/pkg/distro/defs/export_test.go
@@ -13,3 +13,11 @@ func MockDataFS(path string) (restore func()) {
 		defaultDataFS = saved
 	}
 }
+
+func LoaderForTest(path string) *Loader {
+	return NewLoader(os.DirFS(path))
+}
+
+func ClearLoader(d *DistroYAML) {
+	d.loader = nil
+}

--- a/pkg/distro/defs/id.go
+++ b/pkg/distro/defs/id.go
@@ -59,10 +59,8 @@ func matchAndNormalize(reStr, nameVer string) (string, error) {
 // ParseID parse the given nameVer into a distro.ID. It will also
 // apply normalizations from the distros `match` rule. This is needed
 // to support distro names like "rhel-810" without dots.
-//
-// If no match is found it will "nil" and no error (
-func ParseID(nameVer string) (*distro.ID, error) {
-	distros, err := loadDistros()
+func (l *Loader) ParseID(nameVer string) (*distro.ID, error) {
+	distros, err := l.loadDistros()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -43,14 +43,26 @@ var (
 var defaultDataFS fs.FS = distrodefs.Data
 
 func dataFS() fs.FS {
-	// XXX: this is a short term measure, pass a set of
-	// searchPaths down the stack instead
 	dataFS := defaultDataFS
 	if overrideDir := experimentalflags.String("yamldir"); overrideDir != "" {
 		olog.Printf("WARNING: using experimental override dir %q", overrideDir)
 		dataFS = os.DirFS(overrideDir)
 	}
 	return dataFS
+}
+
+type Loader struct {
+	fs fs.FS
+}
+
+func NewLoader(fsys fs.FS) *Loader {
+	return &Loader{fs: fsys}
+}
+
+// BuiltinLoader returns a Loader for the embedded distrodefs FS,
+// with the experimental yamldir override applied if it exists
+func BuiltinLoader() *Loader {
+	return NewLoader(dataFS())
 }
 
 // distrosYAML defines all supported YAML based distributions, since this can
@@ -109,7 +121,8 @@ type DistroYAML struct {
 	DistroLike manifest.Distro `yaml:"distro_like"`
 
 	// set by the loader
-	ID distro.ID
+	ID     distro.ID
+	loader *Loader
 
 	Tweaks *distro.Tweaks `yaml:"tweaks"`
 }
@@ -180,8 +193,8 @@ func (d *DistroYAML) GetTweaks() *distro.Tweaks {
 // are appended together.
 // Note that files are read separately from each other, so anchors and other
 // references can only be done within the same file.
-func loadDistros() (*distrosYAML, error) {
-	dents, err := fs.Glob(dataFS(), "*.yaml")
+func (l *Loader) loadDistros() (*distrosYAML, error) {
+	dents, err := fs.Glob(l.fs, "*.yaml")
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +202,7 @@ func loadDistros() (*distrosYAML, error) {
 	var allDistros distrosYAML
 
 	for _, name := range dents {
-		f, err := dataFS().Open(name)
+		f, err := l.fs.Open(name)
 		if err != nil {
 			return nil, err
 		}
@@ -217,7 +230,11 @@ func loadDistros() (*distrosYAML, error) {
 // with the way distrofactory/reporegistry work which is by defining
 // distros via repository files.
 func NewDistroYAML(nameVer string) (*DistroYAML, error) {
-	foundDistro, err := LoadDistroWithoutImageTypes(nameVer)
+	return BuiltinLoader().NewDistroYAML(nameVer)
+}
+
+func (l *Loader) NewDistroYAML(nameVer string) (*DistroYAML, error) {
+	foundDistro, err := l.LoadDistroWithoutImageTypes(nameVer)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +249,11 @@ func NewDistroYAML(nameVer string) (*DistroYAML, error) {
 }
 
 func LoadDistroWithoutImageTypes(nameVer string) (*DistroYAML, error) {
-	distros, err := loadDistros()
+	return BuiltinLoader().LoadDistroWithoutImageTypes(nameVer)
+}
+
+func (l *Loader) LoadDistroWithoutImageTypes(nameVer string) (*DistroYAML, error) {
+	distros, err := l.loadDistros()
 	if err != nil {
 		return nil, err
 	}
@@ -265,6 +286,7 @@ func LoadDistroWithoutImageTypes(nameVer string) (*DistroYAML, error) {
 		return nil, err
 	}
 	foundDistro.ID = *id
+	foundDistro.loader = l
 	if err := foundDistro.runTemplates(*id); err != nil {
 		return nil, err
 	}
@@ -273,13 +295,17 @@ func LoadDistroWithoutImageTypes(nameVer string) (*DistroYAML, error) {
 }
 
 func (d *DistroYAML) LoadImageTypes() error {
+	if d.loader == nil {
+		return fmt.Errorf("called on DistroYAML without a loader")
+	}
+
 	var configs []imageTypesYAML
 	var err error
 
 	if yamlplus := experimentalflags.Bool("yamlplus"); yamlplus {
-		configs, err = loadImageTypeConfigsPlus(d)
+		configs, err = d.loader.loadImageTypeConfigsPlus(d)
 	} else {
-		configs, err = loadImageTypeConfigs(d)
+		configs, err = d.loader.loadImageTypeConfigs(d)
 	}
 
 	if err != nil {
@@ -288,18 +314,18 @@ func (d *DistroYAML) LoadImageTypes() error {
 	return mergeImageTypeConfigs(d, configs)
 }
 
-func loadImageTypeConfigs(d *DistroYAML) ([]imageTypesYAML, error) {
-	files, err := fs.Glob(dataFS(), filepath.Join(d.DefsPath, "[^_]*.yaml"))
+func (l *Loader) loadImageTypeConfigs(d *DistroYAML) ([]imageTypesYAML, error) {
+	files, err := fs.Glob(l.fs, filepath.Join(d.DefsPath, "[^_]*.yaml"))
 	if err != nil {
 		return nil, err
 	}
 
 	sharedPath := filepath.Join(d.DefsPath, "_shared.yaml")
-	sharedContent, _ := fs.ReadFile(dataFS(), sharedPath)
+	sharedContent, _ := fs.ReadFile(l.fs, sharedPath)
 
 	configs := make([]imageTypesYAML, 0, len(files))
 	for _, fileName := range files {
-		f, err := dataFS().Open(fileName)
+		f, err := l.fs.Open(fileName)
 		if err != nil {
 			return nil, err
 		}
@@ -325,18 +351,18 @@ func loadImageTypeConfigs(d *DistroYAML) ([]imageTypesYAML, error) {
 	return configs, nil
 }
 
-func loadImageTypeConfigsPlus(d *DistroYAML) ([]imageTypesYAML, error) {
-	files, err := fs.Glob(dataFS(), filepath.Join(d.DefsPath, "[^_]*.yaml"))
+func (l *Loader) loadImageTypeConfigsPlus(d *DistroYAML) ([]imageTypesYAML, error) {
+	files, err := fs.Glob(l.fs, filepath.Join(d.DefsPath, "[^_]*.yaml"))
 	if err != nil {
 		return nil, err
 	}
 
 	commonPath := filepath.Join(d.DefsPath, "_common.yaml")
-	commonContent, _ := fs.ReadFile(dataFS(), commonPath)
+	commonContent, _ := fs.ReadFile(l.fs, commonPath)
 
 	configs := make([]imageTypesYAML, 0, len(files))
 	for _, fileName := range files {
-		f, err := dataFS().Open(fileName)
+		f, err := l.fs.Open(fileName)
 		if err != nil {
 			return nil, err
 		}
@@ -347,7 +373,7 @@ func loadImageTypeConfigsPlus(d *DistroYAML) ([]imageTypesYAML, error) {
 			reader = io.MultiReader(bytes.NewReader(commonContent), f)
 		}
 
-		loader := yamlplus.NewLoader(dataFS())
+		loader := yamlplus.NewLoader(l.fs)
 		if err = loader.RegisterRecursively("."); err != nil {
 			return nil, err
 		}

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -1092,6 +1092,7 @@ func TestDistrosLoadingExact(t *testing.T) {
 
 	dist, err := defs.NewDistroYAML("fedora-43")
 	require.NoError(t, err)
+	defs.ClearLoader(dist)
 	assert.Equal(t, dist, &defs.DistroYAML{
 		Name:             "fedora-43",
 		Preview:          true,
@@ -1116,6 +1117,7 @@ func TestDistrosLoadingExact(t *testing.T) {
 
 	dist, err = defs.NewDistroYAML("centos-10")
 	require.NoError(t, err)
+	defs.ClearLoader(dist)
 	assert.Equal(t, dist, &defs.DistroYAML{
 		Name:             "centos-10",
 		Vendor:           "centos",
@@ -1136,6 +1138,7 @@ func TestDistrosLoadingFactoryCompat(t *testing.T) {
 
 	dist, err := defs.NewDistroYAML("rhel-10.1")
 	require.NoError(t, err)
+	defs.ClearLoader(dist)
 	assert.Equal(t, dist, &defs.DistroYAML{
 		Name:             "rhel-10.1",
 		Match:            "rhel-10.*",
@@ -1157,6 +1160,7 @@ func TestDistrosLoadingFactoryCompat(t *testing.T) {
 
 	dist, err = defs.NewDistroYAML("fedora-40")
 	require.NoError(t, err)
+	defs.ClearLoader(dist)
 	assert.Equal(t, dist, &defs.DistroYAML{
 		Name:             "fedora-40",
 		Match:            "fedora-[0-9]*",
@@ -1553,6 +1557,7 @@ distros:
 	} {
 		dist, err := defs.NewDistroYAML(tc.nameVer)
 		require.NoError(t, err)
+		defs.ClearLoader(dist)
 		assert.Equal(t, dist, &defs.DistroYAML{
 			Name:             tc.expectedDistroNameVer,
 			Match:            `(?P<name>rhel)-(?P<major>8)\.?(?P<minor>[0-9]+)`,
@@ -1563,4 +1568,77 @@ distros:
 			ID:               *common.Must(distro.ParseID(tc.expectedDistroNameVer)),
 		})
 	}
+}
+
+func TestLoaderNewDistroYAML(t *testing.T) {
+	baseDir := makeFakeDistrosYAML(t, fakeDistrosYAML, "")
+	loader := defs.LoaderForTest(baseDir)
+
+	dist, err := loader.NewDistroYAML("fedora-43")
+	require.NoError(t, err)
+	require.NotNil(t, dist)
+	assert.Equal(t, "fedora-43", dist.Name)
+	assert.Equal(t, distro.ID{Name: "fedora", MajorVersion: 43, MinorVersion: -1}, dist.ID)
+}
+
+func TestLoaderLoadDistroWithoutImageTypes(t *testing.T) {
+	baseDir := makeFakeDistrosYAML(t, fakeDistrosYAML, "")
+	loader := defs.LoaderForTest(baseDir)
+
+	dist, err := loader.LoadDistroWithoutImageTypes("rhel-10.1")
+	require.NoError(t, err)
+	require.NotNil(t, dist)
+	assert.Equal(t, "rhel-10.1", dist.Name)
+	assert.Equal(t, distro.ID{Name: "rhel", MajorVersion: 10, MinorVersion: 1}, dist.ID)
+}
+
+func TestLoaderParseID(t *testing.T) {
+	baseDir := makeFakeDistrosYAML(t, fakeDistrosYAML, "")
+	loader := defs.LoaderForTest(baseDir)
+
+	id, err := loader.ParseID("fedora-42")
+	require.NoError(t, err)
+	require.NotNil(t, id)
+	assert.Equal(t, &distro.ID{Name: "fedora", MajorVersion: 42, MinorVersion: -1}, id)
+}
+
+func TestLoaderNotFound(t *testing.T) {
+	baseDir := makeFakeDistrosYAML(t, fakeDistrosYAML, "")
+	loader := defs.LoaderForTest(baseDir)
+
+	dist, err := loader.NewDistroYAML("nonexistent-1")
+	require.NoError(t, err)
+	assert.Nil(t, dist)
+}
+
+func TestLoaderIsolation(t *testing.T) {
+	baseDir1 := makeFakeDistrosYAML(t, `
+distros:
+ - name: distro-a-1
+   defs_path: distro-a/
+`, "")
+	baseDir2 := makeFakeDistrosYAML(t, `
+distros:
+ - name: distro-b-1
+   defs_path: distro-b/
+`, "")
+
+	loader1 := defs.LoaderForTest(baseDir1)
+	loader2 := defs.LoaderForTest(baseDir2)
+
+	d1, err := loader1.NewDistroYAML("distro-a-1")
+	require.NoError(t, err)
+	require.NotNil(t, d1)
+
+	d2, err := loader1.NewDistroYAML("distro-b-1")
+	require.NoError(t, err)
+	assert.Nil(t, d2, "loader1 should not find distro-b")
+
+	d3, err := loader2.NewDistroYAML("distro-b-1")
+	require.NoError(t, err)
+	require.NotNil(t, d3)
+
+	d4, err := loader2.NewDistroYAML("distro-a-1")
+	require.NoError(t, err)
+	assert.Nil(t, d4, "loader2 should not find distro-a")
 }

--- a/pkg/distro/generic/bootc.go
+++ b/pkg/distro/generic/bootc.go
@@ -51,6 +51,10 @@ const (
 // ref, use the [github.com/osbuild/images/pkg/bootc.Container] type and its
 // methods.
 func NewBootc(name string, cinfo *bootc.Info) (*BootcDistro, error) {
+	return NewBootcWithLoader(defs.BuiltinLoader(), name, cinfo)
+}
+
+func NewBootcWithLoader(loader *defs.Loader, name string, cinfo *bootc.Info) (*BootcDistro, error) {
 	if cinfo == nil {
 		return nil, errors.New("failed to initialize bootc distro: container info is empty")
 	}
@@ -131,7 +135,7 @@ func NewBootc(name string, cinfo *bootc.Info) (*BootcDistro, error) {
 	}
 
 	// load image types from bootc-generic-1
-	distroYAML, err := defs.LoadDistroWithoutImageTypes("bootc-generic-1")
+	distroYAML, err := loader.LoadDistroWithoutImageTypes("bootc-generic-1")
 	if err != nil {
 		return nil, fmt.Errorf("failed to load bootc image types: %w", err)
 	}

--- a/pkg/distro/generic/bootc_imagetype.go
+++ b/pkg/distro/generic/bootc_imagetype.go
@@ -511,14 +511,14 @@ func (t *bootcImageType) manifestForGenericISO(options distro.ImageOptions, rng 
 // if no direct match can be found it will it will use the ID_LIKE.
 // This should ensure we work on every bootc image that puts a correct
 // ID_LIKE= in /etc/os-release
-func newDistroYAMLFrom(sourceInfo *osinfo.Info) (*defs.DistroYAML, *distro.ID, error) {
+func newDistroYAMLFrom(loader *defs.Loader, sourceInfo *osinfo.Info) (*defs.DistroYAML, *distro.ID, error) {
 	for _, distroID := range append([]string{sourceInfo.OSRelease.ID}, sourceInfo.OSRelease.IDLike...) {
 		nameVer := fmt.Sprintf("%s-%s", distroID, sourceInfo.OSRelease.VersionID)
 		id, err := distro.ParseID(nameVer)
 		if err != nil {
 			return nil, nil, err
 		}
-		distroYAML, err := defs.NewDistroYAML(nameVer)
+		distroYAML, err := loader.NewDistroYAML(nameVer)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -545,7 +545,7 @@ func (t *bootcImageType) manifestForLegacyISO(bp *blueprint.Blueprint, options d
 	archStr := t.arch.Name()
 	sourceInfo := bd.sourceInfo
 
-	distroYAML, id, err := newDistroYAMLFrom(bd.sourceInfo)
+	distroYAML, id, err := newDistroYAMLFrom(defs.BuiltinLoader(), bd.sourceInfo)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/distro/generic/distro.go
+++ b/pkg/distro/generic/distro.go
@@ -47,7 +47,11 @@ type distribution struct {
 }
 
 func New(nameVer string) (distro.Distro, error) {
-	distroYAML, err := defs.NewDistroYAML(nameVer)
+	return NewWithLoader(defs.BuiltinLoader(), nameVer)
+}
+
+func NewWithLoader(loader *defs.Loader, nameVer string) (distro.Distro, error) {
+	distroYAML, err := loader.NewDistroYAML(nameVer)
 	if err != nil {
 		return nil, err
 	}
@@ -253,12 +257,18 @@ func (a *architecture) Distro() distro.Distro {
 }
 
 func DistroFactory(idStr string) distro.Distro {
-	distro, err := New(idStr)
-	if errors.Is(err, ErrDistroNotFound) {
-		return nil
+	return DistroFactoryWithLoader(defs.BuiltinLoader())(idStr)
+}
+
+func DistroFactoryWithLoader(loader *defs.Loader) func(string) distro.Distro {
+	return func(idStr string) distro.Distro {
+		d, err := NewWithLoader(loader, idStr)
+		if errors.Is(err, ErrDistroNotFound) {
+			return nil
+		}
+		if err != nil {
+			panic(fmt.Errorf("%w with distro %s", err, idStr))
+		}
+		return d
 	}
-	if err != nil {
-		panic(fmt.Errorf("%w with distro %s", err, idStr))
-	}
-	return distro
 }

--- a/pkg/distrofactory/distrofactory.go
+++ b/pkg/distrofactory/distrofactory.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 
 	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/distro/generic"
 	"github.com/osbuild/images/pkg/distro/test_distro"
 )
@@ -106,6 +107,14 @@ func New(factories ...FactoryFunc) *Factory {
 func NewDefault() *Factory {
 	return New(
 		generic.DistroFactory,
+	)
+}
+
+// NewDefaultWithLoader returns a Factory that loads distro definitions from
+// the given Loader's filesystem.
+func NewDefaultWithLoader(loader *defs.Loader) *Factory {
+	return New(
+		generic.DistroFactoryWithLoader(loader),
 	)
 }
 

--- a/pkg/distrofactory/distrofactory_test.go
+++ b/pkg/distrofactory/distrofactory_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/images/pkg/distro/defs"
 )
 
 func TestGetDistroDefaultList(t *testing.T) {
@@ -73,6 +75,22 @@ func TestGetDistroDefaultList(t *testing.T) {
 		})
 	}
 
+}
+
+func TestNewDefaultWithLoader(t *testing.T) {
+	loader := defs.BuiltinLoader()
+	df := NewDefaultWithLoader(loader)
+
+	d := df.GetDistro("rhel-10.1")
+	assert.NotNil(t, d)
+	assert.Equal(t, "rhel-10.1", d.Name())
+
+	d = df.GetDistro("fedora-42")
+	assert.NotNil(t, d)
+	assert.Equal(t, "fedora-42", d.Name())
+
+	d = df.GetDistro("nonexistent-1")
+	assert.Nil(t, d)
 }
 
 func TestGetDistroDefaultListWithAliases(t *testing.T) {

--- a/pkg/distroidparser/idparser.go
+++ b/pkg/distroidparser/idparser.go
@@ -58,7 +58,12 @@ func (p *Parser) Standardize(idStr string) (string, error) {
 }
 
 func NewDefaultParser() *Parser {
+	return NewParserWithLoader(defs.BuiltinLoader())
+}
+
+// Parser but *with* a loader set, instead of the default
+func NewParserWithLoader(loader *defs.Loader) *Parser {
 	return New(
-		defs.ParseID,
+		loader.ParseID,
 	)
 }

--- a/pkg/distroidparser/idparser_test.go
+++ b/pkg/distroidparser/idparser_test.go
@@ -194,9 +194,23 @@ func TestDefaltParser(t *testing.T) {
 }
 
 func TestParserDoubleMatch(t *testing.T) {
-	Parser := New(defs.ParseID, defs.ParseID)
+	loader := defs.BuiltinLoader()
+	Parser := New(loader.ParseID, loader.ParseID)
 
 	require.Panics(t, func() {
 		_, _ = Parser.Parse("rhel-90")
 	}, "Parser should panic when rhel-9.0 is matched by multiple parsers")
+}
+
+func TestNewParserWithLoader(t *testing.T) {
+	loader := defs.BuiltinLoader()
+	parser := NewParserWithLoader(loader)
+
+	id, err := parser.Parse("rhel-810")
+	require.NoError(t, err)
+	require.Equal(t, &distro.ID{Name: "rhel", MajorVersion: 8, MinorVersion: 10}, id)
+
+	std, err := parser.Standardize("rhel-810")
+	require.NoError(t, err)
+	require.Equal(t, "rhel-8.10", std)
 }


### PR DESCRIPTION
Currently our definition loader always uses the embedded data filesystem exposed by `dataFS()`. It is possible to switch what `dataFS()` returns with an experimental environment flag.

We want to make loading of definitions a little bit less experimental by allowing a definition path to be set by calling code; instead of the library reading the environment.

A hurdle was that `distro.ParseID` loaded the definitions directly.

In this commit I introduce a new `Loader` type that embeds an `fs.FS`, `ParseID` becomes a method on this `Loader`. Where necessary old constructors that do not take a loader will automatically call the new WithLoader variants by passing the `BuiltinLoader` (which gives the same behavior).

This will allow us to pass custom paths in `image-builder` and `osbuild-composer` through (for example) a `--force-defs-path` and the potential to start shipping our definitions in a subpackage that installs into `/usr` which would allow for much easier downstream patching *and* other distributions shipping their own custom definition packages.