### PR TITLE
ci: enable allow-unsafe-pr-checkout in checkout/7

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - name: Get open PRs
         # Since this workflow doesn't run on a PR trigger, we need to find the


### PR DESCRIPTION
Bumping actions/checkout from version 6 to 7 introduces a new flag we have to use: allow-unsafe-pr-checkout, in order to opt in for check outing fork pull request code by default.

https://github.com/actions/checkout/releases/tag/v7.0.0