### PR TITLE
Add aliases for bootc ami and qcow2 image types (HMS-10949)

### DIFF
--- a/data/distrodefs/bootc-generic/imagetypes.yaml
+++ b/data/distrodefs/bootc-generic/imagetypes.yaml
@@ -125,10 +125,12 @@ image_types:
 
   "ami":
     <<: *raw_image_type
+    aliases: ["aws"]
     filename: "disk.raw"
 
   "qcow2": &qcow2_image_type
     <<: *raw_image_type
+    aliases: ["guest-image"]
     filename: "disk.qcow2"
     mime_type: "application/x-qemu-disk"
     exports: ["qcow2"]


### PR DESCRIPTION
## Summary

Add `aliases` entries to the bootc-generic distrodefs so that `cockpit-image-builder` can resolve user-facing image type names without translating them at the frontend layer.

## Changes

- Add `"aws"` alias for the `ami` bootc image type
- Add `"guest-image"` alias for the `qcow2` bootc image type
