### PR TITLE
partition_table: Make AlignUp clearer

### DIFF
--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -251,7 +251,7 @@ func (pt *PartitionTable) AlignUp(size datasizes.Size) datasizes.Size {
 		// already aligned: return unchanged
 		return size
 	}
-	return ((size + grain) / grain) * grain
+	return (size - (size % grain)) + grain
 }
 
 // Convert the given bytes to the number of sectors.


### PR DESCRIPTION
The way AlignUp was originally written depends on the rounding of the go data types in order to function. This changes it to remove the division and multiplication.