### PR TITLE
many: use `image-builder upload` in tests (HMS-10856)

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -1,6 +1,6 @@
 {
   "common": {
-    "rngseed": 2026052100,
+    "rngseed": 2026063000,
     "dependencies": {
       "bootc-image-builder": {
         "ref": "quay.io/centos-bootc/bootc-image-builder@sha256:9893e7209e5f449b86ababfd2ee02a58cca2e5990f77b06c3539227531fc8120"

--- a/cmd/boot-aws/main.go
+++ b/cmd/boot-aws/main.go
@@ -8,16 +8,12 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/osbuild/image-builder/internal/common"
 	"github.com/osbuild/image-builder/internal/test"
-	"github.com/osbuild/image-builder/pkg/arch"
 	"github.com/osbuild/image-builder/pkg/cloud/awscloud"
-	"github.com/osbuild/image-builder/pkg/platform"
 )
 
 // exitCheck can be deferred from the top of command functions to exit with an
@@ -49,8 +45,6 @@ ssh_authorized_keys:
 // resources created or allocated for an instance that can be cleaned up when
 // tearing down.
 type resources struct {
-	AMI           *string `json:"ami,omitempty"`
-	Snapshot      *string `json:"snapshot,omitempty"`
 	SecurityGroup *string `json:"security-group,omitempty"`
 	InstanceID    *string `json:"instance,omitempty"`
 }
@@ -87,20 +81,7 @@ func newClientFromArgs(flags *pflag.FlagSet) (*awscloud.AWS, error) {
 	return awscloud.New(region, keyID, secretKey, sessionToken)
 }
 
-// getOptionalStringFlag returns the value of a string flag if it's set, or nil
-// if it's not set.
-func getOptionalStringFlag(flags *pflag.FlagSet, name string) (*string, error) {
-	value, err := flags.GetString(name)
-	if err != nil {
-		return nil, err
-	}
-	if value == "" {
-		return nil, nil
-	}
-	return &value, nil
-}
-
-func doSetup(a *awscloud.AWS, filename string, flags *pflag.FlagSet, res *resources) error {
+func doSetup(a *awscloud.AWS, flags *pflag.FlagSet, res *resources) error {
 	username, err := flags.GetString("username")
 	if err != nil {
 		return err
@@ -115,46 +96,7 @@ func doSetup(a *awscloud.AWS, filename string, flags *pflag.FlagSet, res *resour
 		return fmt.Errorf("createUserData(): %s", err.Error())
 	}
 
-	bucketName, err := flags.GetString("bucket")
-	if err != nil {
-		return err
-	}
-	keyName, err := flags.GetString("s3-key")
-	if err != nil {
-		return err
-	}
-
-	uploadOutput, err := a.Upload(filename, bucketName, keyName)
-	if err != nil {
-		return fmt.Errorf("Upload() failed: %s", err.Error())
-	}
-
-	fmt.Printf("file uploaded to %s\n", aws.ToString(uploadOutput.Location))
-
-	var bootMode *platform.BootMode
-	bootModeFlag, err := flags.GetString("boot-mode")
-	if err != nil {
-		return err
-	}
-	switch bootModeFlag {
-	case "legacy-bios":
-		bootMode = common.ToPtr(platform.BOOT_LEGACY)
-	case "uefi":
-		bootMode = common.ToPtr(platform.BOOT_UEFI)
-	case "uefi-preferred":
-		bootMode = common.ToPtr(platform.BOOT_HYBRID)
-	case "":
-		bootMode = nil // no explicit boot mode set
-	default:
-		return fmt.Errorf("invalid boot mode: %s", bootModeFlag)
-	}
-
-	importRole, err := getOptionalStringFlag(flags, "import-role")
-	if err != nil {
-		return err
-	}
-
-	imageName, err := flags.GetString("ami-name")
+	ami, err := flags.GetString("ami")
 	if err != nil {
 		return err
 	}
@@ -163,20 +105,8 @@ func doSetup(a *awscloud.AWS, filename string, flags *pflag.FlagSet, res *resour
 	if err != nil {
 		return err
 	}
-	imgArch, err := arch.FromString(archArg)
-	if err != nil {
-		return err
-	}
 
-	ami, snapshot, err := a.Register(imageName, bucketName, keyName, nil, nil, imgArch, bootMode, importRole)
-	if err != nil {
-		return fmt.Errorf("Register(): %s", err.Error())
-	}
-
-	res.AMI = &ami
-	res.Snapshot = &snapshot
-
-	fmt.Printf("AMI registered: %s\n", ami)
+	fmt.Printf("Using AMI: %s\n", ami)
 
 	securityGroupName := fmt.Sprintf("image-boot-tests-%s", uuid.New().String())
 	securityGroup, err := a.CreateSecurityGroupEC2(securityGroupName, "image-tests-security-group")
@@ -214,7 +144,6 @@ func setup(cmd *cobra.Command, args []string) {
 	var fnerr error
 	defer func() { exitCheck(fnerr) }()
 
-	filename := args[0]
 	flags := cmd.Flags()
 
 	a, err := newClientFromArgs(flags)
@@ -231,7 +160,7 @@ func setup(cmd *cobra.Command, args []string) {
 	}
 	res := &resources{}
 
-	fnerr = doSetup(a, filename, flags, res)
+	fnerr = doSetup(a, flags, res)
 	if fnerr != nil {
 		fmt.Fprintf(os.Stderr, "setup() failed: %s\n", fnerr.Error())
 		fmt.Fprint(os.Stderr, "tearing down resources\n")
@@ -279,12 +208,6 @@ func doTeardown(aws *awscloud.AWS, res *resources) error {
 		}
 	}
 
-	if res.AMI != nil {
-		fmt.Printf("deleting EC2 image %s and snapshot %s\n", *res.AMI, *res.Snapshot)
-		if err := aws.DeleteEC2Image(*res.AMI); err != nil {
-			return fmt.Errorf("failed to deregister image: %v", err)
-		}
-	}
 	return nil
 }
 
@@ -396,9 +319,8 @@ func doRunExec(a *awscloud.AWS, command []string, flags *pflag.FlagSet, res *res
 func runExec(cmd *cobra.Command, args []string) {
 	var fnerr error
 	defer func() { exitCheck(fnerr) }()
-	image := args[0]
 
-	command := args[1:]
+	command := args
 	flags := cmd.Flags()
 
 	a, fnerr := newClientFromArgs(flags)
@@ -415,7 +337,7 @@ func runExec(cmd *cobra.Command, args []string) {
 		}
 	}()
 
-	fnerr = doSetup(a, image, flags, res)
+	fnerr = doSetup(a, flags, res)
 	if fnerr != nil {
 		return
 	}
@@ -426,7 +348,7 @@ func runExec(cmd *cobra.Command, args []string) {
 func setupCLI() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:                   "boot",
-		Long:                  "upload and boot an image to the appropriate cloud provider",
+		Long:                  "boot an image on AWS EC2",
 		DisableFlagsInUseLine: true,
 	}
 
@@ -435,12 +357,8 @@ func setupCLI() *cobra.Command {
 	rootFlags.String("secret-access-key", "", "secret access key")
 	rootFlags.String("session-token", "", "session token")
 	rootFlags.String("region", "", "target region")
-	rootFlags.String("bucket", "", "target S3 bucket name")
-	rootFlags.String("s3-key", "", "target S3 key name")
-	rootFlags.String("ami-name", "", "AMI name")
+	rootFlags.String("ami", "", "AMI ID to boot")
 	rootFlags.String("arch", "", "arch (x86_64 or aarch64)")
-	rootFlags.String("boot-mode", "", "boot mode (legacy-bios, uefi, uefi-preferred)")
-	rootFlags.String("import-role", "", "name of the import role to be used (default is determined by the AWS API, it's usually 'vmimport')")
 	rootFlags.String("username", "", "name of the user to create on the system")
 	rootFlags.String("ssh-pubkey", "", "path to user's public ssh key")
 	rootFlags.String("ssh-privkey", "", "path to user's private ssh key")
@@ -448,14 +366,7 @@ func setupCLI() *cobra.Command {
 	exitCheck(rootCmd.MarkPersistentFlagRequired("access-key-id"))
 	exitCheck(rootCmd.MarkPersistentFlagRequired("secret-access-key"))
 	exitCheck(rootCmd.MarkPersistentFlagRequired("region"))
-	exitCheck(rootCmd.MarkPersistentFlagRequired("bucket"))
-
-	// TODO: make it optional and use UUID if not specified
-	exitCheck(rootCmd.MarkPersistentFlagRequired("s3-key"))
-
-	// TODO: make it optional and use UUID if not specified
-	exitCheck(rootCmd.MarkPersistentFlagRequired("ami-name"))
-
+	exitCheck(rootCmd.MarkPersistentFlagRequired("ami"))
 	exitCheck(rootCmd.MarkPersistentFlagRequired("arch"))
 
 	// TODO: make it optional and use a default
@@ -467,9 +378,9 @@ func setupCLI() *cobra.Command {
 	exitCheck(rootCmd.MarkPersistentFlagRequired("ssh-pubkey"))
 
 	setupCmd := &cobra.Command{
-		Use:                   "setup [--resourcefile <filename>] <filename>",
-		Short:                 "upload and boot an image and save the created resource IDs to a file for later teardown",
-		Args:                  cobra.ExactArgs(1),
+		Use:                   "setup [--resourcefile <filename>]",
+		Short:                 "boot an AMI and save the created resource IDs to a file for later teardown",
+		Args:                  cobra.NoArgs,
 		Run:                   setup,
 		DisableFlagsInUseLine: true,
 	}
@@ -486,10 +397,10 @@ func setupCLI() *cobra.Command {
 	rootCmd.AddCommand(teardownCmd)
 
 	runCmd := &cobra.Command{
-		Use:   "run <image> <executable>...",
-		Short: "upload and boot an image, then upload the specified executable and run it on the remote host",
-		Long:  "upload and boot an image on AWS EC2, then upload the executable file specified by the second positional argument and execute it via SSH with the args on the command line",
-		Args:  cobra.MinimumNArgs(2),
+		Use:   "run <executable>...",
+		Short: "boot an AMI, then upload the specified executable and run it on the remote host",
+		Long:  "boot an AMI on AWS EC2, then upload the executable file specified by the first positional argument and execute it via SSH with the args on the command line",
+		Args:  cobra.MinimumNArgs(1),
 		Run:   runExec,
 	}
 	rootCmd.AddCommand(runCmd)

--- a/cmd/boot-azure/main.go
+++ b/cmd/boot-azure/main.go
@@ -12,12 +12,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/osbuild/image-builder/internal/test"
-	"github.com/osbuild/image-builder/pkg/arch"
 	"github.com/osbuild/image-builder/pkg/cloud/azure"
-)
-
-const (
-	StorageContainer = "images"
 )
 
 // exitCheck can be deferred from the top of command functions to exit with an
@@ -32,10 +27,7 @@ func exitCheck(err error) {
 // resources created or allocated for an instance that can be cleaned up when
 // tearing down.
 type resources struct {
-	VM        *azure.VM           `json:"vm,omitempty"`
-	GI        *azure.GalleryImage `json:"galleryimage,omitempty"`
-	BlobName  *string             `json:"blob,omitempty"`
-	ImageName *string             `json:"image,omitempty"`
+	VM *azure.VM `json:"vm,omitempty"`
 }
 
 func newClientFromArgs(flags *pflag.FlagSet) (*azure.Client, error) {
@@ -87,106 +79,7 @@ func isWindows(flags *pflag.FlagSet) (bool, error) {
 	return snapshot != "", err
 }
 
-func upload(ac *azure.Client, subscription, resourceGroup, localImage, remoteName, architecture string, res *resources) (string, error) {
-	ctx := context.Background()
-	location, err := ac.GetResourceGroupLocation(ctx, resourceGroup)
-	if err != nil {
-		return "", err
-	}
-
-	staccTag := azure.Tag{
-		Name:  "imagesStorageAccount",
-		Value: fmt.Sprintf("location=%s", location),
-	}
-	stacc, err := ac.GetResourceNameByTag(
-		ctx,
-		resourceGroup,
-		staccTag,
-	)
-	if err != nil {
-		return "", err
-	}
-
-	if stacc == "" {
-		stacc = azure.RandomStorageAccountName("images")
-		err = ac.CreateStorageAccount(ctx, resourceGroup, stacc, "", staccTag)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	storekey, err := ac.GetStorageAccountKey(ctx, resourceGroup, stacc)
-	if err != nil {
-		return "", err
-	}
-
-	storeClient, err := azure.NewStorageClient(stacc, storekey)
-	if err != nil {
-		return "", err
-	}
-
-	err = storeClient.CreateStorageContainerIfNotExist(ctx, stacc, StorageContainer)
-	if err != nil {
-		return "", err
-	}
-	blobName := azure.EnsureVHDExtension(remoteName)
-	err = storeClient.UploadPageBlob(
-		azure.BlobMetadata{
-			StorageAccount: stacc,
-			ContainerName:  StorageContainer,
-			BlobName:       blobName,
-		},
-		localImage,
-		azure.DefaultUploadThreads,
-	)
-	if err != nil {
-		return "", err
-	}
-	res.BlobName = &blobName
-
-	switch architecture {
-	case "x86_64":
-		err = ac.RegisterImage(
-			ctx,
-			resourceGroup,
-			stacc,
-			StorageContainer,
-			blobName,
-			remoteName,
-			"",
-			azure.HyperVGenV2,
-		)
-		if err != nil {
-			return "", err
-		}
-		res.ImageName = &remoteName
-		image := fmt.Sprintf(
-			"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/images/%s",
-			subscription, resourceGroup, remoteName)
-		return image, nil
-	case "aarch64":
-		gi, err := ac.RegisterGalleryImage(
-			ctx,
-			resourceGroup,
-			stacc,
-			StorageContainer,
-			blobName,
-			remoteName,
-			"",
-			azure.HyperVGenV2,
-			arch.ARCH_AARCH64,
-		)
-		if err != nil {
-			return "", err
-		}
-		res.GI = gi
-		return res.GI.ImageRef, nil
-	default:
-		return "", fmt.Errorf("upload(): unknown architecture %q", architecture)
-	}
-}
-
-func doSetup(ac *azure.Client, flags *pflag.FlagSet, localImage string, res *resources) error {
+func doSetup(ac *azure.Client, flags *pflag.FlagSet, res *resources) error {
 	rg, err := flags.GetString("resource-group")
 	if err != nil {
 		return err
@@ -197,6 +90,15 @@ func doSetup(ac *azure.Client, flags *pflag.FlagSet, localImage string, res *res
 		return err
 	}
 
+	snapshot, err := flags.GetString("snapshot")
+	if err != nil {
+		return err
+	}
+
+	if image == "" && snapshot == "" {
+		return fmt.Errorf("either --image or --snapshot must be provided")
+	}
+
 	architecture, err := flags.GetString("arch")
 	if err != nil {
 		return err
@@ -205,22 +107,6 @@ func doSetup(ac *azure.Client, flags *pflag.FlagSet, localImage string, res *res
 	windows, err := isWindows(flags)
 	if err != nil {
 		return err
-	}
-
-	// on windows the (wsl) image should be scp'd to the host
-	if localImage != "" && !windows {
-		subscription, err := flags.GetString("subscription")
-		if err != nil {
-			return err
-		}
-		remoteImageName, err := flags.GetString("image-name")
-		if err != nil {
-			return err
-		}
-		image, err = upload(ac, subscription, rg, localImage, remoteImageName, architecture, res)
-		if err != nil {
-			return err
-		}
 	}
 
 	vmName, err := flags.GetString("vm-name")
@@ -264,11 +150,6 @@ func doSetup(ac *azure.Client, flags *pflag.FlagSet, localImage string, res *res
 		return err
 	}
 
-	snapshot, err := flags.GetString("snapshot")
-	if err != nil {
-		return err
-	}
-
 	ctx := context.Background()
 	vm, err := ac.CreateVM(
 		ctx,
@@ -302,24 +183,13 @@ func setup(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	localImage := ""
-	if len(args) == 1 {
-		localImage = args[0]
-	}
-
 	res := &resources{}
-	fnerr = doSetup(ac, flags, localImage, res)
+	fnerr = doSetup(ac, flags, res)
 	if fnerr != nil {
 		fmt.Fprintf(os.Stderr, "setup() failed: %s\n", fnerr.Error())
 		fmt.Fprint(os.Stderr, "tearing down resources\n")
 
-		rg, err := flags.GetString("resource-group")
-		if err != nil {
-			fnerr = fmt.Errorf("failed to get resource group to tear down resources: %s", err.Error())
-			return
-		}
-
-		if err := doTeardown(ac, rg, res); err != nil {
+		if err := doTeardown(ac, res); err != nil {
 			fnerr = fmt.Errorf("failed to tear down resources: %s", err.Error())
 			return
 		}
@@ -353,7 +223,7 @@ func setup(cmd *cobra.Command, args []string) {
 	}
 }
 
-func doTeardown(ac *azure.Client, resourceGroup string, res *resources) error {
+func doTeardown(ac *azure.Client, res *resources) error {
 	ctx := context.Background()
 
 	if res.VM != nil {
@@ -362,62 +232,6 @@ func doTeardown(ac *azure.Client, resourceGroup string, res *resources) error {
 		}
 	}
 
-	if res.GI != nil {
-		if err := ac.DeleteGalleryImage(ctx, res.GI); err != nil {
-			return err
-		}
-	}
-
-	if res.ImageName != nil {
-		if err := ac.DeleteImage(ctx, resourceGroup, *res.ImageName); err != nil {
-			return err
-		}
-	}
-
-	if res.BlobName == nil {
-		return nil
-	}
-
-	location, err := ac.GetResourceGroupLocation(ctx, resourceGroup)
-	if err != nil {
-		return err
-	}
-
-	staccTag := azure.Tag{
-		Name:  "imagesStorageAccount",
-		Value: fmt.Sprintf("location=%s", location),
-	}
-	stacc, err := ac.GetResourceNameByTag(
-		ctx,
-		resourceGroup,
-		staccTag,
-	)
-	if err != nil {
-		return err
-	}
-
-	// storage account no longer exists, so assume everything is gone
-	if stacc == "" {
-		return nil
-	}
-
-	storekey, err := ac.GetStorageAccountKey(ctx, resourceGroup, stacc)
-	if err != nil {
-		return err
-	}
-
-	storeClient, err := azure.NewStorageClient(stacc, storekey)
-	if err != nil {
-		return err
-	}
-
-	if err := storeClient.DeleteBlob(ctx, azure.BlobMetadata{
-		StorageAccount: stacc,
-		ContainerName:  StorageContainer,
-		BlobName:       *res.BlobName,
-	}); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -459,16 +273,10 @@ func teardown(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	rg, err := flags.GetString("resource-group")
-	if err != nil {
-		fnerr = fmt.Errorf("failed to get resource group: %s", err.Error())
-		return
-	}
-
-	fnerr = doTeardown(ac, rg, res)
+	fnerr = doTeardown(ac, res)
 }
 
-func doRunExec(ac *azure.Client, command []string, flags *pflag.FlagSet, localImage string, res *resources) error {
+func doRunExec(command []string, flags *pflag.FlagSet, res *resources) error {
 	privKey, err := flags.GetString("ssh-privkey")
 	if err != nil {
 		return err
@@ -513,6 +321,13 @@ func doRunExec(ac *azure.Client, command []string, flags *pflag.FlagSet, localIm
 	}
 	// on windows the (wsl) image should be scp'd to the host so it can be imported into wsl
 	if windows {
+		localImage, err := flags.GetString("local-image")
+		if err != nil {
+			return err
+		}
+		if localImage == "" {
+			return fmt.Errorf("--local-image is required when using --snapshot")
+		}
 		remotePath := filepath.Base(localImage)
 		if err := test.ScpFile(ip, username, privKey, hostsfile, localImage, remotePath); err != nil {
 			return err
@@ -551,9 +366,8 @@ func doRunExec(ac *azure.Client, command []string, flags *pflag.FlagSet, localIm
 func runExec(cmd *cobra.Command, args []string) {
 	var fnerr error
 	defer func() { exitCheck(fnerr) }()
-	image := args[0]
 
-	command := args[1:]
+	command := args
 	flags := cmd.Flags()
 
 	ac, fnerr := newClientFromArgs(flags)
@@ -563,29 +377,24 @@ func runExec(cmd *cobra.Command, args []string) {
 
 	res := &resources{}
 	defer func() {
-		rg, err := flags.GetString("resource-group")
-		if err != nil {
-			fnerr = fmt.Errorf("failed to get resource group to tear down resources: %s", err.Error())
-			return
-		}
-		if err := doTeardown(ac, rg, res); err != nil {
+		if err := doTeardown(ac, res); err != nil {
 			fnerr = fmt.Errorf("failed to destroy vm: %s", err.Error())
 			return
 		}
 	}()
 
-	fnerr = doSetup(ac, flags, image, res)
+	fnerr = doSetup(ac, flags, res)
 	if fnerr != nil {
 		return
 	}
 
-	fnerr = doRunExec(ac, command, flags, image, res)
+	fnerr = doRunExec(command, flags, res)
 }
 
 func setupCLI() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:                   "boot",
-		Long:                  "upload and boot an image to the appropriate cloud provider",
+		Long:                  "boot an image on Azure",
 		DisableFlagsInUseLine: true,
 	}
 
@@ -598,12 +407,12 @@ func setupCLI() *cobra.Command {
 	rootFlags.String("username", "azure", "name of the user to create on the system")
 	rootFlags.String("ssh-pubkey", "", "path to user's public ssh key, must be an rsa key")
 	rootFlags.String("ssh-privkey", "", "path to user's private ssh key")
-	rootFlags.String("image", "", "full resource ID of the remote image name, this should already exist in the resource group, if no local image is provided")
-	rootFlags.String("snapshot", "", "full resource ID of the snapshot, this should already exist in the resource group and is assumed to be a windows image, local image will be scp'd instead of uploaded")
+	rootFlags.String("image", "", "full resource ID of the remote image, should already exist in the resource group")
+	rootFlags.String("snapshot", "", "full resource ID of the snapshot, assumed to be a windows image for WSL testing")
+	rootFlags.String("local-image", "", "path to local image to SCP to the VM (only for WSL with --snapshot)")
 	rootFlags.String("vm-name", "vm-name", "name of the VM to create, all dependencies will be prefixed with this name")
-	rootFlags.String("image-name", "image-name", "the image and blob will")
 	rootFlags.String("size", "", "size or instance type of the VM to create")
-	rootFlags.String("arch", "x86_64", "size or instance type of the VM to create")
+	rootFlags.String("arch", "x86_64", "architecture (x86_64 or aarch64)")
 
 	exitCheck(rootCmd.MarkPersistentFlagRequired("client-id"))
 	exitCheck(rootCmd.MarkPersistentFlagRequired("client-secret"))
@@ -611,9 +420,9 @@ func setupCLI() *cobra.Command {
 	exitCheck(rootCmd.MarkPersistentFlagRequired("subscription"))
 
 	setupCmd := &cobra.Command{
-		Use:                   "setup [--resourcefile <filename>] <filename>",
-		Short:                 "upload and boot an image and save the created resource IDs to a file for later teardown",
-		Args:                  cobra.MaximumNArgs(1),
+		Use:                   "setup [--resourcefile <filename>]",
+		Short:                 "boot an image and save the created resource IDs to a file for later teardown",
+		Args:                  cobra.NoArgs,
 		Run:                   setup,
 		DisableFlagsInUseLine: true,
 	}
@@ -630,10 +439,10 @@ func setupCLI() *cobra.Command {
 	rootCmd.AddCommand(teardownCmd)
 
 	runCmd := &cobra.Command{
-		Use:   "run <image> <executable>...",
-		Short: "upload and boot an image, then upload the specified executable and run it on the remote host",
-		Long:  "upload and boot an image on Azure, then upload the executable file specified by the second positional argument and execute it via SSH with the args on the command line",
-		Args:  cobra.MinimumNArgs(2),
+		Use:   "run <executable>...",
+		Short: "boot an image, then upload the specified executable and run it on the remote host",
+		Long:  "boot an image on Azure, then upload the executable file specified by the first positional argument and execute it via SSH with the args on the command line",
+		Args:  cobra.MinimumNArgs(1),
 		Run:   runExec,
 	}
 	rootCmd.AddCommand(runCmd)

--- a/cmd/image-builder/bib_cloud.go
+++ b/cmd/image-builder/bib_cloud.go
@@ -53,5 +53,6 @@ func bibUpload(uploader cloud.Uploader, path string, flags *pflag.FlagSet) error
 		size = 0
 	}
 	// #nosec G115
-	return uploader.UploadAndRegister(r, uint64(size), osStderr)
+	_, err = uploader.UploadAndRegister(r, uint64(size), osStderr)
+	return err
 }

--- a/cmd/image-builder/bib_cloud.go
+++ b/cmd/image-builder/bib_cloud.go
@@ -42,7 +42,7 @@ func bibUpload(uploader cloud.Uploader, path string, flags *pflag.FlagSet) error
 		size = st.Size()
 		pbar.SetTotal(size)
 		pbar.Set(pb.Bytes, true)
-		pbar.SetWriter(osStdout)
+		pbar.SetWriter(osStderr)
 		r = pbar.NewProxyReader(file)
 		pbar.Start()
 		defer pbar.Finish()

--- a/cmd/image-builder/bib_main_test.go
+++ b/cmd/image-builder/bib_main_test.go
@@ -184,13 +184,16 @@ func (fa *fakeAwsUploader) Check(status io.Writer) error {
 	return nil
 }
 
-func (fa *fakeAwsUploader) UploadAndRegister(r io.Reader, size uint64, status io.Writer) error {
+func (fa *fakeAwsUploader) UploadAndRegister(r io.Reader, size uint64, status io.Writer) (*cloud.UploadResult, error) {
 	fa.uploadAndRegisterCalls++
 	_, err := io.Copy(&fa.uploadAndRegisterRead, r)
 	if err != nil {
 		panic(err)
 	}
-	return fa.uploadAndRegisterErr
+	if fa.uploadAndRegisterErr != nil {
+		return nil, fa.uploadAndRegisterErr
+	}
+	return &cloud.UploadResult{Provider: "aws"}, nil
 }
 
 func TestHandleAWSFlags(t *testing.T) {

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -605,7 +605,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 
 	if uploader != nil {
 		// XXX: integrate better into the progress, see bib
-		if err := uploadImageWithProgress(uploader, imagePath); err != nil {
+		if _, err := uploadImageWithProgress(uploader, imagePath); err != nil {
 			return err
 		}
 	}

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -816,6 +816,7 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 	uploadCmd.Flags().String("ibmcloud-region", "", "target region for IBM Cloud uploads (only for type=ibmcloud)")
 	uploadCmd.Flags().String("ibmcloud-image-name", "", "name for the uploaded image (only for type=ibmcloud)")
 	uploadCmd.Flags().String("arch", "", "upload for the given architecture")
+	uploadCmd.Flags().String("format", "", "output in a specific format (yaml, json)")
 	rootCmd.AddCommand(uploadCmd)
 
 	buildCmd := &cobra.Command{

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -566,7 +566,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	}
 
 	bootMode := res.ImgType.BootMode()
-	uploader, err := uploaderFor(cmd, res.ImgType.Name(), res.ImgType.Arch().Name(), &bootMode)
+	uploader, err := uploaderFor(cmd, res.ImgType.Name(), res.ImgType.Arch().Name(), &bootMode, "")
 	if errors.Is(err, ErrUploadTypeUnsupported) || errors.Is(err, ErrUploadConfigNotProvided) {
 		err = nil
 	}
@@ -815,6 +815,12 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 	uploadCmd.Flags().String("ibmcloud-bucket", "", "target bucket name for storing the image (only for type=ibmcloud)")
 	uploadCmd.Flags().String("ibmcloud-region", "", "target region for IBM Cloud uploads (only for type=ibmcloud)")
 	uploadCmd.Flags().String("ibmcloud-image-name", "", "name for the uploaded image (only for type=ibmcloud)")
+	uploadCmd.Flags().String("azure-client-id", "", "Azure client ID (only for type=azure)")
+	uploadCmd.Flags().String("azure-client-secret", "", "Azure client secret (only for type=azure)")
+	uploadCmd.Flags().String("azure-tenant", "", "Azure tenant ID (only for type=azure)")
+	uploadCmd.Flags().String("azure-subscription", "", "Azure subscription ID (only for type=azure)")
+	uploadCmd.Flags().String("azure-resource-group", "", "Azure resource group (only for type=azure)")
+	uploadCmd.Flags().String("azure-image-name", "", "name for the uploaded image (only for type=azure)")
 	uploadCmd.Flags().String("arch", "", "upload for the given architecture")
 	uploadCmd.Flags().String("format", "", "output in a specific format (yaml, json)")
 	rootCmd.AddCommand(uploadCmd)

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -806,6 +806,7 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 	uploadCmd.Flags().String("aws-region", "", "target region for AWS uploads (only for type=ami)")
 	uploadCmd.Flags().String("aws-profile", "", "name of the AWS credentials profile (only for type=aws)")
 	uploadCmd.Flags().StringArray("aws-tag", []string{}, "tag the AMI with this Key=Value (only for type=aws)")
+	uploadCmd.Flags().String("aws-boot-mode", "", "boot mode for the AMI: legacy-bios, uefi, uefi-preferred (only for type=aws)")
 	uploadCmd.Flags().String("libvirt-connection", "", "connection URI (only for type=libvirt)")
 	uploadCmd.Flags().String("libvirt-pool", "", "pool name (only for type=libvirt)")
 	uploadCmd.Flags().String("libvirt-volume", "", "volume name (only for type=libvirt)")

--- a/cmd/image-builder/upload.go
+++ b/cmd/image-builder/upload.go
@@ -17,6 +17,7 @@ import (
 	"github.com/osbuild/image-builder/pkg/arch"
 	"github.com/osbuild/image-builder/pkg/cloud"
 	"github.com/osbuild/image-builder/pkg/cloud/awscloud"
+	"github.com/osbuild/image-builder/pkg/cloud/azure"
 	"github.com/osbuild/image-builder/pkg/cloud/ibmcloud"
 	"github.com/osbuild/image-builder/pkg/cloud/libvirt"
 	"github.com/osbuild/image-builder/pkg/cloud/openstack"
@@ -36,6 +37,7 @@ var ErrUploadTypeUnsupported = errors.New("unsupported type")
 // uploader constructors that are mocked in tests
 var (
 	awscloudNewUploader  = awscloud.NewUploader
+	azureNewUploader     = azure.NewUploader
 	libvirtNewUploader   = libvirt.NewUploader
 	openstackNewUploader = openstack.NewUploader
 	ibmNewUploader       = ibmcloud.NewUploader
@@ -81,7 +83,7 @@ func uploaderCheckWithProgress(pbar progress.ProgressBar, uploader cloud.Uploade
 	return uploader.Check(pw)
 }
 
-func uploaderFor(cmd *cobra.Command, typeOrCloud string, targetArch string, bootMode *platform.BootMode) (cloud.Uploader, error) {
+func uploaderFor(cmd *cobra.Command, typeOrCloud string, targetArch string, bootMode *platform.BootMode, imagePath string) (cloud.Uploader, error) {
 	switch typeOrCloud {
 	case "ami", "generic-ami", "aws":
 		return uploaderForCmdAWS(cmd, targetArch, bootMode)
@@ -91,6 +93,8 @@ func uploaderFor(cmd *cobra.Command, typeOrCloud string, targetArch string, boot
 		return uploaderForCmdOpenstack(cmd, targetArch, bootMode)
 	case "ibmcloud":
 		return uploaderForCmdIbmCloud(cmd, targetArch, bootMode)
+	case "azure":
+		return uploaderForCmdAzure(cmd, targetArch, bootMode, imagePath)
 	default:
 		return nil, fmt.Errorf("%w: %q", ErrUploadTypeUnsupported, typeOrCloud)
 	}
@@ -237,6 +241,58 @@ func uploaderForCmdIbmCloud(cmd *cobra.Command, targetArchStr string, bootMode *
 	return ibmNewUploader(region, bucketName, imageName, credentials)
 }
 
+func uploaderForCmdAzure(cmd *cobra.Command, targetArchStr string, bootMode *platform.BootMode, imagePath string) (cloud.Uploader, error) {
+	clientID, err := cmd.Flags().GetString("azure-client-id")
+	if err != nil {
+		return nil, err
+	}
+	clientSecret, err := cmd.Flags().GetString("azure-client-secret")
+	if err != nil {
+		return nil, err
+	}
+	tenant, err := cmd.Flags().GetString("azure-tenant")
+	if err != nil {
+		return nil, err
+	}
+	subscription, err := cmd.Flags().GetString("azure-subscription")
+	if err != nil {
+		return nil, err
+	}
+	resourceGroup, err := cmd.Flags().GetString("azure-resource-group")
+	if err != nil {
+		return nil, err
+	}
+	imageName, err := cmd.Flags().GetString("azure-image-name")
+	if err != nil {
+		return nil, err
+	}
+
+	var missing []string
+	requiredArgs := []string{"azure-client-id", "azure-client-secret", "azure-tenant", "azure-subscription", "azure-resource-group", "azure-image-name"}
+	for _, argName := range requiredArgs {
+		arg, err := cmd.Flags().GetString(argName)
+		if err != nil {
+			return nil, err
+		}
+		if arg == "" {
+			missing = append(missing, fmt.Sprintf("--%s", argName))
+		}
+	}
+	if len(missing) > 0 {
+		if len(missing) == len(requiredArgs) {
+			return nil, fmt.Errorf("%w: %q", ErrUploadConfigNotProvided, missing)
+		}
+		return nil, fmt.Errorf("%w: %q", ErrMissingUploadConfig, missing)
+	}
+
+	targetArch, err := arch.FromString(targetArchStr)
+	if err != nil {
+		return nil, err
+	}
+
+	return azureNewUploader(clientID, clientSecret, tenant, subscription, resourceGroup, imageName, imagePath, targetArch)
+}
+
 func detectArchFromImagePath(imagePath string) string {
 	// This detection is currently rather naive, we just look for
 	// the file name and try to infer from that. We could extend
@@ -283,7 +339,7 @@ func cmdUpload(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	uploader, err := uploaderFor(cmd, uploadTo, targetArch, nil)
+	uploader, err := uploaderFor(cmd, uploadTo, targetArch, nil, imagePath)
 	if err != nil {
 		return err
 	}

--- a/cmd/image-builder/upload.go
+++ b/cmd/image-builder/upload.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.yaml.in/yaml/v3"
 
+	"github.com/osbuild/image-builder/internal/common"
 	"github.com/osbuild/image-builder/pkg/arch"
 	"github.com/osbuild/image-builder/pkg/cloud"
 	"github.com/osbuild/image-builder/pkg/cloud/awscloud"
@@ -313,6 +314,25 @@ func detectArchFromImagePath(imagePath string) string {
 	return ""
 }
 
+func bootModeFromFlag(cmd *cobra.Command) (*platform.BootMode, error) {
+	bootModeFlag, err := cmd.Flags().GetString("aws-boot-mode")
+	if err != nil {
+		return nil, err
+	}
+	switch bootModeFlag {
+	case "":
+		return nil, nil
+	case "legacy-bios":
+		return common.ToPtr(platform.BOOT_LEGACY), nil
+	case "uefi":
+		return common.ToPtr(platform.BOOT_UEFI), nil
+	case "uefi-preferred":
+		return common.ToPtr(platform.BOOT_HYBRID), nil
+	default:
+		return nil, fmt.Errorf("invalid boot mode: %q, supported: legacy-bios, uefi, uefi-preferred", bootModeFlag)
+	}
+}
+
 func cmdUpload(cmd *cobra.Command, args []string) error {
 	imagePath := args[0]
 
@@ -339,7 +359,12 @@ func cmdUpload(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	uploader, err := uploaderFor(cmd, uploadTo, targetArch, nil, imagePath)
+	bootMode, err := bootModeFromFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	uploader, err := uploaderFor(cmd, uploadTo, targetArch, bootMode, imagePath)
 	if err != nil {
 		return err
 	}

--- a/cmd/image-builder/upload.go
+++ b/cmd/image-builder/upload.go
@@ -39,21 +39,21 @@ var (
 	ibmNewUploader       = ibmcloud.NewUploader
 )
 
-func uploadImageWithProgress(uploader cloud.Uploader, imagePath string) error {
+func uploadImageWithProgress(uploader cloud.Uploader, imagePath string) (*cloud.UploadResult, error) {
 	f, err := os.Open(imagePath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer f.Close()
 
 	// setup basic progress
 	st, err := f.Stat()
 	if err != nil {
-		return fmt.Errorf("cannot stat upload: %v", err)
+		return nil, fmt.Errorf("cannot stat upload: %v", err)
 	}
 	sizei64 := st.Size()
 	if sizei64 < 0 {
-		return fmt.Errorf("invalid size read for %s: %d", imagePath, sizei64)
+		return nil, fmt.Errorf("invalid size read for %s: %d", imagePath, sizei64)
 	}
 	size := uint64(sizei64)
 	pbar := pb.New64(st.Size())
@@ -286,5 +286,6 @@ func cmdUpload(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return uploadImageWithProgress(uploader, imagePath)
+	_, err = uploadImageWithProgress(uploader, imagePath)
+	return err
 }

--- a/cmd/image-builder/upload.go
+++ b/cmd/image-builder/upload.go
@@ -62,7 +62,7 @@ func uploadImageWithProgress(uploader cloud.Uploader, imagePath string) (*cloud.
 	size := uint64(sizei64)
 	pbar := pb.New64(st.Size())
 	pbar.Set(pb.Bytes, true)
-	pbar.SetWriter(osStdout)
+	pbar.SetWriter(osStderr)
 	r := pbar.NewProxyReader(f)
 	pbar.Start()
 	defer pbar.Finish()

--- a/cmd/image-builder/upload.go
+++ b/cmd/image-builder/upload.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/cheggaaa/pb/v3"
 	"github.com/spf13/cobra"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/image-builder/pkg/arch"
 	"github.com/osbuild/image-builder/pkg/cloud"
@@ -286,6 +288,30 @@ func cmdUpload(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	_, err = uploadImageWithProgress(uploader, imagePath)
-	return err
+	result, err := uploadImageWithProgress(uploader, imagePath)
+	if err != nil {
+		return err
+	}
+
+	format, err := cmd.Flags().GetString("format")
+	if err != nil {
+		return err
+	}
+	switch format {
+	case "", "yaml":
+		output, err := yaml.Marshal(result)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), string(output))
+	case "json":
+		output, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), string(output))
+	default:
+		return fmt.Errorf("unsupported format %q, supported formats: yaml, json", format)
+	}
+	return nil
 }

--- a/cmd/image-builder/upload_test.go
+++ b/cmd/image-builder/upload_test.go
@@ -84,11 +84,11 @@ func TestUploadWithAWSMock(t *testing.T) {
 		assert.Equal(t, 0, fa.checkCalls)
 		assert.Equal(t, 1, fa.uploadAndRegisterCalls)
 		assert.Equal(t, fakeDiskContent, fa.uploadAndRegisterRead.String())
-		// progress was rendered
-		assert.Contains(t, fakeStdout.String(), "--] 100.00%")
+		// progress was rendered to stderr
+		assert.Contains(t, fakeStderr.String(), "--] 100.00%")
 
-		// warning was passed
-		assert.Equal(t, fakeStderr.String(), tc.expectedWarning)
+		// warning was passed to stderr
+		assert.Contains(t, fakeStderr.String(), tc.expectedWarning)
 
 	}
 }

--- a/cmd/image-builder/upload_test.go
+++ b/cmd/image-builder/upload_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/osbuild/image-builder/internal/common"
 	"github.com/osbuild/image-builder/pkg/arch"
 	"github.com/osbuild/image-builder/pkg/cloud"
 	"github.com/osbuild/image-builder/pkg/cloud/awscloud"
@@ -90,6 +91,56 @@ func TestUploadWithAWSMock(t *testing.T) {
 		// warning was passed to stderr
 		assert.Contains(t, fakeStderr.String(), tc.expectedWarning)
 
+	}
+}
+
+func TestUploadWithAWSBootMode(t *testing.T) {
+	fakeDiskContent := "fake-raw-img"
+
+	for _, tc := range []struct {
+		bootModeArg      string
+		expectedBootMode *platform.BootMode
+	}{
+		{"legacy-bios", common.ToPtr(platform.BOOT_LEGACY)},
+		{"uefi", common.ToPtr(platform.BOOT_UEFI)},
+		{"uefi-preferred", common.ToPtr(platform.BOOT_HYBRID)},
+	} {
+		t.Run(tc.bootModeArg, func(t *testing.T) {
+			fakeImageFilePath := filepath.Join(t.TempDir(), "fake-disk.img")
+			err := os.WriteFile(fakeImageFilePath, []byte(fakeDiskContent), 0600)
+			require.NoError(t, err)
+
+			var uploadOpts *awscloud.UploaderOptions
+			var fa fakeAwsUploader
+			restore := main.MockAwscloudNewUploader(func(region string, bucket string, ami string, opts *awscloud.UploaderOptions) (cloud.Uploader, error) {
+				uploadOpts = opts
+				return &fa, nil
+			})
+			defer restore()
+
+			var fakeStdout, fakeStderr bytes.Buffer
+			restore = main.MockOsStdout(&fakeStdout)
+			defer restore()
+			restore = main.MockOsStderr(&fakeStderr)
+			defer restore()
+
+			restore = main.MockOsArgs([]string{
+				"upload",
+				"--to=aws",
+				"--aws-region=aws-region-1",
+				"--aws-bucket=aws-bucket-2",
+				"--aws-ami-name=aws-ami-3",
+				"--aws-boot-mode=" + tc.bootModeArg,
+				"--arch=x86_64",
+				fakeImageFilePath,
+			})
+			defer restore()
+
+			err = main.Run()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedBootMode, uploadOpts.BootMode)
+		})
 	}
 }
 

--- a/pkg/cloud/awscloud/uploader.go
+++ b/pkg/cloud/awscloud/uploader.go
@@ -111,13 +111,13 @@ func (au *awsUploader) Check(status io.Writer) error {
 	return nil
 }
 
-func (au *awsUploader) UploadAndRegister(r io.Reader, _ uint64, status io.Writer) (err error) {
+func (au *awsUploader) UploadAndRegister(r io.Reader, _ uint64, status io.Writer) (result *cloud.UploadResult, err error) {
 	keyName := fmt.Sprintf("%s-%s", uuid.New().String(), au.imageName)
 	fmt.Fprintf(status, "Uploading %s to %s:%s\n", au.imageName, au.bucketName, keyName)
 
 	res, err := au.client.UploadFromReader(r, au.bucketName, keyName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer func() {
 		if err != nil {
@@ -134,17 +134,17 @@ func (au *awsUploader) UploadAndRegister(r io.Reader, _ uint64, status io.Writer
 	fmt.Fprintf(status, "Registering AMI %s\n", au.imageName)
 	ami, snapshot, err := au.client.Register(au.imageName, au.bucketName, keyName, au.tags, nil, au.targetArch, au.bootMode, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	fmt.Fprintf(status, "Deleted S3 object %s:%s\n", au.bucketName, keyName)
 	if err := au.client.DeleteObject(au.bucketName, keyName); err != nil {
-		return err
+		return nil, err
 	}
 	fmt.Fprintf(status, "AMI registered: %s\nSnapshot ID: %s\n", ami, snapshot)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return &cloud.UploadResult{
+		Provider: "aws",
+		ImageID:  ami,
+	}, nil
 }

--- a/pkg/cloud/awscloud/uploader_test.go
+++ b/pkg/cloud/awscloud/uploader_test.go
@@ -157,8 +157,10 @@ func TestUploaderUploadHappy(t *testing.T) {
 			uploader, err := awscloud.NewUploader("region", "bucket", "ami", tc.opts)
 			assert.NoError(t, err)
 			var uploadLog bytes.Buffer
-			err = uploader.UploadAndRegister(fakeImage, 0, &uploadLog)
+			result, err := uploader.UploadAndRegister(fakeImage, 0, &uploadLog)
 			assert.NoError(t, err)
+			assert.Equal(t, "aws", result.Provider)
+			assert.Equal(t, "image-id", result.ImageID)
 			assert.Equal(t, 1, fa.uploadFromReaderCalls)
 			assert.Equal(t, 1, fa.registerCalls)
 			assert.Equal(t, 1, fa.deleteObjectCalls)
@@ -193,9 +195,10 @@ func TestUploaderUploadButRegisterError(t *testing.T) {
 	uploader, err := awscloud.NewUploader("region", "bucket", "ami", nil)
 	assert.NoError(t, err)
 	var uploadLog bytes.Buffer
-	err = uploader.UploadAndRegister(fakeImage, 0, &uploadLog)
+	result, err := uploader.UploadAndRegister(fakeImage, 0, &uploadLog)
 	// XXX: this should probably have a context
 	assert.EqualError(t, err, "fake-register-err")
+	assert.Nil(t, result)
 	assert.Equal(t, 1, fa.uploadFromReaderCalls)
 	assert.Equal(t, 1, fa.registerCalls)
 	assert.Equal(t, 1, fa.deleteObjectCalls)
@@ -224,7 +227,8 @@ func TestUploaderUploadButRegisterErrorAndDeleteError(t *testing.T) {
 	uploader, err := awscloud.NewUploader("region", "bucket", "ami", nil)
 	assert.NoError(t, err)
 	var uploadLog bytes.Buffer
-	err = uploader.UploadAndRegister(fakeImage, 0, &uploadLog)
+	result, err := uploader.UploadAndRegister(fakeImage, 0, &uploadLog)
 	// XXX: this should probably have a context
 	assert.EqualError(t, err, "fake-register-err\nfake-delete-object-err")
+	assert.Nil(t, result)
 }

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -125,6 +125,10 @@ func NewClient(credentials Credentials, tenantID, subscriptionID string) (*Clien
 	}, nil
 }
 
+func (c *Client) SubscriptionID() string {
+	return c.subscription
+}
+
 // Tag is a name-value pair representing the tag structure in Azure
 type Tag struct {
 	Name  string

--- a/pkg/cloud/azure/uploader.go
+++ b/pkg/cloud/azure/uploader.go
@@ -1,0 +1,174 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/osbuild/image-builder/pkg/arch"
+	"github.com/osbuild/image-builder/pkg/cloud"
+)
+
+const uploaderStorageContainer = "images"
+
+var _ cloud.Uploader = &azureUploader{}
+
+type azureUploader struct {
+	client        *Client
+	resourceGroup string
+	imageName     string
+	architecture  arch.Arch
+}
+
+func NewUploader(clientID, clientSecret, tenant, subscription, resourceGroup, imageName string, architecture arch.Arch) (cloud.Uploader, error) {
+	creds := Credentials{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+	}
+	client, err := NewClient(creds, tenant, subscription)
+	if err != nil {
+		return nil, err
+	}
+
+	return &azureUploader{
+		client:        client,
+		resourceGroup: resourceGroup,
+		imageName:     imageName,
+		architecture:  architecture,
+	}, nil
+}
+
+func (au *azureUploader) Check(status io.Writer) error {
+	ctx := context.Background()
+	fmt.Fprintf(status, "Checking Azure resource group...\n")
+	_, err := au.client.GetResourceGroupLocation(ctx, au.resourceGroup)
+	if err != nil {
+		return fmt.Errorf("cannot access resource group %q: %w", au.resourceGroup, err)
+	}
+	fmt.Fprintf(status, "Upload conditions met.\n")
+	return nil
+}
+
+func (au *azureUploader) UploadAndRegister(r io.Reader, uploadSize uint64, status io.Writer) (*cloud.UploadResult, error) {
+	// UploadPageBlob requires a file path for seeking (MD5 hash then re-read),
+	// so write the reader to a temp file first.
+	tmpFile, err := os.CreateTemp("", "azure-upload-*.vhd")
+	if err != nil {
+		return nil, fmt.Errorf("cannot create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	fmt.Fprintf(status, "Preparing image for upload...\n")
+	if _, err := io.Copy(tmpFile, r); err != nil {
+		return nil, fmt.Errorf("cannot write image to temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+
+	location, err := au.client.GetResourceGroupLocation(ctx, au.resourceGroup)
+	if err != nil {
+		return nil, err
+	}
+
+	staccTag := Tag{
+		Name:  "imagesStorageAccount",
+		Value: fmt.Sprintf("location=%s", location),
+	}
+	stacc, err := au.client.GetResourceNameByTag(ctx, au.resourceGroup, staccTag)
+	if err != nil {
+		return nil, err
+	}
+
+	if stacc == "" {
+		stacc = RandomStorageAccountName("images")
+		fmt.Fprintf(status, "Creating storage account %s...\n", stacc)
+		err = au.client.CreateStorageAccount(ctx, au.resourceGroup, stacc, "", staccTag)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	storekey, err := au.client.GetStorageAccountKey(ctx, au.resourceGroup, stacc)
+	if err != nil {
+		return nil, err
+	}
+
+	storeClient, err := NewStorageClient(stacc, storekey)
+	if err != nil {
+		return nil, err
+	}
+
+	err = storeClient.CreateStorageContainerIfNotExist(ctx, stacc, uploaderStorageContainer)
+	if err != nil {
+		return nil, err
+	}
+
+	blobName := EnsureVHDExtension(au.imageName)
+	fmt.Fprintf(status, "Uploading %s to Azure...\n", blobName)
+	err = storeClient.UploadPageBlob(
+		BlobMetadata{
+			StorageAccount: stacc,
+			ContainerName:  uploaderStorageContainer,
+			BlobName:       blobName,
+		},
+		tmpFile.Name(),
+		DefaultUploadThreads,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	switch au.architecture {
+	case arch.ARCH_X86_64:
+		fmt.Fprintf(status, "Registering image %s...\n", au.imageName)
+		err = au.client.RegisterImage(
+			ctx,
+			au.resourceGroup,
+			stacc,
+			uploaderStorageContainer,
+			blobName,
+			au.imageName,
+			"",
+			HyperVGenV2,
+		)
+		if err != nil {
+			return nil, err
+		}
+		imageID := fmt.Sprintf(
+			"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/images/%s",
+			au.client.SubscriptionID(), au.resourceGroup, au.imageName)
+		fmt.Fprintf(status, "Image registered: %s\n", imageID)
+		return &cloud.UploadResult{
+			Provider: "azure",
+			ImageID:  imageID,
+		}, nil
+	case arch.ARCH_AARCH64:
+		fmt.Fprintf(status, "Registering gallery image %s...\n", au.imageName)
+		gi, err := au.client.RegisterGalleryImage(
+			ctx,
+			au.resourceGroup,
+			stacc,
+			uploaderStorageContainer,
+			blobName,
+			au.imageName,
+			"",
+			HyperVGenV2,
+			arch.ARCH_AARCH64,
+		)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Fprintf(status, "Gallery image registered: %s\n", gi.ImageRef)
+		return &cloud.UploadResult{
+			Provider: "azure",
+			ImageID:  gi.ImageRef,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported architecture %q for Azure upload", au.architecture)
+	}
+}

--- a/pkg/cloud/azure/uploader.go
+++ b/pkg/cloud/azure/uploader.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/osbuild/image-builder/pkg/arch"
 	"github.com/osbuild/image-builder/pkg/cloud"
@@ -18,10 +17,11 @@ type azureUploader struct {
 	client        *Client
 	resourceGroup string
 	imageName     string
+	imagePath     string
 	architecture  arch.Arch
 }
 
-func NewUploader(clientID, clientSecret, tenant, subscription, resourceGroup, imageName string, architecture arch.Arch) (cloud.Uploader, error) {
+func NewUploader(clientID, clientSecret, tenant, subscription, resourceGroup, imageName, imagePath string, architecture arch.Arch) (cloud.Uploader, error) {
 	creds := Credentials{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
@@ -35,6 +35,7 @@ func NewUploader(clientID, clientSecret, tenant, subscription, resourceGroup, im
 		client:        client,
 		resourceGroup: resourceGroup,
 		imageName:     imageName,
+		imagePath:     imagePath,
 		architecture:  architecture,
 	}, nil
 }
@@ -50,24 +51,7 @@ func (au *azureUploader) Check(status io.Writer) error {
 	return nil
 }
 
-func (au *azureUploader) UploadAndRegister(r io.Reader, uploadSize uint64, status io.Writer) (*cloud.UploadResult, error) {
-	// UploadPageBlob requires a file path for seeking (MD5 hash then re-read),
-	// so write the reader to a temp file first.
-	tmpFile, err := os.CreateTemp("", "azure-upload-*.vhd")
-	if err != nil {
-		return nil, fmt.Errorf("cannot create temp file: %w", err)
-	}
-	defer os.Remove(tmpFile.Name())
-	defer tmpFile.Close()
-
-	fmt.Fprintf(status, "Preparing image for upload...\n")
-	if _, err := io.Copy(tmpFile, r); err != nil {
-		return nil, fmt.Errorf("cannot write image to temp file: %w", err)
-	}
-	if err := tmpFile.Close(); err != nil {
-		return nil, err
-	}
-
+func (au *azureUploader) UploadAndRegister(_ io.Reader, _ uint64, status io.Writer) (*cloud.UploadResult, error) {
 	ctx := context.Background()
 
 	location, err := au.client.GetResourceGroupLocation(ctx, au.resourceGroup)
@@ -116,7 +100,7 @@ func (au *azureUploader) UploadAndRegister(r io.Reader, uploadSize uint64, statu
 			ContainerName:  uploaderStorageContainer,
 			BlobName:       blobName,
 		},
-		tmpFile.Name(),
+		au.imagePath,
 		DefaultUploadThreads,
 	)
 	if err != nil {

--- a/pkg/cloud/ibmcloud/ibmcloud.go
+++ b/pkg/cloud/ibmcloud/ibmcloud.go
@@ -53,13 +53,13 @@ func (iu *ibmcloudUploader) Check(status io.Writer) error {
 	return nil
 }
 
-func (iu *ibmcloudUploader) UploadAndRegister(r io.Reader, uploadSize uint64, status io.Writer) (err error) {
+func (iu *ibmcloudUploader) UploadAndRegister(r io.Reader, uploadSize uint64, status io.Writer) (*cloud.UploadResult, error) {
 	fmt.Fprintf(status, "Uploading to IBM Cloud...\n")
 
 	endpoint := fmt.Sprintf("s3.%s.cloud-object-storage.appdomain.cloud", iu.region)
 	credentials, err := iu.getCredentials()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	conf := aws.NewConfig().
 		WithRegion(iu.region).
@@ -69,7 +69,7 @@ func (iu *ibmcloudUploader) UploadAndRegister(r io.Reader, uploadSize uint64, st
 
 	session, err := session.NewSession(conf)
 	if err != nil {
-		return fmt.Errorf("Failed to create a session: %w", err)
+		return nil, fmt.Errorf("Failed to create a session: %w", err)
 	}
 
 	uploader := s3manager.NewUploader(session)
@@ -79,10 +79,12 @@ func (iu *ibmcloudUploader) UploadAndRegister(r io.Reader, uploadSize uint64, st
 		Body:   r,
 	})
 	if err != nil {
-		return fmt.Errorf("Failed to upload: %w", err)
+		return nil, fmt.Errorf("Failed to upload: %w", err)
 	}
 
-	return nil
+	return &cloud.UploadResult{
+		Provider: "ibmcloud",
+	}, nil
 }
 
 func (iu *ibmcloudUploader) getCredentials() (*credentials.Credentials, error) {

--- a/pkg/cloud/libvirt/libvirt.go
+++ b/pkg/cloud/libvirt/libvirt.go
@@ -32,18 +32,18 @@ func (lu *libvirtUploader) Check(status io.Writer) error {
 	return nil
 }
 
-func (lu *libvirtUploader) UploadAndRegister(r io.Reader, uploadSize uint64, status io.Writer) (err error) {
+func (lu *libvirtUploader) UploadAndRegister(r io.Reader, uploadSize uint64, status io.Writer) (*cloud.UploadResult, error) {
 	fmt.Fprintf(status, "Uploading to libvirt...\n")
 
 	conn, err := lv.NewConnect(lu.connection)
 	if err != nil {
-		return fmt.Errorf("Failed to connect to libvirt: %w", err)
+		return nil, fmt.Errorf("Failed to connect to libvirt: %w", err)
 	}
 	defer conn.Close()
 
 	pool, err := conn.LookupStoragePoolByName(lu.pool)
 	if err != nil {
-		return fmt.Errorf("Failed to find storage pool: %w", err)
+		return nil, fmt.Errorf("Failed to find storage pool: %w", err)
 	}
 
 	defer func() {
@@ -55,7 +55,7 @@ func (lu *libvirtUploader) UploadAndRegister(r io.Reader, uploadSize uint64, sta
 	volXML := lu.VolumeXML(lu.volume, uploadSize)
 	vol, err := pool.StorageVolCreateXML(volXML, 0)
 	if err != nil {
-		return fmt.Errorf("Failed to create a libvirt volume: %w", err)
+		return nil, fmt.Errorf("Failed to create a libvirt volume: %w", err)
 	}
 	defer func() {
 		if err := vol.Free(); err != nil {
@@ -65,10 +65,12 @@ func (lu *libvirtUploader) UploadAndRegister(r io.Reader, uploadSize uint64, sta
 
 	err = lu.Upload(conn, vol, r, uploadSize)
 	if err != nil {
-		return fmt.Errorf("Failed to upload the file to libvirt: %w", err)
+		return nil, fmt.Errorf("Failed to upload the file to libvirt: %w", err)
 	}
 
-	return nil
+	return &cloud.UploadResult{
+		Provider: "libvirt",
+	}, nil
 }
 
 func (lu *libvirtUploader) VolumeXML(name string, size uint64) string {

--- a/pkg/cloud/libvirt/libvirt_no_cgo.go
+++ b/pkg/cloud/libvirt/libvirt_no_cgo.go
@@ -22,6 +22,6 @@ func (lu *libvirtUploader) Check(status io.Writer) error {
 	return fmt.Errorf("cannot use libvirt: build without cgo")
 }
 
-func (lu *libvirtUploader) UploadAndRegister(r io.Reader, uploadSize uint64, status io.Writer) (err error) {
-	return fmt.Errorf("cannot use libvirt: build without cgo")
+func (lu *libvirtUploader) UploadAndRegister(r io.Reader, uploadSize uint64, status io.Writer) (*cloud.UploadResult, error) {
+	return nil, fmt.Errorf("cannot use libvirt: build without cgo")
 }

--- a/pkg/cloud/openstack/openstack.go
+++ b/pkg/cloud/openstack/openstack.go
@@ -39,12 +39,12 @@ func (ou *openstackUploader) Check(status io.Writer) error {
 	return nil
 }
 
-func (ou *openstackUploader) UploadAndRegister(r io.Reader, uploadSize uint64, status io.Writer) (err error) {
+func (ou *openstackUploader) UploadAndRegister(r io.Reader, uploadSize uint64, status io.Writer) (*cloud.UploadResult, error) {
 	fmt.Fprintf(status, "Uploading to OpenStack...\n")
 
 	opts, err := ostack.AuthOptionsFromEnv()
 	if err != nil {
-		return fmt.Errorf("Failed to read OpenStack ENV variables. Please source the OpenStack RC file: %w", err)
+		return nil, fmt.Errorf("Failed to read OpenStack ENV variables. Please source the OpenStack RC file: %w", err)
 	}
 
 	// This is needed otherwise we get the following error when authenticating:
@@ -60,14 +60,14 @@ func (ou *openstackUploader) UploadAndRegister(r io.Reader, uploadSize uint64, s
 	ctx := context.Background()
 	provider, err := ostack.AuthenticatedClient(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("Failed to authenticate to OpenStack: %w", err)
+		return nil, fmt.Errorf("Failed to authenticate to OpenStack: %w", err)
 	}
 
 	client, err := ostack.NewImageV2(provider, gophercloud.EndpointOpts{
 		Region: os.Getenv("OS_REGION_NAME"),
 	})
 	if err != nil {
-		return fmt.Errorf("Failed to initialize the client: %w", err)
+		return nil, fmt.Errorf("Failed to initialize the client: %w", err)
 	}
 
 	createOpts := images.CreateOpts{
@@ -77,17 +77,16 @@ func (ou *openstackUploader) UploadAndRegister(r io.Reader, uploadSize uint64, s
 	}
 	img, err := images.Create(ctx, client, createOpts).Extract()
 	if err != nil {
-		return fmt.Errorf("Failed to create the image metadata: %w", err)
+		return nil, fmt.Errorf("Failed to create the image metadata: %w", err)
 	}
 
 	err = imagedata.Upload(ctx, client, img.ID, r).ExtractErr()
 	if err != nil {
-		return fmt.Errorf("Failed to upload the image: %w", err)
+		return nil, fmt.Errorf("Failed to upload the image: %w", err)
 	}
 
-	// This would glitch the progressbar, but once it gets fixed, we would
-	// like to print this message
-	// fmt.Printf("Created image: %s (ID: %s)\n", img.Name, img.ID)
-
-	return nil
+	return &cloud.UploadResult{
+		Provider: "openstack",
+		ImageID:  img.ID,
+	}, nil
 }

--- a/pkg/cloud/uploader.go
+++ b/pkg/cloud/uploader.go
@@ -4,6 +4,13 @@ import (
 	"io"
 )
 
+// UploadResult contains the result of an upload operation.
+// Different cloud providers populate different fields.
+type UploadResult struct {
+	Provider string `json:"provider" yaml:"provider"`
+	ImageID  string `json:"image_id,omitempty" yaml:"image_id,omitempty"`
+}
+
 // Uploader is an interface that is returned from the actual
 // cloud implementation. The uploader will be parameterized
 // by the actual cloud implemntation, e.g.
@@ -22,5 +29,5 @@ type Uploader interface {
 	// To implement progress a proxy reader can be used.
 	// For more complex scenarios an optional uploadSize can be
 	// passed.
-	UploadAndRegister(r io.Reader, uploadSize uint64, status io.Writer) error
+	UploadAndRegister(r io.Reader, uploadSize uint64, status io.Writer) (*UploadResult, error)
 }

--- a/test/scripts/imgtestlib/boot.py
+++ b/test/scripts/imgtestlib/boot.py
@@ -382,21 +382,36 @@ def boot_qemu_pxe(arch, pxe_tar_path):
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
+def upload_to_aws(arch, image_name, image_path):
+    """Upload an image to AWS via image-builder and return the AMI ID."""
+    aws_config = get_aws_config()
+    cmd = ["go", "run", "./cmd/image-builder", "upload",
+           "--to=aws",
+           "--format=json",
+           "--arch", arch,
+           "--aws-ami-name", image_name,
+           "--aws-bucket", aws_config["bucket"],
+           "--aws-region", aws_config["region"],
+           image_path]
+    stdout, _ = runcmd(cmd)
+    result = json.loads(stdout)
+    return result["image_id"]
+
+
 def cmd_boot_aws(arch, image_name, privkey, pubkey, image_path, script_cmd):
     make_check_host_config(arch)
     aws_config = get_aws_config()
+    ami_id = upload_to_aws(arch, image_name, image_path)
     cmd = ["go", "run", "./cmd/boot-aws", "run",
            "--access-key-id", aws_config["key_id"],
            "--secret-access-key", aws_config["secret_key"],
            "--region", aws_config["region"],
-           "--bucket", aws_config["bucket"],
            "--arch", arch,
-           "--ami-name", image_name,
-           "--s3-key", f"images/boot/{image_name}",
+           "--ami", ami_id,
            "--username", "osbuild",
            "--ssh-privkey", privkey,
            "--ssh-pubkey", pubkey,
-           image_path, *script_cmd]
+           *script_cmd]
     runcmd_nc(cmd)
 
 
@@ -470,6 +485,25 @@ def boot_container(distro, arch, image_type, image_path, manifest_id, host_confi
                          [BASE_TEST_EXEC+arch, host_config])
 
 
+def upload_to_azure(arch, image_name, image_path):
+    """Upload an image to Azure via image-builder and return the image ref."""
+    az_config = get_azure_config()
+    cmd = ["go", "run", "./cmd/image-builder", "upload",
+           "--to=azure",
+           "--format=json",
+           "--arch", arch,
+           "--azure-client-id", az_config["client_id"],
+           "--azure-client-secret", az_config["client_secret"],
+           "--azure-tenant", az_config["tenant"],
+           "--azure-subscription", az_config["subscription"],
+           "--azure-resource-group", az_config["resource_group"],
+           "--azure-image-name", image_name,
+           image_path]
+    stdout, _ = runcmd(cmd)
+    result = json.loads(stdout)
+    return result["image_id"]
+
+
 def boot_vhd(distro, arch, image_path, config):
     cmd = [BASE_TEST_EXEC+arch, config]
     make_check_host_config(arch)
@@ -479,6 +513,7 @@ def boot_vhd(distro, arch, image_path, config):
             name = f"{distro}-" + str(uuid.uuid4())
 
             az_config = get_azure_config()
+            image_ref = upload_to_azure(arch, name, raw_image_path)
             cmd = ["go", "run", "./cmd/boot-azure", "run",
                    "--subscription", az_config["subscription"],
                    "--tenant", az_config["tenant"],
@@ -490,8 +525,8 @@ def boot_vhd(distro, arch, image_path, config):
                    "--ssh-pubkey", pubkey,
                    "--vm-name", name,
                    "--arch", arch,
-                   "--image-name", name,
-                   raw_image_path, *cmd]
+                   "--image", image_ref,
+                   *cmd]
             runcmd_nc(cmd)
 
 
@@ -511,13 +546,14 @@ def boot_wsl(distro, arch, image_path, config):
                    "--client-secret", az_config["client_secret"],
                    "--resource-group", az_config["resource_group"],
                    "--snapshot", az_config["windows_snapshot"],
+                   "--local-image", raw_image_path,
                    "--username", "azureuser",
                    "--ssh-privkey", privkey,
                    "--ssh-pubkey", pubkey,
                    "--vm-name", name,
                    "--arch", arch,
                    "--size", "Standard_D2as_v5",
-                   raw_image_path, *cmd]
+                   *cmd]
             runcmd_nc(cmd)
 
 

--- a/test/scripts/imgtestlib/boot.py
+++ b/test/scripts/imgtestlib/boot.py
@@ -381,8 +381,28 @@ def boot_qemu_pxe(arch, pxe_tar_path):
             http_server.wait()
 
 
+def get_boot_mode(distro, arch, image_type):
+    """Get the boot mode for an image type from image-builder describe."""
+    stdout, _ = runcmd(["go", "run", "./cmd/image-builder", "describe",
+                        image_type, "--distro", distro, "--arch", arch])
+    for line in stdout.decode().splitlines():
+        if line.startswith("bootmode:"):
+            mode = line.split(":", 1)[1].strip()
+            mode_map = {
+                "legacy": "legacy-bios",
+                "uefi": "uefi",
+                "hybrid": "uefi-preferred",
+            }
+            try:
+                return mode_map[mode]
+            except KeyError:
+                raise RuntimeError(f"unknown bootmode {mode!r} for {distro}/{arch}/{image_type}") from None
+
+    raise RuntimeError(f"bootmode not found in describe output for {distro}/{arch}/{image_type}")
+
+
 # pylint: disable=too-many-arguments,too-many-positional-arguments
-def upload_to_aws(arch, image_name, image_path):
+def upload_to_aws(arch, image_name, image_path, boot_mode=None):
     """Upload an image to AWS via image-builder and return the AMI ID."""
     aws_config = get_aws_config()
     cmd = ["go", "run", "./cmd/image-builder", "upload",
@@ -391,17 +411,29 @@ def upload_to_aws(arch, image_name, image_path):
            "--arch", arch,
            "--aws-ami-name", image_name,
            "--aws-bucket", aws_config["bucket"],
-           "--aws-region", aws_config["region"],
-           image_path]
+           "--aws-region", aws_config["region"]]
+    if boot_mode:
+        cmd += ["--aws-boot-mode", boot_mode]
+    cmd.append(image_path)
     stdout, _ = runcmd(cmd)
     result = json.loads(stdout)
     return result["image_id"]
 
 
-def cmd_boot_aws(arch, image_name, privkey, pubkey, image_path, script_cmd):
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+def cmd_boot_aws(distro, arch, image_type, image_name, privkey, pubkey, image_path, script_cmd):
     make_check_host_config(arch)
     aws_config = get_aws_config()
-    ami_id = upload_to_aws(arch, image_name, image_path)
+
+    # we special case rhel 7.9 here as it doesn't 'actually exist' in the definitions
+    # for image-builder
+    if distro == "rhel-7.9" and image_type == "ec2":
+        boot_mode = "legacy-bios"
+    else:
+        # otherwise ask for the boot mode
+        boot_mode = get_boot_mode(distro, arch, image_type)
+
+    ami_id = upload_to_aws(arch, image_name, image_path, boot_mode)
     cmd = ["go", "run", "./cmd/boot-aws", "run",
            "--access-key-id", aws_config["key_id"],
            "--secret-access-key", aws_config["secret_key"],
@@ -421,7 +453,7 @@ def boot_ami(distro, arch, image_type, image_path, config):
     with ensure_uncompressed(image_path) as raw_image_path:
         with create_ssh_key() as (privkey, pubkey):
             image_name = f"image-boot-test-{distro}-{arch}-{image_type}-" + str(uuid.uuid4())
-            cmd_boot_aws(arch, image_name, privkey, pubkey, raw_image_path, cmd)
+            cmd_boot_aws(distro, arch, image_type, image_name, privkey, pubkey, raw_image_path, cmd)
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -481,7 +513,7 @@ def boot_container(distro, arch, image_type, image_path, manifest_id, host_confi
             # Build artifacts are owned by root. Make them world accessible.
             runcmd(["sudo", "chmod", "a+rwX", "-R", tmpdir])
             raw_image_path = f"{tmpdir}/image/disk.raw"
-            cmd_boot_aws(arch, image_name, privkey_file, pubkey_file, raw_image_path,
+            cmd_boot_aws(distro, arch, image_type, image_name, privkey_file, pubkey_file, raw_image_path,
                          [BASE_TEST_EXEC+arch, host_config])
 
 


### PR DESCRIPTION
Replace the upload parts of `boot-(aws|azure)` with `image-builder upload`. Had to add some options and move all the Azure upload code since it didn't exist yet.