### PR TITLE
image-builder: distro detection for `build` and `manifest`

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -349,6 +349,22 @@ func getImage(cmd *cobra.Command, args []string) (*imagefilter.Result, error) {
 		}
 		img = &imagefilter.Result{ImgType: imgType, Repos: nil}
 	} else {
+		var bpDistroName string
+		blueprintPath, err := cmd.Flags().GetString("blueprint")
+		if err != nil {
+			return nil, err
+		}
+		if blueprintPath != "" {
+			bp, err := blueprintload.Load(blueprintPath)
+			if err != nil {
+				return nil, err
+			}
+			bpDistroName = bp.Distro
+		}
+		distroStr, err = findDistro(distroStr, bpDistroName)
+		if err != nil {
+			return nil, err
+		}
 		repoOpts := &repoOptions{
 			RepoDir:      repoDir,
 			ExtraRepos:   extraRepos,

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -224,6 +224,46 @@ func TestManifestIntegrationSmoke(t *testing.T) {
 	}
 }
 
+func TestManifestIntegrationAutoDetectDistro(t *testing.T) {
+	restore := main.MockManifestgenDepsolver(fakeDepsolve)
+	defer restore()
+
+	restore = main.MockManifestgenContainerResolver(fakeContainerResolver)
+	defer restore()
+
+	restore = main.MockNewRepoRegistry(testrepos.New)
+	defer restore()
+
+	restore = main.MockDistroGetHostDistroName(func() (string, error) {
+		return "centos-9", nil
+	})
+	defer restore()
+
+	restore = main.MockOsArgs([]string{
+		"manifest",
+		"qcow2",
+		"--arch=x86_64",
+		fmt.Sprintf("--blueprint=%s", makeTestBlueprint(t, testBlueprint)),
+	})
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	var fakeStderr bytes.Buffer
+	restore = main.MockOsStderr(&fakeStderr)
+	defer restore()
+
+	err := main.Run()
+	require.NoError(t, err)
+
+	pipelineNames, err := manifesttest.PipelineNamesFrom(fakeStdout.Bytes())
+	require.NoError(t, err)
+	assert.Contains(t, pipelineNames, "qcow2")
+	assert.Contains(t, fakeStderr.String(), `No distro name specified, selecting "centos-9" based on host`)
+}
+
 func TestManifestIntegrationCrossArch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("manifest generation takes a while")


### PR DESCRIPTION
See https://github.com/osbuild/image-builder/issues/2541 for the bug this resolves. In https://github.com/osbuild/image-builder/commit/40c680562189265f544680864b98a736e6b2855d we restructured to a `getImage` call for the `build` and `manifest` subcommands. This `getImage` call does not perform distribution detection when no distribution is passed.

We don't pass a distribution in Koji nor OpenQA (we detect it on the mock root we run in) thus this bug breaks a bunch of things.

First commit introduces failing testcase, second bug fixes it.

---

This will need a follow-up with more extensive testing and unification of these codepaths between the other subcommands.