### PR TITLE
many: copy boot files from build

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -1752,45 +1752,84 @@ image_types:
       - <<: *aarch64_platform
         image_format: "raw"
         boot_files:
-          - ["/usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2710-rpi-cm0.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2712-rpi-5-b.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2712-rpi-500.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2712-d-rpi-5-b.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2712d0-rpi-5-b.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2712-rpi-cm5-cm4io.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2712-rpi-cm5-cm5io.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2712-rpi-cm5l-cm4io.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bcm2712-rpi-cm5l-cm5io.dtb", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/bootcode.bin", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/config.txt", "/boot/efi/config.txt"]
-          - ["/usr/lib/ostree-boot/efi/fixup.dat", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/fixup4.dat", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/fixup4cd.dat", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/fixup4db.dat", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/fixup4x.dat", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/fixup_cd.dat", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/fixup_db.dat", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/fixup_x.dat", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/overlays", "/boot/efi/"]
-          - ["/usr/share/uboot/rpi_arm64/u-boot.bin", "/boot/efi/rpi-u-boot.bin"]
-          - ["/usr/lib/ostree-boot/efi/start.elf", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/start4.elf", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/start4cd.elf", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/start4db.elf", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/start4x.elf", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/start_cd.elf", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/start_db.elf", "/boot/efi/"]
-          - ["/usr/lib/ostree-boot/efi/start_x.elf", "/boot/efi/"]
+          - src: "/usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2710-rpi-cm0.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2712-rpi-5-b.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2712-rpi-500.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2712-d-rpi-5-b.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2712d0-rpi-5-b.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2712-rpi-cm5-cm4io.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2712-rpi-cm5-cm5io.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2712-rpi-cm5l-cm4io.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bcm2712-rpi-cm5l-cm5io.dtb"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/bootcode.bin"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/config.txt"
+            dst: "/boot/efi/config.txt"
+          - src: "/usr/lib/ostree-boot/efi/fixup.dat"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/fixup4.dat"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/fixup4cd.dat"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/fixup4db.dat"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/fixup4x.dat"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/fixup_cd.dat"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/fixup_db.dat"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/fixup_x.dat"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/overlays"
+            dst: "/boot/efi/"
+          - src: "/usr/share/uboot/rpi_arm64/u-boot.bin"
+            dst: "/boot/efi/rpi-u-boot.bin"
+          - src: "/usr/lib/ostree-boot/efi/start.elf"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/start4.elf"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/start4cd.elf"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/start4db.elf"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/start4x.elf"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/start_cd.elf"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/start_db.elf"
+            dst: "/boot/efi/"
+          - src: "/usr/lib/ostree-boot/efi/start_x.elf"
+            dst: "/boot/efi/"
     partition_table:
       <<: *iot_base_partition_tables
     blueprint:
@@ -1996,7 +2035,8 @@ image_types:
             - "bcm283x-firmware"
             - "uboot-images-armv8"
         boot_files:
-          - ["/usr/share/uboot/rpi_arm64/u-boot.bin", "/boot/efi/rpi-u-boot.bin"]
+          - src: "/usr/share/uboot/rpi_arm64/u-boot.bin"
+            dst: "/boot/efi/rpi-u-boot.bin"
         bootloader: "grub2"
       - *riscv64_uefi_platform
     disk_config:

--- a/pkg/manifest/raw.go
+++ b/pkg/manifest/raw.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/artifact"
+	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/platform"
 )
@@ -70,34 +71,12 @@ func (p *RawImage) serialize() (osbuild.Pipeline, error) {
 
 	bootFiles := p.treePipeline.platform.GetBootFiles()
 	if len(bootFiles) > 0 {
-		// we ignore the bootcopyoptions as they contain a full tree copy instead we make our own, we *do* still want all the other
-		// information such as mountpoints and devices
-		_, bootCopyDevices, bootCopyMounts := osbuild.GenCopyFSTreeOptions(inputName, p.treePipeline.Name(), p.Filename(), pt)
-		bootCopyOptions := &osbuild.CopyStageOptions{}
 		bootCopyInputs := osbuild.NewPipelineTreeInputs(inputName, p.treePipeline.Name())
-
-		// Find the FS root mount name to use as the destination root
-		// for the target when copying the boot files.
-		var fsRootMntName string
-		for _, mnt := range bootCopyMounts {
-			if mnt.Target == "/" {
-				fsRootMntName = mnt.Name
-				break
-			}
+		stage, err := bootFilesCopyStage(bootFiles, bootCopyInputs, inputName, inputName, p.treePipeline.Name(), p.Filename(), pt)
+		if err != nil {
+			return osbuild.Pipeline{}, err
 		}
-
-		if fsRootMntName == "" {
-			return osbuild.Pipeline{}, fmt.Errorf("no mount found for the filesystem root")
-		}
-
-		for _, bf := range bootFiles {
-			bootCopyOptions.Paths = append(bootCopyOptions.Paths, osbuild.CopyStagePath{
-				From: fmt.Sprintf("input://root-tree%s", bf.Src),
-				To:   fmt.Sprintf("mount://%s%s", fsRootMntName, bf.Dst),
-			})
-		}
-
-		pipeline.AddStage(osbuild.NewCopyStage(bootCopyOptions, bootCopyInputs, bootCopyDevices, bootCopyMounts))
+		pipeline.AddStage(stage)
 	}
 
 	for _, stage := range osbuild.GenImageFinishStages(pt, p.Filename()) {
@@ -136,6 +115,36 @@ func (p *RawImage) serialize() (osbuild.Pipeline, error) {
 	}
 
 	return pipeline, nil
+}
+
+func bootFilesCopyStage(
+	bootFiles []platform.BootFile,
+	inputs osbuild.Inputs,
+	srcPrefix, inputName, pipelineName, filename string,
+	pt *disk.PartitionTable,
+) (*osbuild.Stage, error) {
+	_, devices, mounts := osbuild.GenCopyFSTreeOptions(inputName, pipelineName, filename, pt)
+
+	var fsRootMntName string
+	for _, mnt := range mounts {
+		if mnt.Target == "/" {
+			fsRootMntName = mnt.Name
+			break
+		}
+	}
+	if fsRootMntName == "" {
+		return nil, fmt.Errorf("no mount found for the filesystem root")
+	}
+
+	options := &osbuild.CopyStageOptions{}
+	for _, bf := range bootFiles {
+		options.Paths = append(options.Paths, osbuild.CopyStagePath{
+			From: fmt.Sprintf("input://%s%s", srcPrefix, bf.Src),
+			To:   fmt.Sprintf("mount://%s%s", fsRootMntName, bf.Dst),
+		})
+	}
+
+	return osbuild.NewCopyStage(options, inputs, devices, mounts), nil
 }
 
 func (p *RawImage) Export() *artifact.Artifact {

--- a/pkg/manifest/raw.go
+++ b/pkg/manifest/raw.go
@@ -90,10 +90,10 @@ func (p *RawImage) serialize() (osbuild.Pipeline, error) {
 			return osbuild.Pipeline{}, fmt.Errorf("no mount found for the filesystem root")
 		}
 
-		for _, paths := range bootFiles {
+		for _, bf := range bootFiles {
 			bootCopyOptions.Paths = append(bootCopyOptions.Paths, osbuild.CopyStagePath{
-				From: fmt.Sprintf("input://root-tree%s", paths[0]),
-				To:   fmt.Sprintf("mount://%s%s", fsRootMntName, paths[1]),
+				From: fmt.Sprintf("input://root-tree%s", bf.Src),
+				To:   fmt.Sprintf("mount://%s%s", fsRootMntName, bf.Dst),
 			})
 		}
 

--- a/pkg/manifest/raw.go
+++ b/pkg/manifest/raw.go
@@ -69,10 +69,20 @@ func (p *RawImage) serialize() (osbuild.Pipeline, error) {
 	copyInputs := osbuild.NewPipelineTreeInputs(inputName, p.treePipeline.Name())
 	pipeline.AddStage(osbuild.NewCopyStage(copyOptions, copyInputs, copyDevices, copyMounts))
 
-	bootFiles := p.treePipeline.platform.GetBootFiles()
-	if len(bootFiles) > 0 {
-		bootCopyInputs := osbuild.NewPipelineTreeInputs(inputName, p.treePipeline.Name())
-		stage, err := bootFilesCopyStage(bootFiles, bootCopyInputs, inputName, inputName, p.treePipeline.Name(), p.Filename(), pt)
+	treeBootFiles, buildBootFiles := splitBootFiles(p.treePipeline.platform.GetBootFiles())
+	if len(treeBootFiles) > 0 {
+		treeInputName := "root-tree"
+		bootCopyInputs := osbuild.NewPipelineTreeInputs(treeInputName, p.treePipeline.Name())
+		stage, err := bootFilesCopyStage(treeBootFiles, bootCopyInputs, treeInputName, p.Filename(), pt)
+		if err != nil {
+			return osbuild.Pipeline{}, err
+		}
+		pipeline.AddStage(stage)
+	}
+	if len(buildBootFiles) > 0 {
+		buildInputName := "build-tree"
+		buildCopyInputs := osbuild.NewPipelineTreeInputs(buildInputName, p.build.Name())
+		stage, err := bootFilesCopyStage(buildBootFiles, buildCopyInputs, buildInputName, p.Filename(), pt)
 		if err != nil {
 			return osbuild.Pipeline{}, err
 		}
@@ -117,13 +127,24 @@ func (p *RawImage) serialize() (osbuild.Pipeline, error) {
 	return pipeline, nil
 }
 
+func splitBootFiles(bootFiles []platform.BootFile) (tree, build []platform.BootFile) {
+	for _, bf := range bootFiles {
+		if bf.FromBuild {
+			build = append(build, bf)
+		} else {
+			tree = append(tree, bf)
+		}
+	}
+	return tree, build
+}
+
 func bootFilesCopyStage(
 	bootFiles []platform.BootFile,
 	inputs osbuild.Inputs,
-	srcPrefix, inputName, pipelineName, filename string,
+	srcPrefix, filename string,
 	pt *disk.PartitionTable,
 ) (*osbuild.Stage, error) {
-	_, devices, mounts := osbuild.GenCopyFSTreeOptions(inputName, pipelineName, filename, pt)
+	_, devices, mounts := osbuild.GenCopyFSTreeOptions("", "", filename, pt)
 
 	var fsRootMntName string
 	for _, mnt := range mounts {

--- a/pkg/manifest/raw_ostree.go
+++ b/pkg/manifest/raw_ostree.go
@@ -99,10 +99,10 @@ func (p *RawOSTreeImage) serialize() (osbuild.Pipeline, error) {
 			return osbuild.Pipeline{}, fmt.Errorf("no mount found for the filesystem root")
 		}
 
-		for _, paths := range bootFiles {
+		for _, bf := range bootFiles {
 			bootCopyOptions.Paths = append(bootCopyOptions.Paths, osbuild.CopyStagePath{
-				From: fmt.Sprintf("input://ostree-tree/%s%s", commitChecksum, paths[0]),
-				To:   fmt.Sprintf("mount://%s%s", fsRootMntName, paths[1]),
+				From: fmt.Sprintf("input://ostree-tree/%s%s", commitChecksum, bf.Src),
+				To:   fmt.Sprintf("mount://%s%s", fsRootMntName, bf.Dst),
 			})
 		}
 

--- a/pkg/manifest/raw_ostree.go
+++ b/pkg/manifest/raw_ostree.go
@@ -73,40 +73,17 @@ func (p *RawOSTreeImage) serialize() (osbuild.Pipeline, error) {
 
 	bootFiles := p.platform.GetBootFiles()
 	if len(bootFiles) > 0 {
-		// we ignore the bootcopyoptions as they contain a full tree copy instead we make our own, we *do* still want all the other
-		// information such as mountpoints and devices
-		_, bootCopyDevices, bootCopyMounts := osbuild.GenCopyFSTreeOptions(inputName, p.treePipeline.Name(), p.Filename(), pt)
-		bootCopyOptions := &osbuild.CopyStageOptions{}
-
 		commit := p.treePipeline.ostreeSpec
 		commitChecksum := commit.Checksum
-
 		bootCopyInputs := osbuild.OSTreeCheckoutInputs{
 			"ostree-tree": *osbuild.NewOSTreeCheckoutInput("org.osbuild.source", commitChecksum),
 		}
-
-		// Find the FS root mount name to use as the destination root
-		// for the target when copying the boot files.
-		var fsRootMntName string
-		for _, mnt := range bootCopyMounts {
-			if mnt.Target == "/" {
-				fsRootMntName = mnt.Name
-				break
-			}
+		srcPrefix := fmt.Sprintf("ostree-tree/%s", commitChecksum)
+		stage, err := bootFilesCopyStage(bootFiles, bootCopyInputs, srcPrefix, inputName, p.treePipeline.Name(), p.Filename(), pt)
+		if err != nil {
+			return osbuild.Pipeline{}, err
 		}
-
-		if fsRootMntName == "" {
-			return osbuild.Pipeline{}, fmt.Errorf("no mount found for the filesystem root")
-		}
-
-		for _, bf := range bootFiles {
-			bootCopyOptions.Paths = append(bootCopyOptions.Paths, osbuild.CopyStagePath{
-				From: fmt.Sprintf("input://ostree-tree/%s%s", commitChecksum, bf.Src),
-				To:   fmt.Sprintf("mount://%s%s", fsRootMntName, bf.Dst),
-			})
-		}
-
-		pipeline.AddStage(osbuild.NewCopyStage(bootCopyOptions, bootCopyInputs, bootCopyDevices, bootCopyMounts))
+		pipeline.AddStage(stage)
 	}
 
 	for _, stage := range osbuild.GenImageFinishStages(pt, p.Filename()) {

--- a/pkg/manifest/raw_ostree.go
+++ b/pkg/manifest/raw_ostree.go
@@ -71,15 +71,24 @@ func (p *RawOSTreeImage) serialize() (osbuild.Pipeline, error) {
 
 	pipeline.AddStage(osbuild.NewCopyStage(treeCopyOptions, treeCopyInputs, treeCopyDevices, treeCopyMounts))
 
-	bootFiles := p.platform.GetBootFiles()
-	if len(bootFiles) > 0 {
+	treeBootFiles, buildBootFiles := splitBootFiles(p.platform.GetBootFiles())
+	if len(treeBootFiles) > 0 {
 		commit := p.treePipeline.ostreeSpec
 		commitChecksum := commit.Checksum
 		bootCopyInputs := osbuild.OSTreeCheckoutInputs{
 			"ostree-tree": *osbuild.NewOSTreeCheckoutInput("org.osbuild.source", commitChecksum),
 		}
 		srcPrefix := fmt.Sprintf("ostree-tree/%s", commitChecksum)
-		stage, err := bootFilesCopyStage(bootFiles, bootCopyInputs, srcPrefix, inputName, p.treePipeline.Name(), p.Filename(), pt)
+		stage, err := bootFilesCopyStage(treeBootFiles, bootCopyInputs, srcPrefix, p.Filename(), pt)
+		if err != nil {
+			return osbuild.Pipeline{}, err
+		}
+		pipeline.AddStage(stage)
+	}
+	if len(buildBootFiles) > 0 {
+		buildInputName := "build-tree"
+		buildCopyInputs := osbuild.NewPipelineTreeInputs(buildInputName, p.build.Name())
+		stage, err := bootFilesCopyStage(buildBootFiles, buildCopyInputs, buildInputName, p.Filename(), pt)
 		if err != nil {
 			return osbuild.Pipeline{}, err
 		}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -150,8 +150,9 @@ func (f *ImageFormat) UnmarshalYAML(unmarshal func(any) error) error {
 }
 
 type BootFile struct {
-	Src string `yaml:"src" json:"src"`
-	Dst string `yaml:"dst" json:"dst"`
+	Src       string `yaml:"src" json:"src"`
+	Dst       string `yaml:"dst" json:"dst"`
+	FromBuild bool   `yaml:"from_build,omitempty" json:"from_build,omitempty"`
 }
 
 type Platform interface {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -149,6 +149,11 @@ func (f *ImageFormat) UnmarshalYAML(unmarshal func(any) error) error {
 	return common.UnmarshalYAMLviaJSON(f, unmarshal)
 }
 
+type BootFile struct {
+	Src string `yaml:"src" json:"src"`
+	Dst string `yaml:"dst" json:"dst"`
+}
+
 type Platform interface {
 	GetArch() arch.Arch
 	GetImageFormat() ImageFormat
@@ -159,7 +164,7 @@ type Platform interface {
 	GetZiplSupport() bool
 	GetPackages() []string
 	GetBuildPackages() []string
-	GetBootFiles() [][2]string
+	GetBootFiles() []BootFile
 	GetBootloader() Bootloader
 	GetFIPSMenu() bool
 }

--- a/pkg/platform/yaml.go
+++ b/pkg/platform/yaml.go
@@ -20,7 +20,7 @@ type Data struct {
 	// bios support
 	Packages      map[string][]string `yaml:"packages"`
 	BuildPackages map[string][]string `yaml:"build_packages"`
-	BootFiles     [][2]string         `yaml:"boot_files"`
+	BootFiles     []BootFile          `yaml:"boot_files"`
 
 	Bootloader Bootloader `yaml:"bootloader"`
 	FIPSMenu   bool       `yaml:"fips_menu"` // Add FIPS entry to iso bootloader menu
@@ -64,7 +64,7 @@ func (d *Data) GetBuildPackages() []string {
 	}
 	return merged
 }
-func (d *Data) GetBootFiles() [][2]string {
+func (d *Data) GetBootFiles() []BootFile {
 	return d.BootFiles
 }
 

--- a/pkg/platform/yaml_test.go
+++ b/pkg/platform/yaml_test.go
@@ -26,7 +26,8 @@ func TestPlatformYamlSmoke(t *testing.T) {
           bios:
             - grub2-pc-as-bp
         boot_files:
-          - ["/usr/share/uboot/rpi_arm64/u-boot.bin", "/boot/efi/rpi-u-boot.bin"]
+          - src: "/usr/share/uboot/rpi_arm64/u-boot.bin"
+            dst: "/boot/efi/rpi-u-boot.bin"
         extra_uefi_architectures:
           - "ia32"
 `)
@@ -45,8 +46,8 @@ func TestPlatformYamlSmoke(t *testing.T) {
 		BuildPackages: map[string][]string{
 			"bios": []string{"grub2-pc-as-bp"},
 		},
-		BootFiles: [][2]string{
-			{"/usr/share/uboot/rpi_arm64/u-boot.bin", "/boot/efi/rpi-u-boot.bin"},
+		BootFiles: []platform.BootFile{
+			{Src: "/usr/share/uboot/rpi_arm64/u-boot.bin", Dst: "/boot/efi/rpi-u-boot.bin"},
 		},
 		FIPSMenu:               false,
 		ExtraUEFIArchitectures: []string{"ia32"},


### PR DESCRIPTION
In my quest to get things working on systems that don't behave quite the same as other systems I've addressed a concern that was previously raised (turning `boot_files` into a struct instead of a `[2]string`).

I've then gone and added a property to that struct that allows for the file to be copied from the *build* pipeline instead of from whatever the root filesystem is.

This is useful in a few ways:

1. When you don't want to install the package in the root filesystem because it won't get updated anyhow as it doesn't write to the relevant directory (`uboot-images-armv8`).
2. When you have a BLS-conforming layout that disagrees with the RPM macros contained in `efi-srpm-macros` and you want to use files from a package that uses those macros to write directly into `%{_esp_root}` (which is ... `/boot/efi`).

See https://github.com/teamsbc/distribution/issues/24 for more details on 2.

The latter comes with the caveat that one won't get updates to those files as the package is never inside the actual booted system. This isn't a particularly big problem since if those packages *do* get installed they can't write to what they think is the ESP root anyhow; as it's defined as `/boot/efi` which doesn't exist). However, this is still useful to be able to actually build an image that has the ESP directly at `/boot`.

Perhaps in a follow-up we can format in the information we have about the partition table so the definitions do not need to contain hard coded paths but could instead refer to `{{.ESP}}` or `{{.XBOOTLDR}}` or such. But, that's follow-up material.