### PR TITLE
Add hidden pkgsearch subcommand for querying available packages (HMS-11011)

### DIFF
--- a/cmd/image-builder/export_test.go
+++ b/cmd/image-builder/export_test.go
@@ -13,14 +13,15 @@ import (
 )
 
 var (
-	GetOneImage     = getOneImage
-	GetAllImages    = getAllImages
-	Run             = run
-	FindDistro      = findDistro
-	DescribeImage   = describeImage
-	ProgressFromCmd = progressFromCmd
-	BasenameFor     = basenameFor
-	CacheDirForUid  = cacheDirForUid
+	GetOneImage           = getOneImage
+	GetAllImages          = getAllImages
+	Run                   = run
+	FindDistro            = findDistro
+	DescribeImage         = describeImage
+	ProgressFromCmd       = progressFromCmd
+	BasenameFor           = basenameFor
+	CacheDirForUid        = cacheDirForUid
+	NewPkgSearchFormatter = newPkgSearchFormatter
 )
 
 type DescribeImgYAML describeImgYAML

--- a/cmd/image-builder/export_test.go
+++ b/cmd/image-builder/export_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/osbuild/image-builder/pkg/bootc"
 	"github.com/osbuild/image-builder/pkg/cloud"
 	"github.com/osbuild/image-builder/pkg/cloud/awscloud"
+	"github.com/osbuild/image-builder/pkg/distro"
 	"github.com/osbuild/image-builder/pkg/manifestgen"
 	"github.com/osbuild/image-builder/pkg/reporegistry"
+	"github.com/osbuild/image-builder/pkg/rpmmd"
 )
 
 var (
@@ -116,5 +118,13 @@ func MockManifestgenContainerResolver(fn manifestgen.ContainerResolverFunc) (res
 	manifestgenContainerResolver = fn
 	return func() {
 		manifestgenContainerResolver = saved
+	}
+}
+
+func MockPkgSearcher(f func(distro.Distro, string, string, []rpmmd.RepoConfig, []string) (rpmmd.PackageList, error)) (restore func()) {
+	saved := pkgSearcher
+	pkgSearcher = f
+	return func() {
+		pkgSearcher = saved
 	}
 }

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -877,6 +877,19 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 	}
 	rootCmd.AddCommand(manifestCmd)
 
+	pkgSearchCmd := &cobra.Command{
+		Use:          "pkgsearch [pkg1 pkg2 ...]",
+		Short:        "Search for packages available for the given distro (tip: combine with --distro, --arch, --type)",
+		RunE:         cmdPkgSearch,
+		SilenceUsage: true,
+		Hidden:       true,
+	}
+	pkgSearchCmd.Flags().String("format", "", "Output in a specific format (json)")
+	pkgSearchCmd.Flags().String("distro", "", "Search packages for a specific distro (e.g. centos-9)")
+	pkgSearchCmd.Flags().String("arch", "", "Search packages for a specific architecture")
+	pkgSearchCmd.Flags().String("type", "", "Narrow search to repos for a specific image type (e.g. qcow2)")
+	rootCmd.AddCommand(pkgSearchCmd)
+
 	uploadCmd := &cobra.Command{
 		Use:          "upload <image-path>",
 		Short:        "Upload the given image from <image-path>",

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-
 	"strings"
 	"syscall"
 
@@ -593,7 +592,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	}
 	// Fail early if the cache directory is not writable, instead of
 	// waiting for osbuild to fail after slow manifest generation.
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return fmt.Errorf("cannot create cache directory %q: %w\nHint: use --cache to specify a writable path", cacheDir, err)
 	}
 
@@ -614,7 +613,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	}
 	// Ensure the output directory exists before (file) progress starts.
 	outputDir = basenameFor(img, outputDir)
-	if err := os.MkdirAll(outputDir, 0755); err != nil {
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
 		return fmt.Errorf("cannot create output base directory %s: %w", outputDir, err)
 	}
 
@@ -888,6 +887,7 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 	pkgSearchCmd.Flags().String("distro", "", "Search packages for a specific distro (e.g. centos-9)")
 	pkgSearchCmd.Flags().String("arch", "", "Search packages for a specific architecture")
 	pkgSearchCmd.Flags().String("type", "", "Narrow search to repos for a specific image type (e.g. qcow2)")
+	pkgSearchCmd.Flags().String("rpmmd-cache", "", `osbuild directory to cache rpm metadata`)
 	rootCmd.AddCommand(pkgSearchCmd)
 
 	uploadCmd := &cobra.Command{

--- a/cmd/image-builder/pkgsearch.go
+++ b/cmd/image-builder/pkgsearch.go
@@ -57,6 +57,13 @@ func (*jsonPkgFormatter) Output(w io.Writer, pkgs rpmmd.PackageList) error {
 	return enc.Encode(result)
 }
 
+// pkgSearcher performs the actual package search. It is a variable so
+// tests can replace it with a fake that doesn't require osbuild-depsolve-dnf.
+var pkgSearcher = func(d distro.Distro, archStr, cacheDir string, repos []rpmmd.RepoConfig, packages []string) (rpmmd.PackageList, error) {
+	solver := depsolvednf.NewSolver(d.ModulePlatformID(), d.Releasever(), archStr, d.Name(), cacheDir)
+	return solver.SearchMetadata(repos, packages)
+}
+
 func cmdPkgSearch(cmd *cobra.Command, args []string) error {
 	format, err := cmd.Flags().GetString("format")
 	if err != nil {
@@ -155,8 +162,7 @@ func cmdPkgSearch(cmd *cobra.Command, args []string) error {
 		cacheDir = defaultCacheDir()
 	}
 
-	solver := depsolvednf.NewSolver(d.ModulePlatformID(), d.Releasever(), archStr, d.Name(), cacheDir)
-	results, err := solver.SearchMetadata(searchRepos, args)
+	results, err := pkgSearcher(d, archStr, cacheDir, searchRepos, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/image-builder/pkgsearch.go
+++ b/cmd/image-builder/pkgsearch.go
@@ -146,8 +146,15 @@ func cmdPkgSearch(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// XXX set sensible cache dir
-	cacheDir := ""
+	cacheDir, err := cmd.Flags().GetString("rpmmd-cache")
+	if err != nil {
+		return err
+	}
+
+	if cacheDir == "" {
+		cacheDir = defaultCacheDir()
+	}
+
 	solver := depsolvednf.NewSolver(d.ModulePlatformID(), d.Releasever(), archStr, d.Name(), cacheDir)
 	results, err := solver.SearchMetadata(searchRepos, args)
 	if err != nil {

--- a/cmd/image-builder/pkgsearch.go
+++ b/cmd/image-builder/pkgsearch.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/osbuild/image-builder/pkg/arch"
+	"github.com/osbuild/image-builder/pkg/depsolvednf"
+	"github.com/osbuild/image-builder/pkg/distro"
+	"github.com/osbuild/image-builder/pkg/distrofactory"
+	"github.com/osbuild/image-builder/pkg/rpmmd"
+	"github.com/spf13/cobra"
+)
+
+type pkgSearchFormatter interface {
+	Output(io.Writer, rpmmd.PackageList) error
+}
+
+func newPkgSearchFormatter(format string) (pkgSearchFormatter, error) {
+	switch format {
+	case "", "json":
+		return &jsonPkgFormatter{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported format %q (supported: json)", format)
+	}
+}
+
+type pkgSearchPackageJSON struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Release string `json:"release"`
+	Arch    string `json:"arch"`
+	Summary string `json:"summary"`
+}
+
+type pkgSearchResultJSON struct {
+	Packages []pkgSearchPackageJSON `json:"packages"`
+}
+
+type jsonPkgFormatter struct{}
+
+func (*jsonPkgFormatter) Output(w io.Writer, pkgs rpmmd.PackageList) error {
+	result := pkgSearchResultJSON{
+		Packages: make([]pkgSearchPackageJSON, len(pkgs)),
+	}
+	for i, p := range pkgs {
+		result.Packages[i] = pkgSearchPackageJSON{
+			Name:    p.Name,
+			Version: p.Version,
+			Release: p.Release,
+			Arch:    p.Arch,
+			Summary: p.Summary,
+		}
+	}
+	enc := json.NewEncoder(w)
+	return enc.Encode(result)
+}
+
+func cmdPkgSearch(cmd *cobra.Command, args []string) error {
+	format, err := cmd.Flags().GetString("format")
+	if err != nil {
+		return err
+	}
+
+	formatter, err := newPkgSearchFormatter(format)
+	if err != nil {
+		return err
+	}
+
+	repoDir, err := cmd.Flags().GetString("force-repo-dir")
+	if err != nil {
+		return err
+	}
+
+	extraRepos, err := cmd.Flags().GetStringArray("extra-repo")
+	if err != nil {
+		return err
+	}
+
+	forceRepos, err := cmd.Flags().GetStringArray("force-repo")
+	if err != nil {
+		return err
+	}
+
+	distroStr, err := cmd.Flags().GetString("distro")
+	if err != nil {
+		return err
+	}
+
+	distroStr, err = findDistro(distroStr, "")
+	if err != nil {
+		return err
+	}
+
+	archStr, err := cmd.Flags().GetString("arch")
+	if err != nil {
+		return err
+	}
+
+	if archStr == "" {
+		archStr = arch.Current().String()
+	}
+
+	imageType, err := cmd.Flags().GetString("type")
+	if err != nil {
+		return err
+	}
+
+	repoOpts := repoOptions{
+		RepoDir:    repoDir,
+		ExtraRepos: extraRepos,
+	}
+
+	var d distro.Distro
+	var searchRepos []rpmmd.RepoConfig
+	if imageType != "" {
+		img, err := getOneImage(distroStr, imageType, archStr, &repoOpts)
+		if err != nil {
+			return err
+		}
+
+		d = img.ImgType.Arch().Distro()
+		searchRepos = img.Repos
+	} else {
+		factory := distrofactory.NewDefault()
+		d = factory.GetDistro(distroStr)
+		if d == nil {
+			return fmt.Errorf("unknown distro %q", distroStr)
+		}
+
+		registry, err := newRepoRegistry(repoDir, extraRepos)
+		if err != nil {
+			return err
+		}
+		searchRepos, err = registry.ReposByArchName(distroStr, archStr, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(forceRepos) > 0 {
+		searchRepos, err = parseRepoURLs(forceRepos, "force")
+		if err != nil {
+			return err
+		}
+	}
+
+	// XXX set sensible cache dir
+	cacheDir := ""
+	solver := depsolvednf.NewSolver(d.ModulePlatformID(), d.Releasever(), archStr, d.Name(), cacheDir)
+	results, err := solver.SearchMetadata(searchRepos, args)
+	if err != nil {
+		return err
+	}
+
+	return formatter.Output(osStdout, results)
+}

--- a/cmd/image-builder/pkgsearch_test.go
+++ b/cmd/image-builder/pkgsearch_test.go
@@ -1,0 +1,96 @@
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/image-builder/pkg/rpmmd"
+
+	main "github.com/osbuild/image-builder/cmd/image-builder"
+)
+
+func TestNewPkgSearchFormatter(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		format      string
+		expectedErr string
+	}{
+		{
+			name:   "json",
+			format: "json",
+		},
+		{
+			name:   "empty defaults to json",
+			format: "",
+		},
+		{
+			name:        "unsupported format",
+			format:      "text",
+			expectedErr: "unsupported",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fmter, err := main.NewPkgSearchFormatter(tc.format)
+			if tc.expectedErr != "" {
+				assert.Nil(t, fmter)
+				assert.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, fmter)
+		})
+	}
+}
+
+func TestPkgSearchFormatterJSONOutput(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		pkgs         rpmmd.PackageList
+		expectedPkgs int
+		expectedName string
+	}{
+		{
+			name: "multiple packages",
+			pkgs: rpmmd.PackageList{
+				{Name: "bash", Version: "5.1.8", Release: "2.el9", Arch: "x86_64"},
+				{Name: "zsh", Version: "5.8", Release: "7.el9", Arch: "x86_64"},
+			},
+			expectedPkgs: 2,
+			expectedName: "bash",
+		},
+		{
+			name:         "empty package list",
+			pkgs:         rpmmd.PackageList{},
+			expectedPkgs: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fmter, err := main.NewPkgSearchFormatter("json")
+			require.NoError(t, err)
+
+			var buf bytes.Buffer
+			err = fmter.Output(&buf, tc.pkgs)
+			require.NoError(t, err)
+
+			var result struct {
+				Packages []struct {
+					Name    string `json:"name"`
+					Version string `json:"version"`
+					Release string `json:"release"`
+					Arch    string `json:"arch"`
+				} `json:"packages"`
+			}
+			err = json.Unmarshal(buf.Bytes(), &result)
+			require.NoError(t, err)
+			assert.Len(t, result.Packages, tc.expectedPkgs)
+
+			if tc.expectedName != "" {
+				assert.Equal(t, tc.expectedName, result.Packages[0].Name)
+			}
+		})
+	}
+}

--- a/cmd/image-builder/pkgsearch_test.go
+++ b/cmd/image-builder/pkgsearch_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/osbuild/image-builder/pkg/distro"
 	"github.com/osbuild/image-builder/pkg/rpmmd"
+	testrepos "github.com/osbuild/image-builder/test/data/repositories"
 
 	main "github.com/osbuild/image-builder/cmd/image-builder"
 )
@@ -42,6 +44,129 @@ func TestNewPkgSearchFormatter(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.NotNil(t, fmter)
+		})
+	}
+}
+
+var lastCapturedCacheDir string
+
+func fakePkgSearcher(_ distro.Distro, _, cacheDir string, _ []rpmmd.RepoConfig, _ []string) (rpmmd.PackageList, error) {
+	lastCapturedCacheDir = cacheDir
+	return rpmmd.PackageList{
+		{Name: "bash", Version: "5.1.8", Release: "2.el9", Arch: "x86_64"},
+		{Name: "zsh", Version: "5.8", Release: "7.el9", Arch: "x86_64"},
+	}, nil
+}
+
+func TestCmdPkgSearch(t *testing.T) {
+	restorePkgSearcher := main.MockPkgSearcher(fakePkgSearcher)
+	defer restorePkgSearcher()
+
+	restoreRepoRegistry := main.MockNewRepoRegistry(testrepos.New)
+	defer restoreRepoRegistry()
+
+	for _, tc := range []struct {
+		name             string
+		args             []string
+		expectedPkgs     int
+		expectedErr      string
+		expectedCacheDir string
+		mockHostDistro   string
+	}{
+		{
+			name:         "with type",
+			args:         []string{"pkgsearch", "bash", "--distro=centos-9", "--arch=x86_64", "--type=qcow2"},
+			expectedPkgs: 2,
+		},
+		{
+			name:         "without type",
+			args:         []string{"pkgsearch", "bash", "--distro=centos-9", "--arch=x86_64"},
+			expectedPkgs: 2,
+		},
+		{
+			name:         "with json format",
+			args:         []string{"pkgsearch", "bash", "--distro=centos-9", "--arch=x86_64", "--format=json"},
+			expectedPkgs: 2,
+		},
+		{
+			name:         "multiple packages",
+			args:         []string{"pkgsearch", "bash", "zsh", "--distro=centos-9", "--arch=x86_64"},
+			expectedPkgs: 2,
+		},
+		{
+			name:        "unsupported format",
+			args:        []string{"pkgsearch", "bash", "--distro=centos-9", "--arch=x86_64", "--format=text"},
+			expectedErr: "unsupported",
+		},
+		{
+			name:        "invalid distro",
+			args:        []string{"pkgsearch", "bash", "--distro=not-a-distro", "--arch=x86_64"},
+			expectedErr: "not-a-distro",
+		},
+		{
+			name:        "invalid type",
+			args:        []string{"pkgsearch", "bash", "--distro=centos-9", "--arch=x86_64", "--type=not-a-type"},
+			expectedErr: "not-a-type",
+		},
+		{
+			name:         "zero args (no packages)",
+			args:         []string{"pkgsearch", "--distro=centos-9", "--arch=x86_64"},
+			expectedPkgs: 2,
+		},
+		{
+			name:             "with rpmmd-cache",
+			args:             []string{"pkgsearch", "bash", "--distro=centos-9", "--arch=x86_64", "--rpmmd-cache=/tmp/test-cache"},
+			expectedPkgs:     2,
+			expectedCacheDir: "/tmp/test-cache",
+		},
+		{
+			name:           "default distro from host",
+			args:           []string{"pkgsearch", "bash", "--arch=x86_64"},
+			expectedPkgs:   2,
+			mockHostDistro: "centos-9",
+		},
+		{
+			name:         "default arch from host",
+			args:         []string{"pkgsearch", "bash", "--distro=centos-9"},
+			expectedPkgs: 2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.mockHostDistro != "" {
+				restore := main.MockDistroGetHostDistroName(func() (string, error) {
+					return tc.mockHostDistro, nil
+				})
+				defer restore()
+			}
+
+			restore := main.MockOsArgs(tc.args)
+			defer restore()
+
+			var fakeStdout bytes.Buffer
+			restore = main.MockOsStdout(&fakeStdout)
+			defer restore()
+
+			err := main.Run()
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+
+			var result struct {
+				Packages []struct {
+					Name string `json:"name"`
+				} `json:"packages"`
+			}
+			err = json.Unmarshal(fakeStdout.Bytes(), &result)
+			require.NoError(t, err)
+			assert.Len(t, result.Packages, tc.expectedPkgs)
+
+			if tc.expectedCacheDir != "" {
+				assert.Equal(t, tc.expectedCacheDir, lastCapturedCacheDir)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Add `pkgsearch` subcommand for querying available packages

## Summary

Adds a hidden `pkgsearch` subcommand to `image-builder` that searches RPM package metadata for a given distro and architecture, outputting results as JSON. This enables tooling like cockpit-image-builder to query available packages without shelling out to dnf directly.

## Changes

- Add `cmdPkgSearch` handler with distro/arch/type-based repo resolution and a `pkgSearchFormatter` interface for extensible output formats
- Register `pkgsearch` as a hidden subcommand with `--distro`, `--arch`, `--type`, `--format`, and `--rpmmd-cache` flags
- Extract the solver call into a mockable `pkgSearcher` variable and add table-driven tests covering the full command flow, including zero-args invocation and `--rpmmd-cache` passthrough


JIRA: [HMS-11011](https://issues.redhat.com/browse/HMS-11011)

[HMS-11011]: https://redhat.atlassian.net/browse/HMS-11011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ