### PR TITLE
cmd/image-builder: drop `images` from version

### DIFF
--- a/cmd/image-builder/version.go
+++ b/cmd/image-builder/version.go
@@ -20,7 +20,6 @@ type versionDescription struct {
 		Version      string `yaml:"version" json:"version"`
 		Commit       string `yaml:"commit" json:"commit"`
 		Dependencies struct {
-			Images  string `yaml:"images" json:"images"`
 			OSBuild string `yaml:"osbuild" json:"osbuild"`
 		} `yaml:"dependencies" json:"dependencies"`
 	} `yaml:"image-builder" json:"image-builder"`
@@ -34,7 +33,6 @@ func readVersionInfo() *versionDescription {
 	// be defined by whatever is building this project.
 	vd.ImageBuilder.Commit = "unknown"
 	vd.ImageBuilder.Version = version
-	vd.ImageBuilder.Dependencies.Images = "unknown"
 	vd.ImageBuilder.Dependencies.OSBuild = "unknown"
 
 	if bi, ok := debug.ReadBuildInfo(); ok {
@@ -42,12 +40,6 @@ func readVersionInfo() *versionDescription {
 			switch bs.Key {
 			case "vcs.revision":
 				vd.ImageBuilder.Commit = bs.Value
-			}
-		}
-
-		for _, dep := range bi.Deps {
-			if dep.Path == "github.com/osbuild/image-builder" {
-				vd.ImageBuilder.Dependencies.Images = dep.Version
 			}
 		}
 	}

--- a/cmd/image-builder/version_test.go
+++ b/cmd/image-builder/version_test.go
@@ -85,7 +85,6 @@ func TestVersionSubcommandJSON(t *testing.T) {
 
 	deps, ok := ib["dependencies"].(map[string]interface{})
 	require.True(t, ok, "must have dependencies key")
-	assert.Contains(t, deps, "images")
 	assert.Contains(t, deps, "osbuild")
 }
 


### PR DESCRIPTION
It no longer makes sense to show the version of the `images` library as it no longer exists. This executable version is already the version of the 'library'.