### PR TITLE
Test depsolvednf with dnf5 [HMS-10324]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,12 @@ jobs:
       - name: Run depsolver tests with force-dnf to make sure it's not skipped
         run: go test -race ./pkg/depsolvednf/... -force-dnf
 
+      - name: Run depsolver tests with dnf5
+        run: |
+          sudo sed -i 's/"use_dnf5": false/"use_dnf5": true/' /usr/lib/osbuild/solver.json
+          go clean -testcache
+          go test -race ./pkg/depsolvednf/... -force-dnf
+
   container-resolver-tests:
     name: "🛃 Container resolver tests"
     runs-on: ubuntu-24.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,16 +60,15 @@ jobs:
       - name: Run unit tests
         # Skip tests that resolve manifests from local container storage.
         # They are tested separately (see below: requires root)
-        run: go test  -race -timeout 20m ./... -test.skip 'TestBlockingResolverLocalManifest|TestResolverLocalManifest|TestGetManifestLocal'
+        run: go test -count=1 -race -timeout 20m ./... -test.skip 'TestBlockingResolverLocalManifest|TestResolverLocalManifest|TestGetManifestLocal'
 
       - name: Run depsolver tests with force-dnf to make sure it's not skipped
-        run: go test -race ./pkg/depsolvednf/... -force-dnf
+        run: go test -count=1 -race ./pkg/depsolvednf/... -force-dnf
 
       - name: Run depsolver tests with dnf5
         run: |
           sudo sed -i 's/"use_dnf5": false/"use_dnf5": true/' /usr/lib/osbuild/solver.json
-          go clean -testcache
-          go test -race ./pkg/depsolvednf/... -force-dnf
+          go test -count=1 -race ./pkg/depsolvednf/... -force-dnf
 
   container-resolver-tests:
     name: "🛃 Container resolver tests"
@@ -103,13 +102,13 @@ jobs:
       # We need to run the test as root, since we use the root
       # containers-storage for the local resolvers
       - name: Run unit tests for container resolve
-        run: sudo go test ./pkg/container/... --force-local-resolver
+        run: sudo go test -count=1 ./pkg/container/... --force-local-resolver
 
       - name: Run unit tests for bib container
-        run: sudo go test ./pkg/bootc/... --fail-if-podman-missing
+        run: sudo go test -count=1 ./pkg/bootc/... --fail-if-podman-missing
 
       - name: Run tests for bootc container
-        run: sudo go test ./pkg/distro/bootc/... ./pkg/distro/generic/...
+        run: sudo go test -count=1 ./pkg/distro/bootc/... ./pkg/distro/generic/...
 
   unit-tests-cs:
     strategy:

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -865,7 +865,15 @@ func TestManifestOverrideRepo(t *testing.T) {
 	testutil.CaptureStdio(t, func() {
 		err = main.Run()
 	})
-	assert.ErrorContains(t, err, "forced repo#0 xxx.abcdefgh-no-such-host.com/repo: http://xxx.abcdefgh-no-such-host.com/repo]: Cannot download repomd.xml")
+
+	// When using dnf5, the error message differs substantially. More complete
+	// error messages are already covered by the depsolvednf tests for both dnf
+	// and dnf5. Here we just make sure the repo URL appears in the error
+	// message with one of two fragments for each backend.
+	assert.ErrorContains(t, err, "xxx.abcdefgh-no-such-host.com/repo")
+	if !strings.Contains(err.Error(), "Cannot download repomd.xml") && !strings.Contains(err.Error(), "Usable URL not found") {
+		assert.Failf(t, "Unexpected error message", "Error %q does not contain either of the expected messages for dnf or dnf5", err)
+	}
 	// XXX: we should probably look into "images" here, there is a bunch
 	// of redundancy in the full error message:
 	//

--- a/pkg/depsolvednf/depsolvednf_test.go
+++ b/pkg/depsolvednf/depsolvednf_test.go
@@ -971,10 +971,10 @@ func TestErrorRepoInfo(t *testing.T) {
 			restore := mockActiveHandler(h.handler)
 			defer restore()
 
-			assert := assert.New(t)
 			solver := NewSolver("platform:f38", "38", "x86_64", "fedora-38", "/tmp/cache")
 			for idx, tc := range testCases {
 				t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+					assert := assert.New(t)
 					_, err := solver.Depsolve([]rpmmd.PackageSet{
 						{
 							Include:      []string{"osbuild"},

--- a/pkg/depsolvednf/depsolvednf_test.go
+++ b/pkg/depsolvednf/depsolvednf_test.go
@@ -275,6 +275,8 @@ func TestSolverDepsolveAll(t *testing.T) {
 		sbomType    sbom.StandardType
 		// slice of message fragments which are all expected to be in the error
 		expErrs []string
+		// slice of message fragments which are all expected to be in the error (when using dnf5)
+		expErrs5 []string
 	}
 
 	tmpdir := t.TempDir()
@@ -365,7 +367,8 @@ func TestSolverDepsolveAll(t *testing.T) {
 					},
 				},
 			},
-			expErrs: []string{"error depsolving package sets for \"first\"", "missing packages: does-not-exist"},
+			expErrs:  []string{"error depsolving package sets for \"first\"", "missing packages: does-not-exist"},
+			expErrs5: []string{"error depsolving package sets for \"first\"", "No match for argument: does-not-exist"},
 		},
 		"multi-chain-error-second": {
 			// two chain depsolves for different pipelines, second one fails
@@ -395,7 +398,8 @@ func TestSolverDepsolveAll(t *testing.T) {
 					},
 				},
 			},
-			expErrs: []string{"error depsolving package sets for \"second\"", "missing packages: does-not-exist"},
+			expErrs:  []string{"error depsolving package sets for \"second\"", "missing packages: does-not-exist"},
+			expErrs5: []string{"error depsolving package sets for \"second\"", "No match for argument: does-not-exist"},
 		},
 		"multi-chain-with-sbom": {
 			// two chain depsolves for different pipelines with sbom
@@ -429,6 +433,8 @@ func TestSolverDepsolveAll(t *testing.T) {
 		},
 	}
 
+	dnf5 := usingDNF5(t)
+
 	for _, h := range getTestHandlers() {
 		t.Run(h.name, func(t *testing.T) {
 			restore := mockActiveHandler(h.handler)
@@ -444,7 +450,11 @@ func TestSolverDepsolveAll(t *testing.T) {
 					res, err := solver.DepsolveAll(tc.packageSets)
 					if len(tc.expErrs) != 0 {
 						assert.Error(err)
-						for _, expErr := range tc.expErrs {
+						expErrs := tc.expErrs
+						if dnf5 {
+							expErrs = tc.expErrs5
+						}
+						for _, expErr := range expErrs {
 							assert.Contains(err.Error(), expErr)
 						}
 						return
@@ -925,12 +935,30 @@ func expectedDepsolvedPackages(repo rpmmd.RepoConfig) rpmmd.PackageList {
 	return expectedTemplate
 }
 
+func usingDNF5(t *testing.T) bool {
+	t.Helper()
+	data := map[string]bool{}
+	config, err := os.ReadFile("/usr/lib/osbuild/solver.json")
+	if err != nil {
+		t.Fatalf("failed to read solver.json: %s", err)
+	}
+	if err := json.Unmarshal(config, &data); err != nil {
+		t.Fatalf("failed to parse solver.json: %s", err)
+	}
+
+	if _, ok := data["use_dnf5"]; !ok {
+		t.Fatal("expected property 'use_dnf5' not found in solver.json")
+	}
+	return data["use_dnf5"]
+}
+
 func TestErrorRepoInfo(t *testing.T) {
 	requireDNF(t)
 
 	type testCase struct {
-		repo   rpmmd.RepoConfig
-		expMsg string
+		repo    rpmmd.RepoConfig
+		expMsg  string
+		expMsg5 string // expected message when using dnf5
 	}
 
 	testCases := []testCase{
@@ -940,7 +968,8 @@ func TestErrorRepoInfo(t *testing.T) {
 				BaseURLs: []string{"https://0.0.0.0/baseos/repo"},
 				Metalink: "https://0.0.0.0/baseos/metalink",
 			},
-			expMsg: "https://0.0.0.0/baseos/repo",
+			expMsg:  "https://0.0.0.0/baseos/repo",
+			expMsg5: "https://0.0.0.0/baseos/metalink",
 		},
 		{
 			repo: rpmmd.RepoConfig{
@@ -948,23 +977,28 @@ func TestErrorRepoInfo(t *testing.T) {
 				BaseURLs: []string{"https://0.0.0.0/baseos/repo"},
 				Metalink: "https://0.0.0.0/baseos/metalink",
 			},
-			expMsg: "https://0.0.0.0/baseos/repo",
+			expMsg:  "https://0.0.0.0/baseos/repo",
+			expMsg5: "https://0.0.0.0/baseos/metalink",
 		},
 		{
 			repo: rpmmd.RepoConfig{
 				Name:     "fedora",
 				Metalink: "https://0.0.0.0/f35/metalink",
 			},
-			expMsg: "https://0.0.0.0/f35/metalink",
+			expMsg:  "https://0.0.0.0/f35/metalink",
+			expMsg5: "https://0.0.0.0/f35/metalink",
 		},
 		{
 			repo: rpmmd.RepoConfig{
 				Name:       "",
 				MirrorList: "https://0.0.0.0/baseos/mirrors",
 			},
-			expMsg: "https://0.0.0.0/baseos/mirrors",
+			expMsg:  "https://0.0.0.0/baseos/mirrors",
+			expMsg5: "https://0.0.0.0/baseos/mirrors",
 		},
 	}
+
+	dnf5 := usingDNF5(t)
 
 	for _, h := range getTestHandlers() {
 		t.Run(h.name, func(t *testing.T) {
@@ -983,7 +1017,11 @@ func TestErrorRepoInfo(t *testing.T) {
 						},
 					}, sbom.StandardTypeNone)
 					assert.Error(err)
-					assert.Contains(err.Error(), tc.expMsg)
+					expMsg := tc.expMsg
+					if dnf5 {
+						expMsg = tc.expMsg5
+					}
+					assert.Contains(err.Error(), expMsg)
 				})
 			}
 		})


### PR DESCRIPTION
On my main development machine, I have osbuild configured to use dnf5 for depsolving.  The depsolvednf unit tests have been failing for me for a while now but I've been working around it.  Today I got sufficiently annoyed and distracted by it to look into what exactly was failing.

Two tests needed adjustment:
- `TestErrorRepoInfo`: When both a baseurl and metalink or mirrorlist are configured, dnf and dnf5 behave differently.  It seems the order in which these are tried changed and the one that shows up in the final error message depends on the order.  I found https://bugzilla.redhat.com/show_bug.cgi?id=1775184, which lead me to https://github.com/rpm-software-management/librepo/pull/184, which seems to be the related change.
- `TestSolverDepsolveAll`: The error message for missing packages changed from `missing packages: ...` to `No match for argument: ...`.

And one additional error message test in image-builder's `main_test.go`, which I kept a bit more lax.

I added a little `sed` line in the github tests to switch to dnf5 when testing on Fedora, after testing with dnf, and rerun the tests so we can stay on top of the dnf5 compatibility going forward.