### PR TITLE
image-builder/build: add json format option

### DIFF
--- a/cmd/image-builder/build.go
+++ b/cmd/image-builder/build.go
@@ -15,6 +15,7 @@ type buildOptions struct {
 	StoreDir       string
 	OutputBasename string
 	InVm           []string
+	JSONOutput     bool
 
 	WriteManifest bool
 	WriteBuildlog bool
@@ -39,10 +40,11 @@ func buildImage(pbar progress.ProgressBar, res *imagefilter.Result, osbuildManif
 	}
 
 	osbuildOpts := &progress.OSBuildOptions{
-		StoreDir:  opts.StoreDir,
-		OutputDir: opts.OutputDir,
-		Metrics:   opts.Metrics,
-		InVm:      opts.InVm,
+		StoreDir:   opts.StoreDir,
+		OutputDir:  opts.OutputDir,
+		Metrics:    opts.Metrics,
+		InVm:       opts.InVm,
+		JSONOutput: opts.JSONOutput,
 	}
 	if opts.WriteBuildlog {
 		if err := os.MkdirAll(opts.OutputDir, 0755); err != nil {

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -523,6 +523,10 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	format, err := cmd.Flags().GetString("format")
+	if err != nil {
+		return err
+	}
 	// Fail early if the cache directory is not writable, instead of
 	// waiting for osbuild to fail after slow manifest generation.
 	if err := os.MkdirAll(cacheDir, 0755); err != nil {
@@ -590,6 +594,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		WriteManifest:  withManifest,
 		WriteBuildlog:  withBuildlog,
 		Metrics:        withMetrics,
+		JSONOutput:     format == "json",
 	}
 	if runInVm {
 		buildOpts.InVm = []string{"image"}
@@ -835,6 +840,7 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 	buildCmd.Flags().Bool("with-metrics", false, `print timing information at the end of the build`)
 	buildCmd.Flags().String("output-name", "", "set specific output basename")
 	buildCmd.Flags().Bool("in-vm", false, `run the osbuild pipeline in a virtual machine`)
+	buildCmd.Flags().String("format", "", "Output in a specific format (json)")
 	rootCmd.AddCommand(buildCmd)
 	buildCmd.Flags().AddFlagSet(uploadCmd.Flags())
 	// add after the rest of the uploadCmd flag set is added to avoid

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -348,6 +348,7 @@ cat - > "$0".stdin
 
 output_dir=""
 export=""
+format=""
 while [[ $# -gt 0 ]]; do
   key="$1"
   case $key in
@@ -358,6 +359,10 @@ while [[ $# -gt 0 ]]; do
     --export)
       export="$2"
       shift 2
+      ;;
+    --json)
+      format="json"
+      shift 1
       ;;
     *)
       shift 1
@@ -376,6 +381,10 @@ case $export in
     exit 1
     ;;
 esac
+if [ "$format" = "json" ]; then
+  echo '{"message": "hai"}' >&3
+  echo '{"success": true}'
+fi
 `
 }
 
@@ -452,27 +461,38 @@ func TestBuildIntegrationArgs(t *testing.T) {
 	for _, tc := range []struct {
 		args          []string
 		expectedFiles []string
+		expectedLog   string
 	}{
 		{
 			nil,
 			nil,
+			"",
 		}, {
 			[]string{"--with-manifest"},
 			[]string{"centos-9-qcow2-x86_64.osbuild-manifest.json"},
+			"",
 		}, {
 			[]string{"--with-buildlog"},
 			[]string{"centos-9-qcow2-x86_64.buildlog"},
+			"",
 		}, {
 			[]string{"--with-sbom"},
 			[]string{"centos-9-qcow2-x86_64.buildroot-build.spdx.json",
 				"centos-9-qcow2-x86_64.image-os.spdx.json",
 			},
+			"",
 		}, {
 			[]string{"--with-manifest", "--with-sbom"},
 			[]string{"centos-9-qcow2-x86_64.buildroot-build.spdx.json",
 				"centos-9-qcow2-x86_64.image-os.spdx.json",
 				"centos-9-qcow2-x86_64.osbuild-manifest.json",
 			},
+			"",
+		},
+		{
+			[]string{"--format", "json", "--with-buildlog", "--progress", "debug"},
+			[]string{"centos-9-qcow2-x86_64.buildlog"},
+			"{\"success\": true}\n",
 		},
 	} {
 		t.Run(strings.Join(tc.args, ","), func(t *testing.T) {
@@ -500,6 +520,12 @@ func TestBuildIntegrationArgs(t *testing.T) {
 			outputDirPos := slices.Index(osbuildCall, "--output-directory")
 			assert.True(t, outputDirPos > -1)
 			assert.Equal(t, outputDir, osbuildCall[outputDirPos+1])
+
+			if tc.expectedLog != "" {
+				data, err := os.ReadFile(filepath.Join(outputDir, "centos-9-qcow2-x86_64.buildlog"))
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedLog, string(data))
+			}
 
 			// ensure we get exactly the expected files
 			files, err := filepath.Glob(outputDir + "/*")

--- a/pkg/progress/command.go
+++ b/pkg/progress/command.go
@@ -17,10 +17,11 @@ import (
 )
 
 type OSBuildOptions struct {
-	StoreDir  string
-	OutputDir string
-	ExtraEnv  []string
-	InVm      []string
+	StoreDir   string
+	OutputDir  string
+	ExtraEnv   []string
+	InVm       []string
+	JSONOutput bool
 
 	// BuildLog writes the osbuild output to the given writer
 	BuildLog io.Writer
@@ -69,6 +70,9 @@ func newOsbuildCmd(manifest []byte, exports []string, opts *OSBuildOptions) *exe
 	}
 	for _, pipeline := range opts.InVm {
 		cmd.Args = append(cmd.Args, "--in-vm", pipeline)
+	}
+	if opts.JSONOutput {
+		cmd.Args = append(cmd.Args, "--json")
 	}
 	cmd.Env = append(os.Environ(), opts.ExtraEnv...)
 	cmd.Stdin = bytes.NewBuffer(manifest)
@@ -162,6 +166,11 @@ func runOSBuildWithProgress(pb ProgressBar, manifest []byte, exports []string, o
 
 	var tracesMsgs []string
 	oss := osbuildStageMetrics{}
+	traceOut := buildLog
+	// do not pollute the buildlog with non-json stuff
+	if opts.JSONOutput {
+		traceOut = io.Discard
+	}
 	for {
 		st, err := osbuildStatus.Status()
 		if err != nil {
@@ -194,11 +203,14 @@ func runOSBuildWithProgress(pb ProgressBar, manifest []byte, exports []string, o
 		// external build log
 		if st.Message != "" {
 			tracesMsgs = append(tracesMsgs, st.Message)
-			fmt.Fprintln(buildLog, st.Message)
+			// don't pollute the buildlog with non-json stuff
+			if !opts.JSONOutput {
+				fmt.Fprintln(traceOut, st.Message)
+			}
 		}
 		if st.Trace != "" {
 			tracesMsgs = append(tracesMsgs, st.Trace)
-			fmt.Fprintln(buildLog, st.Trace)
+			fmt.Fprintln(traceOut, st.Trace)
 		}
 
 		// store metrics if requested


### PR DESCRIPTION
When `--format json` is passed, the buildlog will contain the json result generated by osbuild. Any status message or trace are not written to the buildlog in order to ensure it contains a single valid json object.