### PR TITLE
Run more bootc-image-builder tests in gitlab [HMS-10854]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1073,6 +1073,12 @@ fail:
   extends: .terraform
   variables:
     RUNNER: aws/fedora-44-x86_64
+  rules:
+    # 1. Skip the job if we're on the github merge queue
+    - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue/'
+      when: never
+    # 2. Fallback rule for any other branch name
+    - if: '$CI_COMMIT_BRANCH'
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
@@ -1083,6 +1089,12 @@ fail:
   extends: .terraform
   variables:
     RUNNER: aws/fedora-44-x86_64
+  rules:
+    # 1. Skip the job if we're on the github merge queue
+    - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue/'
+      when: never
+    # 2. Fallback rule for any other branch name
+    - if: '$CI_COMMIT_BRANCH'
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
@@ -1093,6 +1105,12 @@ fail:
   extends: .terraform
   variables:
     RUNNER: aws/fedora-44-x86_64
+  rules:
+    # 1. Skip the job if we're on the github merge queue
+    - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue/'
+      when: never
+    # 2. Fallback rule for any other branch name
+    - if: '$CI_COMMIT_BRANCH'
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
@@ -1104,6 +1122,12 @@ fail:
   extends: .terraform
   variables:
     RUNNER: aws/fedora-44-aarch64
+  rules:
+    # 1. Skip the job if we're on the github merge queue
+    - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue/'
+      when: never
+    # 2. Fallback rule for any other branch name
+    - if: '$CI_COMMIT_BRANCH'
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
@@ -1114,6 +1138,12 @@ fail:
   extends: .terraform
   variables:
     RUNNER: aws/fedora-44-aarch64
+  rules:
+    # 1. Skip the job if we're on the github merge queue
+    - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue/'
+      when: never
+    # 2. Fallback rule for any other branch name
+    - if: '$CI_COMMIT_BRANCH'
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
@@ -1124,6 +1154,12 @@ fail:
   extends: .terraform
   variables:
     RUNNER: aws/fedora-44-aarch64
+  rules:
+    # 1. Skip the job if we're on the github merge queue
+    - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue/'
+      when: never
+    # 2. Fallback rule for any other branch name
+    - if: '$CI_COMMIT_BRANCH'
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1088,6 +1088,16 @@ fail:
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
     - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_manifest.py
 
+"bootc-image-builder/test-opts-and-progress [x86_64]":
+  stage: gen
+  extends: .terraform
+  variables:
+    RUNNER: aws/fedora-44-x86_64
+  script:
+    - sudo ./test/scripts/install-dependencies
+    - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_opts.py ./bootc-image-builder/test/test_progress.py
+
 
 "bootc-image-builder/test-build-disk [aarch64]":
   stage: gen
@@ -1108,6 +1118,16 @@ fail:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
     - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_manifest.py
+
+"bootc-image-builder/test-opts-and-progress [aarch64]":
+  stage: gen
+  extends: .terraform
+  variables:
+    RUNNER: aws/fedora-44-aarch64
+  script:
+    - sudo ./test/scripts/install-dependencies
+    - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_opts.py ./bootc-image-builder/test/test_progress.py
 
 "generate-ostree-build-config: [centos-9, aarch64]":
   stage: ostree-gen

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1078,6 +1078,16 @@ fail:
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
     - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_build_disk.py
 
+"bootc-image-builder/test-manifest [x86_64]":
+  stage: gen
+  extends: .terraform
+  variables:
+    RUNNER: aws/fedora-44-x86_64
+  script:
+    - sudo ./test/scripts/install-dependencies
+    - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_manifest.py
+
 
 "bootc-image-builder/test-build-disk [aarch64]":
   stage: gen
@@ -1088,6 +1098,16 @@ fail:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
     - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_build_disk.py
+
+"bootc-image-builder/test-manifest [aarch64]":
+  stage: gen
+  extends: .terraform
+  variables:
+    RUNNER: aws/fedora-44-aarch64
+  script:
+    - sudo ./test/scripts/install-dependencies
+    - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_manifest.py
 
 "generate-ostree-build-config: [centos-9, aarch64]":
   stage: ostree-gen

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1068,7 +1068,7 @@ fail:
     - "generate-build-config: [rhel-9.9, x86_64]"
 
 
-"bootc-image-builder [x86_64]":
+"bootc-image-builder/test-build-disk [x86_64]":
   stage: gen
   extends: .terraform
   variables:
@@ -1076,10 +1076,10 @@ fail:
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
-    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_build_disk.py::test_image_is_generated
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_build_disk.py
 
 
-"bootc-image-builder [aarch64]":
+"bootc-image-builder/test-build-disk [aarch64]":
   stage: gen
   extends: .terraform
   variables:
@@ -1087,7 +1087,7 @@ fail:
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
-    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_build_disk.py::test_image_is_generated
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_build_disk.py
 
 "generate-ostree-build-config: [centos-9, aarch64]":
   stage: ostree-gen

--- a/bootc-image-builder/Containerfile
+++ b/bootc-image-builder/Containerfile
@@ -18,6 +18,7 @@ RUN dnf install -y dnf-plugins-core \
 
 # copy as bootc-image-builder
 COPY --from=builder /build/bin/image-builder /usr/bin/bootc-image-builder
+COPY --from=builder /build/bin/bib-canary-* /usr/bin/
 COPY ./data/distrodefs/ /usr/share/bootc-image-builder/defs/
 
 ENTRYPOINT ["/usr/bin/bootc-image-builder"]

--- a/bootc-image-builder/test/containerbuild.py
+++ b/bootc-image-builder/test/containerbuild.py
@@ -30,7 +30,7 @@ def make_container(container_path, arch=None):
         "--arch", arch,
         container_path], encoding="utf8")
     yield container_tag
-    subprocess.check_call(["podman", "rmi", container_tag])
+    subprocess.run(["podman", "rmi", container_tag], check=False)
 
 
 @pytest.fixture(name="build_container", scope="session")
@@ -49,7 +49,7 @@ def build_container_fixture():
         ".",
     ])
     yield container_tag
-    subprocess.check_call(["podman", "rmi", container_tag])
+    subprocess.run(["podman", "rmi", container_tag], check=False)
 
 
 @pytest.fixture(name="build_fake_container", scope="session")
@@ -102,7 +102,7 @@ def build_fake_container_fixture(tmpdir_factory, build_container):
         tmp_path,
     ])
     yield container_tag
-    subprocess.check_call(["podman", "rmi", container_tag])
+    subprocess.run(["podman", "rmi", container_tag], check=False)
 
 
 @pytest.fixture(name="build_erroring_container", scope="session")
@@ -150,4 +150,4 @@ def build_erroring_container_fixture(tmpdir_factory, build_container):
         tmp_path,
     ])
     yield container_tag
-    subprocess.check_call(["podman", "rmi", container_tag])
+    subprocess.run(["podman", "rmi", container_tag], check=False)

--- a/bootc-image-builder/test/test_build_disk.py
+++ b/bootc-image-builder/test/test_build_disk.py
@@ -639,9 +639,8 @@ def has_selinux():
 
 @pytest.mark.skipif(not has_selinux(), reason="selinux not enabled")
 @pytest.mark.parametrize("image_type", gen_testcases("qemu-boot"), indirect=["image_type"])
-def test_image_build_without_se_linux_denials(image_type):
-    pytest.skip("skip until https://github.com/osbuild/bootc-image-builder/issues/645 is resolved")
-
+@pytest.mark.skip("skip until https://github.com/osbuild/bootc-image-builder/issues/645 is resolved")
+def test_image_build_without_selinux_denials(image_type):
     # the journal always contains logs from the image building
     assert image_type.journal_output != ""
     assert not log_has_osbuild_selinux_denials(image_type.journal_output), \

--- a/bootc-image-builder/test/test_build_disk.py
+++ b/bootc-image-builder/test/test_build_disk.py
@@ -597,7 +597,8 @@ def test_ami_boots_in_aws(image_type, force_aws_upload):
     # check that upload progress is in the output log. Uploads looks like:
     # 4.30 GiB / 10.00 GiB [------------>____________] 43.02% 58.04 MiB p/s
     assert "] 100.00%" in image_type.bib_output
-    with testlib.vm.AWS(image_type.metadata["ami_id"]) as test_vm:
+    arch = os.uname().machine
+    with testlib.vm.AWS(image_type.metadata["ami_id"], arch) as test_vm:
         test_vm.run("true", user=image_type.username, password=image_type.password)
         ret = test_vm.run(["echo", "hello"], user=image_type.username, password=image_type.password)
         assert "hello" in ret.stdout

--- a/bootc-image-builder/test/test_build_disk.py
+++ b/bootc-image-builder/test/test_build_disk.py
@@ -11,7 +11,7 @@ import string
 import subprocess
 import tempfile
 import uuid
-from contextlib import ExitStack, contextmanager
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import NamedTuple
 
@@ -645,23 +645,6 @@ def test_image_build_without_se_linux_denials(image_type):
     assert image_type.journal_output != ""
     assert not log_has_osbuild_selinux_denials(image_type.journal_output), \
         f"denials in log {image_type.journal_output}"
-
-
-@pytest.mark.skipif(platform.system() != "Linux", reason="osinfo detect test only runs on linux right now")
-@pytest.mark.skipif(not testutil.has_executable("unsquashfs"), reason="need unsquashfs")
-@pytest.mark.parametrize("image_type", gen_testcases("anaconda-iso"), indirect=["image_type"])
-@pytest.mark.skip(reason="anaconda-iso is not supported")
-def test_iso_install_img_is_squashfs(tmp_path, image_type):
-    installer_iso_path = image_type.img_path
-    with ExitStack() as cm:
-        mount_point = tmp_path / "cdrom"
-        mount_point.mkdir()
-        subprocess.check_call(["mount", installer_iso_path, os.fspath(mount_point)])
-        cm.callback(subprocess.check_call, ["umount", os.fspath(mount_point)])
-        # ensure install.img is the "flat" squashfs, before PR#777 the content
-        # was an intermediate ext4 image "squashfs-root/LiveOS/rootfs.img"
-        output = subprocess.check_output(["unsquashfs", "-ls", mount_point / "images/install.img"], text=True)
-        assert "usr/bin/bootc" in output
 
 
 @pytest.mark.parametrize("images", gen_testcases("multidisk"), indirect=["images"])

--- a/bootc-image-builder/test/test_manifest.py
+++ b/bootc-image-builder/test/test_manifest.py
@@ -10,6 +10,7 @@ import platform
 import subprocess
 import textwrap
 
+import imgtestlib as testlib
 import pytest
 
 import testutil
@@ -935,7 +936,15 @@ def test_manifest_image_customize_filesystem(tmp_path, build_container):
             f"localhost/{container_tag}",
         ], encoding="utf8")
         sfdisk_options = find_stage_options_from(manifest_str, "org.osbuild.sfdisk")
-        assert sfdisk_options["partitions"][2]["size"] == 3 * 1024 * 1024 * 1024 / 512
+        match arch := testlib.testenv.host_container_arch():
+            case "amd64":
+                bootidx = 2
+            case "arm64":
+                bootidx = 1
+            case _:
+                raise RuntimeError(f"test is not configured for {arch}: expected boot index value not set")
+
+        assert sfdisk_options["partitions"][bootidx]["size"] == 3 * 1024 * 1024 * 1024 / 512
 
 
 def test_manifest_image_customize_disk(tmp_path, build_container):
@@ -981,7 +990,15 @@ def test_manifest_image_customize_disk(tmp_path, build_container):
             f"localhost/{container_tag}",
         ], encoding="utf8")
         sfdisk_options = find_stage_options_from(manifest_str, "org.osbuild.sfdisk")
-        assert sfdisk_options["partitions"][2]["size"] == 3 * 1024 * 1024 * 1024 / 512
+        match arch := testlib.testenv.host_container_arch():
+            case "amd64":
+                bootidx = 2
+            case "arm64":
+                bootidx = 1
+            case _:
+                raise RuntimeError(f"test is not configured for {arch}: expected boot index value not set")
+
+        assert sfdisk_options["partitions"][bootidx]["size"] == 3 * 1024 * 1024 * 1024 / 512
 
 
 def test_manifest_image_disk_yaml(tmp_path, build_container):

--- a/bootc-image-builder/test/test_opts.py
+++ b/bootc-image-builder/test/test_opts.py
@@ -1,8 +1,10 @@
+# pylint: disable=fixme
 import os
 import platform
 import subprocess
 
 import pytest
+
 import testutil
 # pylint: disable=unused-import
 from containerbuild import (build_container_fixture,
@@ -50,7 +52,8 @@ def test_bib_chown_opts(tmp_path, container_storage, build_fake_container, chown
     ([], ""),
     (["--target-arch=amd64"], ""),
     (["--target-arch=x86_64"], ""),
-    (["--target-arch=arm64"], "cannot build iso for different target arches yet"),
+    # TODO: re-enable and switch to ISO when we get that working again
+    # (["--target-arch=arm64"], "cannot build iso for different target arches yet"),
 ])
 @pytest.mark.skipif(platform.uname().machine != "x86_64", reason="cross build test only runs on x86")
 def test_opts_arch_is_same_arch_is_fine(tmp_path, build_fake_container, target_arch_opt, expected_err):
@@ -67,7 +70,7 @@ def test_opts_arch_is_same_arch_is_fine(tmp_path, build_fake_container, target_a
         "-v", "/var/lib/containers/storage:/var/lib/containers/storage",
         "-v", f"{output_path}:/output",
         build_fake_container,
-        "--type=iso",
+        "--type=qcow2",
         container_ref,
     ] + target_arch_opt, check=False, capture_output=True, text=True)
     if expected_err == "":

--- a/bootc-image-builder/test/test_progress.py
+++ b/bootc-image-builder/test/test_progress.py
@@ -55,7 +55,7 @@ def test_progress_term_works_without_tty(tmp_path, build_fake_container):
     assert "[|] Manifest generation step" in res.stderr
 
 
-@pytest.mark.skipif(not testutil.can_start_rootful_containers, reason="require a rootful containers (try: sudo)")
+@pytest.mark.skipif(not testutil.can_start_rootful_containers(), reason="require a rootful containers (try: sudo)")
 @pytest.mark.parametrize("progress", ["term", "verbose"])
 def test_progress_error_reporting(tmp_path, build_erroring_container, progress):
     output_path = tmp_path / "output"

--- a/test/scripts/generate-gitlab-ci
+++ b/test/scripts/generate-gitlab-ci
@@ -148,6 +148,16 @@ BOOTC_IMAGE_BUILDER_TEMPLATE = """
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
     - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_build_disk.py
+
+"bootc-image-builder/test-manifest [{arch}]":
+  stage: gen
+  extends: .terraform
+  variables:
+    RUNNER: {runner}-{arch}
+  script:
+    - sudo ./test/scripts/install-dependencies
+    - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_manifest.py
 """
 
 

--- a/test/scripts/generate-gitlab-ci
+++ b/test/scripts/generate-gitlab-ci
@@ -158,6 +158,16 @@ BOOTC_IMAGE_BUILDER_TEMPLATE = """
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
     - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_manifest.py
+
+"bootc-image-builder/test-opts-and-progress [{arch}]":
+  stage: gen
+  extends: .terraform
+  variables:
+    RUNNER: {runner}-{arch}
+  script:
+    - sudo ./test/scripts/install-dependencies
+    - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_opts.py ./bootc-image-builder/test/test_progress.py
 """
 
 

--- a/test/scripts/generate-gitlab-ci
+++ b/test/scripts/generate-gitlab-ci
@@ -139,7 +139,7 @@ MANIFEST_GEN_TEMPLATE = """
 """
 
 BOOTC_IMAGE_BUILDER_TEMPLATE = """
-"bootc-image-builder [{arch}]":
+"bootc-image-builder/test-build-disk [{arch}]":
   stage: gen
   extends: .terraform
   variables:
@@ -147,7 +147,7 @@ BOOTC_IMAGE_BUILDER_TEMPLATE = """
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
-    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_build_disk.py::test_image_is_generated
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests ./bootc-image-builder/test/test_build_disk.py
 """
 
 

--- a/test/scripts/generate-gitlab-ci
+++ b/test/scripts/generate-gitlab-ci
@@ -144,6 +144,12 @@ BOOTC_IMAGE_BUILDER_TEMPLATE = """
   extends: .terraform
   variables:
     RUNNER: {runner}-{arch}
+  rules:
+    # 1. Skip the job if we're on the github merge queue
+    - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue/'
+      when: never
+    # 2. Fallback rule for any other branch name
+    - if: '$CI_COMMIT_BRANCH'
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
@@ -154,6 +160,12 @@ BOOTC_IMAGE_BUILDER_TEMPLATE = """
   extends: .terraform
   variables:
     RUNNER: {runner}-{arch}
+  rules:
+    # 1. Skip the job if we're on the github merge queue
+    - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue/'
+      when: never
+    # 2. Fallback rule for any other branch name
+    - if: '$CI_COMMIT_BRANCH'
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
@@ -164,6 +176,12 @@ BOOTC_IMAGE_BUILDER_TEMPLATE = """
   extends: .terraform
   variables:
     RUNNER: {runner}-{arch}
+  rules:
+    # 1. Skip the job if we're on the github merge queue
+    - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue/'
+      when: never
+    # 2. Fallback rule for any other branch name
+    - if: '$CI_COMMIT_BRANCH'
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests

--- a/test/scripts/imgtestlib/vm.py
+++ b/test/scripts/imgtestlib/vm.py
@@ -336,15 +336,23 @@ class QEMU(VM):
 
 class AWS(VM):
 
-    _instance_type = "t3.medium"  # set based on architecture when we add arm tests
+    @property
+    def _instance_type(self):
+        if self._arch == "x86_64":
+            return "t3.medium"
+        if self._arch == "aarch64":
+            return "m6g.large"
 
-    def __init__(self, ami_id):
+        raise RuntimeError(f"unsupported architecture {self._arch}")
+
+    def __init__(self, ami_id, arch):
         super().__init__()
         self._ssh_port = 22
         self._ami_id = ami_id
         self._ec2_instance = None
         self._ec2_security_group = None
         self._ec2_resource = boto3.resource("ec2", region_name=AWS_REGION)
+        self._arch = arch
 
     def start(self):
         if self.running():


### PR DESCRIPTION
Enable more bootc-image-builder tests in gitlab.

This PR expands the testing of the existing gitlab job and adds two jobs (per architecture) that run more of the existing tests using pytest.

This change will add a lot more work to the gitlab testing pipelines that will be run on every PR and in the merge queue.  See [this comment on the relevant ticket](https://redhat.atlassian.net/browse/HMS-10854?focusedCommentId=17582961) for the full plan.