### PR TITLE
test: fix build info cache path creation to use correct runner_distro

### DIFF
--- a/test/scripts/imgtestlib/cache.py
+++ b/test/scripts/imgtestlib/cache.py
@@ -8,7 +8,7 @@ from .build import (gen_build_name, get_manifest_id, read_build_info,
                     write_build_info)
 from .gitlab import log_section
 from .run import runcmd, runcmd_nc
-from .testenv import get_host_distro, get_osbuild_commit
+from .testenv import get_ci_runner_for, get_osbuild_commit
 
 S3_BUCKET = "s3://" + os.environ.get("AWS_BUCKET", "images-ci-cache")
 S3_PREFIX = "images/builds"
@@ -62,7 +62,8 @@ def gen_build_info_dir_path_prefix(distro=None, arch=None, manifest_id=None, osb
     responsible for prepending the location root to the generated path.
 
     If no 'osbuild_ref' is specified, the value returned by get_osbuild_commit() for the 'runner_distro' will be used.
-    if no 'runner_distro' is specified, the value returned by get_host_distro() will be used.
+    if no 'runner_distro' is specified, calls get_ci_runner_for() to get the corresponding runner for the distro and
+    architecture from the Schutzfile (with image type "*").
 
     A fully specified path is returned if all of the 'distro', 'arch' and 'manifest_id' parameters are specified,
     otherwise a partial path is returned. Partial path may be useful for working with a superset of build infos.
@@ -73,7 +74,12 @@ def gen_build_info_dir_path_prefix(distro=None, arch=None, manifest_id=None, osb
     The returned path always has a trailing separator at the end to signal that it is a directory.
     """
     if runner_distro is None:
-        runner_distro = get_host_distro()
+        runner = get_ci_runner_for(distro, arch, image_type="*")
+        # Runners are defined as <platform>/<distro> (e.g. aws/fedora-44)
+        runner = runner.split("/")[1]
+        # special case for CentOS Stream. Our runners use centos-stream-N but the cache path generator reads os-release
+        # to create the host distro name, which ends up as centos-N
+        runner_distro = runner.replace("centos-stream", "centos")
     if osbuild_ref is None:
         osbuild_ref = get_osbuild_commit(runner_distro)
 

--- a/test/scripts/imgtestlib/core.py
+++ b/test/scripts/imgtestlib/core.py
@@ -10,8 +10,7 @@ from .build import get_manifest_id
 from .cache import dl_build_info, gen_build_info_dir_path_prefix
 from .gitlab import log_section
 from .run import runcmd
-from .testenv import (get_bib_ref, get_ci_runner_for, host_container_arch,
-                      rng_seed_env)
+from .testenv import get_bib_ref, host_container_arch, rng_seed_env
 
 TEST_CACHE_ROOT = ".cache/osbuild-images"
 CONFIGS_PATH = "./test/configs"
@@ -266,19 +265,10 @@ def filter_builds(manifests, distro=None, arch=None, skip_ostree_pull=True):
         # add manifest id to build request
         build_request["manifest-checksum"] = manifest_id
 
-        # The config generator runner distro might differ from the builder. The cache path includes the runner distro as
-        # a component when a directory is created, so we need to use that to check for a hit.
-        runner = get_ci_runner_for(distro, arch, "*")
-        # Runners are defined as <platform>/<distro> (e.g. aws/fedora-44)
-        runner = runner.split("/")[1]
-        # special case for CentOS Stream. Our runners use centos-stream-N but the cache path generator reads os-release
-        # to create the host distro name, which ends up as centos-N
-        runner = runner.replace("centos-stream", "centos")
-
         # check if the hash_fname exists in the synced directory
         build_info_dir = os.path.join(
             dl_root_path,
-            gen_build_info_dir_path_prefix(distro, arch, manifest_id, runner_distro=runner)
+            gen_build_info_dir_path_prefix(distro, arch, manifest_id)
         )
 
         if check_for_build(manifest_fname, build_request, data["manifest"], build_info_dir, errors):
@@ -370,7 +360,6 @@ def get_tag_for(runner):
         return "terraform/openstack"
 
     raise ValueError(f"Unknown runner: {runner}")
-
 
 
 def build_metadata_filenames(basename: str) -> set[str]:

--- a/test/scripts/test_imgtestlib.py
+++ b/test/scripts/test_imgtestlib.py
@@ -118,7 +118,7 @@ def test_read_seed():
 ))
 def test_gen_build_info_dir_path_prefix(kwargs, expected):
     # we need to patch the functions that were imported into the cache namespace, not the originals in .testenv
-    with patch("imgtestlib.cache.get_host_distro", return_value="fedora-999"), \
+    with patch("imgtestlib.cache.get_ci_runner_for", return_value="aws/fedora-999"), \
          patch("imgtestlib.cache.get_osbuild_commit", return_value="abcdef123456"):
         assert testlib.cache.gen_build_info_dir_path_prefix(**kwargs) == expected
 
@@ -206,7 +206,7 @@ def test_gen_build_info_dir_path_prefix(kwargs, expected):
 ))
 def test_gen_build_info_s3_dir_path(kwargs, expected):
     # we need to patch the functions that were imported into the cache namespace, not the originals in .testenv
-    with patch("imgtestlib.cache.get_host_distro", return_value="fedora-999"), \
+    with patch("imgtestlib.cache.get_ci_runner_for", return_value="aws/fedora-999"), \
          patch("imgtestlib.cache.get_osbuild_commit", return_value="abcdef123456"):
         assert testlib.cache.gen_build_info_s3_dir_path(**kwargs) == expected
 


### PR DESCRIPTION
In commit e24d7994d69c2e70afacb6779c85086e4b655c5b I attempted to fix the problem of having the build config generator run on a different distro than the build itself.  The problem was that by using the host distro to determine the runner path component in the cache meant that building on one distribution (CentOS Stream 9 for RHEL 7 images) and generating the configs on a different distribution (Fedora 44 for all) would always miss and cause rebuilds.  The attempted fix sets the runner distro to the appropriate one when filtering manifests for the rebuild. However, this fix neglected an important step: The cache download that precedes the filtering was still using the host distro path component. So when generating build configs for RHEL 7, the following occurred:
- Download build info from cache with runner distro Fedora 44 (the host distro).
- Check for build info using the a runner distro CentOS 9 (the runner for the build for RHEL 7).
- Miss every check.

This commit fixes the gen_build_info_dir_path_prefix() function to always consult the Schutzfile for the runner distro path component, essentially moving the previous fix into the function that's always used to construct cache paths, so all cache-related functionality uses the correct paths.