### PR TITLE
gitlab: remove setup-show option for pytest

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1082,7 +1082,7 @@ fail:
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
-    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_build_cross.py
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_build_cross.py
 
 
 "bootc-image-builder/test/test_build_disk.py [x86_64]":
@@ -1099,7 +1099,7 @@ fail:
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
-    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_build_disk.py
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_build_disk.py
 
 
 "bootc-image-builder/test/test_build_iso.py [x86_64]":
@@ -1116,7 +1116,7 @@ fail:
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
-    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_build_iso.py
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_build_iso.py
 
 
 "bootc-image-builder/test/test_manifest.py [x86_64]":
@@ -1133,7 +1133,7 @@ fail:
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
-    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_manifest.py
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_manifest.py
 
 
 "bootc-image-builder/test/test_opts.py [x86_64]":
@@ -1150,7 +1150,7 @@ fail:
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
-    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_opts.py
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_opts.py
 
 
 "bootc-image-builder/test/test_build_cross.py [aarch64]":
@@ -1167,7 +1167,7 @@ fail:
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
-    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_build_cross.py
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_build_cross.py
 
 
 "bootc-image-builder/test/test_build_disk.py [aarch64]":
@@ -1184,7 +1184,7 @@ fail:
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
-    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_build_disk.py
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_build_disk.py
 
 
 "bootc-image-builder/test/test_manifest.py [aarch64]":
@@ -1201,7 +1201,7 @@ fail:
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
-    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_manifest.py
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_manifest.py
 
 
 "bootc-image-builder/test/test_opts.py [aarch64]":
@@ -1218,7 +1218,7 @@ fail:
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
-    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_opts.py
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_opts.py
 
 "generate-ostree-build-config: [centos-9, aarch64]":
   stage: ostree-gen

--- a/test/scripts/generate-gitlab-ci
+++ b/test/scripts/generate-gitlab-ci
@@ -154,7 +154,7 @@ BOOTC_IMAGE_BUILDER_TEMPLATE = """
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
-    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --setup-show --basetemp=/var/tmp/bootc-image-builder-tests {test_file_path}
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests {test_file_path}
 """
 
 


### PR DESCRIPTION
In f58502be3442ae2a24d8412a85256539d49cbd69 I added the --setup-show option to the pytest call, which prints the fixture setup and teardown during a run.  This turns out to be very ugly and makes it harder to spot failed tests.  Reverting.