### PR TITLE
Add Custom menus to X86 and PPC64 ISO bootloaders

### DIFF
--- a/pkg/image/iso_bootloaders.go
+++ b/pkg/image/iso_bootloaders.go
@@ -9,6 +9,10 @@ import (
 type ISOBootloaders struct {
 	InstallerCustomizations *manifest.InstallerCustomizations
 	ISOCustomizations       *manifest.ISOCustomizations
+
+	// Grub2 menu customization for x86, ppc64, uefi iso menus, not supported by syslinux
+	// Setting these turns off all of the default menus
+	Custom []manifest.ISOGrub2MenuEntry
 }
 
 func (img *ISOBootloaders) Bootloaders(buildPipeline manifest.Build, platform platform.Platform, kernelOpts []string) []manifest.ISOBootloader {
@@ -33,6 +37,15 @@ func (img *ISOBootloaders) Bootloaders(buildPipeline manifest.Build, platform pl
 		grub2.ISOLabel = img.ISOCustomizations.Label
 		grub2.KernelOpts = kernelOpts
 		grub2.DefaultMenu = img.InstallerCustomizations.DefaultMenu
+
+		for _, entry := range img.Custom {
+			grub2.Custom = append(grub2.Custom, manifest.ISOGrub2MenuEntry{
+				Name:   entry.Name,
+				Linux:  entry.Linux,
+				Initrd: entry.Initrd,
+			})
+		}
+
 		bootloaders = append(bootloaders, grub2)
 		addUEFIBootTree = true
 
@@ -42,6 +55,15 @@ func (img *ISOBootloaders) Bootloaders(buildPipeline manifest.Build, platform pl
 		grub2ppc64.ISOLabel = img.ISOCustomizations.Label
 		grub2ppc64.KernelOpts = kernelOpts
 		grub2ppc64.DefaultMenu = img.InstallerCustomizations.DefaultMenu
+
+		for _, entry := range img.Custom {
+			grub2ppc64.Custom = append(grub2ppc64.Custom, manifest.ISOGrub2MenuEntry{
+				Name:   entry.Name,
+				Linux:  entry.Linux,
+				Initrd: entry.Initrd,
+			})
+		}
+
 		bootloaders = append(bootloaders, grub2ppc64)
 
 	case manifest.S390ISOBoot:
@@ -53,13 +75,22 @@ func (img *ISOBootloaders) Bootloaders(buildPipeline manifest.Build, platform pl
 
 	if addUEFIBootTree {
 		// EFI bootloader adds a pipeline and adds stages
-		bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.InstallerCustomizations.Product, img.InstallerCustomizations.OSVersion)
-		bootTreePipeline.Platform = platform
-		bootTreePipeline.UEFIVendor = platform.GetUEFIVendor()
-		bootTreePipeline.ISOLabel = img.ISOCustomizations.Label
-		bootTreePipeline.DefaultMenu = img.InstallerCustomizations.DefaultMenu
-		bootTreePipeline.KernelOpts = kernelOpts
-		bootloaders = append(bootloaders, bootTreePipeline)
+		efiPipeline := manifest.NewEFIBootTree(buildPipeline, img.InstallerCustomizations.Product, img.InstallerCustomizations.OSVersion)
+		efiPipeline.Platform = platform
+		efiPipeline.UEFIVendor = platform.GetUEFIVendor()
+		efiPipeline.ISOLabel = img.ISOCustomizations.Label
+		efiPipeline.DefaultMenu = img.InstallerCustomizations.DefaultMenu
+		efiPipeline.KernelOpts = kernelOpts
+
+		for _, entry := range img.Custom {
+			efiPipeline.MenuEntries = append(efiPipeline.MenuEntries, manifest.ISOGrub2MenuEntry{
+				Name:   entry.Name,
+				Linux:  entry.Linux,
+				Initrd: entry.Initrd,
+			})
+		}
+
+		bootloaders = append(bootloaders, efiPipeline)
 	}
 	return bootloaders
 }

--- a/pkg/image/iso_bootloaders_test.go
+++ b/pkg/image/iso_bootloaders_test.go
@@ -36,12 +36,23 @@ func TestBootType(t *testing.T) {
 
 	type testCase struct {
 		bootType manifest.ISOBootType
+		custom   []manifest.ISOGrub2MenuEntry
 		expected []results
+	}
+
+	var noCustomMenus []manifest.ISOGrub2MenuEntry
+	customMenus := []manifest.ISOGrub2MenuEntry{
+		manifest.ISOGrub2MenuEntry{
+			Name: "Boot Linux", Linux: "vmlinuz", Initrd: "initrd.img",
+		},
+		manifest.ISOGrub2MenuEntry{
+			Name: "Boot Linux Debug", Linux: "vmlinuz debug", Initrd: "initrd.img",
+		},
 	}
 
 	// Check the stages and files for each bootloader type
 	tests := []testCase{
-		testCase{manifest.Grub2UEFIOnlyISOBoot, []results{{
+		testCase{manifest.Grub2UEFIOnlyISOBoot, noCustomMenus, []results{{
 			stages: []string{
 				"org.osbuild.truncate",
 				"org.osbuild.mkfs.fat",
@@ -49,7 +60,7 @@ func TestBootType(t *testing.T) {
 				"org.osbuild.copy"},
 			paths: []string{}},
 		}},
-		testCase{manifest.SyslinuxISOBoot, []results{
+		testCase{manifest.SyslinuxISOBoot, noCustomMenus, []results{
 			{stages: []string{"org.osbuild.isolinux"}, paths: []string{}}, {
 				stages: []string{
 					"org.osbuild.truncate",
@@ -58,7 +69,7 @@ func TestBootType(t *testing.T) {
 					"org.osbuild.copy"},
 				paths: []string{}},
 		}},
-		testCase{manifest.Grub2ISOBoot, []results{{
+		testCase{manifest.Grub2ISOBoot, noCustomMenus, []results{{
 			stages: []string{
 				"org.osbuild.grub2.iso.legacy",
 				"org.osbuild.grub2.inst"},
@@ -70,14 +81,33 @@ func TestBootType(t *testing.T) {
 				"org.osbuild.copy"},
 			paths: []string{}},
 		}},
-		testCase{manifest.Grub2PPCISOBoot, []results{{
+		testCase{manifest.Grub2ISOBoot, customMenus, []results{{
+			stages: []string{
+				"org.osbuild.grub2.iso.legacy",
+				"org.osbuild.grub2.inst"},
+			paths: []string{}}, {
+			stages: []string{
+				"org.osbuild.truncate",
+				"org.osbuild.mkfs.fat",
+				"org.osbuild.copy",
+				"org.osbuild.copy"},
+			paths: []string{}},
+		}},
+		testCase{manifest.Grub2PPCISOBoot, noCustomMenus, []results{{
 			stages: []string{
 				"org.osbuild.grub2.iso.legacy",
 				"org.osbuild.mkdir",
 				"org.osbuild.copy"},
 			paths: []string{"/ppc/bootinfo.txt"}},
 		}},
-		testCase{manifest.S390ISOBoot, []results{{
+		testCase{manifest.Grub2PPCISOBoot, customMenus, []results{{
+			stages: []string{
+				"org.osbuild.grub2.iso.legacy",
+				"org.osbuild.mkdir",
+				"org.osbuild.copy"},
+			paths: []string{"/ppc/bootinfo.txt"}},
+		}},
+		testCase{manifest.S390ISOBoot, noCustomMenus, []results{{
 			stages: []string{
 				"org.osbuild.copy",
 				"org.osbuild.copy",
@@ -99,6 +129,7 @@ func TestBootType(t *testing.T) {
 		mf := manifest.New()
 		buildPipeline := image.AddBuildBootstrapPipelines(&mf, runner, nil, nil)
 		ibl.ISOCustomizations.BootType = tc.bootType
+		ibl.Custom = tc.custom
 		bootloaders := ibl.Bootloaders(buildPipeline, testPlatform, []string{})
 		require.Len(t, bootloaders, len(tc.expected))
 
@@ -109,7 +140,27 @@ func TestBootType(t *testing.T) {
 			assert.Equal(t, stageNames(stages), tc.expected[i].stages)
 			assert.Len(t, files, len(tc.expected[i].paths), fmt.Sprintf("%v", filePaths(files)))
 			assert.Equal(t, filePaths(files), tc.expected[i].paths)
+
+			// Check grub2 custom menus when set
+			grub2Stage := findStage("org.osbuild.grub2.iso.legacy", stages)
+			if grub2Stage == nil {
+				continue
+			}
+			options := grub2Stage.Options.(*osbuild.Grub2ISOLegacyStageOptions)
+			require.NotNil(t, options)
+			checkCustomMenus(t, tc.custom, options.Custom)
 		}
+	}
+}
+
+func checkCustomMenus(t *testing.T,
+	expected []manifest.ISOGrub2MenuEntry,
+	menus []osbuild.Grub2ISOLegacyCustomEntryOptions) {
+	require.Equal(t, len(expected), len(menus))
+	for i := range expected {
+		require.Equal(t, expected[i].Name, menus[i].Name)
+		require.Equal(t, expected[i].Linux, menus[i].Linux)
+		require.Equal(t, expected[i].Initrd, menus[i].Initrd)
 	}
 }
 
@@ -127,4 +178,13 @@ func filePaths(files []*fsnode.File) []string {
 		paths = append(paths, f.Path())
 	}
 	return paths
+}
+
+func findStage(name string, stages []*osbuild.Stage) *osbuild.Stage {
+	for _, s := range stages {
+		if s.Type == name {
+			return s
+		}
+	}
+	return nil
 }

--- a/pkg/manifest/iso_bootloaders.go
+++ b/pkg/manifest/iso_bootloaders.go
@@ -63,6 +63,8 @@ type Grub2X86Boot struct {
 
 	// Default Grub2 menu on the ISO
 	DefaultMenu int
+	// Custom menu entries (overrides all default entries)
+	Custom []ISOGrub2MenuEntry
 }
 
 func NewGrub2X86Bootloader(buildPipeline Build, product, version string) *Grub2X86Boot {
@@ -101,6 +103,22 @@ func (boot *Grub2X86Boot) GetISOBootStages(inputName string, _ *disk.PartitionTa
 		Config:          grub2config,
 	}
 
+	// If any menu entries are defined we turn off all default
+	// entries and instead append our own entries
+	if len(boot.Custom) > 0 {
+		options.Troubleshooting = false
+		options.Test = false
+		options.Install = false
+
+		for _, entry := range boot.Custom {
+			options.Custom = append(options.Custom, osbuild.Grub2ISOLegacyCustomEntryOptions{
+				Name:   entry.Name,
+				Linux:  entry.Linux,
+				Initrd: entry.Initrd,
+			})
+		}
+	}
+
 	stages = append(stages, osbuild.NewGrub2ISOLegacyStage(options))
 
 	// Add a stage to create the eltorito.img file for grub2 BIOS boot support
@@ -124,6 +142,8 @@ type Grub2PPC64Boot struct {
 
 	// Default Grub2 menu on the ISO
 	DefaultMenu int
+	// Custom menu entries (overrides all default entries)
+	Custom []ISOGrub2MenuEntry
 }
 
 func NewGrub2PPC64Bootloader(buildPipeline Build, product, version string) *Grub2PPC64Boot {
@@ -163,6 +183,23 @@ func (boot *Grub2PPC64Boot) GetISOBootStages(inputName string, _ *disk.Partition
 		Config:          grub2config,
 		Platform:        "powerpc-ieee1275",
 	}
+
+	// If any menu entries are defined we turn off all default
+	// entries and instead append our own entries
+	if len(boot.Custom) > 0 {
+		options.Troubleshooting = false
+		options.Test = false
+		options.Install = false
+
+		for _, entry := range boot.Custom {
+			options.Custom = append(options.Custom, osbuild.Grub2ISOLegacyCustomEntryOptions{
+				Name:   entry.Name,
+				Linux:  entry.Linux,
+				Initrd: entry.Initrd,
+			})
+		}
+	}
+
 	stages = append(stages, osbuild.NewGrub2ISOLegacyStage(options))
 
 	// Add the bootinfo.txt file which is used by the CHRP boot method to point to grub2


### PR DESCRIPTION
Adds support for setting custom menus, with tests. Will be used by later commits.

Related: HMS-10627