### PR TITLE
manifest: use boot root for fix bls

### DIFF
--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -570,13 +570,15 @@ func (p *OS) serialize() (osbuild.Pipeline, error) {
 
 	bootloader := p.platform.GetBootloader()
 
+	bootRoot := "/boot"
+
 	if bootloader == platform.BOOTLOADER_UKI && p.PartitionTable != nil {
-		espMountpoint, err := findESPMountpoint(p.PartitionTable)
+		bootRoot, err = findESPMountpoint(p.PartitionTable)
 		if err != nil {
 			return osbuild.Pipeline{}, err
 		}
 		baseRPMOptions.KernelInstallEnv = &osbuild.KernelInstallEnv{
-			BootRoot: espMountpoint,
+			BootRoot: bootRoot,
 		}
 	}
 
@@ -593,7 +595,7 @@ func (p *OS) serialize() (osbuild.Pipeline, error) {
 			xbootldrMountpoint = ""
 		}
 
-		bootRoot := espMountpoint
+		bootRoot = espMountpoint
 		if xbootldrMountpoint != "" {
 			bootRoot = xbootldrMountpoint
 		}
@@ -612,11 +614,15 @@ func (p *OS) serialize() (osbuild.Pipeline, error) {
 	if !p.OSCustomizations.NoBLS {
 		fixBLSOptions := &osbuild.FixBLSStageOptions{}
 
-		// If the /boot is on a separate partition, the prefix for the BLS stage must be ""
-		if p.PartitionTable != nil && p.PartitionTable.FindMountableOnPlain("/boot") != nil {
+		// If the bootRoot is on a separate partition, the prefix for the BLS stage must be "" as
+		// the bootloader looks relative to the partition this is the case no matter if the bootRoot
+		// is the ESP or the XBOOTLDR
+		if p.PartitionTable != nil && p.PartitionTable.FindMountableOnPlain(bootRoot) != nil {
 			fixBLSOptions.Prefix = common.ToPtr("")
 		}
 
+		// When the bootloader is systemd we need to do the same dance to find the boot root that
+		// was used previously
 		if bootloader == platform.BOOTLOADER_SYSTEMD {
 			fixBLSOptions.RequireBootPrefix = common.ToPtr(false)
 		}

--- a/pkg/manifest/os_test.go
+++ b/pkg/manifest/os_test.go
@@ -948,6 +948,54 @@ func TestOSPipelineSystemdBootFixBLS(t *testing.T) {
 	opts := st.Options.(*osbuild.FixBLSStageOptions)
 	require.NotNil(t, opts.RequireBootPrefix)
 	assert.Equal(t, false, *opts.RequireBootPrefix)
+	require.NotNil(t, opts.Prefix)
+	assert.Equal(t, "", *opts.Prefix)
+}
+
+func TestOSPipelineSystemdBootFixBLSXBootLDR(t *testing.T) {
+	os := manifest.NewTestOSWithPlatform(&platform.Data{
+		Arch:       arch.ARCH_X86_64,
+		Bootloader: platform.BOOTLOADER_SYSTEMD,
+	})
+	os.PartitionTable = makeSystemdBootPartitionTableWithXBootLDR()
+
+	pipeline, err := os.Serialize()
+	require.NoError(t, err)
+
+	st := findStage("org.osbuild.fix-bls", pipeline.Stages)
+	require.NotNil(t, st)
+	opts := st.Options.(*osbuild.FixBLSStageOptions)
+	require.NotNil(t, opts.RequireBootPrefix)
+	assert.Equal(t, false, *opts.RequireBootPrefix)
+	require.NotNil(t, opts.Prefix)
+	assert.Equal(t, "", *opts.Prefix)
+}
+
+func TestOSPipelineFixBLSPrefixSeparateBoot(t *testing.T) {
+	os := manifest.NewTestOS()
+	os.PartitionTable = testdisk.MakeFakePartitionTable("/", "/boot")
+
+	pipeline, err := os.Serialize()
+	require.NoError(t, err)
+
+	st := findStage("org.osbuild.fix-bls", pipeline.Stages)
+	require.NotNil(t, st)
+	opts := st.Options.(*osbuild.FixBLSStageOptions)
+	require.NotNil(t, opts.Prefix)
+	assert.Equal(t, "", *opts.Prefix)
+}
+
+func TestOSPipelineFixBLSPrefixNoSeparateBoot(t *testing.T) {
+	os := manifest.NewTestOS()
+	os.PartitionTable = testdisk.MakeFakePartitionTable("/")
+
+	pipeline, err := os.Serialize()
+	require.NoError(t, err)
+
+	st := findStage("org.osbuild.fix-bls", pipeline.Stages)
+	require.NotNil(t, st)
+	opts := st.Options.(*osbuild.FixBLSStageOptions)
+	assert.Nil(t, opts.Prefix)
 }
 
 func TestOSPipelineSystemdBootKernelInstallEnv(t *testing.T) {


### PR DESCRIPTION
Instead of always assuming `/boot` is the only mountpoint where BLS entries might be verify if whatever the boot root was (still defaulting to `/boot`) is a separate partition.

This fixes the case where the `bootRoot` is the ESP (for example; with `systemd-boot` and no XBOOTLDR) which is a separate partition and thus the leading path needs to be stripped.