### PR TITLE
bib: Replace logrus usage with olog

### DIFF
--- a/bootc-image-builder/test/test_opts.py
+++ b/bootc-image-builder/test/test_opts.py
@@ -80,28 +80,6 @@ def test_opts_arch_is_same_arch_is_fine(tmp_path, build_fake_container, target_a
         assert expected_err in res.stderr
 
 
-@pytest.mark.parametrize("with_debug", [False, True])
-def test_bib_log_level_smoke(tmp_path, container_storage, build_fake_container, with_debug):
-    output_path = tmp_path / "output"
-    output_path.mkdir(exist_ok=True)
-
-    container_ref = "quay.io/centos-bootc/centos-bootc:stream9"
-    testutil.pull_container(container_ref)
-
-    log_debug = ["--log-level", "debug"] if with_debug else []
-    res = subprocess.run([
-        "podman", "run", "--rm",
-        "--privileged",
-        "--security-opt", "label=type:unconfined_t",
-        "-v", f"{container_storage}:/var/lib/containers/storage",
-        "-v", f"{output_path}:/output",
-        build_fake_container,
-        *log_debug,
-        container_ref,
-    ], check=True, capture_output=True, text=True)
-    assert ('level=debug' in res.stderr) == with_debug
-
-
 def test_bib_help_hides_config(tmp_path, container_storage, build_fake_container):
     output_path = tmp_path / "output"
     output_path.mkdir(exist_ok=True)

--- a/cmd/image-builder/bib_legacy.go
+++ b/cmd/image-builder/bib_legacy.go
@@ -5,7 +5,6 @@ import (
 	"math/rand"
 
 	"github.com/osbuild/blueprint/pkg/blueprint"
-	"github.com/sirupsen/logrus"
 
 	"github.com/osbuild/image-builder/internal/cmdutil"
 	"github.com/osbuild/image-builder/pkg/arch"
@@ -20,6 +19,7 @@ import (
 	"github.com/osbuild/image-builder/pkg/distro/generic"
 	"github.com/osbuild/image-builder/pkg/image"
 	"github.com/osbuild/image-builder/pkg/manifest"
+	"github.com/osbuild/image-builder/pkg/olog"
 	"github.com/osbuild/image-builder/pkg/osbuild"
 	"github.com/osbuild/image-builder/pkg/platform"
 	"github.com/osbuild/image-builder/pkg/rpmmd"
@@ -68,7 +68,7 @@ func manifestFromCobraForLegacyISO(imgref, buildImgref, imgTypeStr, rootFs, rpmC
 	}
 	defer func() {
 		if err := container.Stop(); err != nil {
-			logrus.Warnf("error stopping container: %v", err)
+			olog.Printf("ERROR: problem stopping container: %v", err)
 		}
 	}()
 
@@ -98,7 +98,7 @@ func manifestFromCobraForLegacyISO(imgref, buildImgref, imgTypeStr, rootFs, rpmC
 	defer func() {
 		if startedBuildContainer {
 			if err := buildContainer.Stop(); err != nil {
-				logrus.Warnf("error stopping container: %v", err)
+				olog.Printf("ERROR: problem stopping container: %v", err)
 			}
 		}
 	}()

--- a/cmd/image-builder/bib_main.go
+++ b/cmd/image-builder/bib_main.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime/debug"
 	"strconv"
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 
@@ -27,6 +27,7 @@ import (
 	"github.com/osbuild/image-builder/pkg/experimentalflags"
 	"github.com/osbuild/image-builder/pkg/manifest"
 	"github.com/osbuild/image-builder/pkg/manifestgen"
+	"github.com/osbuild/image-builder/pkg/olog"
 	"github.com/osbuild/image-builder/pkg/osbuild"
 	"github.com/osbuild/image-builder/pkg/reporegistry"
 	"github.com/osbuild/image-builder/pkg/rpmmd"
@@ -269,7 +270,7 @@ func handleAWSFlags(cmd *cobra.Command) (cloud.Uploader, error) {
 		return nil, err
 	}
 	status := io.Discard
-	if logrus.GetLevel() >= logrus.InfoLevel {
+	if rootLogLevel != "" {
 		status = os.Stderr
 	}
 	// check as many permission prerequisites as possible before starting
@@ -298,11 +299,9 @@ func bibCmdBuild(cmd *cobra.Command, args []string) error {
 	targetArch, _ := cmd.Flags().GetString("target-arch")
 	progressType, _ := cmd.Flags().GetString("progress")
 
-	logrus.Debug("Validating environment")
 	if err := setup.Validate(targetArch, false); err != nil {
 		return fmt.Errorf("cannot validate the setup: %w", err)
 	}
-	logrus.Debug("Ensuring environment setup")
 	switch setup.IsContainer() {
 	case false:
 		fmt.Fprintf(os.Stderr, "WARNING: running outside a container, this is an unsupported configuration\n")
@@ -422,15 +421,11 @@ func bibRootPreRunE(cmd *cobra.Command, _ []string) error {
 	progress, _ := cmd.Flags().GetString("progress")
 	switch {
 	case rootLogLevel != "":
-		level, err := logrus.ParseLevel(rootLogLevel)
-		if err != nil {
-			return err
-		}
-		logrus.SetLevel(level)
+		olog.SetDefault(log.New(os.Stderr, "", 0))
 	case verbose:
-		logrus.SetLevel(logrus.InfoLevel)
+		olog.SetDefault(log.New(os.Stderr, "", 0))
+		rootLogLevel = "verbose"
 	default:
-		logrus.SetLevel(logrus.ErrorLevel)
 	}
 	if verbose && progress == "auto" {
 		if err := cmd.Flags().Set("progress", "verbose"); err != nil {
@@ -459,7 +454,7 @@ func bibVersionFromBuildInfo() (string, error) {
 		case "vcs.modified":
 			bT, err := strconv.ParseBool(bs.Value)
 			if err != nil {
-				logrus.Errorf("Error parsing 'vcs.modified': %v", err)
+				olog.Printf("ERROR: parsing 'vcs.modified': %v", err)
 				bT = true
 			}
 			buildTainted = bT

--- a/cmd/image-builder/bib_main_test.go
+++ b/cmd/image-builder/bib_main_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/stretchr/testify/assert"
@@ -123,19 +122,16 @@ func TestCobraCmdline(t *testing.T) {
 
 func TestCobraCmdlineVerbose(t *testing.T) {
 	for _, tc := range []struct {
-		cmdline             []string
-		expectedProgress    string
-		expectedLogrusLevel logrus.Level
+		cmdline          []string
+		expectedProgress string
 	}{
 		{
 			[]string{"quay.io..."},
 			"auto",
-			logrus.ErrorLevel,
 		},
 		{
 			[]string{"-v", "quay.io..."},
 			"verbose",
-			logrus.InfoLevel,
 		},
 	} {
 		restore := mockOsArgs(tc.cmdline)
@@ -161,7 +157,6 @@ func TestCobraCmdlineVerbose(t *testing.T) {
 			err = rootCmd.Execute()
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedProgress, progressFlag)
-			assert.Equal(t, tc.expectedLogrusLevel, logrus.GetLevel())
 		})
 	}
 }

--- a/cmd/image-builder/bib_mtls.go
+++ b/cmd/image-builder/bib_mtls.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path"
 
+	"github.com/osbuild/image-builder/pkg/olog"
 	"github.com/osbuild/image-builder/pkg/rpmmd"
-	"github.com/sirupsen/logrus"
 )
 
 type mTLSConfig struct {
@@ -68,7 +68,7 @@ func prepareOsbuildMTLSConfig(mTLS *mTLSConfig) (envVars []string, cleanup func(
 
 	cleanupFn := func() {
 		if err := os.RemoveAll(dir); err != nil {
-			logrus.Warnf("prepareOsbuildMTLSConfig: failed to remove temporary directory %s: %v", dir, err)
+			olog.Printf("WARNING: prepareOsbuildMTLSConfig: failed to remove temporary directory %s: %v", dir, err)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/oracle/oci-go-sdk/v54 v54.0.0
 	github.com/osbuild/blueprint v1.32.0
-	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -156,6 +155,7 @@ require (
 	github.com/sigstore/fulcio v1.6.6 // indirect
 	github.com/sigstore/protobuf-specs v0.4.1 // indirect
 	github.com/sigstore/sigstore v1.9.5 // indirect
+	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/smallstep/pkcs7 v0.1.1 // indirect
 	github.com/sony/gobreaker v0.4.2-0.20210216022020-dd874f9dd33b // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -16,8 +16,9 @@ $GO_BINARY download
 $GO_BINARY mod tidy
 
 # Check banned packages
-if grep "github.com/(go-yaml/yaml|sirupsen/logrus)" go.mod | grep -v "// indirect" | grep -q .; then
-	echo "error: banned direct dependency found" >&2
+if grep -E "github.com/(go-yaml/yaml|sirupsen/logrus)" go.mod | grep -v "// indirect" | grep -q .; then
+	echo "error: banned direct dependency found:" >&2
+	grep -E "github.com/(go-yaml/yaml|sirupsen/logrus)" go.mod >&2
 	exit 1
 fi
 


### PR DESCRIPTION
logrus was removed in commit dbdc5c30572aab20568d92250f712a1ed7a5b888
but snuck back in with the bib merge. This removes it and replaces it
with olog.
    
The log level now accepts any string, which simply turns on all the
logging output in addition to using the progress bar. This is different
from the verbose flag which turns on all the output from the osbuild
stages.
