### PR TITLE
github: enable building the bootc-image-builder container [HMS-11005]

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,5 +1,5 @@
 ---
-name: Container
+name: Containers
 
 on:  # yamllint disable-line rule:truthy
   push:
@@ -10,8 +10,8 @@ on:  # yamllint disable-line rule:truthy
     types: ["checks_requested"]
 
 jobs:
-  build-base:
-    name: Build & Push
+  build-ib:
+    name: Build & Push (image-builder)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -50,5 +50,47 @@ jobs:
           file: ./Containerfile
           push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
           cache-from: type=registry,ref=ghcr.io/osbuild/image-builder:latest
+          cache-to: type=inline
+          tags: ${{ steps.meta.outputs.tags }}
+
+  build-bib:
+    name: Build & Push (bootc-image-builder)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate container image metadata
+        uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: |
+            ghcr.io/osbuild/bootc-image-builder
+          tags: |
+            type=ref,event=tag,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=latest
+            type=sha,format=long,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: ./bootc-image-builder/Containerfile
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+          cache-from: type=registry,ref=ghcr.io/osbuild/bootc-image-builder:latest
           cache-to: type=inline
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Add a second job to the Container (now Containers) workflow that builds the bootc-image-builder container.

The [bootc-image-builder container](https://ghcr.io/osbuild/bootc-image-builder) package on GitHub is still marked as archived because it's linked to the archived bootc-image-builder repository.  I changed the linked repository for the package and we'll be able to push to it from this repo.  This is the same situation we have with the [image-builder-cli container](https://ghcr.io/osbuild/image-builder-cli).