### PR TITLE
github: drop the reverse dependency check with image-builder-cli

### DIFF
--- a/.github/workflows/test-osbuild-composer-integration.yml
+++ b/.github/workflows/test-osbuild-composer-integration.yml
@@ -3,20 +3,19 @@ name: "Reverse dependency integration"
 
 # PLEASE UPDATE THIS COMMENT IF ANY RELEVANT CHANGES ARE MADE TO THE WORKFLOW
 #
-# This workflow tests if an open PR breaks osbuild-composer's or
-# image-builder-cli's compatibility with images. If it does, it posts a message
+# This workflow tests if an open PR breaks osbuild-composer's compatibility
+# with image-builder. If it does, it posts a message
 # on the PR itself notifying the author and reviewers of this change. The
 # workflow works as follows (duplicated for each target project):
 #
-# 1. Checks out the target project repositories (osbuild/osbuild-composer and
-#    osbuild/image-builder-cli)
-# 2. Replaces the osbuild/images dependency with the base of the PR (this is
-#    the HEAD of main at the time the PR was opened or updated) and runs
-#    the target project's unit tests.
+# 1. Checks out the osbuild-composer repository.
+# 2. Replaces the osbuild/image-builder dependency with the base of the PR
+#    (this is the HEAD of main at the time the PR was opened or updated) and
+#    runs the target project's unit tests.
 # 3. If the unit tests on the base (step 2) succeed, replaces the
-#    osbuild/images dependency with the *HEAD* of the open PR and runs the
-#    target project's unit tests. If the tests on the base failed, no further
-#    action is taken.
+#    osbuild/image-builder dependency with the *HEAD* of the open PR and runs
+#    the target project's unit tests. If the tests on the base failed, no
+#    further action is taken.
 # 4. At most one of two messages is posted:
 # 4.1 Posts a message on the open PR only if the unit tests with the base (step
 #     2) succeed and the unit tests with the PR HEAD (step 3) fail. This
@@ -81,22 +80,22 @@ jobs:
           ref: main
           set-safe-directory: true
 
-      - name: Check out osbuild/images for the PR
+      - name: Check out osbuild/image-builder for the PR
         uses: actions/checkout@v6
         with:
-          path: images
+          path: image-builder
           ref: ${{ github.event.pull_request.head.sha }}
           set-safe-directory: true
 
       - name: Mark the working directory as safe for git
         run: git config --global --add safe.directory "$(pwd)"
 
-      - name: Update the osbuild/images reference to the base (main)
+      - name: Update the osbuild/image-builder reference to the base (main)
         env:
           base_sha: ${{ github.event.pull_request.base.sha }}
         run: |
           cd osbuild-composer
-          go mod edit -replace github.com/osbuild/images=github.com/osbuild/images@$base_sha
+          go mod edit -replace github.com/osbuild/image-builder=github.com/osbuild/image-builder@$base_sha
 
       - name: Run unit tests (main)
         working-directory: osbuild-composer
@@ -110,16 +109,16 @@ jobs:
             echo "base_test=0" >> $GITHUB_OUTPUT
           fi
 
-      - name: Update the osbuild/images reference to the PR HEAD
+      - name: Update the osbuild/image-builder reference to the PR HEAD
         # if the base tests failed, there's no need to run the PR HEAD tests
         if: steps.tests-base.outputs.base_test == 1
         # Restore and clean the checkout and replace the dependency again using
-        # images from the checkout above
+        # image-builder from the checkout above
         run: |
           cd osbuild-composer
           git restore .
           git clean -xfd .
-          go mod edit -replace github.com/osbuild/images=../images
+          go mod edit -replace github.com/osbuild/image-builder=../image-builder
 
       - name: Run unit tests (PR HEAD)
         id: tests-pr
@@ -149,7 +148,7 @@ jobs:
           repo-token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
           issue: ${{ github.event.pull_request.number }}
           message: |
-            This PR changes the images API or behaviour causing integration failures with osbuild-composer. The next update of the images dependency in osbuild-composer will need work to adapt to these changes.
+            This PR changes the image-builder API or behaviour causing integration failures with osbuild-composer. The next update of the image-builder dependency in osbuild-composer will need work to adapt to these changes.
 
             This is simply a notice. It will not block this PR from being merged.
 
@@ -161,119 +160,5 @@ jobs:
           update-only: true  # don't write a message if there isn't one already
           issue: ${{ github.event.pull_request.number }}
           message: |
-            A previous version of this PR changed the images API or behaviour causing integration issues with osbuild-composer.
-            This is now fixed.
-
-  unit-tests-ib-cli:
-    name: "🛃 image-builder-cli: Unit tests"
-    runs-on: ubuntu-24.04
-    container:
-      image: registry.fedoraproject.org/fedora:latest
-    env:
-      # workaround for expired cert at source of indirect dependency
-      # (go.opencensus.io/trace)
-      GOPROXY: "https://proxy.golang.org|direct"
-    outputs:
-      # Define job outputs
-      # (see https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs#example-defining-outputs-for-a-job)
-      # One output for the test with the base and one for the test against the PR
-      base_test: ${{ steps.tests-base.outputs.base_test }}
-      pr_test: ${{ steps.tests-pr.outputs.pr_test }}
-
-    steps:
-      # krb5-devel is needed to test internal/upload/koji package
-      # gcc is needed to build the mock depsolver binary for the unit tests
-      # gpgme-devel is needed for container upload dependencies
-      - name: Install build and test dependencies
-        run: dnf -y install krb5-devel gcc git-core go gpgme-devel osbuild-depsolve-dnf btrfs-progs-devel device-mapper-devel jq
-
-      - name: Check out image-builder-cli main branch
-        uses: actions/checkout@v6
-        with:
-          path: image-builder-cli
-          repository: osbuild/image-builder-cli
-          ref: main
-          set-safe-directory: true
-
-      - name: Check out osbuild/images for the PR
-        uses: actions/checkout@v6
-        with:
-          path: images
-          ref: ${{ github.event.pull_request.head.sha }}
-          set-safe-directory: true
-
-      - name: Mark the working directory as safe for git
-        run: git config --global --add safe.directory "$(pwd)"
-
-      - name: Update the osbuild/images reference to the base (main)
-        env:
-          base_sha: ${{ github.event.pull_request.base.sha }}
-        run: |
-          cd image-builder-cli
-          go mod edit -replace github.com/osbuild/images=github.com/osbuild/images@$base_sha
-
-      - name: Run unit tests (main)
-        working-directory: image-builder-cli
-        id: tests-base
-        # This step will not fail if the test fails, but it will write the
-        # failure to GITHUB_OUTPUT
-        run: |
-          if go mod tidy && go test -race ./...; then
-            echo "base_test=1" >> $GITHUB_OUTPUT
-          else
-            echo "base_test=0" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Update the osbuild/images reference to the PR HEAD
-        # if the base tests failed, there's no need to run the PR HEAD tests
-        if: steps.tests-base.outputs.base_test == 1
-        # Restore and clean the checkout and replace the dependency again using
-        # images from the checkout above
-        run: |
-          cd image-builder-cli
-          git restore .
-          git clean -xfd .
-          go mod edit -replace github.com/osbuild/images=../images
-
-      - name: Run unit tests (PR HEAD)
-        id: tests-pr
-        working-directory: image-builder-cli
-        # if the base tests failed, there's no need to run the PR HEAD tests
-        if: steps.tests-base.outputs.base_test == 1
-        # This step will not fail if the test fails, but it will write the
-        # failure to GITHUB_OUTPUT
-        run: |
-          if go mod tidy && go test -race ./...; then
-            echo "pr_test=1" >> $GITHUB_OUTPUT
-          else
-            echo "pr_test=0" >> $GITHUB_OUTPUT
-          fi
-
-  post-results-ib-cli:
-    name: "Post notice (image-builder-cli)"
-    permissions:
-      pull-requests: write
-    runs-on: ubuntu-24.04
-    needs: unit-tests-ib-cli
-    steps:
-      - name: Add comment (breakage)
-        uses: mshick/add-pr-comment@v3
-        if: needs.unit-tests-ib-cli.outputs.base_test == 1  &&  needs.unit-tests-ib-cli.outputs.pr_test == 0
-        with:
-          repo-token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
-          issue: ${{ github.event.pull_request.number }}
-          message: |
-            This PR changes the images API or behaviour causing integration failures with image-builder-cli. The next update of the images dependency in image-builder-cli will need work to adapt to these changes.
-
-            This is simply a notice. It will not block this PR from being merged.
-
-      - name: Update comment (fixed)
-        uses: mshick/add-pr-comment@v3
-        if: needs.unit-tests-ib-cli.outputs.pr_test == 1
-        with:
-          repo-token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
-          update-only: true  # don't write a message if there isn't one already
-          issue: ${{ github.event.pull_request.number }}
-          message: |
-            A previous version of this PR changed the images API or behaviour causing integration issues with image-builder-cli.
+            A previous version of this PR changed the image-builder API or behaviour causing integration issues with osbuild-composer.
             This is now fixed.


### PR DESCRIPTION
We are image-builder.