### PR TITLE
disk: take the ESP size from the image type's partition table (RHEL-214147)

### DIFF
--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -730,6 +731,23 @@ func (pt *PartitionTable) FindMountableOnPlain(mountpoint string) Mountable {
 	return path[0].(Mountable)
 }
 
+// ESPSize returns the size of the EFI system partition in the PartitionTable.
+// Returns 0 if the table has no ESP. The ESP is identified by its partition
+// type, not by its mountpoint, so that tables which mount it somewhere other
+// than /boot/efi are still detected. Besides the GPT GUID and the DOS ID,
+// plain FAT16 ("06") also counts: the aarch64 DOS tables (IoT, minimal-raw)
+// type their ESP that way for firmware that reads the FAT partition directly.
+func (pt *PartitionTable) ESPSize() datasizes.Size {
+	for _, part := range pt.Partitions {
+		if strings.EqualFold(part.Type, EFISystemPartitionGUID) ||
+			strings.EqualFold(part.Type, EFISystemPartitionDOSID) ||
+			part.Type == FAT16BDOSID {
+			return part.Size
+		}
+	}
+	return 0
+}
+
 func clampFSSize(mountpoint string, size datasizes.Size) datasizes.Size {
 	// set a minimum size of 1GB for all mountpoints
 	// with the exception for '/boot' (= 500 MB)
@@ -1197,20 +1215,30 @@ func hasESP(disk *blueprint.DiskCustomization) bool {
 	return false
 }
 
+// defaultESPSize is the size of the automatically created EFI system partition
+// when the caller does not specify one in CustomPartitionTableOptions.
+const defaultESPSize = 200 * datasizes.MiB
+
 // addPartitionsForBootMode creates partitions to satisfy the boot mode requirements:
 //   - BIOS/legacy: adds a 1 MiB BIOS boot partition.
-//   - UEFI: adds a 200 MiB EFI system partition.
+//   - UEFI: adds an EFI system partition of options.ESPSize (or defaultESPSize).
 //   - Hybrid: adds both.
 //
 // The function will append the new partitions to the end of the existing
 // partition table therefore it is best to call this function early to put them
 // near the front (as is conventional).
-func addPartitionsForBootMode(pt *PartitionTable, disk *blueprint.DiskCustomization, bootMode platform.BootMode, architecture arch.Arch) error {
+func addPartitionsForBootMode(pt *PartitionTable, disk *blueprint.DiskCustomization, options *CustomPartitionTableOptions) error {
+	bootMode := options.BootMode
 	if bootMode == platform.BOOT_NONE {
 		return nil
 	}
 
-	switch architecture {
+	espSize := options.ESPSize
+	if espSize == 0 {
+		espSize = defaultESPSize
+	}
+
+	switch options.Architecture {
 	case arch.ARCH_PPC64LE:
 		// UEFI is not supported for PPC CPUs so we don't need to
 		// add an ESP partition there
@@ -1226,7 +1254,7 @@ func addPartitionsForBootMode(pt *PartitionTable, disk *blueprint.DiskCustomizat
 	case arch.ARCH_AARCH64, arch.ARCH_RISCV64:
 		// (our) aarch64/riscv64 only supports UEFI right now
 		if !hasESP(disk) {
-			part, err := mkESP(200*datasizes.MiB, pt.Type)
+			part, err := mkESP(espSize, pt.Type)
 			if err != nil {
 				return err
 			}
@@ -1246,7 +1274,7 @@ func addPartitionsForBootMode(pt *PartitionTable, disk *blueprint.DiskCustomizat
 		case platform.BOOT_UEFI:
 			// add ESP if needed
 			if !hasESP(disk) {
-				part, err := mkESP(200*datasizes.MiB, pt.Type)
+				part, err := mkESP(espSize, pt.Type)
 				if err != nil {
 					return err
 				}
@@ -1261,7 +1289,7 @@ func addPartitionsForBootMode(pt *PartitionTable, disk *blueprint.DiskCustomizat
 			}
 			pt.Partitions = append(pt.Partitions, bios)
 			if !hasESP(disk) {
-				esp, err := mkESP(200*datasizes.MiB, pt.Type)
+				esp, err := mkESP(espSize, pt.Type)
 				if err != nil {
 					return err
 				}
@@ -1272,7 +1300,7 @@ func addPartitionsForBootMode(pt *PartitionTable, disk *blueprint.DiskCustomizat
 			return fmt.Errorf("unknown or unsupported boot mode type with enum value %d", bootMode)
 		}
 	default:
-		return fmt.Errorf("unknown or unsupported architecture %v", architecture)
+		return fmt.Errorf("unknown or unsupported architecture %v", options.Architecture)
 	}
 }
 
@@ -1354,6 +1382,13 @@ type CustomPartitionTableOptions struct {
 	// enable automatic discovery. It has no effect and is not required when
 	// the PartitionTableType is PT_DOS.
 	Architecture arch.Arch
+
+	// ESPSize is the size of the EFI system partition that gets created
+	// automatically when the boot mode requires one and the customizations
+	// don't define one. Callers should set this to the ESP size of the image
+	// type's own partition table so that customizing the partitioning does not
+	// silently change it. If unset, defaultESPSize is used.
+	ESPSize datasizes.Size
 }
 
 // Returns the default filesystem type if the fstype is empty. If both are
@@ -1446,7 +1481,7 @@ func NewCustomPartitionTable(customizations *blueprint.DiskCustomization, option
 	// add any partition(s) that are needed for booting (like /boot/efi)
 	// if needed
 	//
-	if err := addPartitionsForBootMode(pt, customizations, options.BootMode, options.Architecture); err != nil {
+	if err := addPartitionsForBootMode(pt, customizations, options); err != nil {
 		return nil, fmt.Errorf("%s %w", errPrefix, err)
 	}
 	// add the /boot partition (if it is needed)

--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -732,20 +732,22 @@ func (pt *PartitionTable) FindMountableOnPlain(mountpoint string) Mountable {
 }
 
 // ESPSize returns the size of the EFI system partition in the PartitionTable.
-// Returns 0 if the table has no ESP. The ESP is identified by its partition
-// type, not by its mountpoint, so that tables which mount it somewhere other
-// than /boot/efi are still detected. Besides the GPT GUID and the DOS ID,
-// plain FAT16 ("06") also counts: the aarch64 DOS tables (IoT, minimal-raw)
-// type their ESP that way for firmware that reads the FAT partition directly.
+// Returns 0 if the table has no ESP.
+// For DOS partition tables we match type "ef" or "06" if mounted at /boot/efi.
 func (pt *PartitionTable) ESPSize() datasizes.Size {
+	var fat16ESP datasizes.Size
 	for _, part := range pt.Partitions {
 		if strings.EqualFold(part.Type, EFISystemPartitionGUID) ||
-			strings.EqualFold(part.Type, EFISystemPartitionDOSID) ||
-			part.Type == FAT16BDOSID {
+			strings.EqualFold(part.Type, EFISystemPartitionDOSID) {
 			return part.Size
 		}
+		if strings.EqualFold(part.Type, FAT16BDOSID) && fat16ESP == 0 {
+			if mnt, ok := part.Payload.(Mountable); ok && mnt.GetMountpoint() == "/boot/efi" {
+				fat16ESP = part.Size
+			}
+		}
 	}
-	return 0
+	return fat16ESP
 }
 
 func clampFSSize(mountpoint string, size datasizes.Size) datasizes.Size {

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -936,10 +936,12 @@ func TestAddBootPartition(t *testing.T) {
 
 func TestAddPartitionsForBootMode(t *testing.T) {
 	type testCase struct {
-		pt       disk.PartitionTable
-		bootMode platform.BootMode
-		expected disk.PartitionTable
-		errmsg   string
+		pt           disk.PartitionTable
+		bootMode     platform.BootMode
+		architecture arch.Arch // ARCH_X86_64 if unset
+		espSize      datasizes.Size
+		expected     disk.PartitionTable
+		errmsg       string
 	}
 
 	testCases := map[string]testCase{
@@ -1093,6 +1095,87 @@ func TestAddPartitionsForBootMode(t *testing.T) {
 				},
 			},
 		},
+		"uefi-gpt-custom-esp-size": {
+			pt:       disk.PartitionTable{Type: disk.PT_GPT},
+			bootMode: platform.BOOT_UEFI,
+			espSize:  512 * datasizes.MiB,
+			expected: disk.PartitionTable{
+				Type: disk.PT_GPT,
+				Partitions: []disk.Partition{
+					{
+						Start: 0 * datasizes.MiB,
+						Size:  512 * datasizes.MiB,
+						Type:  disk.EFISystemPartitionGUID,
+						UUID:  disk.EFISystemPartitionUUID,
+						Payload: &disk.Filesystem{
+							Type:         "vfat",
+							UUID:         disk.EFIFilesystemUUID,
+							Mountpoint:   "/boot/efi",
+							Label:        "ESP",
+							FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+							FSTabFreq:    0,
+							FSTabPassNo:  2,
+						},
+					},
+				},
+			},
+		},
+		"hybrid-gpt-custom-esp-size": {
+			pt:       disk.PartitionTable{Type: disk.PT_GPT},
+			bootMode: platform.BOOT_HYBRID,
+			espSize:  512 * datasizes.MiB,
+			expected: disk.PartitionTable{
+				Type: disk.PT_GPT,
+				Partitions: []disk.Partition{
+					{
+						Size:     1 * datasizes.MiB,
+						Bootable: true,
+						Type:     disk.BIOSBootPartitionGUID,
+						UUID:     disk.BIOSBootPartitionUUID,
+					},
+					{
+						Size: 512 * datasizes.MiB,
+						Type: disk.EFISystemPartitionGUID,
+						UUID: disk.EFISystemPartitionUUID,
+						Payload: &disk.Filesystem{
+							Type:         "vfat",
+							UUID:         disk.EFIFilesystemUUID,
+							Mountpoint:   "/boot/efi",
+							Label:        "ESP",
+							FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+							FSTabFreq:    0,
+							FSTabPassNo:  2,
+						},
+					},
+				},
+			},
+		},
+		"aarch64-uefi-gpt-custom-esp-size": {
+			pt:           disk.PartitionTable{Type: disk.PT_GPT},
+			bootMode:     platform.BOOT_UEFI,
+			architecture: arch.ARCH_AARCH64,
+			espSize:      512 * datasizes.MiB,
+			expected: disk.PartitionTable{
+				Type: disk.PT_GPT,
+				Partitions: []disk.Partition{
+					{
+						Start: 0 * datasizes.MiB,
+						Size:  512 * datasizes.MiB,
+						Type:  disk.EFISystemPartitionGUID,
+						UUID:  disk.EFISystemPartitionUUID,
+						Payload: &disk.Filesystem{
+							Type:         "vfat",
+							UUID:         disk.EFIFilesystemUUID,
+							Mountpoint:   "/boot/efi",
+							Label:        "ESP",
+							FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+							FSTabFreq:    0,
+							FSTabPassNo:  2,
+						},
+					},
+				},
+			},
+		},
 		"bad-pttype-bios": {
 			pt:       disk.PartitionTable{Type: disk.PartitionTableType(911)},
 			bootMode: platform.BOOT_LEGACY,
@@ -1120,13 +1203,130 @@ func TestAddPartitionsForBootMode(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 			pt := tc.pt
-			err := disk.AddPartitionsForBootMode(&pt, nil, tc.bootMode, arch.ARCH_X86_64)
+			architecture := tc.architecture
+			if architecture == arch.ARCH_UNSET {
+				architecture = arch.ARCH_X86_64
+			}
+			options := &disk.CustomPartitionTableOptions{
+				BootMode:     tc.bootMode,
+				Architecture: architecture,
+				ESPSize:      tc.espSize,
+			}
+			err := disk.AddPartitionsForBootMode(&pt, nil, options)
 			if tc.errmsg == "" {
 				assert.NoError(err)
 				assert.Equal(tc.expected, pt)
 			} else {
 				assert.EqualError(err, tc.errmsg)
 			}
+		})
+	}
+}
+
+func TestPartitionTableESPSize(t *testing.T) {
+	type testCase struct {
+		pt       disk.PartitionTable
+		expected datasizes.Size
+	}
+
+	testCases := map[string]testCase{
+		"gpt": {
+			pt: disk.PartitionTable{
+				Type: disk.PT_GPT,
+				Partitions: []disk.Partition{
+					{Size: 1 * datasizes.MiB, Type: disk.BIOSBootPartitionGUID},
+					{Size: 512 * datasizes.MiB, Type: disk.EFISystemPartitionGUID},
+					{Size: 2 * datasizes.GiB, Type: disk.FilesystemDataGUID},
+				},
+			},
+			expected: 512 * datasizes.MiB,
+		},
+		"dos": {
+			pt: disk.PartitionTable{
+				Type: disk.PT_DOS,
+				Partitions: []disk.Partition{
+					{Size: 500 * datasizes.MiB, Type: disk.EFISystemPartitionDOSID},
+				},
+			},
+			expected: 500 * datasizes.MiB,
+		},
+		"dos-fat16": {
+			// the aarch64 DOS tables (IoT, minimal-raw) type their ESP as
+			// plain FAT16 instead of "ef"
+			pt: disk.PartitionTable{
+				Type: disk.PT_DOS,
+				Partitions: []disk.Partition{
+					{Size: 501 * datasizes.MiB, Type: disk.FAT16BDOSID, Bootable: true},
+					{Size: 2 * datasizes.GiB, Type: disk.FilesystemLinuxDOSID},
+				},
+			},
+			expected: 501 * datasizes.MiB,
+		},
+		"no-esp": {
+			pt: disk.PartitionTable{
+				Type: disk.PT_GPT,
+				Partitions: []disk.Partition{
+					{Size: 2 * datasizes.GiB, Type: disk.FilesystemDataGUID},
+				},
+			},
+			expected: 0,
+		},
+		"empty": {
+			pt:       disk.PartitionTable{Type: disk.PT_GPT},
+			expected: 0,
+		},
+	}
+
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.pt.ESPSize())
+		})
+	}
+}
+
+// The ESP size of the image type's own partition table must survive disk
+// customizations that don't mention /boot/efi themselves. Without this, an
+// image type such as azure-cvm, whose kernels live in the ESP because it is
+// UKI-based, would silently get the generic default instead.
+func TestNewCustomPartitionTableKeepsImageTypeESPSize(t *testing.T) {
+	customizations := &blueprint.DiskCustomization{
+		Partitions: []blueprint.PartitionCustomization{
+			{
+				Type: "plain",
+				FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+					Mountpoint: "/",
+					FSType:     "ext4",
+				},
+			},
+		},
+	}
+
+	testCases := map[string]struct {
+		espSize  datasizes.Size
+		expected datasizes.Size
+	}{
+		"unset-falls-back-to-default": {espSize: 0, expected: 200 * datasizes.MiB},
+		"option-honoured":             {espSize: 512 * datasizes.MiB, expected: 512 * datasizes.MiB},
+	}
+
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
+			options := &disk.CustomPartitionTableOptions{
+				PartitionTableType: disk.PT_GPT,
+				BootMode:           platform.BOOT_UEFI,
+				DefaultFSType:      disk.FS_EXT4,
+				Architecture:       arch.ARCH_X86_64,
+				ESPSize:            tc.espSize,
+			}
+			pt, err := disk.NewCustomPartitionTable(customizations, options, nil, rand.New(rand.NewSource(0))) // #nosec G404
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, pt.ESPSize())
+
+			esp := pt.FindMountable("/boot/efi")
+			require.NotNil(t, esp, "no ESP created for a UEFI boot mode")
 		})
 	}
 }

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -1256,11 +1256,48 @@ func TestPartitionTableESPSize(t *testing.T) {
 			pt: disk.PartitionTable{
 				Type: disk.PT_DOS,
 				Partitions: []disk.Partition{
-					{Size: 501 * datasizes.MiB, Type: disk.FAT16BDOSID, Bootable: true},
+					{
+						Size:     501 * datasizes.MiB,
+						Type:     disk.FAT16BDOSID,
+						Bootable: true,
+						Payload:  &disk.Filesystem{Type: "vfat", Mountpoint: "/boot/efi"},
+					},
 					{Size: 2 * datasizes.GiB, Type: disk.FilesystemLinuxDOSID},
 				},
 			},
 			expected: 501 * datasizes.MiB,
+		},
+		"dos-fat16-not-an-esp": {
+			// a FAT16 partition that is not mounted at /boot/efi is a data
+			// partition, not a mistyped ESP, and must not be picked up
+			pt: disk.PartitionTable{
+				Type: disk.PT_DOS,
+				Partitions: []disk.Partition{
+					{
+						Size:    128 * datasizes.MiB,
+						Type:    disk.FAT16BDOSID,
+						Payload: &disk.Filesystem{Type: "vfat", Mountpoint: "/data"},
+					},
+					{Size: 2 * datasizes.GiB, Type: disk.FilesystemLinuxDOSID},
+				},
+			},
+			expected: 0,
+		},
+		"dos-fat16-before-real-esp": {
+			// an unambiguously typed ESP wins over an earlier FAT16 partition
+			// wherever it appears in the table
+			pt: disk.PartitionTable{
+				Type: disk.PT_DOS,
+				Partitions: []disk.Partition{
+					{
+						Size:    128 * datasizes.MiB,
+						Type:    disk.FAT16BDOSID,
+						Payload: &disk.Filesystem{Type: "vfat", Mountpoint: "/data"},
+					},
+					{Size: 512 * datasizes.MiB, Type: disk.EFISystemPartitionDOSID},
+				},
+			},
+			expected: 512 * datasizes.MiB,
 		},
 		"no-esp": {
 			pt: disk.PartitionTable{

--- a/pkg/distro/generic/bootc_image_test.go
+++ b/pkg/distro/generic/bootc_image_test.go
@@ -367,6 +367,33 @@ func TestGenPartitionTableSetsRootfsForAllFilesystemsBtrfs(t *testing.T) {
 	mnt, _ = findMountableSizeableFor(pt, "/boot/efi")
 	assert.Equal(t, "vfat", mnt.GetFSType())
 }
+
+// the ESP size of the base partition table (501 MiB in the bootc-generic
+// definitions) must survive a disk customization that doesn't mention
+// /boot/efi
+func TestGenPartitionTableDiskCustomizationKeepsESPSize(t *testing.T) {
+	rng := createRand()
+
+	imgType := NewTestBootcImageType(t, "qcow2")
+
+	cus := &blueprint.Customizations{
+		Disk: &blueprint.DiskCustomization{
+			Partitions: []blueprint.PartitionCustomization{
+				{
+					Type: "plain",
+					FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+						Mountpoint: "/",
+						FSType:     "xfs",
+					},
+				},
+			},
+		},
+	}
+	pt, err := imgType.genPartitionTable(cus, 0, rng)
+	assert.NoError(t, err)
+	assert.Equal(t, datasizes.Size(501*datasizes.MiB), pt.ESPSize())
+}
+
 func TestGenPartitionTableDiskCustomizationRunsValidateLayoutConstraints(t *testing.T) {
 	rng := createRand()
 

--- a/pkg/distro/generic/bootc_imagetype.go
+++ b/pkg/distro/generic/bootc_imagetype.go
@@ -936,6 +936,7 @@ func (t *bootcImageType) genPartitionTableDiskCust(basept *disk.PartitionTable, 
 		DefaultFSType:    defaultFSType,
 		RequiredMinSizes: requiredMinSizes,
 		Architecture:     t.arch.arch,
+		ESPSize:          basept.ESPSize(),
 	}
 	return disk.NewCustomPartitionTable(diskCust, partOptions, nil, rng)
 }

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -196,6 +196,9 @@ func (t *imageType) getPartitionTable(customizations *blueprint.Customizations, 
 			DefaultFSType:      defaultFsType,
 			RequiredMinSizes:   t.ImageTypeYAML.RequiredPartitionSizes,
 			Architecture:       t.platform.GetArch(),
+			// the ESP size is not customizable either, so keep the one the
+			// image type defines instead of falling back to a generic default
+			ESPSize: basePartitionTable.ESPSize(),
 		}
 		return disk.NewCustomPartitionTable(partitioning, partOptions, nil, rng)
 	}

--- a/pkg/distro/generic/rhel10_internal_test.go
+++ b/pkg/distro/generic/rhel10_internal_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/osbuild/blueprint/pkg/blueprint"
 	"github.com/osbuild/image-builder/internal/common"
+	"github.com/osbuild/image-builder/pkg/datasizes"
 	"github.com/osbuild/image-builder/pkg/disk"
 	"github.com/osbuild/image-builder/pkg/distro"
 	"github.com/osbuild/image-builder/pkg/distro/distro_test_common"
@@ -103,4 +104,34 @@ func TestESP(t *testing.T) {
 		it := i.(*imageType)
 		return it.getPartitionTable(&blueprint.Customizations{}, distro.ImageOptions{}, rng)
 	})
+}
+
+// ec2-cvm is UKI-based: its kernels live in the ESP, so the 512 MiB ESP of
+// its base partition table must survive a disk customization that doesn't
+// mention /boot/efi.
+func TestRhel10DiskCustomizationKeepsESPSize(t *testing.T) {
+	dist := DistroFactory("rhel-10.0")
+	require.NotNil(t, dist)
+	a, err := dist.GetArch("x86_64")
+	require.NoError(t, err)
+	imgType, err := a.GetImageType("ec2-cvm")
+	require.NoError(t, err)
+	it := imgType.(*imageType)
+
+	customizations := &blueprint.Customizations{
+		Disk: &blueprint.DiskCustomization{
+			Partitions: []blueprint.PartitionCustomization{
+				{
+					Type: "plain",
+					FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+						Mountpoint: "/",
+						FSType:     "xfs",
+					},
+				},
+			},
+		},
+	}
+	pt, err := it.getPartitionTable(customizations, distro.ImageOptions{}, rng)
+	require.NoError(t, err)
+	assert.Equal(t, datasizes.Size(512*datasizes.MiB), pt.ESPSize())
 }


### PR DESCRIPTION
When a blueprint contains a partitioning customization we build the partition table with NewCustomPartitionTable(), which derives almost everything from the customization and only inherits the partition table *type* from the image type's own table. The EFI system partition that addPartitionsForBootMode() adds when the customization doesn't declare one was therefore hardcoded to 200 MiB, silently discarding whatever the image type defines.

A user who customizes their disk without mentioning /boot/efi is not opting out of the image type's ESP; they are expressing no opinion about it, and should get the same ESP an uncustomized build would give them. The definitions vary more than the hardcoded value suggests: rhel-8 defaults to 100 MiB, the rhel-8/9 edge types use 127 MiB, rhel-9/10 "oci" and "azure" use 500 MiB, Fedora IoT and the generic bootc types use 501 MiB, and the CVM types use 512 MiB. Adding any disk customization silently replaced all of those with 200 MiB.

For most image types the mismatch is only cosmetic, since the ESP holds just shim and grub, which are a few MiB. It is a real bug for UKI-based image types: "ec2-cvm" and "azure-cvm" (rhel-9 and rhel-10) set bootloader: uki, which redirects the kernel install root to the ESP, so the kernel and initrd live there instead of in /boot. Those types declare a 512 MiB ESP for that reason. Building one with any partitioning customization that doesn't happen to mention /boot/efi produced a 200 MiB ESP instead, leaving no room for a kernel update on the running system.

Thread the size through CustomPartitionTableOptions, as we already do for RequiredMinSizes, and have both callers pass the ESP size of the image type's base partition table. Add PartitionTable.ESPSize() to look it up, identifying the ESP by partition type rather than by mountpoint so tables that mount it elsewhere still work. Three types count as an ESP: the GPT GUID, the DOS ID "ef", and plain FAT16 "06", which the aarch64 DOS tables (IoT, minimal-raw) use for firmware that reads the FAT partition directly.

The 200 MiB default is kept as a fallback for callers that don't set the option and for image types whose base table has no ESP. Customized builds now follow the image type's declaration in both directions -- rhel-8 shrinks to its declared 100 MiB just as the CVM types grow to 512 MiB -- and an image type can change its ESP size purely in YAML and have it apply to customized builds too.