### PR TITLE
imgtestlib: configure setuptools package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
   "scp==0.15.0",
 ]
 
+[tool.setuptools.packages.find]
+where = ["test/scripts"]
+
 # make imgtestlib importable when running pytest
 [tool.pytest.ini_options]
 pythonpath = ["test/scripts"]


### PR DESCRIPTION
Configure setuptools to discover packages under `test/scripts` so `imgtestlib` installs with this project instead of only being reachable through pytest `pythonpath` settings in local test runs. Enable downstream projects to import and reuse `vm.py` for image boot tests without copying helper modules into each repository.

I would like to try using this for boot testing the RHEL EKS AMI images (without forking the scripts).