### PR TITLE
distro/generic: pass subscription options to pxe-tar-xz images (HMS-11108)

### DIFF
--- a/pkg/distro/generic/bootc_image_test.go
+++ b/pkg/distro/generic/bootc_image_test.go
@@ -699,23 +699,26 @@ func TestGenPartitionTableFromOSInfo(t *testing.T) {
 	assert.Contains(t, string(manifestJson), "01010101-01011-01011-01011-01010101")
 }
 
-// Each bootc manifestFor* variant hand-copies customizations, so pin that the
-// disk variant does not forget to pass Subscription through.
+// Each bootc manifestFor* variant hand-copies customizations, so pin that
+// every variant does not forget to pass Subscription through.
 func TestManifestSubscriptionCustomization(t *testing.T) {
-	imgType := NewTestBootcImageType(t, "qcow2")
-	imgOpts := distro.ImageOptions{
-		Subscription: &subscription.ImageOptions{
-			Organization:  "2040324",
-			ActivationKey: "my-secret-key",
-		},
+	for _, imgTypeName := range []string{"qcow2", "pxe-tar-xz"} {
+		t.Run(imgTypeName, func(t *testing.T) {
+			imgType := NewTestBootcImageType(t, imgTypeName)
+			imgOpts := distro.ImageOptions{
+				Subscription: &subscription.ImageOptions{
+					Organization:  "2040324",
+					ActivationKey: "my-secret-key",
+				},
+			}
+
+			mf, _, err := imgType.Manifest(&blueprint.Blueprint{}, imgOpts, nil, common.ToPtr(int64(0)))
+			assert.NoError(t, err)
+			manifestJson, err := mf.Serialize(nil, diskContainers, nil, nil, nil)
+			assert.NoError(t, err)
+
+			assert.Contains(t, string(manifestJson), "osbuild-subscription-register.service")
+			assert.Contains(t, string(manifestJson), "/etc/osbuild-subscription-register.env")
+		})
 	}
-
-	mf, _, err := imgType.Manifest(&blueprint.Blueprint{}, imgOpts, nil, common.ToPtr(int64(0)))
-	assert.NoError(t, err)
-	manifestJson, err := mf.Serialize(nil, diskContainers, nil, nil, nil)
-	assert.NoError(t, err)
-
-	// assert on names, not stage types: mount units share them
-	assert.Contains(t, string(manifestJson), "osbuild-subscription-register.service")
-	assert.Contains(t, string(manifestJson), "/etc/osbuild-subscription-register.env")
 }

--- a/pkg/distro/generic/bootc_imagetype.go
+++ b/pkg/distro/generic/bootc_imagetype.go
@@ -694,6 +694,7 @@ func (t *bootcImageType) manifestForPXETar(bp *blueprint.Blueprint, options dist
 		img.BuildOptions = opts
 	}
 	img.Compression = t.ImageTypeYAML.Compression
+	img.OSCustomizations.Subscription = options.Subscription
 	img.OSCustomizations.Users = users.UsersFromBP(customizations.GetUsers())
 
 	groups, err := customizations.GetGroups()


### PR DESCRIPTION
Support for subscription serialization was added to raw bootc images in 96573cd. This commit adds subscription support to the pxe-tar-xz image type (for bootc).

I manually tested this. I was able to build and boot an image and confirm that the registration service ran. You can see it here in Inventory/Systems although note that it appears as package mode for some reason (I don't know how Systems determines this, but I'd assume it is a bug on their side).

<img width="3172" height="712" alt="image" src="https://github.com/user-attachments/assets/da8f583d-a864-4290-a1a1-e19b69dfa51e" />
