### PR TITLE
generic/bootc: allow disk.yaml to provide root filesystem type

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -393,9 +393,22 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 		if err != nil {
 			return nil, err
 		}
-		if bootcDefaultFs != "" {
+
+		// Log informational message about root filesystem configuration source.
+		// disk.yaml always takes priority over --bootc-default-fs and bootc config.
+		diskYamlRootFs := bootcInfo.OSInfo.GetDiskYamlRootFs()
+		if diskYamlRootFs != "" {
+			if bootcDefaultFs != "" {
+				pbar.SetPulseMsgf("Using disk.yaml root filesystem (%s), ignoring --bootc-default-fs (%s)", diskYamlRootFs, bootcDefaultFs)
+			} else if bootcInfo.DefaultRootFs != "" {
+				pbar.SetPulseMsgf("Using disk.yaml root filesystem (%s), ignoring bootc config (%s)", diskYamlRootFs, bootcInfo.DefaultRootFs)
+			} else {
+				pbar.SetPulseMsgf("Using disk.yaml root filesystem (%s)", diskYamlRootFs)
+			}
+		} else if bootcDefaultFs != "" {
 			bootcInfo.DefaultRootFs = bootcDefaultFs
 		}
+
 		distro, err := generic.NewBootc("bootc", bootcInfo)
 		if err != nil {
 			return nil, err

--- a/pkg/bib/osinfo/osinfo.go
+++ b/pkg/bib/osinfo/osinfo.go
@@ -89,6 +89,19 @@ func (info *Info) HasModules(modules []string) (bool, error) {
 	return true, nil
 }
 
+// GetDiskYamlRootFs returns the root filesystem type from the partition table
+// defined in disk.yaml, or an empty string if not defined.
+func (info *Info) GetDiskYamlRootFs() string {
+	if info == nil || info.PartitionTable == nil {
+		return ""
+	}
+	rootMountable := info.PartitionTable.FindMountable("/")
+	if rootMountable != nil {
+		return rootMountable.GetFSType()
+	}
+	return ""
+}
+
 func validateOSRelease(osrelease map[string]string) error {
 	// VARIANT_ID, PLATFORM_ID are optional
 	for _, key := range []string{"ID", "VERSION_ID", "NAME"} {

--- a/pkg/distro/generic/bootc.go
+++ b/pkg/distro/generic/bootc.go
@@ -80,7 +80,13 @@ func NewBootcWithLoader(loader *defs.Loader, name string, cinfo *bootc.Info) (*B
 	if cinfo.Arch == "" {
 		missing = append(missing, "Arch")
 	}
-	if cinfo.DefaultRootFs == "" {
+	// disk.yaml's partition table always takes priority over bootc install
+	// configuration as it is specific to this tool. Fall back to DefaultRootFs
+	// from bootc config if no partition table is provided.
+	diskYamlRootFs := cinfo.OSInfo.GetDiskYamlRootFs()
+	if diskYamlRootFs != "" {
+		cinfo.DefaultRootFs = diskYamlRootFs
+	} else if cinfo.DefaultRootFs == "" {
 		missing = append(missing, "DefaultRootFs")
 	}
 	if cinfo.Size == 0 {

--- a/pkg/distro/generic/bootc_test.go
+++ b/pkg/distro/generic/bootc_test.go
@@ -157,6 +157,258 @@ func TestNewBootc(t *testing.T) {
 			expectedError: "failed to initialize bootc distro: missing required info: Arch, DefaultRootFs, Size, OSInfo",
 		},
 
+		"defaultrootfs-from-partition-table": {
+			// When DefaultRootFs is empty but disk.yaml provides a partition
+			// table with root filesystem, use the fs type from the partition table
+			info: &bootc.Info{
+				Imgref:  "example.com/containers/distro-bootc:version12",
+				ImageID: "acf88e518194fac963a1b2e2e4110e38a4ce5fb3fceddd624fae8997d4566930",
+				Arch:    "x86_64",
+				Size:    100 * datasizes.MiB,
+				OSInfo: &osinfo.Info{
+					OSRelease: osinfo.OSRelease{
+						ID:        "aos",
+						VersionID: "5000",
+					},
+					PartitionTable: &disk.PartitionTable{
+						Type: disk.PT_GPT,
+						Partitions: []disk.Partition{
+							{
+								Payload: &disk.Filesystem{
+									Type:       "ext4",
+									Mountpoint: "/",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDistro: &BootcDistro{
+				imgref:      "example.com/containers/distro-bootc:version12",
+				imageID:     "acf88e518194fac963a1b2e2e4110e38a4ce5fb3fceddd624fae8997d4566930",
+				buildImgref: "example.com/containers/distro-bootc:version12",
+				sourceInfo: &osinfo.Info{
+					OSRelease: osinfo.OSRelease{
+						ID:        "aos",
+						VersionID: "5000",
+					},
+					PartitionTable: &disk.PartitionTable{
+						Type: disk.PT_GPT,
+						Partitions: []disk.Partition{
+							{
+								Payload: &disk.Filesystem{
+									Type:       "ext4",
+									Mountpoint: "/",
+								},
+							},
+						},
+					},
+				},
+				buildSourceInfo: &osinfo.Info{
+					OSRelease: osinfo.OSRelease{
+						ID:        "aos",
+						VersionID: "5000",
+					},
+					PartitionTable: &disk.PartitionTable{
+						Type: disk.PT_GPT,
+						Partitions: []disk.Partition{
+							{
+								Payload: &disk.Filesystem{
+									Type:       "ext4",
+									Mountpoint: "/",
+								},
+							},
+						},
+					},
+				},
+				id: distro.ID{
+					Name:         "bootc-aos",
+					MajorVersion: 5000,
+					MinorVersion: -1,
+				},
+				releasever:    "5000",
+				defaultFs:     "ext4",
+				rootfsMinSize: 200 * datasizes.MiB,
+				arches: map[string]distro.Arch{
+					"x86_64": &architecture{
+						arch: arch.ARCH_X86_64,
+					},
+				},
+			},
+		},
+
+		"disk-yaml-overrides-bootc-config": {
+			// When both bootc config (DefaultRootFs) and disk.yaml (PartitionTable)
+			// provide root filesystem type, disk.yaml should always take priority
+			info: &bootc.Info{
+				Imgref:        "example.com/containers/distro-bootc:version12",
+				ImageID:       "acf88e518194fac963a1b2e2e4110e38a4ce5fb3fceddd624fae8997d4566930",
+				Arch:          "x86_64",
+				DefaultRootFs: "xfs", // bootc config says xfs
+				Size:          100 * datasizes.MiB,
+				OSInfo: &osinfo.Info{
+					OSRelease: osinfo.OSRelease{
+						ID:        "aos",
+						VersionID: "5000",
+					},
+					PartitionTable: &disk.PartitionTable{
+						Type: disk.PT_GPT,
+						Partitions: []disk.Partition{
+							{
+								Payload: &disk.Filesystem{
+									Type:       "ext4", // disk.yaml says ext4
+									Mountpoint: "/",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDistro: &BootcDistro{
+				imgref:      "example.com/containers/distro-bootc:version12",
+				imageID:     "acf88e518194fac963a1b2e2e4110e38a4ce5fb3fceddd624fae8997d4566930",
+				buildImgref: "example.com/containers/distro-bootc:version12",
+				sourceInfo: &osinfo.Info{
+					OSRelease: osinfo.OSRelease{
+						ID:        "aos",
+						VersionID: "5000",
+					},
+					PartitionTable: &disk.PartitionTable{
+						Type: disk.PT_GPT,
+						Partitions: []disk.Partition{
+							{
+								Payload: &disk.Filesystem{
+									Type:       "ext4",
+									Mountpoint: "/",
+								},
+							},
+						},
+					},
+				},
+				buildSourceInfo: &osinfo.Info{
+					OSRelease: osinfo.OSRelease{
+						ID:        "aos",
+						VersionID: "5000",
+					},
+					PartitionTable: &disk.PartitionTable{
+						Type: disk.PT_GPT,
+						Partitions: []disk.Partition{
+							{
+								Payload: &disk.Filesystem{
+									Type:       "ext4",
+									Mountpoint: "/",
+								},
+							},
+						},
+					},
+				},
+				id: distro.ID{
+					Name:         "bootc-aos",
+					MajorVersion: 5000,
+					MinorVersion: -1,
+				},
+				releasever:    "5000",
+				defaultFs:     "ext4", // disk.yaml wins over bootc config
+				rootfsMinSize: 200 * datasizes.MiB,
+				arches: map[string]distro.Arch{
+					"x86_64": &architecture{
+						arch: arch.ARCH_X86_64,
+					},
+				},
+			},
+		},
+
+		"defaultrootfs-from-partition-table-btrfs": {
+			// Test with btrfs subvolumes as root filesystem
+			info: &bootc.Info{
+				Imgref:  "example.com/containers/distro-bootc:version12",
+				ImageID: "acf88e518194fac963a1b2e2e4110e38a4ce5fb3fceddd624fae8997d4566930",
+				Arch:    "x86_64",
+				Size:    100 * datasizes.MiB,
+				OSInfo: &osinfo.Info{
+					OSRelease: osinfo.OSRelease{
+						ID:        "aos",
+						VersionID: "5000",
+					},
+					PartitionTable: &disk.PartitionTable{
+						Type: disk.PT_GPT,
+						Partitions: []disk.Partition{
+							{
+								Payload: &disk.Btrfs{
+									Subvolumes: []disk.BtrfsSubvolume{
+										{
+											Name:       "root",
+											Mountpoint: "/",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDistro: &BootcDistro{
+				imgref:      "example.com/containers/distro-bootc:version12",
+				imageID:     "acf88e518194fac963a1b2e2e4110e38a4ce5fb3fceddd624fae8997d4566930",
+				buildImgref: "example.com/containers/distro-bootc:version12",
+				sourceInfo: &osinfo.Info{
+					OSRelease: osinfo.OSRelease{
+						ID:        "aos",
+						VersionID: "5000",
+					},
+					PartitionTable: &disk.PartitionTable{
+						Type: disk.PT_GPT,
+						Partitions: []disk.Partition{
+							{
+								Payload: &disk.Btrfs{
+									Subvolumes: []disk.BtrfsSubvolume{
+										{
+											Name:       "root",
+											Mountpoint: "/",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				buildSourceInfo: &osinfo.Info{
+					OSRelease: osinfo.OSRelease{
+						ID:        "aos",
+						VersionID: "5000",
+					},
+					PartitionTable: &disk.PartitionTable{
+						Type: disk.PT_GPT,
+						Partitions: []disk.Partition{
+							{
+								Payload: &disk.Btrfs{
+									Subvolumes: []disk.BtrfsSubvolume{
+										{
+											Name:       "root",
+											Mountpoint: "/",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				id: distro.ID{
+					Name:         "bootc-aos",
+					MajorVersion: 5000,
+					MinorVersion: -1,
+				},
+				releasever:    "5000",
+				defaultFs:     "btrfs",
+				rootfsMinSize: 200 * datasizes.MiB,
+				arches: map[string]distro.Arch{
+					"x86_64": &architecture{
+						arch: arch.ARCH_X86_64,
+					},
+				},
+			},
+		},
+
 		"osinfo-without-values": {
 			info: &bootc.Info{
 				Imgref:        "example.com/containers/distro-bootc:version12",


### PR DESCRIPTION
When a container includes a `disk.yaml` with a partition table, its
root filesystem type always takes priority over both
`--bootc-default-fs` CLI argument and `bootc install print-configuration`.

The `GetDiskYamlRootFs` method is added to `osinfo.Info` to allow reuse
of the partition table root filesystem detection logic from any
package.

Closes: https://github.com/osbuild/image-builder/issues/2380

Assisted-by: OpenCode (Claude Opus 4)