### PR TITLE
distrodefs: Add aliases to Fedora for GCP (HMS-11182)

### DIFF
--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -2759,6 +2759,7 @@ image_types:
 
   "cloud-gce": &cloud_gce
     <<: *cloud_base
+    name_aliases: ["gcp", "gce"]
     filename: "image.tar.gz"
     mime_type: "application/gzip"
     exports: ["archive"]


### PR DESCRIPTION
This should enable building Fedora through service as CRC's API uses `gcp` which is something that the destrodefs do not recognize. Fix it by adding aliases similar to guest-image and others.