### PR TITLE
container: add SetAuthFilePath method to Resolver

### DIFF
--- a/pkg/container/resolver.go
+++ b/pkg/container/resolver.go
@@ -20,6 +20,8 @@ type Resolver interface {
 
 	Resolve(spec SourceSpec) (Spec, error)
 	ResolveAll(sources map[string][]SourceSpec) (map[string][]Spec, error)
+
+	SetAuthFilePath(path string)
 }
 
 type asyncResolver struct {
@@ -44,6 +46,7 @@ type SourceSpec struct {
 func NewResolver(arch string) *asyncResolver {
 	// NOTE: this should return the Resolver interface, but osbuild-composer
 	// sets the AuthFilePath and for now we don't want to break the API.
+	// Do the switch once composer switches to the SetAuthFilePath method.
 	return &asyncResolver{
 		queue: make(chan resolveResult, 2),
 		Arch:  arch,
@@ -76,6 +79,10 @@ func (r *asyncResolver) Add(spec SourceSpec) {
 		}
 		r.queue <- resolveResult{spec: spec, err: err}
 	}()
+}
+
+func (r *asyncResolver) SetAuthFilePath(path string) {
+	r.AuthFilePath = path
 }
 
 func (r *asyncResolver) Finish() ([]Spec, error) {
@@ -151,6 +158,10 @@ func NewBlockingResolver(arch string) Resolver {
 		Arch:      arch,
 		newClient: NewClient,
 	}
+}
+
+func (r *blockingResolver) SetAuthFilePath(path string) {
+	r.AuthFilePath = path
 }
 
 func (r *blockingResolver) Add(src SourceSpec) {

--- a/pkg/container/resolver_internal_test.go
+++ b/pkg/container/resolver_internal_test.go
@@ -1,0 +1,22 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Smoke tests for the SetAuthFilePath method on the Resolver interface.
+// These need to be in the container package because they access internal fields.
+
+func TestAsyncResolverSetAuthFilePath(t *testing.T) {
+	resolver := NewResolver("amd64")
+	resolver.SetAuthFilePath("/path/to/auth.json")
+	assert.Equal(t, "/path/to/auth.json", resolver.AuthFilePath)
+}
+
+func TestBlockingResolverSetAuthFilePath(t *testing.T) {
+	resolver := NewBlockingResolver("amd64")
+	resolver.SetAuthFilePath("/path/to/auth.json")
+	assert.Equal(t, "/path/to/auth.json", resolver.(*blockingResolver).AuthFilePath)
+}


### PR DESCRIPTION
As a part of https://github.com/osbuild/osbuild-composer/pull/5218 I wanted to switch to the blocking resolver as we want to drop the async one going forward. However, it's not possible to set the auth file using the Resolver interface.

Let's add a SetAuthFilePath method to the interface to fill this gap and unblock osbuild-composer's migration to the blocking resolver.