### PR TITLE
many: initial `systemd-boot` support

### DIFF
--- a/pkg/disk/partition.go
+++ b/pkg/disk/partition.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/datasizes"
@@ -101,7 +102,7 @@ func (p *Partition) IsBIOSBoot() bool {
 		return false
 	}
 
-	return p.Type == BIOSBootPartitionGUID || p.Type == BIOSBootPartitionDOSID
+	return strings.EqualFold(p.Type, BIOSBootPartitionGUID) || p.Type == BIOSBootPartitionDOSID
 }
 
 func (p *Partition) IsPReP() bool {
@@ -109,7 +110,7 @@ func (p *Partition) IsPReP() bool {
 		return false
 	}
 
-	return p.Type == PRepPartitionDOSID || p.Type == PRePartitionGUID
+	return p.Type == PRepPartitionDOSID || strings.EqualFold(p.Type, PRePartitionGUID)
 }
 
 func (p *Partition) MarshalJSON() ([]byte, error) {

--- a/pkg/manifest/export_test.go
+++ b/pkg/manifest/export_test.go
@@ -31,19 +31,20 @@ func (p *OS) AddStagesForAllFilesAndInlineData(pipeline *osbuild.Pipeline, files
 // TODO: make all tests external and define this only in the manifest_test
 // package.
 func NewTestOS() *OS {
+	return NewTestOSWithPlatform(&platform.Data{
+		Arch:         arch.ARCH_X86_64,
+		BIOSPlatform: "i386-pc",
+	})
+}
+
+func NewTestOSWithPlatform(pf *platform.Data) *OS {
 	repos := []rpmmd.RepoConfig{}
 	m := New()
 	runner := &runner.Fedora{Version: 38}
 	build := NewBuild(&m, runner, repos, nil)
 	build.Checkpoint()
 
-	// create an x86_64 platform with bios boot
-	platform := &platform.Data{
-		Arch:         arch.ARCH_X86_64,
-		BIOSPlatform: "i386-pc",
-	}
-
-	os := NewOS(build, platform, repos)
+	os := NewOS(build, pf, repos)
 
 	return os
 }

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -568,13 +568,38 @@ func (p *OS) serialize() (osbuild.Pipeline, error) {
 	}
 	baseRPMOptions.InstallLangs = p.OSCustomizations.InstallLangs
 
-	if p.platform.GetBootloader() == platform.BOOTLOADER_UKI && p.PartitionTable != nil {
+	bootloader := p.platform.GetBootloader()
+
+	if bootloader == platform.BOOTLOADER_UKI && p.PartitionTable != nil {
 		espMountpoint, err := findESPMountpoint(p.PartitionTable)
 		if err != nil {
 			return osbuild.Pipeline{}, err
 		}
 		baseRPMOptions.KernelInstallEnv = &osbuild.KernelInstallEnv{
 			BootRoot: espMountpoint,
+		}
+	}
+
+	if bootloader == platform.BOOTLOADER_SYSTEMD && p.PartitionTable != nil {
+		// ESP is required
+		espMountpoint, err := findESPMountpoint(p.PartitionTable)
+		if err != nil {
+			return osbuild.Pipeline{}, err
+		}
+
+		// XBOOTLDR is optional
+		xbootldrMountpoint, err := findXBootLDRMountpoint(p.PartitionTable)
+		if err != nil {
+			xbootldrMountpoint = ""
+		}
+
+		bootRoot := espMountpoint
+		if xbootldrMountpoint != "" {
+			bootRoot = xbootldrMountpoint
+		}
+
+		baseRPMOptions.KernelInstallEnv = &osbuild.KernelInstallEnv{
+			BootRoot: bootRoot,
 		}
 	}
 
@@ -585,12 +610,18 @@ func (p *OS) serialize() (osbuild.Pipeline, error) {
 	pipeline.AddStages(rpmStages...)
 
 	if !p.OSCustomizations.NoBLS {
+		fixBLSOptions := &osbuild.FixBLSStageOptions{}
+
 		// If the /boot is on a separate partition, the prefix for the BLS stage must be ""
-		if p.PartitionTable == nil || p.PartitionTable.FindMountableOnPlain("/boot") == nil {
-			pipeline.AddStage(osbuild.NewFixBLSStage(&osbuild.FixBLSStageOptions{}))
-		} else {
-			pipeline.AddStage(osbuild.NewFixBLSStage(&osbuild.FixBLSStageOptions{Prefix: common.ToPtr("")}))
+		if p.PartitionTable != nil && p.PartitionTable.FindMountableOnPlain("/boot") != nil {
+			fixBLSOptions.Prefix = common.ToPtr("")
 		}
+
+		if bootloader == platform.BOOTLOADER_SYSTEMD {
+			fixBLSOptions.RequireBootPrefix = common.ToPtr(false)
+		}
+
+		pipeline.AddStage(osbuild.NewFixBLSStage(fixBLSOptions))
 	}
 
 	if len(p.containerSpecs) > 0 {
@@ -1181,6 +1212,27 @@ func findESPMountpoint(pt *disk.PartitionTable) (string, error) {
 	}
 
 	return espMountpoint, nil
+}
+
+func findXBootLDRMountpoint(pt *disk.PartitionTable) (string, error) {
+	xbootldrMountpoint := ""
+	_ = pt.ForEachMountable(func(mnt disk.Mountable, path []disk.Entity) error {
+		parent := path[1]
+		if partition, ok := parent.(*disk.Partition); ok {
+			if partition.Type != disk.XBootLDRPartitionGUID {
+				return nil
+			}
+
+			xbootldrMountpoint = mnt.GetMountpoint()
+		}
+		return nil
+	})
+
+	if xbootldrMountpoint == "" {
+		return "", fmt.Errorf("failed to find mountpoint for XBOOTLDR when generating boot CSV file")
+	}
+
+	return xbootldrMountpoint, nil
 }
 
 // The 99-uki-uefi-setup.install script, prior to v25.3 of the uki-direct

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -1197,7 +1197,7 @@ func findESPMountpoint(pt *disk.PartitionTable) (string, error) {
 		parent := path[1]
 		if partition, ok := parent.(*disk.Partition); ok {
 			// ESP filesystem parent must be a plain partition
-			if partition.Type != disk.EFISystemPartitionGUID {
+			if !strings.EqualFold(partition.Type, disk.EFISystemPartitionGUID) {
 				return nil
 			}
 
@@ -1219,7 +1219,7 @@ func findXBootLDRMountpoint(pt *disk.PartitionTable) (string, error) {
 	_ = pt.ForEachMountable(func(mnt disk.Mountable, path []disk.Entity) error {
 		parent := path[1]
 		if partition, ok := parent.(*disk.Partition); ok {
-			if partition.Type != disk.XBootLDRPartitionGUID {
+			if !strings.EqualFold(partition.Type, disk.XBootLDRPartitionGUID) {
 				return nil
 			}
 

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/subscription"
 	"github.com/osbuild/images/pkg/depsolvednf"
+	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
@@ -875,5 +876,114 @@ func TestOSPackageSetChainStructure(t *testing.T) {
 					"package set %d Include mismatch", idx)
 			}
 		})
+	}
+}
+
+func makeSystemdBootPartitionTable() *disk.PartitionTable {
+	return &disk.PartitionTable{
+		Type: disk.PT_GPT,
+		Partitions: []disk.Partition{
+			{
+				Size: 200 * testdisk.MiB,
+				Type: disk.EFISystemPartitionGUID,
+				Payload: &disk.Filesystem{
+					Type:       "vfat",
+					Mountpoint: "/boot/efi",
+				},
+			},
+			{
+				Type: disk.FilesystemDataGUID,
+				Payload: &disk.Filesystem{
+					Type:       "ext4",
+					Mountpoint: "/",
+				},
+			},
+		},
+	}
+}
+
+func makeSystemdBootPartitionTableWithXBootLDR() *disk.PartitionTable {
+	return &disk.PartitionTable{
+		Type: disk.PT_GPT,
+		Partitions: []disk.Partition{
+			{
+				Size: 200 * testdisk.MiB,
+				Type: disk.EFISystemPartitionGUID,
+				Payload: &disk.Filesystem{
+					Type:       "vfat",
+					Mountpoint: "/boot/efi",
+				},
+			},
+			{
+				Size: 500 * testdisk.MiB,
+				Type: disk.XBootLDRPartitionGUID,
+				Payload: &disk.Filesystem{
+					Type:       "ext4",
+					Mountpoint: "/boot",
+				},
+			},
+			{
+				Type: disk.FilesystemDataGUID,
+				Payload: &disk.Filesystem{
+					Type:       "ext4",
+					Mountpoint: "/",
+				},
+			},
+		},
+	}
+}
+
+func TestOSPipelineSystemdBootFixBLS(t *testing.T) {
+	os := manifest.NewTestOSWithPlatform(&platform.Data{
+		Arch:       arch.ARCH_X86_64,
+		Bootloader: platform.BOOTLOADER_SYSTEMD,
+	})
+	os.PartitionTable = makeSystemdBootPartitionTable()
+
+	pipeline, err := os.Serialize()
+	require.NoError(t, err)
+
+	st := findStage("org.osbuild.fix-bls", pipeline.Stages)
+	require.NotNil(t, st)
+	opts := st.Options.(*osbuild.FixBLSStageOptions)
+	require.NotNil(t, opts.RequireBootPrefix)
+	assert.Equal(t, false, *opts.RequireBootPrefix)
+}
+
+func TestOSPipelineSystemdBootKernelInstallEnv(t *testing.T) {
+	os := manifest.NewTestOSWithPlatform(&platform.Data{
+		Arch:       arch.ARCH_X86_64,
+		Bootloader: platform.BOOTLOADER_SYSTEMD,
+	})
+	os.PartitionTable = makeSystemdBootPartitionTable()
+
+	pipeline, err := os.Serialize()
+	require.NoError(t, err)
+
+	rpmStages := findStages("org.osbuild.rpm", pipeline.Stages)
+	require.NotEmpty(t, rpmStages)
+	for _, st := range rpmStages {
+		opts := st.Options.(*osbuild.RPMStageOptions)
+		require.NotNil(t, opts.KernelInstallEnv)
+		assert.Equal(t, "/boot/efi", opts.KernelInstallEnv.BootRoot)
+	}
+}
+
+func TestOSPipelineSystemdBootKernelInstallEnvXBootLDR(t *testing.T) {
+	os := manifest.NewTestOSWithPlatform(&platform.Data{
+		Arch:       arch.ARCH_X86_64,
+		Bootloader: platform.BOOTLOADER_SYSTEMD,
+	})
+	os.PartitionTable = makeSystemdBootPartitionTableWithXBootLDR()
+
+	pipeline, err := os.Serialize()
+	require.NoError(t, err)
+
+	rpmStages := findStages("org.osbuild.rpm", pipeline.Stages)
+	require.NotEmpty(t, rpmStages)
+	for _, st := range rpmStages {
+		opts := st.Options.(*osbuild.RPMStageOptions)
+		require.NotNil(t, opts.KernelInstallEnv)
+		assert.Equal(t, "/boot", opts.KernelInstallEnv.BootRoot)
 	}
 }

--- a/pkg/manifest/raw.go
+++ b/pkg/manifest/raw.go
@@ -6,6 +6,7 @@ import (
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/artifact"
 	"github.com/osbuild/images/pkg/osbuild"
+	"github.com/osbuild/images/pkg/platform"
 )
 
 // A RawImage represents a raw image file which can be booted in a
@@ -111,6 +112,27 @@ func (p *RawImage) serialize() (osbuild.Pipeline, error) {
 		if grubLegacy := p.treePipeline.platform.GetBIOSPlatform(); grubLegacy != "" {
 			pipeline.AddStage(osbuild.NewGrub2InstStage(osbuild.NewGrub2InstStageOption(p.Filename(), pt, grubLegacy)))
 		}
+	}
+
+	if p.treePipeline.platform.GetBootloader() == platform.BOOTLOADER_SYSTEMD {
+		_, bootctlDevices, bootctlMounts := osbuild.GenCopyFSTreeOptions(inputName, p.treePipeline.Name(), p.Filename(), pt)
+
+		opts := &osbuild.BootctlInstallRootStageOptions{
+			Root: "mount://-/",
+		}
+
+		// ESP is required
+		espMountpoint, err := findESPMountpoint(p.treePipeline.PartitionTable)
+		if err != nil {
+			return osbuild.Pipeline{}, err
+		}
+		opts.ESPPath = espMountpoint
+
+		// XBOOTLDR is optional so we don't need to check the error, if there's
+		// an error it's empty and the stage options will omit it
+		opts.BootPath, _ = findXBootLDRMountpoint(p.treePipeline.PartitionTable)
+
+		pipeline.AddStage(osbuild.NewBootctlInstallRootStage(opts, bootctlDevices, bootctlMounts))
 	}
 
 	return pipeline, nil

--- a/pkg/osbuild/bootctl_install_root.go
+++ b/pkg/osbuild/bootctl_install_root.go
@@ -1,0 +1,22 @@
+package osbuild
+
+type BootctlInstallRootStageOptions struct {
+	Root               string `json:"root"`
+	ESPPath            string `json:"esp-path,omitempty"`
+	BootPath           string `json:"boot-path,omitempty"`
+	RelaxESPChecks     bool   `json:"relax-esp-checks,omitempty"`
+	RandomSeed         string `json:"random-seed,omitempty"`
+	MakeEntryDirectory string `json:"make-entry-directory,omitempty"`
+	EntryToken         string `json:"entry-token,omitempty"`
+}
+
+func (BootctlInstallRootStageOptions) isStageOptions() {}
+
+func NewBootctlInstallRootStage(opts *BootctlInstallRootStageOptions, devices map[string]Device, mounts []Mount) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.bootctl.install.root",
+		Options: opts,
+		Devices: devices,
+		Mounts:  mounts,
+	}
+}

--- a/pkg/osbuild/bootctl_install_root_test.go
+++ b/pkg/osbuild/bootctl_install_root_test.go
@@ -1,0 +1,88 @@
+package osbuild_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+func TestNewBootctlInstallRootStage(t *testing.T) {
+	opts := &osbuild.BootctlInstallRootStageOptions{
+		Root: "mount://-/",
+	}
+
+	stage := osbuild.NewBootctlInstallRootStage(opts, nil, nil)
+	assert.Equal(t, "org.osbuild.bootctl.install.root", stage.Type)
+	assert.Equal(t, opts, stage.Options)
+}
+
+func TestBootctlInstallRootStageJSON(t *testing.T) {
+	opts := &osbuild.BootctlInstallRootStageOptions{
+		Root:     "mount://-/",
+		ESPPath:  "/boot/efi",
+		BootPath: "/boot",
+	}
+
+	stage := osbuild.NewBootctlInstallRootStage(opts, nil, nil)
+	data, err := json.MarshalIndent(stage, "", "  ")
+	require.NoError(t, err)
+
+	assert.Equal(t, `{
+  "type": "org.osbuild.bootctl.install.root",
+  "options": {
+    "root": "mount://-/",
+    "esp-path": "/boot/efi",
+    "boot-path": "/boot"
+  }
+}`, string(data))
+}
+
+func TestBootctlInstallRootStageJSONAllOptions(t *testing.T) {
+	opts := &osbuild.BootctlInstallRootStageOptions{
+		Root:               "mount://-/",
+		ESPPath:            "/boot/efi",
+		BootPath:           "/boot",
+		RelaxESPChecks:     true,
+		RandomSeed:         "no",
+		MakeEntryDirectory: "yes",
+		EntryToken:         "os-id",
+	}
+
+	stage := osbuild.NewBootctlInstallRootStage(opts, nil, nil)
+	data, err := json.MarshalIndent(stage, "", "  ")
+	require.NoError(t, err)
+
+	assert.Equal(t, `{
+  "type": "org.osbuild.bootctl.install.root",
+  "options": {
+    "root": "mount://-/",
+    "esp-path": "/boot/efi",
+    "boot-path": "/boot",
+    "relax-esp-checks": true,
+    "random-seed": "no",
+    "make-entry-directory": "yes",
+    "entry-token": "os-id"
+  }
+}`, string(data))
+}
+
+func TestBootctlInstallRootStageJSONOmitEmpty(t *testing.T) {
+	opts := &osbuild.BootctlInstallRootStageOptions{
+		Root: "mount://-/",
+	}
+
+	stage := osbuild.NewBootctlInstallRootStage(opts, nil, nil)
+	data, err := json.MarshalIndent(stage, "", "  ")
+	require.NoError(t, err)
+
+	assert.Equal(t, `{
+  "type": "org.osbuild.bootctl.install.root",
+  "options": {
+    "root": "mount://-/"
+  }
+}`, string(data))
+}

--- a/pkg/osbuild/fix_bls_stage.go
+++ b/pkg/osbuild/fix_bls_stage.go
@@ -7,9 +7,15 @@ package osbuild
 // file-system partition. If `/boot` is on a separate partition, the correct
 // path would be `/loader/.../` The `prefix` can be used to adjust for that.
 // By default it is `/boot`, i.e. assumes `/boot` is on the root file-system.
+// RequireBootPrefix controls whether the fix-bls stage expects a path prefix
+// before /boot in BLS entries. When nil (the default), the stage assumes a
+// prefix is present (i.e. the traditional grub2 layout). Set to false for
+// systemd-boot where 90-loaderentry writes paths starting at /boot with no
+// leading prefix.
 type FixBLSStageOptions struct {
 	// Prefix defaults to "/boot" if not provided
-	Prefix *string `json:"prefix,omitempty"`
+	Prefix            *string `json:"prefix,omitempty"`
+	RequireBootPrefix *bool   `json:"require_boot_prefix,omitempty"`
 }
 
 func (FixBLSStageOptions) isStageOptions() {}

--- a/pkg/osbuild/fix_bls_stage_test.go
+++ b/pkg/osbuild/fix_bls_stage_test.go
@@ -1,9 +1,13 @@
 package osbuild
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/internal/common"
 )
 
 func TestNewFixBLSStage(t *testing.T) {
@@ -13,4 +17,50 @@ func TestNewFixBLSStage(t *testing.T) {
 	}
 	actualStage := NewFixBLSStage(&FixBLSStageOptions{})
 	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestFixBLSStageJSONRequireBootPrefix(t *testing.T) {
+	opts := &FixBLSStageOptions{
+		RequireBootPrefix: common.ToPtr(false),
+	}
+	stage := NewFixBLSStage(opts)
+	data, err := json.MarshalIndent(stage, "", "  ")
+	require.NoError(t, err)
+
+	assert.Equal(t, `{
+  "type": "org.osbuild.fix-bls",
+  "options": {
+    "require_boot_prefix": false
+  }
+}`, string(data))
+}
+
+func TestFixBLSStageJSONPrefixAndRequireBootPrefix(t *testing.T) {
+	opts := &FixBLSStageOptions{
+		Prefix:            common.ToPtr(""),
+		RequireBootPrefix: common.ToPtr(false),
+	}
+	stage := NewFixBLSStage(opts)
+	data, err := json.MarshalIndent(stage, "", "  ")
+	require.NoError(t, err)
+
+	assert.Equal(t, `{
+  "type": "org.osbuild.fix-bls",
+  "options": {
+    "prefix": "",
+    "require_boot_prefix": false
+  }
+}`, string(data))
+}
+
+func TestFixBLSStageJSONOmitEmpty(t *testing.T) {
+	opts := &FixBLSStageOptions{}
+	stage := NewFixBLSStage(opts)
+	data, err := json.MarshalIndent(stage, "", "  ")
+	require.NoError(t, err)
+
+	assert.Equal(t, `{
+  "type": "org.osbuild.fix-bls",
+  "options": {}
+}`, string(data))
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -31,7 +31,29 @@ const ( // bootloader enum
 	BOOTLOADER_GRUB2
 	BOOTLOADER_ZIPL
 	BOOTLOADER_UKI
+	BOOTLOADER_SYSTEMD
 )
+
+func (b Bootloader) String() string {
+	switch b {
+	case BOOTLOADER_NONE:
+		return "none"
+	case BOOTLOADER_GRUB2:
+		return "grub2"
+	case BOOTLOADER_ZIPL:
+		return "zipl"
+	case BOOTLOADER_UKI:
+		return "uki"
+	case BOOTLOADER_SYSTEMD:
+		return "systemd"
+	default:
+		panic(fmt.Errorf("unknown bootloader %d", b))
+	}
+}
+
+func (b Bootloader) MarshalJSON() ([]byte, error) {
+	return json.Marshal(b.String())
+}
 
 func (b *Bootloader) UnmarshalJSON(data []byte) (err error) {
 	var s string
@@ -55,6 +77,8 @@ func FromString(b string) (Bootloader, error) {
 		return BOOTLOADER_ZIPL, nil
 	case "uki":
 		return BOOTLOADER_UKI, nil
+	case "systemd":
+		return BOOTLOADER_SYSTEMD, nil
 	case "", "none":
 		return BOOTLOADER_NONE, nil
 	default:

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -11,6 +11,38 @@ import (
 	"github.com/osbuild/images/pkg/platform"
 )
 
+func TestBootloaderString(t *testing.T) {
+	assert.Equal(t, "none", platform.BOOTLOADER_NONE.String())
+	assert.Equal(t, "grub2", platform.BOOTLOADER_GRUB2.String())
+	assert.Equal(t, "zipl", platform.BOOTLOADER_ZIPL.String())
+	assert.Equal(t, "uki", platform.BOOTLOADER_UKI.String())
+	assert.Equal(t, "systemd", platform.BOOTLOADER_SYSTEMD.String())
+}
+
+func TestBootloaderStringUnknown(t *testing.T) {
+	assert.PanicsWithError(t, "unknown bootloader 999", func() {
+		_ = platform.Bootloader(999).String()
+	})
+}
+
+func TestBootloaderRoundtrip(t *testing.T) {
+	bootloaders := []platform.Bootloader{
+		platform.BOOTLOADER_NONE,
+		platform.BOOTLOADER_GRUB2,
+		platform.BOOTLOADER_ZIPL,
+		platform.BOOTLOADER_UKI,
+		platform.BOOTLOADER_SYSTEMD,
+	}
+	for _, bl := range bootloaders {
+		data, err := json.Marshal(bl)
+		assert.NoError(t, err)
+		var got platform.Bootloader
+		err = json.Unmarshal(data, &got)
+		assert.NoError(t, err)
+		assert.Equal(t, bl, got)
+	}
+}
+
 func TestImageFormatString(t *testing.T) {
 	assert.Equal(t, "unset", platform.FORMAT_UNSET.String())
 	assert.Equal(t, "ova", platform.FORMAT_OVA.String())


### PR DESCRIPTION
This PR implements the new/changes stages for `bootctl.install.root` and `fix-bls`. It then introduces a new bootloader `systemd`.

When/if `systemd-boot` is selected as the bootloader in a platform we automatically determine the boot-root in the way the BLS dictates us to do. We don't install `systemd-boot` inside the `os` pipeline as it does checks on the paths it is given to determine if they are actual mountpoints and/or filesystems. We pass the ESP/XBOOTLDR explicitly but they could also be auto-detected if we want that.

This works in my testing for YAML definitions that have only an ESP, or both an ESP and XBOOTLDR.

There's probably plenty we can improve here such as moving the find*Mountpoint functions into `pkg/disk` and generalizing them; however I'd like to do that as part of more sweeping change to `pkg/disk` where I'll also cover auto-mountpoints, auto-types, based on the recently added policies.

Let's not have a boot test yet until I've used this for a bit and am sure it's stable and doesn't need to change. There are likely functionalities missing that I might like still and haven't thought about yet.