### PR TITLE
test: go 1.27 compatibility

### DIFF
--- a/pkg/customizations/fsnode/fsnode_test.go
+++ b/pkg/customizations/fsnode/fsnode_test.go
@@ -239,10 +239,10 @@ func TestFsNodeUnmarshalBadFile(t *testing.T) {
 		inputYAML   string
 		expectedErr string
 	}{
-		{`path: 123`, `json: cannot unmarshal number into Go struct field .*.Path of type string`},
-		{`mode: -rw-rw-r--`, ` json: cannot unmarshal string into Go struct field .*.Mode of type fs.FileMode`},
-		{`mode: -1`, `cannot unmarshal number -1 into Go struct field .*.Mode of type fs.FileMode`},
-		{`mode: 5_000_000_000`, `json: cannot unmarshal number 5000000000 into Go struct field .*.Mode of type fs.FileMode`},
+		{`path: 123`, `json: cannot unmarshal number into Go struct field .*.[pP]ath of type string`},
+		{`mode: -rw-rw-r--`, `json: cannot unmarshal string into Go struct field .*.[mM]ode of type fs.FileMode`},
+		{`mode: -1`, `cannot unmarshal number -1 into Go struct field .*.[mM]ode of type fs.FileMode`},
+		{`mode: 5_000_000_000`, `json: cannot unmarshal number 5000000000 into Go struct field .*.[mM]ode of type fs.FileMode`},
 		{"path: /foo\nuser: 3.14", `user ID must be int`},
 		{"path: /foo\ngroup: 2.71", `group ID must be int`},
 		{"path: /foo\nuser: -1", `user ID must be non-negative`},

--- a/pkg/disk/partition_test.go
+++ b/pkg/disk/partition_test.go
@@ -123,7 +123,7 @@ func TestUnmarshalNullPayload(t *testing.T) {
 func TestAllPayloadEntityExported(t *testing.T) {
 	modulePath := "."
 	cfg := &packages.Config{
-		Mode: packages.NeedTypes | packages.NeedTypesInfo,
+		Mode: packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports | packages.NeedDeps,
 	}
 	pkgs, err := packages.Load(cfg, modulePath)
 	assert.NoError(t, err)


### PR DESCRIPTION
In Go 1.27 the default JSON encoder was changed and thus error messages are slightly different. Let's accept both.

Closes: #2502