### PR TITLE
Improve error message for pkgsearch with no packages

### DIFF
--- a/cmd/image-builder/pkgsearch.go
+++ b/cmd/image-builder/pkgsearch.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 
@@ -65,6 +66,10 @@ var pkgSearcher = func(d distro.Distro, archStr, cacheDir string, repos []rpmmd.
 }
 
 func cmdPkgSearch(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return errors.New("at least one package name is required")
+	}
+
 	format, err := cmd.Flags().GetString("format")
 	if err != nil {
 		return err

--- a/cmd/image-builder/pkgsearch_test.go
+++ b/cmd/image-builder/pkgsearch_test.go
@@ -109,9 +109,9 @@ func TestCmdPkgSearch(t *testing.T) {
 			expectedErr: "not-a-type",
 		},
 		{
-			name:         "zero args (no packages)",
-			args:         []string{"pkgsearch", "--distro=centos-9", "--arch=x86_64"},
-			expectedPkgs: 2,
+			name:        "zero args (no packages)",
+			args:        []string{"pkgsearch", "--distro=centos-9", "--arch=x86_64"},
+			expectedErr: "at least one package name is required",
 		},
 		{
 			name:             "with rpmmd-cache",


### PR DESCRIPTION
Improve error message for pkgsearch with no packages

## Summary

Return a clear error when `pkgsearch` is invoked without any package names instead of silently returning all packages.

## Changes

- Add an early argument check in `cmdPkgSearch` that returns an explicit error when no package names are provided
- Update the existing "zero args" test case to assert the new error message instead of expecting a successful result
