### PR TITLE
progress: add file progress (HMS-10977)

### DIFF
--- a/cmd/image-builder/bib_main.go
+++ b/cmd/image-builder/bib_main.go
@@ -219,7 +219,7 @@ func bibManifestFromCobra(cmd *cobra.Command, args []string, pbar progress.Progr
 }
 
 func bibCmdManifest(cmd *cobra.Command, args []string) error {
-	pbar, err := progress.New("")
+	pbar, err := progress.New("", progress.ProgressConfig{})
 	if err != nil {
 		// this should never happen
 		return fmt.Errorf("cannot create progress bar: %w", err)
@@ -324,7 +324,7 @@ func bibCmdBuild(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("chowning is not allowed in output directory")
 	}
 
-	pbar, err := progress.New(progressType)
+	pbar, err := progress.New(progressType, progress.ProgressConfig{})
 	if err != nil {
 		return fmt.Errorf("cannto create progress bar: %w", err)
 	}

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -244,15 +244,8 @@ type cmdManifestWrapperOptions struct {
 // used in tests
 var manifestgenDepsolver manifestgen.DepsolveFunc
 
-func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []string, w io.Writer, wd io.Writer, wrapperOpts *cmdManifestWrapperOptions) (*imagefilter.Result, error) {
-	if wrapperOpts == nil {
-		wrapperOpts = &cmdManifestWrapperOptions{}
-	}
+func getImage(cmd *cobra.Command, args []string) (*imagefilter.Result, error) {
 	repoDir, err := cmd.Flags().GetString("force-repo-dir")
-	if err != nil {
-		return nil, err
-	}
-	rpmmdCacheDir, err := cmd.Flags().GetString("rpmmd-cache")
 	if err != nil {
 		return nil, err
 	}
@@ -275,63 +268,7 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if err != nil {
 		return nil, err
 	}
-	withSBOM, err := cmd.Flags().GetBool("with-sbom")
-	if err != nil {
-		return nil, err
-	}
-	withRPMList, err := cmd.Flags().GetBool("with-rpmlist")
-	if err != nil {
-		return nil, err
-	}
-	ignoreWarnings, err := cmd.Flags().GetBool("ignore-warnings")
-	if err != nil {
-		return nil, err
-	}
-	outputDir, err := cmd.Flags().GetString("output-dir")
-	if err != nil {
-		return nil, err
-	}
-	ostreeImgOpts, err := ostreeImageOptions(cmd)
-	if err != nil {
-		return nil, err
-	}
-	useLibrepo, err := cmd.Flags().GetBool("use-librepo")
-	if err != nil {
-		return nil, err
-	}
 	bootcDefaultFs, err := cmd.Flags().GetString("bootc-default-fs")
-	if err != nil {
-		return nil, err
-	}
-	var preview *bool
-	// Verify that the flag was actually passed. If it wasn't passed
-	// we keep our nil value so that images used the distro-defined
-	// value for preview. Otherwise use the provided value so the
-	// distro value gets overridden.
-	if cmd.Flags().Lookup("preview").Changed {
-		value, err := cmd.Flags().GetBool("preview")
-		if err != nil {
-			return nil, err
-		}
-		preview = &value
-	}
-	var rpmDownloader osbuild.RpmDownloader
-	if useLibrepo {
-		rpmDownloader = osbuild.RpmDownloaderLibrepo
-	}
-	blueprintPath, err := cmd.Flags().GetString("blueprint")
-	if err != nil {
-		return nil, err
-	}
-	var customSeed *int64
-	if cmd.Flags().Changed("seed") {
-		seedFlagVal, err := cmd.Flags().GetInt64("seed")
-		if err != nil {
-			return nil, err
-		}
-		customSeed = &seedFlagVal
-	}
-	subscription, err := subscriptionImageOptions(cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -346,40 +283,11 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if err != nil {
 		return nil, err
 	}
-	bootcInstallerPayloadRef, err := cmd.Flags().GetString("bootc-installer-payload-ref")
-	if err != nil {
-		return nil, err
-	}
-	bootcOmitDefaultKernelArgs, err := cmd.Flags().GetBool("bootc-no-default-kernel-args")
-	if err != nil {
-		return nil, err
-	}
 	forceDefsDir, err := cmd.Flags().GetString("force-defs-dir")
 	if err != nil {
 		return nil, err
 	}
-
-	// no error check here as this is (deliberately) not defined on
-	// "manifest" (if "images" learn to set the output filename in
-	// manifests we would change this
-	outputFilename, _ := cmd.Flags().GetString("output-name")
-
-	bp, err := blueprintload.Load(blueprintPath)
-	if err != nil {
-		return nil, err
-	}
-	if bootcRef == "" {
-		distroStr, err = findDistro(distroStr, bp.Distro)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		distroStr = "bootc-based"
-	}
-
 	imgTypeStr := args[0]
-	pbar.SetPulseMsgf("Manifest generation step")
-	pbar.SetMessagef("Building manifest for %s-%s", distroStr, imgTypeStr)
 
 	var img *imagefilter.Result
 	if bootcRef != "" {
@@ -398,6 +306,14 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 		// disk.yaml always takes priority over --bootc-default-fs and bootc config.
 		diskYamlRootFs := bootcInfo.OSInfo.GetDiskYamlRootFs()
 		if diskYamlRootFs != "" {
+			// XXX: hack, temporary progress bar, the file progress bar cannot be
+			// constructed before we have the img. Use the verbose bar, as the terminal
+			// bar would be overwritten by the next terminal message before anyone could
+			// see it.
+			pbar, err := progress.New("verbose")
+			if err != nil {
+				return nil, err
+			}
 			if bootcDefaultFs != "" {
 				pbar.SetPulseMsgf("Using disk.yaml root filesystem (%s), ignoring --bootc-default-fs (%s)", diskYamlRootFs, bootcDefaultFs)
 			} else if bootcInfo.DefaultRootFs != "" {
@@ -431,10 +347,6 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 			return nil, err
 		}
 		img = &imagefilter.Result{ImgType: imgType, Repos: nil}
-		// XXX: hack to skip repo loading for the bootc image.
-		// We need to add a SkipRepositories or similar to
-		// manifestgen instead to make this clean
-		forceRepos = []string{"https://example.com/not-used"}
 	} else {
 		repoOpts := &repoOptions{
 			RepoDir:      repoDir,
@@ -450,6 +362,130 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if len(img.ImgType.Exports()) > 1 {
 		return nil, fmt.Errorf("image %q has multiple exports: this is current unsupport: please report this as a bug", basenameFor(img, ""))
 	}
+	return img, err
+}
+
+func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []string, img *imagefilter.Result, w io.Writer, wd io.Writer, wrapperOpts *cmdManifestWrapperOptions) error {
+	if wrapperOpts == nil {
+		wrapperOpts = &cmdManifestWrapperOptions{}
+	}
+	repoDir, err := cmd.Flags().GetString("force-repo-dir")
+	if err != nil {
+		return err
+	}
+	rpmmdCacheDir, err := cmd.Flags().GetString("rpmmd-cache")
+	if err != nil {
+		return err
+	}
+	extraRepos, err := cmd.Flags().GetStringArray("extra-repo")
+	if err != nil {
+		return err
+	}
+	forceRepos, err := cmd.Flags().GetStringArray("force-repo")
+	if err != nil {
+		return err
+	}
+	distroStr, err := cmd.Flags().GetString("distro")
+	if err != nil {
+		return err
+	}
+	withSBOM, err := cmd.Flags().GetBool("with-sbom")
+	if err != nil {
+		return err
+	}
+	withRPMList, err := cmd.Flags().GetBool("with-rpmlist")
+	if err != nil {
+		return err
+	}
+	ignoreWarnings, err := cmd.Flags().GetBool("ignore-warnings")
+	if err != nil {
+		return err
+	}
+	outputDir, err := cmd.Flags().GetString("output-dir")
+	if err != nil {
+		return err
+	}
+	ostreeImgOpts, err := ostreeImageOptions(cmd)
+	if err != nil {
+		return err
+	}
+	useLibrepo, err := cmd.Flags().GetBool("use-librepo")
+	if err != nil {
+		return err
+	}
+	var preview *bool
+	// Verify that the flag was actually passed. If it wasn't passed
+	// we keep our nil value so that images used the distro-defined
+	// value for preview. Otherwise use the provided value so the
+	// distro value gets overridden.
+	if cmd.Flags().Lookup("preview").Changed {
+		value, err := cmd.Flags().GetBool("preview")
+		if err != nil {
+			return err
+		}
+		preview = &value
+	}
+	var rpmDownloader osbuild.RpmDownloader
+	if useLibrepo {
+		rpmDownloader = osbuild.RpmDownloaderLibrepo
+	}
+	blueprintPath, err := cmd.Flags().GetString("blueprint")
+	if err != nil {
+		return err
+	}
+	var customSeed *int64
+	if cmd.Flags().Changed("seed") {
+		seedFlagVal, err := cmd.Flags().GetInt64("seed")
+		if err != nil {
+			return err
+		}
+		customSeed = &seedFlagVal
+	}
+	subscription, err := subscriptionImageOptions(cmd)
+	if err != nil {
+		return err
+	}
+	bootcRef, err := cmd.Flags().GetString("bootc-ref")
+	if err != nil {
+		return err
+	}
+	if bootcRef != "" && distroStr != "" {
+		return fmt.Errorf("cannot use --distro with --bootc-ref")
+	}
+	bootcInstallerPayloadRef, err := cmd.Flags().GetString("bootc-installer-payload-ref")
+	if err != nil {
+		return err
+	}
+	bootcOmitDefaultKernelArgs, err := cmd.Flags().GetBool("bootc-no-default-kernel-args")
+	if err != nil {
+		return err
+	}
+
+	// no error check here as this is (deliberately) not defined on
+	// "manifest" (if "images" learn to set the output filename in
+	// manifests we would change this
+	outputFilename, _ := cmd.Flags().GetString("output-name")
+
+	bp, err := blueprintload.Load(blueprintPath)
+	if err != nil {
+		return err
+	}
+	if bootcRef == "" {
+		distroStr, err = findDistro(distroStr, bp.Distro)
+		if err != nil {
+			return err
+		}
+	} else {
+		distroStr = "bootc-based"
+		// XXX: hack to skip repo loading for the bootc image.
+		// We need to add a SkipRepositories or similar to
+		// manifestgen instead to make this clean
+		forceRepos = []string{"https://example.com/not-used"}
+	}
+
+	imgTypeStr := args[0]
+	pbar.SetPulseMsgf("Manifest generation step")
+	pbar.SetMessagef("Building manifest for %s-%s", distroStr, imgTypeStr)
 
 	opts := &manifestOptions{
 		ManifestgenOptions: manifestgen.Options{
@@ -478,8 +514,7 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if opts.ManifestgenOptions.UseBootstrapContainer {
 		fmt.Fprintf(os.Stderr, "WARNING: using experimental cross-architecture building to build %q\n", img.ImgType.Arch().Name())
 	}
-	err = generateManifest(repoDir, extraRepos, img, w, opts)
-	return img, err
+	return generateManifest(repoDir, extraRepos, img, w, opts)
 }
 
 func cmdManifest(cmd *cobra.Command, args []string) error {
@@ -487,8 +522,11 @@ func cmdManifest(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	_, err = cmdManifestWrapper(pbar, cmd, args, osStdout, io.Discard, nil)
-	return err
+	img, err := getImage(cmd, args)
+	if err != nil {
+		return err
+	}
+	return cmdManifestWrapper(pbar, cmd, args, img, osStdout, io.Discard, nil)
 }
 
 func progressFromCmd(cmd *cobra.Command) (progress.ProgressBar, error) {
@@ -561,6 +599,17 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	img, err := getImage(cmd, args)
+	if err != nil {
+		return err
+	}
+	// Ensure the output directory exists before (file) progress starts.
+	outputDir = basenameFor(img, outputDir)
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("cannot create output base directory %s: %w", outputDir, err)
+	}
+
 	pbar.Start()
 	defer pbar.Stop()
 	go func() {
@@ -577,13 +626,13 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 
 	// We discard any warnings from the depsolver until we figure out a better
 	// idea (likely in manifestgen)
-	res, err := cmdManifestWrapper(pbar, cmd, args, &mf, io.Discard, opts)
+	err = cmdManifestWrapper(pbar, cmd, args, img, &mf, io.Discard, opts)
 	if err != nil {
 		return err
 	}
 
-	bootMode := res.ImgType.BootMode()
-	uploader, err := uploaderFor(cmd, res.ImgType.Name(), res.ImgType.Arch().Name(), &bootMode, "")
+	bootMode := img.ImgType.BootMode()
+	uploader, err := uploaderFor(cmd, img.ImgType.Name(), img.ImgType.Arch().Name(), &bootMode, "")
 	if errors.Is(err, ErrUploadTypeUnsupported) || errors.Is(err, ErrUploadConfigNotProvided) {
 		err = nil
 	}
@@ -598,7 +647,6 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	outputDir = basenameFor(res, outputDir)
 
 	buildOpts := &buildOptions{
 		OutputDir:      outputDir,
@@ -613,7 +661,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		buildOpts.InVm = []string{"image"}
 	}
 	pbar.SetPulseMsgf("Image building step")
-	imagePath, err := buildImage(pbar, res, mf.Bytes(), buildOpts)
+	imagePath, err := buildImage(pbar, img, mf.Bytes(), buildOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -310,7 +310,7 @@ func getImage(cmd *cobra.Command, args []string) (*imagefilter.Result, error) {
 			// constructed before we have the img. Use the verbose bar, as the terminal
 			// bar would be overwritten by the next terminal message before anyone could
 			// see it.
-			pbar, err := progress.New("verbose")
+			pbar, err := progress.New("verbose", progress.ProgressConfig{})
 			if err != nil {
 				return nil, err
 			}
@@ -518,7 +518,7 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 }
 
 func cmdManifest(cmd *cobra.Command, args []string) error {
-	pbar, err := progress.New("")
+	pbar, err := progress.New("", progress.ProgressConfig{})
 	if err != nil {
 		return err
 	}
@@ -529,7 +529,7 @@ func cmdManifest(cmd *cobra.Command, args []string) error {
 	return cmdManifestWrapper(pbar, cmd, args, img, osStdout, io.Discard, nil)
 }
 
-func progressFromCmd(cmd *cobra.Command) (progress.ProgressBar, error) {
+func progressFromCmd(cmd *cobra.Command, conf progress.ProgressConfig) (progress.ProgressBar, error) {
 	progressType, err := cmd.Flags().GetString("progress")
 	if err != nil {
 		return nil, err
@@ -542,7 +542,7 @@ func progressFromCmd(cmd *cobra.Command) (progress.ProgressBar, error) {
 		progressType = "verbose"
 	}
 
-	return progress.New(progressType)
+	return progress.New(progressType, conf)
 }
 
 func cmdBuild(cmd *cobra.Command, args []string) error {
@@ -595,11 +595,6 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("running in VM outside container is not supported yet")
 	}
 
-	pbar, err := progressFromCmd(cmd)
-	if err != nil {
-		return err
-	}
-
 	img, err := getImage(cmd, args)
 	if err != nil {
 		return err
@@ -608,6 +603,13 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	outputDir = basenameFor(img, outputDir)
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return fmt.Errorf("cannot create output base directory %s: %w", outputDir, err)
+	}
+
+	pbar, err := progressFromCmd(cmd, progress.ProgressConfig{
+		FilePath: filepath.Join(outputDir, fmt.Sprintf("%s.progress", basenameFor(img, outputBasename))),
+	})
+	if err != nil {
+		return err
 	}
 
 	pbar.Start()

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/osbuild/image-builder/pkg/distro"
 	"github.com/osbuild/image-builder/pkg/manifestgen/manifestmock"
 	"github.com/osbuild/image-builder/pkg/osbuild/manifesttest"
+	"github.com/osbuild/image-builder/pkg/progress"
 	"github.com/osbuild/image-builder/pkg/rpmmd"
 	testrepos "github.com/osbuild/image-builder/test/data/repositories"
 
@@ -490,8 +491,8 @@ func TestBuildIntegrationArgs(t *testing.T) {
 			"",
 		},
 		{
-			[]string{"--format", "json", "--with-buildlog", "--progress", "debug"},
-			[]string{"centos-9-qcow2-x86_64.buildlog"},
+			[]string{"--format", "json", "--with-buildlog", "--progress", "file"},
+			[]string{"centos-9-qcow2-x86_64.buildlog", "centos-9-qcow2-x86_64.progress"},
 			"{\"success\": true}\n",
 		},
 	} {
@@ -799,7 +800,7 @@ func TestProgressFromCmd(t *testing.T) {
 	} {
 		assert.NoError(t, cmd.Flags().Set("progress", tc.progress))
 		assert.NoError(t, cmd.Flags().Set("verbose", fmt.Sprintf("%v", tc.verbose)))
-		pbar, err := main.ProgressFromCmd(cmd)
+		pbar, err := main.ProgressFromCmd(cmd, progress.ProgressConfig{})
 		assert.NoError(t, err)
 		assert.Equal(t, tc.expectedProgress, fmt.Sprintf("%T", pbar))
 	}

--- a/pkg/progress/command.go
+++ b/pkg/progress/command.go
@@ -45,7 +45,7 @@ func RunOSBuild(pb ProgressBar, manifest []byte, exports []string, opts *OSBuild
 	// checked with them we can remove the runOSBuildNoProgress() and
 	// just run with the new runOSBuildWithProgress() helper.
 	switch pb.(type) {
-	case *terminalProgressBar, *debugProgressBar:
+	case *terminalProgressBar, *debugProgressBar, *fileProgressBar:
 		return runOSBuildWithProgress(pb, manifest, exports, opts)
 	default:
 		return runOSBuildNoProgress(pb, manifest, exports, opts)

--- a/pkg/progress/command_test.go
+++ b/pkg/progress/command_test.go
@@ -34,7 +34,7 @@ exit 112
 `))
 	defer restore()
 
-	pbar, err := progress.New("debug")
+	pbar, err := progress.New("debug", progress.ProgressConfig{})
 	assert.NoError(t, err)
 	err = progress.RunOSBuild(pbar, []byte(`{"fake":"manifest"}`), nil, nil)
 	assert.EqualError(t, err, `error running osbuild: exit status 112
@@ -61,7 +61,7 @@ done
 `, signalDeliveredMarkerPath)))
 	defer restore()
 
-	pbar, err := progress.New("debug")
+	pbar, err := progress.New("debug", progress.ProgressConfig{})
 	assert.NoError(t, err)
 	err = progress.RunOSBuild(pbar, []byte(`{"fake":"manifest"}`), nil, nil)
 	assert.EqualError(t, err, `error parsing osbuild status, please report a bug and try with "--progress=verbose": cannot scan line "invalid-json\n": invalid character 'i' looking for beginning of value`)
@@ -99,7 +99,7 @@ sleep 0.1
 	restore = progress.MockOsStderr(&fakeStderr)
 	defer restore()
 
-	pbar, err := progress.New("term")
+	pbar, err := progress.New("term", progress.ProgressConfig{})
 	assert.NoError(t, err)
 
 	var buildLog bytes.Buffer
@@ -128,7 +128,7 @@ echo osbuild-stdout-output
 	restore = progress.MockOsStderr(&fakeStderr)
 	defer restore()
 
-	pbar, err := progress.New("verbose")
+	pbar, err := progress.New("verbose", progress.ProgressConfig{})
 	assert.NoError(t, err)
 
 	var buildLog bytes.Buffer
@@ -148,7 +148,7 @@ func TestRunOSBuildCacheMaxSize(t *testing.T) {
 	restore := progress.MockOsbuildCmd(fakeOsbuildBinary)
 	defer restore()
 
-	pbar, err := progress.New("debug")
+	pbar, err := progress.New("debug", progress.ProgressConfig{})
 	assert.NoError(t, err)
 
 	osbuildOpts := &progress.OSBuildOptions{

--- a/pkg/progress/export_test.go
+++ b/pkg/progress/export_test.go
@@ -8,6 +8,7 @@ type (
 	TerminalProgressBar = terminalProgressBar
 	DebugProgressBar    = debugProgressBar
 	VerboseProgressBar  = verboseProgressBar
+	FileProgressItem    = fileProgressItem
 )
 
 var (

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -2,6 +2,7 @@ package progress
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -79,8 +80,13 @@ type ProgressBar interface {
 	Write(p []byte) (n int, err error)
 }
 
+type ProgressConfig struct {
+	// file progress only
+	FilePath string
+}
+
 // New creates a new progressbar based on the requested type
-func New(typ string) (ProgressBar, error) {
+func New(typ string, config ProgressConfig) (ProgressBar, error) {
 	updateTerminalSize(os.Stdout.Fd())
 	w, h := getTerminalSize()
 
@@ -98,6 +104,8 @@ func New(typ string) (ProgressBar, error) {
 		return NewTerminalProgressBar()
 	case "debug":
 		return NewDebugProgressBar()
+	case "file":
+		return NewFileProgressBar(config.FilePath)
 	default:
 		return nil, fmt.Errorf("unknown progress type: %q", typ)
 	}
@@ -362,4 +370,87 @@ func (b *debugProgressBar) SetProgress(subLevel int, msg string, done int, total
 	fmt.Fprintf(b.w, "%s[%v / %v] %s", strings.Repeat("  ", subLevel), done, total, msg)
 	fmt.Fprintf(b.w, "\n")
 	return nil
+}
+
+type fileProgressBar struct {
+	path string
+
+	// Keeps track of different levels of (sub)progress.
+	levels []*fileProgressItem
+}
+
+type fileProgressItem struct {
+	Msg         string            `json:"message"`
+	SubProgress *fileProgressItem `json:"subprogress,omitempty"`
+	Done        int               `json:"done"`
+	Total       int               `json:"total"`
+}
+
+// NewFileProgressBar starts a new "file" progressbar that will write any progress to a file.
+// Messages without progress information are ignored. The file progress never writes out subprogress
+// without the progress above it.
+func NewFileProgressBar(path string) (ProgressBar, error) {
+	b := &fileProgressBar{path: path}
+	return b, nil
+}
+
+func (b *fileProgressBar) SetPulseMsgf(msg string, args ...any) {
+	// nop: only messages with progress information are important
+}
+
+func (b *fileProgressBar) SetMessagef(msg string, args ...any) {
+	// nop: only messages with progress information are important
+}
+
+func (b *fileProgressBar) Start() {
+}
+
+func (b *fileProgressBar) Write(p []byte) (n int, err error) {
+	// use os.Rename to ensure atomic updates
+	tmpPath := fmt.Sprintf("%s.1", b.path)
+	//nolint:gosec // G306, progress can be readable by other users
+	err = os.WriteFile(tmpPath, p, 0644)
+	if err != nil {
+		return 0, err
+	}
+	return len(p), os.Rename(tmpPath, b.path)
+}
+
+func (b *fileProgressBar) Stop() {
+}
+
+func (b *fileProgressBar) SetProgress(level int, msg string, done int, total int) error {
+	item := fileProgressItem{
+		Msg:   msg,
+		Done:  done,
+		Total: total,
+	}
+	if level >= len(b.levels) {
+		b.levels = append(b.levels, &item)
+	} else {
+		// When a specific level completes, drop all sublevels. For instance, this ensures
+		// that subprogress of stages is cleared after completing a pipeline.
+		if done > b.levels[level].Done {
+			b.levels = b.levels[:level+1]
+		}
+		b.levels[level] = &item
+	}
+
+	for i := 0; i < len(b.levels)-1; i++ {
+		b.levels[i].SubProgress = b.levels[i+1]
+	}
+
+	data, err := json.Marshal(b.levels[0])
+	if err != nil {
+		return err
+	}
+
+	// use os.Rename to ensure atomic updates
+	tmpPath := fmt.Sprintf("%s.1", b.path)
+	//nolint:gosec // G306, progress can be readable by other users
+	err = os.WriteFile(tmpPath, data, 0644)
+	if err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, b.path)
 }

--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -2,7 +2,10 @@ package progress_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -34,7 +37,7 @@ func TestProgressNew(t *testing.T) {
 			})
 			defer restoreGetTermSize()
 
-			pb, err := progress.New(tc.typ)
+			pb, err := progress.New(tc.typ, progress.ProgressConfig{})
 			if tc.expectedErr == "" {
 				assert.NoError(t, err)
 				assert.Equal(t, reflect.TypeOf(pb), reflect.TypeOf(tc.expected), fmt.Sprintf("[%v] %T not the expected %T", tc.typ, pb, tc.expected))
@@ -146,9 +149,72 @@ func TestProgressNewAutoselect(t *testing.T) {
 			})
 			defer restoreGetTermSize()
 
-			pb, err := progress.New("auto")
+			pb, err := progress.New("auto", progress.ProgressConfig{})
 			assert.NoError(t, err)
 			assert.Equal(t, reflect.TypeOf(pb), reflect.TypeOf(tc.expected), fmt.Sprintf("[%v] %T not the expected %T", tc.onTerm, pb, tc.expected))
 		})
 	}
+}
+
+func TestFileProgress(t *testing.T) {
+	testDir := t.TempDir()
+	progressFile := filepath.Join(testDir, "progress")
+
+	pbar, err := progress.NewFileProgressBar(progressFile)
+	assert.NoError(t, err)
+	pbar.Start()
+	_, err = os.Stat(progressFile)
+	assert.True(t, os.IsNotExist(err))
+
+	pbar.SetPulseMsgf("pulse-msg")
+	_, err = os.Stat(progressFile)
+	assert.True(t, os.IsNotExist(err))
+	pbar.SetMessagef("some-message")
+	_, err = os.Stat(progressFile)
+	assert.True(t, os.IsNotExist(err))
+
+	err = pbar.SetProgress(0, "set-progress-msg", 0, 5)
+	assert.NoError(t, err)
+	data, err := os.ReadFile(progressFile)
+	assert.NoError(t, err)
+	var item progress.FileProgressItem
+	err = json.Unmarshal(data, &item)
+	assert.NoError(t, err)
+	assert.Equal(t, progress.FileProgressItem{
+		Msg:   "set-progress-msg",
+		Done:  0,
+		Total: 5,
+	}, item)
+
+	err = pbar.SetProgress(1, "set-subprogress-msg", 0, 1)
+	assert.NoError(t, err)
+	data, err = os.ReadFile(progressFile)
+	assert.NoError(t, err)
+	item = progress.FileProgressItem{}
+	err = json.Unmarshal(data, &item)
+	assert.NoError(t, err)
+	assert.Equal(t, progress.FileProgressItem{
+		Msg:   "set-progress-msg",
+		Done:  0,
+		Total: 5,
+		SubProgress: &progress.FileProgressItem{
+			Msg:   "set-subprogress-msg",
+			Done:  0,
+			Total: 1,
+		},
+	}, item)
+
+	// subprogress is cleared after the above progress increments done counter
+	err = pbar.SetProgress(0, "set-2nd-progress-msg", 1, 5)
+	assert.NoError(t, err)
+	data, err = os.ReadFile(progressFile)
+	assert.NoError(t, err)
+	item = progress.FileProgressItem{}
+	err = json.Unmarshal(data, &item)
+	assert.NoError(t, err)
+	assert.Equal(t, progress.FileProgressItem{
+		Msg:   "set-2nd-progress-msg",
+		Done:  1,
+		Total: 5,
+	}, item)
 }


### PR DESCRIPTION
    This progress "bar" creates a file in the output directory ending with
    ".progress". The file only contains the last status, meaning it is
    truncated each time. Each line is a valid JSON struct. Regular messages
    without progress are ignored. Finally, no subprogress is printed without
    the context of the progress above (for instance the progress of overal
    pipelines and the stages within the currently running pipeline will be
    contained in a single statement).

