### PR TITLE
osbuild: ddi mount

### DIFF
--- a/pkg/osbuild/ddi_mount.go
+++ b/pkg/osbuild/ddi_mount.go
@@ -1,0 +1,21 @@
+package osbuild
+
+type DDIMountOptions struct {
+	GrowFS      *bool  `json:"growfs,omitempty"`
+	ReadOnly    *bool  `json:"read-only,omitempty"`
+	Fsck        *bool  `json:"fsck,omitempty"`
+	Discard     string `json:"discard,omitempty"`
+	ImagePolicy string `json:"image-policy,omitempty"`
+	ImageFilter string `json:"image-filter,omitempty"`
+}
+
+func (DDIMountOptions) isMountOptions() {}
+
+func NewDDIMount(name, source, target string) *Mount {
+	return &Mount{
+		Type:   "org.osbuild.ddi",
+		Name:   name,
+		Source: source,
+		Target: target,
+	}
+}

--- a/pkg/osbuild/ddi_mount_test.go
+++ b/pkg/osbuild/ddi_mount_test.go
@@ -1,0 +1,73 @@
+package osbuild_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/image-builder/internal/common"
+	"github.com/osbuild/image-builder/pkg/osbuild"
+)
+
+func TestDDIMountBasic(t *testing.T) {
+	mnt := osbuild.NewDDIMount("ddi", "image.raw", "/sysroot")
+	data, err := json.MarshalIndent(mnt, "", "  ")
+	require.Nil(t, err)
+	assert.Equal(t, `
+{
+  "name": "ddi",
+  "type": "org.osbuild.ddi",
+  "source": "image.raw",
+  "target": "/sysroot"
+}`[1:], string(data))
+}
+
+func TestDDIMountAllOptions(t *testing.T) {
+	mnt := osbuild.NewDDIMount("ddi", "image.raw", "/sysroot")
+	mnt.Options = &osbuild.DDIMountOptions{
+		GrowFS:      common.ToPtr(false),
+		ReadOnly:    common.ToPtr(true),
+		Fsck:        common.ToPtr(false),
+		Discard:     "all",
+		ImagePolicy: "root=verity",
+		ImageFilter: "usr",
+	}
+	data, err := json.MarshalIndent(mnt, "", "  ")
+	require.Nil(t, err)
+	assert.Equal(t, `
+{
+  "name": "ddi",
+  "type": "org.osbuild.ddi",
+  "source": "image.raw",
+  "target": "/sysroot",
+  "options": {
+    "growfs": false,
+    "read-only": true,
+    "fsck": false,
+    "discard": "all",
+    "image-policy": "root=verity",
+    "image-filter": "usr"
+  }
+}`[1:], string(data))
+}
+
+func TestDDIMountPartialOptions(t *testing.T) {
+	mnt := osbuild.NewDDIMount("ddi", "image.raw", "/sysroot")
+	mnt.Options = &osbuild.DDIMountOptions{
+		ReadOnly: common.ToPtr(true),
+	}
+	data, err := json.MarshalIndent(mnt, "", "  ")
+	require.Nil(t, err)
+	assert.Equal(t, `
+{
+  "name": "ddi",
+  "type": "org.osbuild.ddi",
+  "source": "image.raw",
+  "target": "/sysroot",
+  "options": {
+    "read-only": true
+  }
+}`[1:], string(data))
+}

--- a/pkg/osbuild/mount_test.go
+++ b/pkg/osbuild/mount_test.go
@@ -80,6 +80,17 @@ func TestNewMounts(t *testing.T) {
 		}
 		assert.Equal(expected, actual)
 	}
+
+	{ // ddi
+		actual := osbuild.NewDDIMount("ddi", "image.raw", "/sysroot")
+		expected := &osbuild.Mount{
+			Name:   "ddi",
+			Type:   "org.osbuild.ddi",
+			Source: "image.raw",
+			Target: "/sysroot",
+		}
+		assert.Equal(expected, actual)
+	}
 }
 
 func TestMountJsonAll(t *testing.T) {


### PR DESCRIPTION
`osbuild` gained the ability to mount Discoverable Disk Images through `systemd-dissect` [1]. Let's do the necessary plumbing here to land that.

There are no users of this codepath yet, but that also makes it nice and small to review.

The required `osbuild` version is already set correctly; DDI mounts were introduced in `osbuild` 183.

[1]: https://github.com/osbuild/osbuild/pull/2459