### PR TITLE
test/imgtestlib: boot test network installer on RHEL 10.2

### DIFF
--- a/test/scripts/imgtestlib/core.py
+++ b/test/scripts/imgtestlib/core.py
@@ -402,7 +402,7 @@ def can_boot_test(manifest_fname, manifest_data, image_type, arch, distro, bluep
             return False
 
     if image_type in ["network-installer", "everything-network-installer", "server-network-installer"]:
-        if distro in ["rhel-10.1", "rhel-10.2", "rhel-10.3"]:
+        if distro in ["rhel-10.1", "rhel-10.3"]:  # 10.1 should be removed soon
             print("  not bootable: rhel network-installer tests have incomplete repos in nightly snapshot"
                   "and won't install")
             return False


### PR DESCRIPTION
Originally disabled because beta repos were causing issues [1].  Both distro versions are GA now and should work.

[1] https://github.com/osbuild/images/pull/2044#issue-3667039388