### PR TITLE
imgtestlib: support bootc-foundry image types

### DIFF
--- a/test/scripts/imgtestlib/core.py
+++ b/test/scripts/imgtestlib/core.py
@@ -359,27 +359,31 @@ def get_tag_for(runner):
     raise ValueError(f"Unknown runner: {runner}")
 
 
+
 def find_image_file(build_path: str) -> str:
     """
-    Find the path to the image by reading the manifest to get the name of the last pipeline and searching for the file
-    under the directory named after the pipeline. Raises RuntimeError if no or multiple files are found in the expected
-    path.
+    Find the path to the image by reading the manifest and finding the exported pipeline's output directory.
+    A manifest may contain multiple pipelines but only one is exported during a build. This function finds the
+    exported pipeline by checking which pipeline directory exists in the build output.
+    Raises RuntimeError if no or multiple exported directories are found, or if the directory doesn't contain
+    exactly one file.
     """
     manifest_file = os.path.join(build_path, "manifest.json")
     with open(manifest_file, encoding="utf-8") as manifest:
         data = json.load(manifest)
 
-    last_pipeline = data["pipelines"][-1]["name"]
-    files = os.listdir(os.path.join(build_path, last_pipeline))
-    if len(files) > 1:
-        error = "Multiple files found in build path while searching for image file"
-        error += "\n".join(files)
-        raise RuntimeError(error)
+    pipeline_names = [p["name"] for p in data["pipelines"] if p["name"] != "build"]
+    export_dirs = [p for p in pipeline_names if os.path.isdir(os.path.join(build_path, p))]
 
-    if len(files) == 0:
-        raise RuntimeError("No found in build path while searching for image file")
+    if len(export_dirs) != 1:
+        raise RuntimeError(f"Expected exactly one exported pipeline directory in {build_path}, found: {export_dirs}")
 
-    return os.path.join(build_path, last_pipeline, files[0])
+    files = os.listdir(os.path.join(build_path, export_dirs[0]))
+    if len(files) != 1:
+        raise RuntimeError(
+            f"Expected exactly one file in export directory '{export_dirs[0]}', found: {files}")
+
+    return os.path.join(build_path, export_dirs[0], files[0])
 
 
 def read_manifest(build_path: str) -> Dict:

--- a/test/scripts/test_imgtestlib.py
+++ b/test/scripts/test_imgtestlib.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess as sp
 import tempfile
@@ -259,3 +260,152 @@ def test_skopeo_inspect_localstore(arch):
 
         # arch arg to skopeo_inspect_id doesn't matter here
         assert testlib.skopeo_inspect_id(f"{transport}[vfs@{tmpdir}]{image}", arch) == image_ids[arch]
+
+
+def test_find_image_file_single_export():
+    """Test find_image_file with a single exported pipeline (excluding build)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create manifest with build and one export pipeline
+        manifest = {
+            "pipelines": [
+                {"name": "build"},
+                {"name": "qcow2"}
+            ]
+        }
+        manifest_path = os.path.join(tmpdir, "manifest.json")
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f)
+
+        # Create the export directory and file
+        export_dir = os.path.join(tmpdir, "qcow2")
+        os.makedirs(export_dir)
+        image_file = os.path.join(export_dir, "disk.qcow2")
+        with open(image_file, "w", encoding="utf-8") as f:
+            f.write("fake image")
+
+        # Test that it finds the correct file
+        result = testlib.find_image_file(tmpdir)
+        assert result == image_file
+
+
+def test_find_image_file_multiple_pipelines_one_export():
+    """Test find_image_file when manifest has multiple pipelines but only one is exported."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create manifest with build and multiple pipelines, but only one exported
+        manifest = {
+            "pipelines": [
+                {"name": "build"},
+                {"name": "image"},
+                {"name": "qcow2"},
+                {"name": "archive"}
+            ]
+        }
+        manifest_path = os.path.join(tmpdir, "manifest.json")
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f)
+
+        # Create only the archive directory (the actual export)
+        export_dir = os.path.join(tmpdir, "archive")
+        os.makedirs(export_dir)
+        image_file = os.path.join(export_dir, "image.tar")
+        with open(image_file, "w", encoding="utf-8") as f:
+            f.write("fake archive")
+
+        # Test that it finds the correct file from the exported pipeline
+        result = testlib.find_image_file(tmpdir)
+        assert result == image_file
+
+
+def test_find_image_file_no_export_directory():
+    """Test find_image_file raises error when no export directory exists."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create manifest but no export directories
+        manifest = {
+            "pipelines": [
+                {"name": "build"},
+                {"name": "qcow2"}
+            ]
+        }
+        manifest_path = os.path.join(tmpdir, "manifest.json")
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f)
+
+        # Don't create any export directories
+        with pytest.raises(RuntimeError, match="Expected exactly one exported pipeline directory"):
+            testlib.find_image_file(tmpdir)
+
+
+def test_find_image_file_multiple_export_directories():
+    """Test find_image_file raises error when multiple export directories exist."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create manifest with multiple pipelines
+        manifest = {
+            "pipelines": [
+                {"name": "build"},
+                {"name": "qcow2"},
+                {"name": "vmdk"}
+            ]
+        }
+        manifest_path = os.path.join(tmpdir, "manifest.json")
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f)
+
+        # Create multiple export directories
+        for pipeline in ["qcow2", "vmdk"]:
+            export_dir = os.path.join(tmpdir, pipeline)
+            os.makedirs(export_dir)
+            with open(os.path.join(export_dir, f"disk.{pipeline}"), "w", encoding="utf-8") as f:
+                f.write("fake image")
+
+        # Should raise error about multiple export directories
+        with pytest.raises(RuntimeError, match="Expected exactly one exported pipeline directory"):
+            testlib.find_image_file(tmpdir)
+
+
+def test_find_image_file_no_files_in_export():
+    """Test find_image_file raises error when export directory is empty."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create manifest
+        manifest = {
+            "pipelines": [
+                {"name": "build"},
+                {"name": "qcow2"}
+            ]
+        }
+        manifest_path = os.path.join(tmpdir, "manifest.json")
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f)
+
+        # Create export directory but no files
+        export_dir = os.path.join(tmpdir, "qcow2")
+        os.makedirs(export_dir)
+
+        # Should raise error about no files
+        with pytest.raises(RuntimeError, match="Expected exactly one file in export directory"):
+            testlib.find_image_file(tmpdir)
+
+
+def test_find_image_file_multiple_files_in_export():
+    """Test find_image_file raises error when export directory has multiple files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create manifest
+        manifest = {
+            "pipelines": [
+                {"name": "build"},
+                {"name": "qcow2"}
+            ]
+        }
+        manifest_path = os.path.join(tmpdir, "manifest.json")
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f)
+
+        # Create export directory with multiple files
+        export_dir = os.path.join(tmpdir, "qcow2")
+        os.makedirs(export_dir)
+        for filename in ["disk1.qcow2", "disk2.qcow2"]:
+            with open(os.path.join(export_dir, filename), "w", encoding="utf-8") as f:
+                f.write("fake image")
+
+        # Should raise error about multiple files
+        with pytest.raises(RuntimeError, match="Expected exactly one file in export directory"):
+            testlib.find_image_file(tmpdir)


### PR DESCRIPTION
It looks like recent refactoring broke the boot tests for bootc-foundry images. This commit fixes the issue by updating the image type detection logic to handle the new format.

---

Solves:

```
$ test/boot.sh
Booting image from: /home/fedora/~/builds/redhat/services/products/image-builder/ci/bootc-foundry/build/bootc_hummingbird_20251124-aarch64-qcow2-bootc_foundry
Build config: /home/fedora/~/builds/redhat/services/products/image-builder/ci/bootc-foundry/build/bootc_hummingbird_20251124-aarch64-qcow2-bootc_foundry/config.json
Booting image
00:00
Traceback (most recent call last):
  File "/home/fedora/~/builds/redhat/services/products/image-builder/ci/bootc-foundry/_images/./test/scripts/boot-image", line 25, in <module>
    main()
    ~~~~^^
  File "/home/fedora/~/builds/redhat/services/products/image-builder/ci/bootc-foundry/_images/./test/scripts/boot-image", line 21, in main
    testlib.boot_image(search_path, build_config_path, keep)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/contextlib.py", line 85, in inner
    return func(*args, **kwds)
  File "/home/fedora/~/builds/redhat/services/products/image-builder/ci/bootc-foundry/_images/test/scripts/imgtestlib/boot.py", line 527, in boot_image
    image_path = find_image_file(search_path)
  File "/home/fedora/~/builds/redhat/services/products/image-builder/ci/bootc-foundry/_images/test/scripts/imgtestlib/core.py", line 373, in find_image_file
    files = os.listdir(os.path.join(build_path, last_pipeline))
FileNotFoundError: [Errno 2] No such file or directory: '/home/fedora/~/builds/redhat/services/products/image-builder/ci/bootc-foundry/build/bootc_hummingbird_20251124-aarch64-qcow2-bootc_foundry/gce'
```

---

I do not understand why we do this for bootc manifests, so unsure if this is a proper solution to the problem.