### PR TITLE
Simplify early manifest generation code and enable custom seeds for bootc-based images

### DIFF
--- a/cmd/image-builder/bib_cmd.go
+++ b/cmd/image-builder/bib_cmd.go
@@ -139,6 +139,7 @@ func setupBibManifestCmd() (*cobra.Command, error) {
 	if err := manifestCmd.Flags().MarkHidden("config"); err != nil {
 		return nil, fmt.Errorf("cannot hide 'config' :%w", err)
 	}
+	manifestCmd.Flags().Int64("seed", 0, `rng seed, some values are derived randomly, pinning the seed allows more reproducibility if you need it. must be an integer. only used when changed.`)
 
 	return manifestCmd, nil
 }

--- a/cmd/image-builder/bib_main.go
+++ b/cmd/image-builder/bib_main.go
@@ -59,8 +59,8 @@ func saveManifest(ms manifest.OSBuildManifest, fpath string) error {
 // the progress bar (this function cannot know what else needs to happen
 // after manifest generation).
 //
-// This code is very similar to main.go:cmdManifestWrapper (which is
-// sad), but consolidate is hard because:
+// This code is very similar to main.go:generateManifest (which is sad), but
+// consolidate is hard because:
 //  1. We need to support anaconda-iso here which means we need to provide a custom
 //     depsolve function to extract the mTLS config from the container image, this is
 //     something we consider legacy so ibcli:main.go does not have it

--- a/cmd/image-builder/bib_main.go
+++ b/cmd/image-builder/bib_main.go
@@ -80,6 +80,15 @@ func bibManifestFromCobra(cmd *cobra.Command, args []string, pbar progress.Progr
 	installerPayloadRef, _ := cmd.Flags().GetString("installer-payload-ref")
 	useLibrepo, _ := cmd.Flags().GetBool("use-librepo")
 
+	var customSeed *int64
+	if cmd.Flags().Changed("seed") {
+		seedFlagVal, err := cmd.Flags().GetInt64("seed")
+		if err != nil {
+			return nil, nil, err
+		}
+		customSeed = &seedFlagVal
+	}
+
 	// If --local was given, warn in the case of --local or --local=true (true is the default), error in the case of --local=false
 	if cmd.Flags().Changed("local") {
 		localStorage, _ := cmd.Flags().GetBool("local")
@@ -181,7 +190,8 @@ func bibManifestFromCobra(cmd *cobra.Command, args []string, pbar progress.Progr
 	}
 	var mTLS *mTLSConfig
 	mg, err := manifestgen.New(repos, &manifestgen.Options{
-		Cachedir: rpmCacheRoot,
+		Cachedir:   rpmCacheRoot,
+		CustomSeed: customSeed,
 		// XXX: hack to skip repo loading for the bootc image.
 		// We need to add a SkipRepositories or similar to
 		// manifestgen instead to make this clean

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -20,12 +21,15 @@ import (
 	"github.com/osbuild/image-builder/pkg/bootc"
 	"github.com/osbuild/image-builder/pkg/cloud"
 	"github.com/osbuild/image-builder/pkg/customizations/subscription"
+	"github.com/osbuild/image-builder/pkg/distro"
 	"github.com/osbuild/image-builder/pkg/distro/generic"
 	"github.com/osbuild/image-builder/pkg/imagefilter"
 	"github.com/osbuild/image-builder/pkg/manifestgen"
 	"github.com/osbuild/image-builder/pkg/osbuild"
 	"github.com/osbuild/image-builder/pkg/ostree"
 	"github.com/osbuild/image-builder/pkg/progress"
+	"github.com/osbuild/image-builder/pkg/rhsm/facts"
+	"github.com/osbuild/image-builder/pkg/sbom"
 
 	"github.com/osbuild/image-builder/internal/blueprintload"
 	"github.com/osbuild/image-builder/pkg/setup"
@@ -379,7 +383,7 @@ func getImage(cmd *cobra.Command, args []string) (*imagefilter.Result, error) {
 	return img, err
 }
 
-func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []string, img *imagefilter.Result, wd io.Writer, wrapperOpts *cmdManifestWrapperOptions) ([]byte, error) {
+func generateManifest(pbar progress.ProgressBar, cmd *cobra.Command, args []string, img *imagefilter.Result, wd io.Writer, wrapperOpts *cmdManifestWrapperOptions) ([]byte, error) {
 	if wrapperOpts == nil {
 		wrapperOpts = &cmdManifestWrapperOptions{}
 	}
@@ -540,7 +544,66 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if opts.ManifestgenOptions.UseBootstrapContainer {
 		fmt.Fprintf(os.Stderr, "WARNING: using experimental cross-architecture building to build %q\n", img.ImgType.Arch().Name())
 	}
-	return generateManifest(repoDir, extraRepos, img, opts)
+
+	repos, err := newRepoRegistry(repoDir, extraRepos)
+	if err != nil {
+		return nil, err
+	}
+	manifestGenOpts := &opts.ManifestgenOptions
+	if opts.WithSBOM {
+		outputDir := basenameFor(img, opts.OutputDir)
+		manifestGenOpts.SBOMWriter = func(filename string, content io.Reader, docType sbom.StandardType) error {
+			filename = fmt.Sprintf("%s.%s", basenameFor(img, opts.OutputFilename), strings.SplitN(filename, ".", 2)[1])
+			return fileWriter(outputDir, filename, content)
+		}
+	}
+	if len(opts.ForceRepos) > 0 {
+		forcedRepos, err := parseRepoURLs(opts.ForceRepos, "forced")
+		if err != nil {
+			return nil, err
+		}
+		manifestGenOpts.OverrideRepos = forcedRepos
+	}
+	if opts.IgnoreWarnings {
+		manifestGenOpts.WarningsOutput = os.Stderr
+	}
+
+	if opts.WithRPMList {
+		outputDir := basenameFor(img, opts.OutputDir)
+		manifestGenOpts.RPMListWriter = func(filename string, content io.Reader) error {
+			filename = fmt.Sprintf("%s.%s", basenameFor(img, opts.OutputFilename), filename)
+			return fileWriter(outputDir, filename, content)
+		}
+	}
+
+	mg, err := manifestgen.New(repos, manifestGenOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	imgOpts := &distro.ImageOptions{
+		Facts:        &facts.ImageOptions{APIType: facts.IBCLI_APITYPE},
+		OSTree:       opts.Ostree,
+		Subscription: opts.Subscription,
+		Size:         opts.ImageSize,
+		Bootc: &distro.BootcImageOptions{
+			InstallerPayloadRef:      opts.BootcInstallerPayloadRef,
+			OmitDefaultKernelArgs:    opts.BootcOmitDefaultKernelArgs,
+			UseRemoteContainerSource: opts.BootcRemote,
+		},
+		Preview: opts.Preview,
+	}
+
+	mf, err := mg.Generate(bp, img.ImgType, imgOpts)
+	if err != nil {
+		return nil, err
+	}
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, []byte(mf), "", "    "); err != nil {
+		return nil, err
+	}
+
+	return append(pretty.Bytes(), '\n'), nil
 }
 
 func cmdManifest(cmd *cobra.Command, args []string) error {
@@ -552,7 +615,7 @@ func cmdManifest(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	mf, err := cmdManifestWrapper(pbar, cmd, args, img, io.Discard, nil)
+	mf, err := generateManifest(pbar, cmd, args, img, io.Discard, nil)
 	if err != nil {
 		return err
 	}
@@ -662,7 +725,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 
 	// We discard any warnings from the depsolver until we figure out a better
 	// idea (likely in manifestgen)
-	mf, err := cmdManifestWrapper(pbar, cmd, args, img, io.Discard, opts)
+	mf, err := generateManifest(pbar, cmd, args, img, io.Discard, opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -541,7 +541,12 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if opts.ManifestgenOptions.UseBootstrapContainer {
 		fmt.Fprintf(os.Stderr, "WARNING: using experimental cross-architecture building to build %q\n", img.ImgType.Arch().Name())
 	}
-	return generateManifest(repoDir, extraRepos, img, w, opts)
+	mf, err := generateManifest(repoDir, extraRepos, img, opts)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(mf)
+	return err
 }
 
 func cmdManifest(cmd *cobra.Command, args []string) error {

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -380,61 +379,61 @@ func getImage(cmd *cobra.Command, args []string) (*imagefilter.Result, error) {
 	return img, err
 }
 
-func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []string, img *imagefilter.Result, w io.Writer, wd io.Writer, wrapperOpts *cmdManifestWrapperOptions) error {
+func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []string, img *imagefilter.Result, wd io.Writer, wrapperOpts *cmdManifestWrapperOptions) ([]byte, error) {
 	if wrapperOpts == nil {
 		wrapperOpts = &cmdManifestWrapperOptions{}
 	}
 	repoDir, err := cmd.Flags().GetString("force-repo-dir")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	rpmmdCacheDir, err := cmd.Flags().GetString("rpmmd-cache")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	extraRepos, err := cmd.Flags().GetStringArray("extra-repo")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	forceRepos, err := cmd.Flags().GetStringArray("force-repo")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	distroStr, err := cmd.Flags().GetString("distro")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	withSBOM, err := cmd.Flags().GetBool("with-sbom")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	withRPMList, err := cmd.Flags().GetBool("with-rpmlist")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	ignoreWarnings, err := cmd.Flags().GetBool("ignore-warnings")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	outputDir, err := cmd.Flags().GetString("output-dir")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	ostreeImgOpts, err := ostreeImageOptions(cmd)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	useLibrepo, err := cmd.Flags().GetBool("use-librepo")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	bootcRemote, err := cmd.Flags().GetBool("bootc-pull-container")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	imageSize, err := cmd.Flags().GetUint64("image-size")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var preview *bool
@@ -445,7 +444,7 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if cmd.Flags().Lookup("preview").Changed {
 		value, err := cmd.Flags().GetBool("preview")
 		if err != nil {
-			return err
+			return nil, err
 		}
 		preview = &value
 	}
@@ -455,34 +454,34 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	}
 	blueprintPath, err := cmd.Flags().GetString("blueprint")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	var customSeed *int64
 	if cmd.Flags().Changed("seed") {
 		seedFlagVal, err := cmd.Flags().GetInt64("seed")
 		if err != nil {
-			return err
+			return nil, err
 		}
 		customSeed = &seedFlagVal
 	}
 	subscription, err := subscriptionImageOptions(cmd)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	bootcRef, err := cmd.Flags().GetString("bootc-ref")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if bootcRef != "" && distroStr != "" {
-		return fmt.Errorf("cannot use --distro with --bootc-ref")
+		return nil, fmt.Errorf("cannot use --distro with --bootc-ref")
 	}
 	bootcInstallerPayloadRef, err := cmd.Flags().GetString("bootc-installer-payload-ref")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	bootcOmitDefaultKernelArgs, err := cmd.Flags().GetBool("bootc-no-default-kernel-args")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// no error check here as this is (deliberately) not defined on
@@ -492,12 +491,12 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 
 	bp, err := blueprintload.Load(blueprintPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if bootcRef == "" {
 		distroStr, err = findDistro(distroStr, bp.Distro)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	} else {
 		distroStr = "bootc-based"
@@ -541,12 +540,7 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if opts.ManifestgenOptions.UseBootstrapContainer {
 		fmt.Fprintf(os.Stderr, "WARNING: using experimental cross-architecture building to build %q\n", img.ImgType.Arch().Name())
 	}
-	mf, err := generateManifest(repoDir, extraRepos, img, opts)
-	if err != nil {
-		return err
-	}
-	_, err = w.Write(mf)
-	return err
+	return generateManifest(repoDir, extraRepos, img, opts)
 }
 
 func cmdManifest(cmd *cobra.Command, args []string) error {
@@ -558,7 +552,12 @@ func cmdManifest(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return cmdManifestWrapper(pbar, cmd, args, img, osStdout, io.Discard, nil)
+	mf, err := cmdManifestWrapper(pbar, cmd, args, img, io.Discard, nil)
+	if err != nil {
+		return err
+	}
+	_, err = osStdout.Write(mf)
+	return err
 }
 
 func progressFromCmd(cmd *cobra.Command, conf progress.ProgressConfig) (progress.ProgressBar, error) {
@@ -657,14 +656,13 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		pbar.Stop()
 	}()
 
-	var mf bytes.Buffer
 	opts := &cmdManifestWrapperOptions{
 		useBootstrapIfNeeded: true,
 	}
 
 	// We discard any warnings from the depsolver until we figure out a better
 	// idea (likely in manifestgen)
-	err = cmdManifestWrapper(pbar, cmd, args, img, &mf, io.Discard, opts)
+	mf, err := cmdManifestWrapper(pbar, cmd, args, img, io.Discard, opts)
 	if err != nil {
 		return err
 	}
@@ -699,7 +697,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		buildOpts.InVm = []string{"image"}
 	}
 	pbar.SetPulseMsgf("Image building step")
-	imagePath, err := buildImage(pbar, img, mf.Bytes(), buildOpts)
+	imagePath, err := buildImage(pbar, img, mf, buildOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -514,34 +514,17 @@ func generateManifest(pbar progress.ProgressBar, cmd *cobra.Command, args []stri
 	pbar.SetPulseMsgf("Manifest generation step")
 	pbar.SetMessagef("Building manifest for %s-%s", distroStr, imgTypeStr)
 
-	opts := &manifestOptions{
-		ManifestgenOptions: manifestgen.Options{
-			Cachedir:               rpmmdCacheDir,
-			CustomSeed:             customSeed,
-			RpmDownloader:          rpmDownloader,
-			DepsolveWarningsOutput: wd,
-			Depsolve:               manifestgenDepsolver,
-			ContainerResolver:      manifestgenContainerResolver,
-		},
-		OutputDir:                  outputDir,
-		OutputFilename:             outputFilename,
-		BlueprintPath:              blueprintPath,
-		Ostree:                     ostreeImgOpts,
-		BootcRef:                   bootcRef,
-		BootcInstallerPayloadRef:   bootcInstallerPayloadRef,
-		BootcOmitDefaultKernelArgs: bootcOmitDefaultKernelArgs,
-		BootcRemote:                bootcRemote,
-		ImageSize:                  imageSize,
-		WithSBOM:                   withSBOM,
-		WithRPMList:                withRPMList,
-		IgnoreWarnings:             ignoreWarnings,
-		Subscription:               subscription,
-		Preview:                    preview,
-
-		ForceRepos: forceRepos,
+	mgOptions := manifestgen.Options{
+		Cachedir:               rpmmdCacheDir,
+		CustomSeed:             customSeed,
+		RpmDownloader:          rpmDownloader,
+		DepsolveWarningsOutput: wd,
+		Depsolve:               manifestgenDepsolver,
+		ContainerResolver:      manifestgenContainerResolver,
 	}
-	opts.ManifestgenOptions.UseBootstrapContainer = wrapperOpts.useBootstrapIfNeeded && (img.ImgType.Arch().Name() != arch.Current().String())
-	if opts.ManifestgenOptions.UseBootstrapContainer {
+
+	mgOptions.UseBootstrapContainer = wrapperOpts.useBootstrapIfNeeded && (img.ImgType.Arch().Name() != arch.Current().String())
+	if mgOptions.UseBootstrapContainer {
 		fmt.Fprintf(os.Stderr, "WARNING: using experimental cross-architecture building to build %q\n", img.ImgType.Arch().Name())
 	}
 
@@ -549,49 +532,48 @@ func generateManifest(pbar progress.ProgressBar, cmd *cobra.Command, args []stri
 	if err != nil {
 		return nil, err
 	}
-	manifestGenOpts := &opts.ManifestgenOptions
-	if opts.WithSBOM {
-		outputDir := basenameFor(img, opts.OutputDir)
-		manifestGenOpts.SBOMWriter = func(filename string, content io.Reader, docType sbom.StandardType) error {
-			filename = fmt.Sprintf("%s.%s", basenameFor(img, opts.OutputFilename), strings.SplitN(filename, ".", 2)[1])
+	if withSBOM {
+		outputDir := basenameFor(img, outputDir)
+		mgOptions.SBOMWriter = func(filename string, content io.Reader, docType sbom.StandardType) error {
+			filename = fmt.Sprintf("%s.%s", basenameFor(img, outputFilename), strings.SplitN(filename, ".", 2)[1])
 			return fileWriter(outputDir, filename, content)
 		}
 	}
-	if len(opts.ForceRepos) > 0 {
-		forcedRepos, err := parseRepoURLs(opts.ForceRepos, "forced")
+	if len(forceRepos) > 0 {
+		forcedRepos, err := parseRepoURLs(forceRepos, "forced")
 		if err != nil {
 			return nil, err
 		}
-		manifestGenOpts.OverrideRepos = forcedRepos
+		mgOptions.OverrideRepos = forcedRepos
 	}
-	if opts.IgnoreWarnings {
-		manifestGenOpts.WarningsOutput = os.Stderr
+	if ignoreWarnings {
+		mgOptions.WarningsOutput = os.Stderr
 	}
 
-	if opts.WithRPMList {
-		outputDir := basenameFor(img, opts.OutputDir)
-		manifestGenOpts.RPMListWriter = func(filename string, content io.Reader) error {
-			filename = fmt.Sprintf("%s.%s", basenameFor(img, opts.OutputFilename), filename)
+	if withRPMList {
+		outputDir := basenameFor(img, outputDir)
+		mgOptions.RPMListWriter = func(filename string, content io.Reader) error {
+			filename = fmt.Sprintf("%s.%s", basenameFor(img, outputFilename), filename)
 			return fileWriter(outputDir, filename, content)
 		}
 	}
 
-	mg, err := manifestgen.New(repos, manifestGenOpts)
+	mg, err := manifestgen.New(repos, &mgOptions)
 	if err != nil {
 		return nil, err
 	}
 
 	imgOpts := &distro.ImageOptions{
 		Facts:        &facts.ImageOptions{APIType: facts.IBCLI_APITYPE},
-		OSTree:       opts.Ostree,
-		Subscription: opts.Subscription,
-		Size:         opts.ImageSize,
+		OSTree:       ostreeImgOpts,
+		Subscription: subscription,
+		Size:         imageSize,
 		Bootc: &distro.BootcImageOptions{
-			InstallerPayloadRef:      opts.BootcInstallerPayloadRef,
-			OmitDefaultKernelArgs:    opts.BootcOmitDefaultKernelArgs,
-			UseRemoteContainerSource: opts.BootcRemote,
+			InstallerPayloadRef:      bootcInstallerPayloadRef,
+			OmitDefaultKernelArgs:    bootcOmitDefaultKernelArgs,
+			UseRemoteContainerSource: bootcRemote,
 		},
-		Preview: opts.Preview,
+		Preview: preview,
 	}
 
 	mf, err := mg.Generate(bp, img.ImgType, imgOpts)

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -61,11 +61,10 @@ func fileWriter(outputDir, filename string, content io.Reader) error {
 	return f.Sync()
 }
 
-// XXX: just return []byte instead of using output writer
-func generateManifest(repoDir string, extraRepos []string, img *imagefilter.Result, output io.Writer, opts *manifestOptions) error {
+func generateManifest(repoDir string, extraRepos []string, img *imagefilter.Result, opts *manifestOptions) ([]byte, error) {
 	repos, err := newRepoRegistry(repoDir, extraRepos)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	manifestGenOpts := &opts.ManifestgenOptions
 	if opts.WithSBOM {
@@ -78,7 +77,7 @@ func generateManifest(repoDir string, extraRepos []string, img *imagefilter.Resu
 	if len(opts.ForceRepos) > 0 {
 		forcedRepos, err := parseRepoURLs(opts.ForceRepos, "forced")
 		if err != nil {
-			return err
+			return nil, err
 		}
 		manifestGenOpts.OverrideRepos = forcedRepos
 	}
@@ -96,12 +95,12 @@ func generateManifest(repoDir string, extraRepos []string, img *imagefilter.Resu
 
 	mg, err := manifestgen.New(repos, manifestGenOpts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	bp, err := blueprintload.Load(opts.BlueprintPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	imgOpts := &distro.ImageOptions{
@@ -119,18 +118,12 @@ func generateManifest(repoDir string, extraRepos []string, img *imagefilter.Resu
 
 	mf, err := mg.Generate(bp, img.ImgType, imgOpts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	var pretty bytes.Buffer
 	if err := json.Indent(&pretty, []byte(mf), "", "    "); err != nil {
-		return err
+		return nil, err
 	}
 
-	if _, err := pretty.WriteTo(output); err != nil {
-		return err
-	}
-	if _, err := output.Write([]byte{'\n'}); err != nil {
-		return err
-	}
-	return nil
+	return append(pretty.Bytes(), '\n'), nil
 }

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -4,34 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-
-	"github.com/osbuild/image-builder/pkg/customizations/subscription"
-	"github.com/osbuild/image-builder/pkg/manifestgen"
-	"github.com/osbuild/image-builder/pkg/osbuild"
-	"github.com/osbuild/image-builder/pkg/ostree"
 )
-
-type manifestOptions struct {
-	ManifestgenOptions manifestgen.Options
-
-	OutputDir                  string
-	OutputFilename             string
-	BlueprintPath              string
-	Ostree                     *ostree.ImageOptions
-	BootcRef                   string
-	BootcInstallerPayloadRef   string
-	BootcOmitDefaultKernelArgs bool
-	BootcRemote                bool
-	ImageSize                  uint64
-	Subscription               *subscription.ImageOptions
-	RpmDownloader              osbuild.RpmDownloader
-	WithSBOM                   bool
-	WithRPMList                bool
-	IgnoreWarnings             bool
-	Preview                    *bool
-
-	ForceRepos []string
-}
 
 func fileWriter(outputDir, filename string, content io.Reader) error {
 	p := filepath.Join(outputDir, filename)

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -1,24 +1,14 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/osbuild/image-builder/pkg/customizations/subscription"
-	"github.com/osbuild/image-builder/pkg/distro"
-	"github.com/osbuild/image-builder/pkg/imagefilter"
 	"github.com/osbuild/image-builder/pkg/manifestgen"
 	"github.com/osbuild/image-builder/pkg/osbuild"
 	"github.com/osbuild/image-builder/pkg/ostree"
-	"github.com/osbuild/image-builder/pkg/rhsm/facts"
-	"github.com/osbuild/image-builder/pkg/sbom"
-
-	"github.com/osbuild/image-builder/internal/blueprintload"
 )
 
 type manifestOptions struct {
@@ -59,71 +49,4 @@ func fileWriter(outputDir, filename string, content io.Reader) error {
 	}
 
 	return f.Sync()
-}
-
-func generateManifest(repoDir string, extraRepos []string, img *imagefilter.Result, opts *manifestOptions) ([]byte, error) {
-	repos, err := newRepoRegistry(repoDir, extraRepos)
-	if err != nil {
-		return nil, err
-	}
-	manifestGenOpts := &opts.ManifestgenOptions
-	if opts.WithSBOM {
-		outputDir := basenameFor(img, opts.OutputDir)
-		manifestGenOpts.SBOMWriter = func(filename string, content io.Reader, docType sbom.StandardType) error {
-			filename = fmt.Sprintf("%s.%s", basenameFor(img, opts.OutputFilename), strings.SplitN(filename, ".", 2)[1])
-			return fileWriter(outputDir, filename, content)
-		}
-	}
-	if len(opts.ForceRepos) > 0 {
-		forcedRepos, err := parseRepoURLs(opts.ForceRepos, "forced")
-		if err != nil {
-			return nil, err
-		}
-		manifestGenOpts.OverrideRepos = forcedRepos
-	}
-	if opts.IgnoreWarnings {
-		manifestGenOpts.WarningsOutput = os.Stderr
-	}
-
-	if opts.WithRPMList {
-		outputDir := basenameFor(img, opts.OutputDir)
-		manifestGenOpts.RPMListWriter = func(filename string, content io.Reader) error {
-			filename = fmt.Sprintf("%s.%s", basenameFor(img, opts.OutputFilename), filename)
-			return fileWriter(outputDir, filename, content)
-		}
-	}
-
-	mg, err := manifestgen.New(repos, manifestGenOpts)
-	if err != nil {
-		return nil, err
-	}
-
-	bp, err := blueprintload.Load(opts.BlueprintPath)
-	if err != nil {
-		return nil, err
-	}
-
-	imgOpts := &distro.ImageOptions{
-		Facts:        &facts.ImageOptions{APIType: facts.IBCLI_APITYPE},
-		OSTree:       opts.Ostree,
-		Subscription: opts.Subscription,
-		Size:         opts.ImageSize,
-		Bootc: &distro.BootcImageOptions{
-			InstallerPayloadRef:      opts.BootcInstallerPayloadRef,
-			OmitDefaultKernelArgs:    opts.BootcOmitDefaultKernelArgs,
-			UseRemoteContainerSource: opts.BootcRemote,
-		},
-		Preview: opts.Preview,
-	}
-
-	mf, err := mg.Generate(bp, img.ImgType, imgOpts)
-	if err != nil {
-		return nil, err
-	}
-	var pretty bytes.Buffer
-	if err := json.Indent(&pretty, []byte(mf), "", "    "); err != nil {
-		return nil, err
-	}
-
-	return append(pretty.Bytes(), '\n'), nil
 }

--- a/pkg/distro/generic/bootc_imagetype.go
+++ b/pkg/distro/generic/bootc_imagetype.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/osbuild/blueprint/pkg/blueprint"
-	"github.com/osbuild/image-builder/internal/cmdutil"
 	"github.com/osbuild/image-builder/internal/common"
 	"github.com/osbuild/image-builder/pkg/arch"
 	"github.com/osbuild/image-builder/pkg/bib/osinfo"
@@ -154,15 +153,12 @@ func (t *bootcImageType) checkOptions(bp *blueprint.Blueprint) []string {
 func (t *bootcImageType) Manifest(bp *blueprint.Blueprint, options distro.ImageOptions, repos []rpmmd.RepoConfig, seedp *int64) (*manifest.Manifest, []string, error) {
 	validationWarnings := t.checkOptions(bp)
 
-	mani, manifestWarnings, err := t.manifestWithoutValidation(bp, options)
+	mani, manifestWarnings, err := t.manifestWithoutValidation(bp, options, seedp)
 	return mani, append(validationWarnings, manifestWarnings...), err
 }
 
-func (t *bootcImageType) manifestWithoutValidation(bp *blueprint.Blueprint, options distro.ImageOptions) (*manifest.Manifest, []string, error) {
-	seed, err := cmdutil.NewRNGSeed()
-	if err != nil {
-		return nil, nil, err
-	}
+func (t *bootcImageType) manifestWithoutValidation(bp *blueprint.Blueprint, options distro.ImageOptions, seedp *int64) (*manifest.Manifest, []string, error) {
+	seed := distro.SeedFrom(seedp)
 	//nolint:gosec
 	rng := rand.New(rand.NewSource(seed))
 


### PR DESCRIPTION
Another small PR towards simplifying and deduplicating the code that handles image-builder and bootc-image-builder.  This still doesn't actually deduplicate anything, but it simplifies the manifest generation code in `cmd/image-builder` a bit.  It also makes one functional change: The `--seed` option had no effect when generating bootc manifests and that's now been fixed.