### PR TITLE
many: fix non-determistic manifest generation

### DIFF
--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -2,7 +2,9 @@ package generic
 
 import (
 	"fmt"
+	"maps"
 	"math/rand"
+	"slices"
 	"strings"
 	"sync"
 
@@ -242,8 +244,8 @@ func osCustomizations(t *imageType, osPackageSet rpmmd.PackageSet, options distr
 		osc.Files = append(osc.Files, gpgKeyFiles...)
 	}
 
-	for filename, repos := range yumRepos {
-		osc.YUMRepos = append(osc.YUMRepos, osbuild.NewYumReposStageOptions(filename, repos))
+	for _, filename := range slices.Sorted(maps.Keys(yumRepos)) {
+		osc.YUMRepos = append(osc.YUMRepos, osbuild.NewYumReposStageOptions(filename, yumRepos[filename]))
 	}
 
 	if oscapConfig := c.GetOpenSCAP(); oscapConfig != nil {

--- a/pkg/manifest/bootc_pxetree.go
+++ b/pkg/manifest/bootc_pxetree.go
@@ -2,6 +2,8 @@ package manifest
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/osbuild/images/internal/common"
@@ -237,7 +239,7 @@ func (p *BootcPXETree) getChmodFiles() map[string]osbuild.ChmodStagePathOptions 
 // GetTarFiles returns the list of files in the tree to be included in a tar
 func (p *BootcPXETree) GetTarFiles() []string {
 	var files []string
-	for f := range p.getChmodFiles() {
+	for _, f := range slices.Sorted(maps.Keys(p.getChmodFiles())) {
 		// Tar needs relative paths
 		files = append(files, strings.TrimPrefix(f, "/"))
 	}

--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -3,6 +3,8 @@ package manifest
 import (
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
@@ -356,7 +358,8 @@ func (p *BuildrootFromContainer) serialize() (osbuild.Pipeline, error) {
 		pipeline.AddStage(stage)
 	}
 
-	for copyFilesFrom, copyFiles := range p.copyFilesFrom {
+	for _, copyFilesFrom := range slices.Sorted(maps.Keys(p.copyFilesFrom)) {
+		copyFiles := p.copyFilesFrom[copyFilesFrom]
 		inputName := "copy-tree"
 		paths := []osbuild.CopyStagePath{}
 		for _, copyPath := range copyFiles {


### PR DESCRIPTION
We want manifests to be generated in a deterministic way. A common source of non-determinism is Go is iterating over maps - Go actually doesn't guarantee the iteration order. Thus, when creating an array from a map, we always need to sort the map deterministically before creating the array.

My research found 3 places like this in the codebase, and this commit fixes them.