### PR TITLE
many: plumb sdboot options

### DIFF
--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -702,6 +702,39 @@ image_types:
 	})
 }
 
+func TestDefsDistroImageConfigSystemdBoot(t *testing.T) {
+	fakeDistroYaml := `
+distros:
+  - name: test-distro-1
+    vendor: test-vendor
+    defs_path: test-distro-1/
+    image_config:
+      default:
+        systemd_boot:
+          random-seed: "no"
+          make-entry-directory: "yes"
+          entry-token: "os-id"
+`
+
+	fakeImageTypeYaml := `
+image_types:
+  test_type:
+    filename: foo
+`
+	baseDir := makeFakeDistrosYAML(t, fakeDistroYaml, fakeImageTypeYaml)
+	restore := defs.MockDataFS(baseDir)
+	defer restore()
+	dist, err := defs.NewDistroYAML("test-distro-1")
+	assert.NoError(t, err)
+	assert.Equal(t, &distro.ImageConfig{
+		SystemdBoot: &osbuild.SystemdBootConfig{
+			RandomSeed:         "no",
+			MakeEntryDirectory: "yes",
+			EntryToken:         "os-id",
+		},
+	}, dist.ImageConfig())
+}
+
 func TestDefsPartitionTableErrorsNotForImageType(t *testing.T) {
 	badDistroYamlMissingPartitionTable := `
 image_types:

--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -346,6 +346,8 @@ func osCustomizations(t *imageType, osPackageSet rpmmd.PackageSet, options distr
 		osc.NoBLS = *imageConfig.NoBLS
 	}
 
+	osc.SystemdBoot = imageConfig.SystemdBoot
+
 	ca, err := c.GetCACerts()
 	if err != nil {
 		panic(fmt.Sprintf("unexpected error checking CA certs: %v", err))

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -116,6 +116,8 @@ type ImageConfig struct {
 	// instead of BLS. Required for legacy systems like RHEL 7.
 	NoBLS *bool `yaml:"no_bls,omitempty"`
 
+	SystemdBoot *osbuild.SystemdBootConfig `yaml:"systemd_boot,omitempty"`
+
 	// OSTree specific configuration
 
 	// Read only sysroot and boot

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -180,6 +180,8 @@ type OSCustomizations struct {
 	// instead of BLS. Required for legacy systems like RHEL 7.
 	NoBLS bool
 
+	SystemdBoot *osbuild.SystemdBootConfig
+
 	// InstallWeakDeps enables installation of weak dependencies for packages
 	// that are statically defined for the pipeline.
 	// Defaults to True.

--- a/pkg/manifest/raw.go
+++ b/pkg/manifest/raw.go
@@ -121,6 +121,12 @@ func (p *RawImage) serialize() (osbuild.Pipeline, error) {
 		// an error it's empty and the stage options will omit it
 		opts.BootPath, _ = findXBootLDRMountpoint(p.treePipeline.PartitionTable)
 
+		if cfg := p.treePipeline.OSCustomizations.SystemdBoot; cfg != nil {
+			opts.RandomSeed = cfg.RandomSeed
+			opts.MakeEntryDirectory = cfg.MakeEntryDirectory
+			opts.EntryToken = cfg.EntryToken
+		}
+
 		pipeline.AddStage(osbuild.NewBootctlInstallRootStage(opts, bootctlDevices, bootctlMounts))
 	}
 

--- a/pkg/osbuild/bootctl_install_root.go
+++ b/pkg/osbuild/bootctl_install_root.go
@@ -1,5 +1,11 @@
 package osbuild
 
+type SystemdBootConfig struct {
+	RandomSeed         string `json:"random-seed,omitempty" yaml:"random-seed,omitempty"`
+	MakeEntryDirectory string `json:"make-entry-directory,omitempty" yaml:"make-entry-directory,omitempty"`
+	EntryToken         string `json:"entry-token,omitempty" yaml:"entry-token,omitempty"`
+}
+
 type BootctlInstallRootStageOptions struct {
 	Root               string `json:"root"`
 	ESPPath            string `json:"esp-path,omitempty"`


### PR DESCRIPTION
We introduced additional options for systemd-boot configuration but never actually plumbed them through into the configuration or definitions.

Let's do that now so they can be set.