### PR TITLE
bib_legacy: Use functions from bootc

### DIFF
--- a/cmd/image-builder/bib_legacy.go
+++ b/cmd/image-builder/bib_legacy.go
@@ -3,9 +3,6 @@ package main
 import (
 	"fmt"
 	"math/rand"
-	"slices"
-	"strconv"
-	"strings"
 
 	"github.com/osbuild/blueprint/pkg/blueprint"
 	"github.com/sirupsen/logrus"
@@ -18,6 +15,7 @@ import (
 	"github.com/osbuild/image-builder/pkg/customizations/kickstart"
 	"github.com/osbuild/image-builder/pkg/depsolvednf"
 	"github.com/osbuild/image-builder/pkg/disk"
+	"github.com/osbuild/image-builder/pkg/distro/bootc"
 	"github.com/osbuild/image-builder/pkg/distro/defs"
 	"github.com/osbuild/image-builder/pkg/distro/generic"
 	"github.com/osbuild/image-builder/pkg/image"
@@ -25,7 +23,6 @@ import (
 	"github.com/osbuild/image-builder/pkg/osbuild"
 	"github.com/osbuild/image-builder/pkg/platform"
 	"github.com/osbuild/image-builder/pkg/rpmmd"
-	"github.com/osbuild/image-builder/pkg/runner"
 
 	podman_container "github.com/osbuild/image-builder/pkg/bootc"
 )
@@ -224,54 +221,6 @@ func makeISOManifest(c *ManifestConfig, solver *depsolvednf.Solver, cacheRoot st
 	return mf, depsolvedRepos, nil
 }
 
-func labelForISO(os *osinfo.OSRelease, arch *arch.Arch) string {
-	switch os.ID {
-	case "fedora":
-		return fmt.Sprintf("Fedora-S-dvd-%s-%s", arch, os.VersionID)
-	case "centos":
-		labelTemplate := "CentOS-Stream-%s-BaseOS-%s"
-		if os.VersionID == "8" {
-			labelTemplate = "CentOS-Stream-%s-%s-dvd"
-		}
-		return fmt.Sprintf(labelTemplate, os.VersionID, arch)
-	case "rhel":
-		version := strings.ReplaceAll(os.VersionID, ".", "-")
-		return fmt.Sprintf("RHEL-%s-BaseOS-%s", version, arch)
-	default:
-		return fmt.Sprintf("Container-Installer-%s", arch)
-	}
-}
-
-// from:https://github.com/osbuild/images/blob/v0.207.0/data/distrodefs/rhel-10/imagetypes.yaml#L169
-var loraxRhelTemplates = []manifest.InstallerLoraxTemplate{
-	manifest.InstallerLoraxTemplate{Path: "80-rhel/runtime-postinstall.tmpl"},
-	manifest.InstallerLoraxTemplate{Path: "80-rhel/runtime-cleanup.tmpl", AfterDracut: true},
-}
-
-// from:https://github.com/osbuild/images/blob/v0.207.0/data/distrodefs/fedora/imagetypes.yaml#L408
-var loraxFedoraTemplates = []manifest.InstallerLoraxTemplate{
-	manifest.InstallerLoraxTemplate{Path: "99-generic/runtime-postinstall.tmpl"},
-	manifest.InstallerLoraxTemplate{Path: "99-generic/runtime-cleanup.tmpl", AfterDracut: true},
-}
-
-func loraxTemplates(si osinfo.OSRelease) []manifest.InstallerLoraxTemplate {
-	switch {
-	case si.ID == "rhel" || slices.Contains(si.IDLike, "rhel") || si.VersionID == "eln":
-		return loraxRhelTemplates
-	default:
-		return loraxFedoraTemplates
-	}
-}
-
-func loraxTemplatePackage(si osinfo.OSRelease) string {
-	switch {
-	case si.ID == "rhel" || slices.Contains(si.IDLike, "rhel") || si.VersionID == "eln":
-		return "lorax-templates-rhel"
-	default:
-		return "lorax-templates-generic"
-	}
-}
-
 func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, error) {
 	if c.Imgref == "" {
 		return nil, fmt.Errorf("pipeline: no base image defined")
@@ -353,7 +302,7 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 	if isoCust != nil && isoCust.VolumeID != "" {
 		img.ISOCustomizations.Label = isoCust.VolumeID
 	} else {
-		img.ISOCustomizations.Label = labelForISO(&c.SourceInfo.OSRelease, &c.Architecture)
+		img.ISOCustomizations.Label = bootc.LabelForISO(&c.SourceInfo.OSRelease, c.Architecture.String())
 	}
 	img.InstallerCustomizations.FIPS = customizations.GetFIPS()
 	img.Kickstart, err = kickstart.New(customizations)
@@ -388,8 +337,8 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 	img.Kickstart.OSTree = &kickstart.OSTree{
 		OSName: "default",
 	}
-	img.InstallerCustomizations.LoraxTemplates = loraxTemplates(c.SourceInfo.OSRelease)
-	img.InstallerCustomizations.LoraxTemplatePackage = loraxTemplatePackage(c.SourceInfo.OSRelease)
+	img.InstallerCustomizations.LoraxTemplates = bootc.LoraxTemplates(c.SourceInfo.OSRelease)
+	img.InstallerCustomizations.LoraxTemplatePackage = bootc.LoraxTemplatePackage(c.SourceInfo.OSRelease)
 
 	// see https://github.com/osbuild/bootc-image-builder/issues/733
 	img.ISOCustomizations.RootfsType = manifest.SquashfsRootfs
@@ -402,7 +351,7 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 
 	mf := manifest.New()
 
-	foundDistro, foundRunner, err := getDistroAndRunner(c.SourceInfo.OSRelease)
+	foundDistro, foundRunner, err := bootc.GetDistroAndRunner(c.SourceInfo.OSRelease)
 	if err != nil {
 		return nil, fmt.Errorf("failed to infer distro and runner: %w", err)
 	}
@@ -410,65 +359,4 @@ func manifestForISO(c *ManifestConfig, rng *rand.Rand) (*manifest.Manifest, erro
 
 	_, err = img.InstantiateManifest(&mf, nil, foundRunner, rng)
 	return &mf, err
-}
-
-func getDistroAndRunner(osRelease osinfo.OSRelease) (manifest.Distro, runner.Runner, error) {
-	switch osRelease.ID {
-	case "fedora":
-		version, err := strconv.ParseUint(osRelease.VersionID, 10, 64)
-		if err != nil {
-			return manifest.DISTRO_NULL, nil, fmt.Errorf("cannot parse Fedora version (%s): %w", osRelease.VersionID, err)
-		}
-
-		return manifest.DISTRO_FEDORA, &runner.Fedora{
-			Version: version,
-		}, nil
-	case "centos":
-		version, err := strconv.ParseUint(osRelease.VersionID, 10, 64)
-		if err != nil {
-			return manifest.DISTRO_NULL, nil, fmt.Errorf("cannot parse CentOS version (%s): %w", osRelease.VersionID, err)
-		}
-		r := &runner.CentOS{
-			Version: version,
-		}
-		switch version {
-		case 9:
-			return manifest.DISTRO_EL9, r, nil
-		case 10:
-			return manifest.DISTRO_EL10, r, nil
-		default:
-			logrus.Warnf("Unknown CentOS version %d, using default distro for manifest generation", version)
-			return manifest.DISTRO_NULL, r, nil
-		}
-
-	case "rhel":
-		versionParts := strings.Split(osRelease.VersionID, ".")
-		if len(versionParts) != 2 {
-			return manifest.DISTRO_NULL, nil, fmt.Errorf("invalid RHEL version format: %s", osRelease.VersionID)
-		}
-		major, err := strconv.ParseUint(versionParts[0], 10, 64)
-		if err != nil {
-			return manifest.DISTRO_NULL, nil, fmt.Errorf("cannot parse RHEL major version (%s): %w", versionParts[0], err)
-		}
-		minor, err := strconv.ParseUint(versionParts[1], 10, 64)
-		if err != nil {
-			return manifest.DISTRO_NULL, nil, fmt.Errorf("cannot parse RHEL minor version (%s): %w", versionParts[1], err)
-		}
-		r := &runner.RHEL{
-			Major: major,
-			Minor: minor,
-		}
-		switch major {
-		case 9:
-			return manifest.DISTRO_EL9, r, nil
-		case 10:
-			return manifest.DISTRO_EL10, r, nil
-		default:
-			logrus.Warnf("Unknown RHEL version %d, using default distro for manifest generation", major)
-			return manifest.DISTRO_NULL, r, nil
-		}
-	}
-
-	logrus.Warnf("Unknown distro %s, using default runner", osRelease.ID)
-	return manifest.DISTRO_NULL, &runner.Linux{}, nil
 }


### PR DESCRIPTION
Use the shared versions of LabelForISO, LoraxTemplates, LoraxTemplatePackage, and GetDistroAndRunner from bootc.

Related: HMS-10969