### PR TITLE
pkg/rhsm: match subscription baseurls with wildcards (RHEL-36789)

### DIFF
--- a/pkg/depsolvednf/v2.go
+++ b/pkg/depsolvednf/v2.go
@@ -438,7 +438,7 @@ func (h *v2Handler) reposFromRPMMD(cfg *solverConfig, rpmRepos []rpmmd.RepoConfi
 
 			// NOTE: It is assumed that the s.subscriptions are not nil if the repo needs RHSM secrets
 			// because validateSubscriptionsForRepos() is called before makeDepsolveRequest().
-			secrets, err := cfg.subscriptions.GetSecretsForBaseurl(rr.BaseURLs, cfg.arch, cfg.releaseVer)
+			secrets, err := cfg.subscriptions.GetSecretsForBaseurl(rr.BaseURLs)
 			if err != nil {
 				return nil, fmt.Errorf("getting RHSM secrets for baseurl %s failed: %w", rr.BaseURLs, err)
 			}

--- a/pkg/rhsm/secrets.go
+++ b/pkg/rhsm/secrets.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/osbuild/image-builder/pkg/olog"
@@ -177,13 +178,31 @@ func parseRepoFile(content []byte) ([]subscription, error) {
 	return subscriptions, nil
 }
 
+// baseurlToRegex turns a redhat.repo baseurl into a matcher by replacing the yum
+// variables ($releasever, $arch, $basearch, $uuid) with a non-slash wildcard,
+// mirroring osbuild's util/rhsm.py so depsolve-time secret lookup agrees with
+// osbuild's download-time matching. Wildcarding $releasever rather than
+// substituting the major-only releasever is what lets both rolling (9) and
+// point-release (9.8) requests match; substituting would bind it to "9" and send
+// point releases to the fallback.
+func baseurlToRegex(baseurl string) (*regexp.Regexp, error) {
+	escaped := regexp.QuoteMeta(baseurl)
+	for _, variable := range []string{`\$releasever`, `\$arch`, `\$basearch`, `\$uuid`} {
+		escaped = strings.ReplaceAll(escaped, variable, `[^/]*`)
+	}
+	// anchored at the start only, matching Python's re.match
+	return regexp.Compile("^" + escaped)
+}
+
 // GetSecretsForBaseurl queries the Subscriptions structure for a RHSMSecrets of a single repository.
-func (s *Subscriptions) GetSecretsForBaseurl(baseurls []string, arch, releasever string) (*RHSMSecrets, error) {
+func (s *Subscriptions) GetSecretsForBaseurl(baseurls []string) (*RHSMSecrets, error) {
 	for _, subs := range s.available {
+		re, err := baseurlToRegex(subs.baseurl)
+		if err != nil {
+			return nil, fmt.Errorf("cannot match subscription baseurl %q: %w", subs.baseurl, err)
+		}
 		for _, baseurl := range baseurls {
-			url := strings.ReplaceAll(subs.baseurl, "$basearch", arch)
-			url = strings.ReplaceAll(url, "$releasever", releasever)
-			if url == baseurl {
+			if re.MatchString(baseurl) {
 				return &RHSMSecrets{
 					SSLCACert:     subs.sslCACert,
 					SSLClientKey:  subs.sslClientKey,

--- a/pkg/rhsm/secrets_test.go
+++ b/pkg/rhsm/secrets_test.go
@@ -34,6 +34,22 @@ metadata_expire = 86400
 enabled_metadata = 0
 `
 
+// SATELLITE_REPO is a redhat.repo from a Satellite-registered host: the baseurl is
+// templated on $releasever with a literal arch, and sslcacert is the Katello CA
+// rather than the default redhat-uep.pem.
+var SATELLITE_REPO = `[rhel-10-for-x86_64-baseos-rpms]
+name = Red Hat Enterprise Linux 10 for x86_64 - BaseOS (RPMs)
+baseurl = https://satellite.example.com/pulp/content/dist/rhel10/$releasever/x86_64/baseos/os
+enabled = 1
+gpgcheck = 1
+sslverify = 1
+sslcacert = /etc/rhsm/ca/katello-server-ca.pem
+sslclientkey = /etc/pki/entitlement/517534911145439618-key.pem
+sslclientcert = /etc/pki/entitlement/517534911145439618.pem
+metadata_expire = 1
+enabled_metadata = 1
+`
+
 func TestParseRepoFile(t *testing.T) {
 	input := []byte(VALID_REPO)
 	repoFileContent, err := parseRepoFile(input)
@@ -41,9 +57,100 @@ func TestParseRepoFile(t *testing.T) {
 	subscriptions := Subscriptions{
 		available: repoFileContent,
 	}
-	secrets, err := subscriptions.GetSecretsForBaseurl([]string{"https://cdn.redhat.com/content/dist/middleware/jws/1.0/x86_64/os"}, "x86_64", "")
+	secrets, err := subscriptions.GetSecretsForBaseurl([]string{"https://cdn.redhat.com/content/dist/middleware/jws/1.0/x86_64/os"})
 	require.NoError(t, err, "Failed to get secrets for a baseurl")
 	assert.Equal(t, secrets.SSLCACert, "/etc/rhsm/ca/redhat-uep.pem", "Unexpected path to the CA certificate")
 	assert.Equal(t, secrets.SSLClientCert, "/etc/pki/entitlement/456.pem", "Unexpected path to the client cert")
 	assert.Equal(t, secrets.SSLClientKey, "/etc/pki/entitlement/123-key.pem", "Unexpected path to the client key")
+}
+
+// no fallback secrets set, so a miss surfaces as an error rather than the
+// fallback CA, isolating these cases to the matching behaviour.
+func TestGetSecretsForBaseurlMatching(t *testing.T) {
+	repoFileContent, err := parseRepoFile([]byte(SATELLITE_REPO))
+	require.NoError(t, err, "Failed to parse the .repo file")
+	subscriptions := Subscriptions{available: repoFileContent}
+
+	base := "https://satellite.example.com/pulp/content/dist/rhel10"
+	for _, tc := range []struct {
+		name      string
+		url       string
+		wantMatch bool
+	}{
+		{"rolling", base + "/10/x86_64/baseos/os", true},
+		{"point release", base + "/10.2/x86_64/baseos/os", true},
+		{"wrong path structure", base + "/10/x86_64/appstream/os", false},
+		{"different host", "https://cdn.redhat.com/content/dist/rhel10/10/x86_64/baseos/os", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			secrets, err := subscriptions.GetSecretsForBaseurl([]string{tc.url})
+			if !tc.wantMatch {
+				assert.Error(t, err, "expected no match for %q", tc.url)
+				return
+			}
+			require.NoError(t, err, "expected a match for %q", tc.url)
+			assert.Equal(t, "/etc/rhsm/ca/katello-server-ca.pem", secrets.SSLCACert)
+			assert.Equal(t, "/etc/pki/entitlement/517534911145439618.pem", secrets.SSLClientCert)
+			assert.Equal(t, "/etc/pki/entitlement/517534911145439618-key.pem", secrets.SSLClientKey)
+		})
+	}
+}
+
+// A point-release request must resolve to the matching subscription's CA, not the
+// global fallback CA, even when a fallback is set.
+func TestGetSecretsForBaseurlPointReleasePrefersSubscriptionCA(t *testing.T) {
+	repoFileContent, err := parseRepoFile([]byte(SATELLITE_REPO))
+	require.NoError(t, err, "Failed to parse the .repo file")
+	subscriptions := Subscriptions{
+		available: repoFileContent,
+		secrets: &RHSMSecrets{
+			SSLCACert:     "/etc/rhsm/ca/redhat-uep.pem",
+			SSLClientKey:  "/etc/pki/entitlement/fallback-key.pem",
+			SSLClientCert: "/etc/pki/entitlement/fallback.pem",
+		},
+	}
+	secrets, err := subscriptions.GetSecretsForBaseurl(
+		[]string{"https://satellite.example.com/pulp/content/dist/rhel10/10.2/x86_64/baseos/os"})
+	require.NoError(t, err, "Failed to get secrets for a point-release baseurl")
+	assert.Equal(t, "/etc/rhsm/ca/katello-server-ca.pem", secrets.SSLCACert,
+		"must prefer the subscription's Katello CA over the redhat-uep.pem fallback")
+}
+
+func TestGetSecretsForBaseurlFallback(t *testing.T) {
+	repoFileContent, err := parseRepoFile([]byte(SATELLITE_REPO))
+	require.NoError(t, err, "Failed to parse the .repo file")
+	subscriptions := Subscriptions{
+		available: repoFileContent,
+		secrets: &RHSMSecrets{
+			SSLCACert:     "/etc/rhsm/ca/redhat-uep.pem",
+			SSLClientKey:  "/etc/pki/entitlement/fallback-key.pem",
+			SSLClientCert: "/etc/pki/entitlement/fallback.pem",
+		},
+	}
+	secrets, err := subscriptions.GetSecretsForBaseurl([]string{"https://unrelated.example.com/some/path"})
+	require.NoError(t, err, "expected fallback secrets to be returned")
+	assert.Equal(t, "/etc/pki/entitlement/fallback-key.pem", secrets.SSLClientKey)
+}
+
+// mirrors the cases in osbuild's test_util_rhsm.py::TestUrlMatching.
+func TestBaseurlToRegex(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		baseurl   string
+		url       string
+		wantMatch bool
+	}{
+		{"basearch", "https://cdn.redhat.com/1.0/$basearch/os", "https://cdn.redhat.com/1.0/x86_64/os/Packages/test.rpm", true},
+		{"releasever and basearch", "https://cdn.redhat.com/$releasever/repo/$basearch/os", "https://cdn.redhat.com/9/repo/x86_64/os/test.rpm", true},
+		{"point release releasever", "https://cdn.redhat.com/$releasever/repo/$basearch/os", "https://cdn.redhat.com/9.8/repo/x86_64/os/test.rpm", true},
+		{"wrong path structure", "https://cdn.redhat.com/$releasever/repo/$basearch/os", "https://cdn.redhat.com/9/different/x86_64/os/test.rpm", false},
+		{"different host", "https://cdn.redhat.com/1.0/$basearch/os", "https://other.host.com/1.0/x86_64/os/test.rpm", false},
+		{"uuid variable", "https://cdn.redhat.com/$uuid/content", "https://cdn.redhat.com/abc-123-def/content/test.rpm", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			re, err := baseurlToRegex(tc.baseurl)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantMatch, re.MatchString(tc.url))
+		})
+	}
 }


### PR DESCRIPTION
GetSecretsForBaseurl matched a requested repository baseurl against the host's redhat.repo entries by substituting the major-only releasever and the arch into each subscription baseurl and comparing for equality. Repository definitions ship both a rolling baseurl (e.g. .../9/...) and point-release baseurls (e.g. .../9.8/...), so for a point release the substituted subscription URL (.../9/...) never equalled the requested URL (.../9.8/...).  The lookup then fell through to the global fallback secrets, which hardcode the CA certificate to /etc/rhsm/ca/redhat-uep.pem.  On a Satellite host the correct CA is the Katello certificate that redhat.repo points sslcacert at, so the fallback returned the wrong CA and depsolving failed.

Match the yum variables ($releasever, $arch, $basearch, $uuid) with a non-slash wildcard instead, mirroring osbuild's util/rhsm.py.  A point-release request then matches the subscription regardless of the releasever or arch, so the per-subscription certificates are returned.  The matching no longer depends on the substituted values, so the now-unused arch and releasever parameters are dropped.