### PR TITLE
cmd/image-builder: mock simple integration tests (HMS-10857)

### DIFF
--- a/cmd/image-builder/export_test.go
+++ b/cmd/image-builder/export_test.go
@@ -25,25 +25,25 @@ var (
 
 type DescribeImgYAML describeImgYAML
 
-func MockOsArgs(new []string) (restore func()) {
+func MockOsArgs(args []string) (restore func()) {
 	saved := os.Args
-	os.Args = append([]string{"argv0"}, new...)
+	os.Args = append([]string{"argv0"}, args...)
 	return func() {
 		os.Args = saved
 	}
 }
 
-func MockOsStdout(new io.Writer) (restore func()) {
+func MockOsStdout(w io.Writer) (restore func()) {
 	saved := osStdout
-	osStdout = new
+	osStdout = w
 	return func() {
 		osStdout = saved
 	}
 }
 
-func MockOsStderr(new io.Writer) (restore func()) {
+func MockOsStderr(w io.Writer) (restore func()) {
 	saved := osStderr
-	osStderr = new
+	osStderr = w
 	return func() {
 		osStderr = saved
 	}
@@ -102,10 +102,18 @@ func MockDirSize(f func(string) (int64, error)) (restore func()) {
 	}
 }
 
-func MockManifestgenDepsolver(new manifestgen.DepsolveFunc) (restore func()) {
+func MockManifestgenDepsolver(fn manifestgen.DepsolveFunc) (restore func()) {
 	saved := manifestgenDepsolver
-	manifestgenDepsolver = new
+	manifestgenDepsolver = fn
 	return func() {
 		manifestgenDepsolver = saved
+	}
+}
+
+func MockManifestgenContainerResolver(fn manifestgen.ContainerResolverFunc) (restore func()) {
+	saved := manifestgenContainerResolver
+	manifestgenContainerResolver = fn
+	return func() {
+		manifestgenContainerResolver = saved
 	}
 }

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -243,6 +243,7 @@ type cmdManifestWrapperOptions struct {
 
 // used in tests
 var manifestgenDepsolver manifestgen.DepsolveFunc
+var manifestgenContainerResolver manifestgen.ContainerResolverFunc
 
 func getImage(cmd *cobra.Command, args []string) (*imagefilter.Result, error) {
 	repoDir, err := cmd.Flags().GetString("force-repo-dir")
@@ -494,6 +495,7 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 			RpmDownloader:          rpmDownloader,
 			DepsolveWarningsOutput: wd,
 			Depsolve:               manifestgenDepsolver,
+			ContainerResolver:      manifestgenContainerResolver,
 		},
 		OutputDir:                  outputDir,
 		OutputFilename:             outputFilename,

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/osbuild/image-builder/internal/common"
+	"github.com/osbuild/image-builder/pkg/container"
 	"github.com/osbuild/image-builder/pkg/depsolvednf"
 	"github.com/osbuild/image-builder/pkg/distro"
 	"github.com/osbuild/image-builder/pkg/manifestgen/manifestmock"
@@ -177,14 +179,13 @@ func makeTestBlueprint(t *testing.T, testBlueprint string) string {
 
 // XXX: move to pytest like bib maybe?
 func TestManifestIntegrationSmoke(t *testing.T) {
-	if testing.Short() {
-		t.Skip("manifest generation takes a while")
-	}
-	if !hasDepsolveDnf() {
-		t.Skip("no osbuild-depsolve-dnf binary found")
-	}
+	restore := main.MockManifestgenDepsolver(fakeDepsolve)
+	defer restore()
 
-	restore := main.MockNewRepoRegistry(testrepos.New)
+	restore = main.MockManifestgenContainerResolver(fakeContainerResolver)
+	defer restore()
+
+	restore = main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
 
 	for _, useLibrepo := range []bool{false, true} {
@@ -216,7 +217,7 @@ func TestManifestIntegrationSmoke(t *testing.T) {
 
 			// XXX: provide helpers in manifesttest to extract this in a nicer way
 			assertJsonContains(t, fakeStdout.String(), `{"type":"org.osbuild.users","options":{"users":{"alice":{}}}}`)
-			assertJsonContains(t, fakeStdout.String(), `"image":{"name":"registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"`)
+			assertJsonContains(t, fakeStdout.String(), `"image":{"name":"resolved-cnt-registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"`)
 
 			assert.Equal(t, strings.Contains(fakeStdout.String(), "org.osbuild.librepo"), useLibrepo)
 		})
@@ -390,14 +391,13 @@ fi
 }
 
 func TestBuildIntegrationHappy(t *testing.T) {
-	if testing.Short() {
-		t.Skip("manifest generation takes a while")
-	}
-	if !hasDepsolveDnf() {
-		t.Skip("no osbuild-depsolve-dnf binary found")
-	}
+	restore := main.MockManifestgenDepsolver(fakeDepsolve)
+	defer restore()
 
-	restore := main.MockNewRepoRegistry(testrepos.New)
+	restore = main.MockManifestgenContainerResolver(fakeContainerResolver)
+	defer restore()
+
+	restore = main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
 
 	var fakeStdout bytes.Buffer
@@ -425,7 +425,8 @@ func TestBuildIntegrationHappy(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	assert.Contains(t, fakeStdout.String(), `Image build successful: centos-9-qcow2-x86_64/centos-9-qcow2-x86_64.qcow2`)
+	currentArch := arch.Current().String()
+	assert.Contains(t, fakeStdout.String(), fmt.Sprintf(`Image build successful: centos-9-qcow2-%s/centos-9-qcow2-%s.qcow2`, currentArch, currentArch))
 
 	// ensure osbuild was run exactly one
 	require.Equal(t, 1, len(fakeOsbuildCmd.CallArgsList()))
@@ -437,28 +438,29 @@ func TestBuildIntegrationHappy(t *testing.T) {
 	// and we passed the output dir
 	outputDirPos := slices.Index(osbuildCall, "--output-directory")
 	assert.True(t, outputDirPos > -1)
-	assert.Equal(t, "centos-9-qcow2-x86_64", osbuildCall[outputDirPos+1])
+	assert.Equal(t, fmt.Sprintf("centos-9-qcow2-%s", currentArch), osbuildCall[outputDirPos+1])
 
 	// ... and that the manifest passed to osbuild
 	manifest, err := os.ReadFile(fakeOsbuildCmd.Path() + ".stdin")
 	assert.NoError(t, err)
 	// XXX: provide helpers in manifesttest to extract this in a nicer way
 	assertJsonContains(t, string(manifest), `{"type":"org.osbuild.users","options":{"users":{"alice":{}}}}`)
-	assertJsonContains(t, string(manifest), `"image":{"name":"registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"`)
+	assertJsonContains(t, string(manifest), `"image":{"name":"resolved-cnt-registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"`)
 }
 
 func TestBuildIntegrationArgs(t *testing.T) {
-	if testing.Short() {
-		t.Skip("manifest generation takes a while")
-	}
-	if !hasDepsolveDnf() {
-		t.Skip("no osbuild-depsolve-dnf binary found")
-	}
+	restore := main.MockManifestgenDepsolver(fakeDepsolve)
+	defer restore()
 
-	restore := main.MockNewRepoRegistry(testrepos.New)
+	restore = main.MockManifestgenContainerResolver(fakeContainerResolver)
+	defer restore()
+
+	restore = main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
 
 	cacheDir := t.TempDir()
+	currentArch := arch.Current().String()
+	prefix := fmt.Sprintf("centos-9-qcow2-%s", currentArch)
 	for _, tc := range []struct {
 		args          []string
 		expectedFiles []string
@@ -470,29 +472,34 @@ func TestBuildIntegrationArgs(t *testing.T) {
 			"",
 		}, {
 			[]string{"--with-manifest"},
-			[]string{"centos-9-qcow2-x86_64.osbuild-manifest.json"},
+			[]string{prefix + ".osbuild-manifest.json"},
 			"",
 		}, {
 			[]string{"--with-buildlog"},
-			[]string{"centos-9-qcow2-x86_64.buildlog"},
+			[]string{prefix + ".buildlog"},
 			"",
 		}, {
 			[]string{"--with-sbom"},
-			[]string{"centos-9-qcow2-x86_64.buildroot-build.spdx.json",
-				"centos-9-qcow2-x86_64.image-os.spdx.json",
+			[]string{prefix + ".buildroot-build.spdx.json",
+				prefix + ".image-os.spdx.json",
 			},
 			"",
 		}, {
 			[]string{"--with-manifest", "--with-sbom"},
-			[]string{"centos-9-qcow2-x86_64.buildroot-build.spdx.json",
-				"centos-9-qcow2-x86_64.image-os.spdx.json",
-				"centos-9-qcow2-x86_64.osbuild-manifest.json",
+			[]string{prefix + ".buildroot-build.spdx.json",
+				prefix + ".image-os.spdx.json",
+				prefix + ".osbuild-manifest.json",
 			},
 			"",
 		},
 		{
 			[]string{"--format", "json", "--with-buildlog", "--progress", "file"},
-			[]string{"centos-9-qcow2-x86_64.buildlog", "centos-9-qcow2-x86_64.progress"},
+			[]string{prefix + ".buildlog", prefix + ".progress"},
+			"{\"success\": true}\n",
+		},
+		{
+			[]string{"--format", "json", "--with-buildlog", "--progress", "debug"},
+			[]string{prefix + ".buildlog"},
 			"{\"success\": true}\n",
 		},
 	} {
@@ -523,7 +530,7 @@ func TestBuildIntegrationArgs(t *testing.T) {
 			assert.Equal(t, outputDir, osbuildCall[outputDirPos+1])
 
 			if tc.expectedLog != "" {
-				data, err := os.ReadFile(filepath.Join(outputDir, "centos-9-qcow2-x86_64.buildlog"))
+				data, err := os.ReadFile(filepath.Join(outputDir, prefix+".buildlog"))
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expectedLog, string(data))
 			}
@@ -553,14 +560,13 @@ exit 1
 `
 
 func TestBuildIntegrationErrorsProgressVerbose(t *testing.T) {
-	if testing.Short() {
-		t.Skip("manifest generation takes a while")
-	}
-	if !hasDepsolveDnf() {
-		t.Skip("no osbuild-depsolve-dnf binary found")
-	}
+	restore := main.MockManifestgenDepsolver(fakeDepsolve)
+	defer restore()
 
-	restore := main.MockNewRepoRegistry(testrepos.New)
+	restore = main.MockManifestgenContainerResolver(fakeContainerResolver)
+	defer restore()
+
+	restore = main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
 
 	outputDir := t.TempDir()
@@ -586,14 +592,13 @@ func TestBuildIntegrationErrorsProgressVerbose(t *testing.T) {
 }
 
 func TestBuildIntegrationErrorsProgressVerboseWithBuildlog(t *testing.T) {
-	if testing.Short() {
-		t.Skip("manifest generation takes a while")
-	}
-	if !hasDepsolveDnf() {
-		t.Skip("no osbuild-depsolve-dnf binary found")
-	}
+	restore := main.MockManifestgenDepsolver(fakeDepsolve)
+	defer restore()
 
-	restore := main.MockNewRepoRegistry(testrepos.New)
+	restore = main.MockManifestgenContainerResolver(fakeContainerResolver)
+	defer restore()
+
+	restore = main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
 
 	outputDir := t.TempDir()
@@ -626,7 +631,7 @@ exit 1
 	assert.Contains(t, stdout, "error on stdout\n")
 	assert.Contains(t, stdout, "error on stderr\n")
 
-	buildLog, err := os.ReadFile(filepath.Join(outputDir, "centos-9-qcow2-x86_64.buildlog"))
+	buildLog, err := os.ReadFile(filepath.Join(outputDir, fmt.Sprintf("centos-9-qcow2-%s.buildlog", arch.Current())))
 	assert.NoError(t, err)
 	assert.Equal(t, string(buildLog), `error on stdout
 error on stderr
@@ -634,14 +639,13 @@ error on stderr
 }
 
 func TestBuildIntegrationErrorsProgressTerm(t *testing.T) {
-	if testing.Short() {
-		t.Skip("manifest generation takes a while")
-	}
-	if !hasDepsolveDnf() {
-		t.Skip("no osbuild-depsolve-dnf binary found")
-	}
+	restore := main.MockManifestgenDepsolver(fakeDepsolve)
+	defer restore()
 
-	restore := main.MockNewRepoRegistry(testrepos.New)
+	restore = main.MockManifestgenContainerResolver(fakeContainerResolver)
+	defer restore()
+
+	restore = main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
 
 	for _, withBuildlog := range []bool{false, true} {
@@ -676,15 +680,16 @@ error on stderr
 			assert.NotContains(t, stdout, "error on stdout")
 			assert.NotContains(t, stderr, "error on stderr")
 
+			buildlogName := fmt.Sprintf("centos-9-qcow2-%s.buildlog", arch.Current())
 			if withBuildlog {
-				buildLog, err := os.ReadFile(filepath.Join(outputDir, "centos-9-qcow2-x86_64.buildlog"))
+				buildLog, err := os.ReadFile(filepath.Join(outputDir, buildlogName))
 				assert.NoError(t, err)
 				assert.Equal(t, string(buildLog), `error on stdout
 error on stderr
 osbuild-stage-output
 `)
 			} else {
-				_, err := os.Stat(filepath.Join(outputDir, "centos-9-qcow2-x86_64.buildlog"))
+				_, err := os.Stat(filepath.Join(outputDir, buildlogName))
 				assert.True(t, os.IsNotExist(err))
 			}
 		})
@@ -692,15 +697,15 @@ osbuild-stage-output
 }
 
 func TestManifestIntegrationWithSBOMWithOutputDir(t *testing.T) {
-	if testing.Short() {
-		t.Skip("manifest generation takes a while")
-	}
-	if !hasDepsolveDnf() {
-		t.Skip("no osbuild-depsolve-dnf binary found")
-	}
+	restore := main.MockManifestgenDepsolver(fakeDepsolve)
+	defer restore()
+
+	restore = main.MockManifestgenContainerResolver(fakeContainerResolver)
+	defer restore()
+
 	outputDir := filepath.Join(t.TempDir(), "output-dir")
 
-	restore := main.MockNewRepoRegistry(testrepos.New)
+	restore = main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
 
 	restore = main.MockOsArgs([]string{
@@ -813,6 +818,7 @@ func TestManifestExtraRepos(t *testing.T) {
 	if !hasDepsolveDnf() {
 		t.Skip("no osbuild-depsolve-dnf binary found")
 	}
+
 	if _, err := exec.LookPath("createrepo_c"); err != nil {
 		t.Skip("need createrepo_c to run this test")
 	}
@@ -909,15 +915,19 @@ func TestManifestOverrideRepo(t *testing.T) {
 }
 
 func TestBuildCrossArchSmoke(t *testing.T) {
-	if testing.Short() {
-		t.Skip("manifest generation takes a while")
-	}
-	if !hasDepsolveDnf() {
-		t.Skip("no osbuild-depsolve-dnf binary found")
-	}
-
-	restore := main.MockNewRepoRegistry(testrepos.New)
+	restore := main.MockManifestgenDepsolver(fakeDepsolve)
 	defer restore()
+
+	restore = main.MockManifestgenContainerResolver(fakeContainerResolver)
+	defer restore()
+
+	restore = main.MockNewRepoRegistry(testrepos.New)
+	defer restore()
+
+	crossArch := arch.ARCH_AARCH64
+	if arch.Current() == arch.ARCH_AARCH64 {
+		crossArch = arch.ARCH_X86_64
+	}
 
 	tmpdir := t.TempDir()
 	for _, withCrossArch := range []bool{false, true} {
@@ -929,7 +939,7 @@ func TestBuildCrossArchSmoke(t *testing.T) {
 			"--output-dir", tmpdir,
 		}
 		if withCrossArch {
-			cmd = append(cmd, "--arch=aarch64")
+			cmd = append(cmd, fmt.Sprintf("--arch=%s", crossArch))
 		}
 		restore = main.MockOsArgs(cmd)
 		defer restore()
@@ -948,7 +958,7 @@ func TestBuildCrossArchSmoke(t *testing.T) {
 		pipelines, err := manifesttest.PipelineNamesFrom(manifest)
 		assert.NoError(t, err)
 		crossArchPipeline := "bootstrap-buildroot"
-		crossArchWarning := `WARNING: using experimental cross-architecture building to build "aarch64"`
+		crossArchWarning := fmt.Sprintf(`WARNING: using experimental cross-architecture building to build %q`, crossArch)
 		if withCrossArch {
 			assert.Contains(t, pipelines, crossArchPipeline)
 			assert.Contains(t, stderr, crossArchWarning)
@@ -960,14 +970,13 @@ func TestBuildCrossArchSmoke(t *testing.T) {
 }
 
 func TestBuildIntegrationOutputFilename(t *testing.T) {
-	if testing.Short() {
-		t.Skip("manifest generation takes a while")
-	}
-	if !hasDepsolveDnf() {
-		t.Skip("no osbuild-depsolve-dnf binary found")
-	}
+	restore := main.MockManifestgenDepsolver(fakeDepsolve)
+	defer restore()
 
-	restore := main.MockNewRepoRegistry(testrepos.New)
+	restore = main.MockManifestgenContainerResolver(fakeContainerResolver)
+	defer restore()
+
+	restore = main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
 
 	var fakeStdout bytes.Buffer
@@ -1054,8 +1063,28 @@ func fakeDepsolve(solver *depsolvednf.Solver, cacheDir string, depsolveWarningsO
 	return depsolvedSets, nil
 }
 
+func fakeContainerResolver(containerSources map[string][]container.SourceSpec, archName string) (map[string][]container.Spec, error) {
+	containerSpecs := make(map[string][]container.Spec, len(containerSources))
+	for plName, sourceSpecs := range containerSources {
+		var containers []container.Spec
+		for _, spec := range sourceSpecs {
+			containers = append(containers, container.Spec{
+				Source:  fmt.Sprintf("resolved-cnt-%s", spec.Source),
+				Digest:  "sha256:" + testutil.SHA256For("digest:"+spec.Source),
+				ImageID: "sha256:" + testutil.SHA256For("id:"+spec.Source),
+				Arch:    common.Must(arch.FromString(archName)),
+			})
+		}
+		containerSpecs[plName] = containers
+	}
+	return containerSpecs, nil
+}
+
 func TestManifestIntegrationWithRegistrations(t *testing.T) {
 	restore := main.MockManifestgenDepsolver(fakeDepsolve)
+	defer restore()
+
+	restore = main.MockManifestgenContainerResolver(fakeContainerResolver)
 	defer restore()
 
 	restore = main.MockNewRepoRegistry(testrepos.New)
@@ -1106,6 +1135,9 @@ func TestManifestIntegrationWithRegistrations(t *testing.T) {
 
 func TestManifestIntegrationWarningsHandling(t *testing.T) {
 	restore := main.MockManifestgenDepsolver(fakeDepsolve)
+	defer restore()
+
+	restore = main.MockManifestgenContainerResolver(fakeContainerResolver)
 	defer restore()
 
 	restore = main.MockNewRepoRegistry(testrepos.New)

--- a/cmd/image-builder/upload_test.go
+++ b/cmd/image-builder/upload_test.go
@@ -19,7 +19,25 @@ import (
 
 	main "github.com/osbuild/image-builder/cmd/image-builder"
 	"github.com/osbuild/image-builder/internal/testutil"
+	testrepos "github.com/osbuild/image-builder/test/data/repositories"
 )
+
+func skipIfNoAMISupport(t *testing.T) {
+	t.Helper()
+	switch arch.Current() {
+	case arch.ARCH_X86_64, arch.ARCH_AARCH64:
+		return
+	default:
+		t.Skipf("AMI image type not available for %s", arch.Current())
+	}
+}
+
+func expectedBootModeForCurrentArch() platform.BootMode {
+	if arch.Current() == arch.ARCH_X86_64 {
+		return platform.BOOT_HYBRID
+	}
+	return platform.BOOT_UEFI
+}
 
 func TestUploadWithAWSMock(t *testing.T) {
 	fakeDiskContent := "fake-raw-img"
@@ -182,17 +200,20 @@ func TestUploadCmdlineErrors(t *testing.T) {
 }
 
 func TestBuildAndUploadWithAWSMock(t *testing.T) {
-	if testing.Short() {
-		t.Skip("manifest generation takes a while")
-	}
-	if !hasDepsolveDnf() {
-		t.Skip("no osbuild-depsolve-dnf binary found")
-	}
+	skipIfNoAMISupport(t)
+	restore := main.MockManifestgenDepsolver(fakeDepsolve)
+	defer restore()
+
+	restore = main.MockManifestgenContainerResolver(fakeContainerResolver)
+	defer restore()
+
+	restore = main.MockNewRepoRegistry(testrepos.New)
+	defer restore()
 
 	var regionName, bucketName, amiName string
 	var fa fakeAwsUploader
 	var uploadOpts *awscloud.UploaderOptions
-	restore := main.MockAwscloudNewUploader(func(region string, bucket string, ami string, opts *awscloud.UploaderOptions) (cloud.Uploader, error) {
+	restore = main.MockAwscloudNewUploader(func(region string, bucket string, ami string, opts *awscloud.UploaderOptions) (cloud.Uploader, error) {
 		regionName = region
 		bucketName = bucket
 		amiName = ami
@@ -226,7 +247,7 @@ func TestBuildAndUploadWithAWSMock(t *testing.T) {
 	assert.Equal(t, regionName, "aws-region-1")
 	assert.Equal(t, bucketName, "aws-bucket-2")
 	assert.Equal(t, amiName, "aws-ami-3")
-	expectedBootMode := platform.BOOT_HYBRID
+	expectedBootMode := expectedBootModeForCurrentArch()
 	assert.Equal(t, &awscloud.UploaderOptions{BootMode: &expectedBootMode, TargetArch: arch.Current()}, uploadOpts)
 	assert.Equal(t, 1, fa.checkCalls)
 	assert.Equal(t, 1, fa.uploadAndRegisterCalls)
@@ -234,17 +255,20 @@ func TestBuildAndUploadWithAWSMock(t *testing.T) {
 }
 
 func TestBuildAndUploadFedoraWithAWSMock(t *testing.T) {
-	if testing.Short() {
-		t.Skip("manifest generation takes a while")
-	}
-	if !hasDepsolveDnf() {
-		t.Skip("no osbuild-depsolve-dnf binary found")
-	}
+	skipIfNoAMISupport(t)
+	restore := main.MockManifestgenDepsolver(fakeDepsolve)
+	defer restore()
+
+	restore = main.MockManifestgenContainerResolver(fakeContainerResolver)
+	defer restore()
+
+	restore = main.MockNewRepoRegistry(testrepos.New)
+	defer restore()
 
 	var regionName, bucketName, amiName string
 	var fa fakeAwsUploader
 	var uploadOpts *awscloud.UploaderOptions
-	restore := main.MockAwscloudNewUploader(func(region string, bucket string, ami string, opts *awscloud.UploaderOptions) (cloud.Uploader, error) {
+	restore = main.MockAwscloudNewUploader(func(region string, bucket string, ami string, opts *awscloud.UploaderOptions) (cloud.Uploader, error) {
 		regionName = region
 		bucketName = bucket
 		amiName = ami
@@ -278,7 +302,7 @@ func TestBuildAndUploadFedoraWithAWSMock(t *testing.T) {
 	assert.Equal(t, regionName, "aws-region-1")
 	assert.Equal(t, bucketName, "aws-bucket-2")
 	assert.Equal(t, amiName, "aws-ami-3")
-	expectedBootMode := platform.BOOT_HYBRID
+	expectedBootMode := expectedBootModeForCurrentArch()
 	assert.Equal(t, &awscloud.UploaderOptions{BootMode: &expectedBootMode, TargetArch: arch.Current()}, uploadOpts)
 	assert.Equal(t, 1, fa.checkCalls)
 	assert.Equal(t, 1, fa.uploadAndRegisterCalls)
@@ -286,17 +310,20 @@ func TestBuildAndUploadFedoraWithAWSMock(t *testing.T) {
 }
 
 func TestBuildAmiButNotUpload(t *testing.T) {
-	if testing.Short() {
-		t.Skip("manifest generation takes a while")
-	}
-	if !hasDepsolveDnf() {
-		t.Skip("no osbuild-depsolve-dnf binary found")
-	}
+	skipIfNoAMISupport(t)
+	restore := main.MockManifestgenDepsolver(fakeDepsolve)
+	defer restore()
+
+	restore = main.MockManifestgenContainerResolver(fakeContainerResolver)
+	defer restore()
+
+	restore = main.MockNewRepoRegistry(testrepos.New)
+	defer restore()
 
 	fa := fakeAwsUploader{
 		uploadAndRegisterErr: fmt.Errorf("upload should not be called"),
 	}
-	restore := main.MockAwscloudNewUploader(func(region string, bucket string, ami string, opts *awscloud.UploaderOptions) (cloud.Uploader, error) {
+	restore = main.MockAwscloudNewUploader(func(region string, bucket string, ami string, opts *awscloud.UploaderOptions) (cloud.Uploader, error) {
 		return &fa, nil
 	})
 	defer restore()
@@ -324,18 +351,21 @@ func TestBuildAmiButNotUpload(t *testing.T) {
 }
 
 func TestBuildAndUploadWithAWSPartialCmdlineErrors(t *testing.T) {
-	if testing.Short() {
-		t.Skip("manifest generation takes a while")
-	}
-	if !hasDepsolveDnf() {
-		t.Skip("no osbuild-depsolve-dnf binary found")
-	}
+	skipIfNoAMISupport(t)
+	restore := main.MockManifestgenDepsolver(fakeDepsolve)
+	defer restore()
+
+	restore = main.MockManifestgenContainerResolver(fakeContainerResolver)
+	defer restore()
+
+	restore = main.MockNewRepoRegistry(testrepos.New)
+	defer restore()
 
 	outputDir := t.TempDir()
 	fakeOsbuildScript := makeFakeOsbuildScript()
 	testutil.MockCommand(t, "osbuild", fakeOsbuildScript)
 
-	restore := main.MockOsArgs([]string{
+	restore = main.MockOsArgs([]string{
 		"build",
 		"--output-dir", outputDir,
 		// note that --aws-{ami-name,bucket} is missing

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -2,6 +2,8 @@ package testutil
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,6 +13,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+func SHA256For(s string) string {
+	h := sha256.New()
+	h.Write([]byte(s))
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
 
 type MockCmd struct {
 	binDir string

--- a/pkg/manifestgen/manifestgen_test.go
+++ b/pkg/manifestgen/manifestgen_test.go
@@ -2,7 +2,6 @@ package manifestgen_test
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/osbuild/blueprint/pkg/blueprint"
 	"github.com/osbuild/image-builder/internal/common"
+	"github.com/osbuild/image-builder/internal/testutil"
 	"github.com/osbuild/image-builder/pkg/arch"
 	"github.com/osbuild/image-builder/pkg/container"
 	"github.com/osbuild/image-builder/pkg/depsolvednf"
@@ -30,13 +30,6 @@ import (
 	"github.com/osbuild/image-builder/pkg/sbom"
 	testrepos "github.com/osbuild/image-builder/test/data/repositories"
 )
-
-func sha256For(s string) string {
-	h := sha256.New()
-	h.Write([]byte(s))
-	bs := h.Sum(nil)
-	return fmt.Sprintf("%x", bs)
-}
 
 func TestManifestGeneratorDepsolve(t *testing.T) {
 	repos, err := testrepos.New()
@@ -175,8 +168,8 @@ func fakeContainerResolver(containerSources map[string][]container.SourceSpec, a
 		for _, spec := range sourceSpecs {
 			containers = append(containers, container.Spec{
 				Source:  fmt.Sprintf("resolved-cnt-%s", spec.Source),
-				Digest:  "sha256:" + sha256For("digest:"+spec.Source),
-				ImageID: "sha256:" + sha256For("id:"+spec.Source),
+				Digest:  "sha256:" + testutil.SHA256For("digest:"+spec.Source),
+				ImageID: "sha256:" + testutil.SHA256For("id:"+spec.Source),
 				Arch:    common.Must(arch.FromString(archName)),
 			})
 		}


### PR DESCRIPTION
Mock the integration tests that are easy and straightforward to mock. This reduces the test time significantly as we're not performing real dependency solving anymore in most of the tests.

---

Note this doesn't *really* make things faster that much. The test suite still takes long as almost every test calls `main.Run()` which loads distribution definitions which takes 2-3 seconds for *every* test.

We also can't make the tests parallel without rewriting the entire mocking strategy since we're mocking globals 🙁 